### PR TITLE
Say once what a rule handle reads as, and hold the sentence to the writer

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -200,11 +200,11 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      */
     private static boolean calls(MethodModel method, String owner, String member) {
         return method.code().map(code -> code.elementStream().anyMatch(element ->
-                element instanceof InvokeInstruction called
+                (element instanceof InvokeInstruction called
                         && owner.equals(called.owner().name().stringValue())
-                        && member.equals(called.name().stringValue())
-                || element instanceof InvokeDynamicInstruction dynamic
-                        && handedOver(dynamic, owner, member))).orElse(false);
+                        && member.equals(called.name().stringValue()))
+                || (element instanceof InvokeDynamicInstruction dynamic
+                        && handedOver(dynamic, owner, member)))).orElse(false);
     }
 
     /** Whether the bootstrap of {@code dynamic} hands over {@code member} on {@code owner}. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -7,15 +7,17 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.classfile.ClassFile;
+import java.lang.classfile.MethodModel;
 import java.lang.classfile.constantpool.FieldRefEntry;
-import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.instruction.InvokeInstruction;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,8 +60,15 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      * and it is why this list is short on purpose.
      */
     private static final List<String> SAYING_IT_IN_PROSE = List.of(
-            "souther/compiler/report/AdequacyReport -> " + PROSE + "#said",
-            "souther/compiler/report/GeneratedRows -> " + PROSE + "#said");
+            "souther/compiler/report/AdequacyReport"
+                    + "#cited(Set, SourceNameResolver, SourceId)",
+            "souther/compiler/report/AdequacyReport"
+                    + "#declared(StringBuilder, AdequacyReport$ModuleReport, SourceNameResolver)",
+            "souther/compiler/report/AdequacyReport#partition lambda taking (StringBuilder,"
+                    + " BorderAssessment, SourceNameResolver, SourceId, PointRole, RoleAnswer)",
+            "souther/compiler/report/AdequacyReport#partition(StringBuilder,"
+                    + " AdequacyReport$BehaviorReport, SourceId, SourceNameResolver)",
+            "souther/compiler/report/GeneratedRows#about(Adequacy$Finding)");
 
     /**
      * And every class that writes one into the document, which is one.
@@ -68,7 +77,13 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      * writers of one document are two vocabularies for a consumer to learn.
      */
     private static final List<String> WRITING_IT_INTO_THE_DOCUMENT = List.of(
-            "souther/compiler/report/AdequacyReport -> " + SURFACE + "#put");
+            "souther/compiler/report/AdequacyReport#findings(ArrayNode, List, DocumentSources)",
+            "souther/compiler/report/AdequacyReport"
+                    + "#obligations(ArrayNode, List, Map, DocumentSources)",
+            "souther/compiler/report/AdequacyReport#partition lambda taking (DocumentArray,"
+                    + " DocumentSources, PartitionEvidence$NotRead)",
+            "souther/compiler/report/AdequacyReport#partition(ObjectNode, PartitionEvidence,"
+                    + " Measure, List, ClaimAnnotations, DocumentSources)");
 
     @Test
     void everyClassThatTurnsARuleHandleIntoWordsIsWrittenDown() {
@@ -121,22 +136,62 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
                 "the classes this reads are in more than the one module that declares the sentence");
     }
 
-    /** Every class naming a method called {@code member} on {@code owner}, as the class and what it
-     *  named. */
+    /**
+     * Every method calling {@code member} on {@code owner}, as the class and the method.
+     *
+     * <p>The method and not the class, because the class is not the boundary. One class writes the
+     * report a person reads and the document a consumer keys on, so a class allowed to say a handle
+     * in prose is a class that may put those words under any field of the document and add no row
+     * here. Which method it happened in is what tells those two apart.
+     */
     private static Set<String> naming(String owner, String member) {
         Set<String> found = new TreeSet<>();
         for (Path module : REPOSITORY.modules()) {
             for (Path each : classesUnder(module)) {
-                for (PoolEntry entry : constantPoolOf(each)) {
-                    if (entry instanceof MemberRefEntry named
-                            && owner.equals(named.owner().name().stringValue())
-                            && member.equals(named.name().stringValue())) {
-                        found.add(internalName(module, each) + " -> " + owner + "#" + member);
+                for (MethodModel method : ClassFile.of().parse(bytesOf(each)).methods()) {
+                    if (calls(method, owner, member)) {
+                        found.add(internalName(module, each) + "#" + said(method));
                     }
                 }
             }
         }
         return found;
+    }
+
+    /**
+     * The method somebody wrote, as a name and what it takes.
+     *
+     * <p>What it takes, because a name is not a method: this writer says a partition in the report a
+     * person reads and in the document, and both are called {@code partition}. Told apart by name
+     * alone, a handle rendered in prose inside the one that writes the document would arrive here as
+     * a row that was already allowed — which is the whole distinction these rows exist to draw.
+     *
+     * <p>And the method somebody wrote, because a lambda is compiled to a method of its own, named
+     * after the one it was written in and numbered within the class. The number moves when a lambda
+     * is added anywhere above it, so a row carrying one would go red for edits that have nothing to
+     * do with handles.
+     */
+    private static String said(MethodModel method) {
+        String compiled = method.methodName().stringValue();
+        String taking = method.methodTypeSymbol().parameterList().stream()
+                .map(each -> each.displayName())
+                .collect(Collectors.joining(", ", "(", ")"));
+        if (compiled.startsWith("lambda$")) {
+            // What a lambda takes is what it captured and what it is applied to, which is not what
+            // the method around it takes — and is what tells one lambda of that method from
+            // another now that the number is gone.
+            return compiled.substring("lambda$".length(), compiled.lastIndexOf('$'))
+                    + " lambda taking " + taking;
+        }
+        return compiled + taking;
+    }
+
+    /** Whether {@code method}'s own code names {@code member} on {@code owner}. */
+    private static boolean calls(MethodModel method, String owner, String member) {
+        return method.code().map(code -> code.elementStream().anyMatch(element ->
+                element instanceof InvokeInstruction called
+                        && owner.equals(called.owner().name().stringValue())
+                        && member.equals(called.name().stringValue()))).orElse(false);
     }
 
     /**
@@ -194,8 +249,12 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
     }
 
     private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
+        return ClassFile.of().parse(bytesOf(compiled)).constantPool();
+    }
+
+    private static byte[] bytesOf(Path compiled) {
         try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
+            return Files.readAllBytes(compiled);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -9,7 +9,10 @@ import java.io.UncheckedIOException;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.constantpool.FieldRefEntry;
+import java.lang.classfile.constantpool.LoadableConstantEntry;
+import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,9 +80,9 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      * writers of one document are two vocabularies for a consumer to learn.
      */
     private static final List<String> WRITING_IT_INTO_THE_DOCUMENT = List.of(
-            "souther/compiler/report/AdequacyReport#findings(ArrayNode, List, DocumentSources)",
+            "souther/compiler/report/AdequacyReport#findings(DocumentArray, List, DocumentSources)",
             "souther/compiler/report/AdequacyReport"
-                    + "#obligations(ArrayNode, List, Map, DocumentSources)",
+                    + "#obligations(DocumentArray, List, Map, DocumentSources)",
             "souther/compiler/report/AdequacyReport#partition lambda taking (DocumentArray,"
                     + " DocumentSources, PartitionEvidence$NotRead)",
             "souther/compiler/report/AdequacyReport#partition(ObjectNode, PartitionEvidence,"
@@ -186,12 +189,36 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
         return compiled + taking;
     }
 
-    /** Whether {@code method}'s own code names {@code member} on {@code owner}. */
+    /**
+     * Whether {@code method}'s own code names {@code member} on {@code owner}.
+     *
+     * <p>Called, or handed to something that will call it. A method reference compiles to an
+     * {@code invokedynamic} whose bootstrap carries the target as a method handle, and nothing in
+     * the method's instructions names the target at all — so a walk over calls alone answers no for
+     * {@code RuleHandleProse::said}, which renders a handle as surely as calling it. The claim to
+     * read both is what makes this a walk over compiled classes rather than over the source.
+     */
     private static boolean calls(MethodModel method, String owner, String member) {
         return method.code().map(code -> code.elementStream().anyMatch(element ->
                 element instanceof InvokeInstruction called
                         && owner.equals(called.owner().name().stringValue())
-                        && member.equals(called.name().stringValue()))).orElse(false);
+                        && member.equals(called.name().stringValue())
+                || element instanceof InvokeDynamicInstruction dynamic
+                        && handedOver(dynamic, owner, member))).orElse(false);
+    }
+
+    /** Whether the bootstrap of {@code dynamic} hands over {@code member} on {@code owner}. */
+    private static boolean handedOver(InvokeDynamicInstruction dynamic, String owner,
+                                      String member) {
+        for (LoadableConstantEntry argument
+                : dynamic.invokedynamic().bootstrap().arguments()) {
+            if (argument instanceof MethodHandleEntry handle
+                    && owner.equals(handle.reference().owner().name().stringValue())
+                    && member.equals(handle.reference().name().stringValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -1,0 +1,234 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.constantpool.FieldRefEntry;
+import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may say what a rule handle reads as, and which fields of the document one is written into.
+ *
+ * <p>The document says how a reader is sent to a rule in five fields, and the schema says of each
+ * that it carries such a handle. What holds those two lists together is a comparison between the
+ * schema and {@code RuleHandleSurface} — and that comparison is worth what the surface is worth: if
+ * a handle can reach a document field without going through one, the enum is a list of the places
+ * somebody remembered, which is the thing this whole issue is about one layer up.
+ *
+ * <p>So it is read off the compiled classes rather than trusted. Two questions, and neither is
+ * answerable by looking at the enum: who renders a handle at all, and which fields are written
+ * through it. A renderer reached by a method reference renders as surely as one called here, which
+ * is the other reason to read the classes rather than the source.
+ *
+ * <p>What the rows leave open is deliberate: a class may put whatever string it likes under whatever
+ * key. What it cannot do is get a rule handle's words without appearing here.
+ */
+class WhoMaySayWhatARuleHandleReadsAsTest {
+
+    private static final String PROSE = "souther/compiler/publish/RuleHandleProse";
+
+    private static final String SURFACE = "souther/compiler/publish/RuleHandleSurface";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * Every class that asks what a handle reads as outside a document, and why it may.
+     *
+     * <p>Two, and both write the report a person reads. {@code AdequacyReport} says a rule in the
+     * lines under a behavior; {@code GeneratedRows} says the same rule beside a row it composed, and
+     * says it that way so that a reader meeting the finding in both places meets one sentence.
+     *
+     * <p>A row added here is a place that turns a handle into words with no field of the schema
+     * behind it. That is what a document field written past the surface would look like from here,
+     * and it is why this list is short on purpose.
+     */
+    private static final List<String> SAYING_IT_IN_PROSE = List.of(
+            "souther/compiler/report/AdequacyReport -> " + PROSE + "#said",
+            "souther/compiler/report/GeneratedRows -> " + PROSE + "#said");
+
+    /**
+     * And every class that writes one into the document, which is one.
+     *
+     * <p>The document is written in one place, so a second row here is a second writer — and two
+     * writers of one document are two vocabularies for a consumer to learn.
+     */
+    private static final List<String> WRITING_IT_INTO_THE_DOCUMENT = List.of(
+            "souther/compiler/report/AdequacyReport -> " + SURFACE + "#put");
+
+    @Test
+    void everyClassThatTurnsARuleHandleIntoWordsIsWrittenDown() {
+        assertEquals(SAYING_IT_IN_PROSE, new ArrayList<>(naming(PROSE, "said")),
+                "a class here turns a handle into words with nothing in the schema behind it, which"
+                        + " is what a document field written past the surface looks like");
+    }
+
+    @Test
+    void andEveryClassThatWritesOneIntoTheDocumentIsWrittenDown() {
+        assertEquals(WRITING_IT_INTO_THE_DOCUMENT, new ArrayList<>(naming(SURFACE, "put")),
+                "the document is written in one place, and a handle reaches a consumer through the"
+                        + " fields that place names");
+    }
+
+    /**
+     * And every field the surface declares is one the writer writes.
+     *
+     * <p>The other direction. A constant nobody names is a field the schema is held to carry a
+     * handle in while nothing puts one there — the comparison against the schema would pass, and
+     * what it would be comparing is two lists of intentions.
+     */
+    @Test
+    void andEveryFieldTheSurfaceDeclaresIsOneSomethingWrites() {
+        assertEquals(surfaceConstants(), used(SURFACE),
+                "the fields the surface declares and the fields something writes through");
+    }
+
+    /**
+     * The walk reads every module's classes.
+     *
+     * <p>Asked of the modules the repository has and not of what a build happened to leave: a module
+     * whose classes are missing is one whose calls this cannot see, and the rows from the rest would
+     * match and this would pass while answering about fewer modules than it names.
+     */
+    @Test
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        List<String> unbuilt = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
+                unbuilt.add(module.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), unbuilt,
+                "a module whose classes are not built is one this walk passes over, and a walk that"
+                        + " passes over a module answers about the rest while saying it answers"
+                        + " about all of them");
+        assertTrue(modulesRead() > 1,
+                "the classes this reads are in more than the one module that declares the sentence");
+    }
+
+    /** Every class naming a method called {@code member} on {@code owner}, as the class and what it
+     *  named. */
+    private static Set<String> naming(String owner, String member) {
+        Set<String> found = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                for (PoolEntry entry : constantPoolOf(each)) {
+                    if (entry instanceof MemberRefEntry named
+                            && owner.equals(named.owner().name().stringValue())
+                            && member.equals(named.name().stringValue())) {
+                        found.add(internalName(module, each) + " -> " + owner + "#" + member);
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Every constant of {@code owner} that some other class reads.
+     *
+     * <p>The owner itself is passed over. An enum's own class file names every constant it declares,
+     * because that is where they are made — counted, this would answer that every field the surface
+     * declares is written and go on answering it with nothing writing any of them.
+     */
+    private static Set<String> used(String owner) {
+        Set<String> found = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                if (internalName(module, each).equals(owner)) {
+                    continue;
+                }
+                for (PoolEntry entry : constantPoolOf(each)) {
+                    if (entry instanceof FieldRefEntry read
+                            && owner.equals(read.owner().name().stringValue())
+                            && surfaceConstants().contains(read.name().stringValue())) {
+                        found.add(read.name().stringValue());
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The fields the surface declares, read off the enum rather than written here.
+     *
+     * <p>Loaded by name, because this module compiles against the compiler and a list of constants
+     * copied into a test is one more list to keep — which is the shape being checked.
+     */
+    private static Set<String> surfaceConstants() {
+        Set<String> out = new TreeSet<>();
+        try {
+            for (Object each : Class.forName(SURFACE.replace('/', '.')).getEnumConstants()) {
+                out.add(((Enum<?>) each).name());
+            }
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("the surface this is about is on the classpath", e);
+        }
+        return out;
+    }
+
+    private static int modulesRead() {
+        int read = 0;
+        for (Path module : REPOSITORY.modules()) {
+            if (!classesUnder(module).isEmpty()) {
+                read++;
+            }
+        }
+        return read;
+    }
+
+    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The class's own binary name, taken against the directory it was found under rather than off
+     *  the first {@code classes} in the path, which a checkout under one would be. */
+    private static String internalName(Path module, Path compiled) {
+        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
+        return name.substring(0, name.length() - ".class".length());
+    }
+
+    private static Path classesOf(Path module) {
+        return module.resolve("target").resolve("classes");
+    }
+
+    /** Whether the module has main sources to have been built from. A module holding only tests or
+     *  only a pom leaves no classes and is not one this walk is missing. */
+    private static boolean hasMainSources(Path module) {
+        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
+    }
+
+    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
+     *  them: a test makes one to look at it and ships nothing. */
+    private static List<Path> classesUnder(Path module) {
+        Path where = classesOf(module);
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/AFieldWhoseOrderIsThisCompilersIsWrittenThroughACrossingTest.java
+++ b/souther-bench/src/test/java/souther/bench/AFieldWhoseOrderIsThisCompilersIsWrittenThroughACrossingTest.java
@@ -2,6 +2,7 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.publish.DocumentPart;
 import souther.compiler.publish.PublicationOrders;
 
 import java.util.ArrayList;
@@ -36,6 +37,8 @@ class AFieldWhoseOrderIsThisCompilersIsWrittenThroughACrossingTest {
 
     private static final String STARTS_AN_ARRAY = "putArray";
 
+    private static final String NAMES_A_PART = "souther.compiler.publish.DocumentPart";
+
     private static final Set<String> CROSSINGS = Set.of(
             "souther.compiler.publish.CanonicalArrangement",
             "souther.compiler.publish.CanonicalSelection",
@@ -55,7 +58,12 @@ class AFieldWhoseOrderIsThisCompilersIsWrittenThroughACrossingTest {
         for (Compiled.Invocation each : called()) {
             if (each.site().member().equals(STARTS_AN_ARRAY)
                     && each.site().from().startsWith("souther.compiler.report.")
-                    && each.said().isEmpty()) {
+                    && each.said().isEmpty()
+                    // The call and not the method it is in. A method that starts one array by
+                    // naming a part of the document says nothing about the arrays beside it, and
+                    // excusing it as a whole is how a check written to keep a population from
+                    // shrinking lets one shrink.
+                    && !each.site().owner().equals(NAMES_A_PART)) {
                 unread.add(each.site().at());
             }
         }
@@ -131,14 +139,51 @@ class AFieldWhoseOrderIsThisCompilersIsWrittenThroughACrossingTest {
                 out.addAll(each.said());
             }
         }
+        out.addAll(namesStartedThrough(method));
         return out;
     }
 
-    /** The methods that start an array under {@code field}, read off the name written at the call. */
+    /**
+     * The arrays {@code method} starts by naming a part of the document rather than a string.
+     *
+     * <p>The five parts that carry a rule handle are started through {@link DocumentPart}, which is
+     * what makes a part's name and the place the schema declares it one value instead of two
+     * literals a writer could disagree about. The name is still written down and still read here —
+     * it moved from the call into a constant the call reads, and the set of them is closed by the
+     * enum, so an array started this way cannot leave the population in silence either.
+     */
+    private static Set<String> namesStartedThrough(String method) throws Exception {
+        Set<String> out = new LinkedHashSet<>();
+        boolean starts = false;
+        for (Compiled.Invocation each : called()) {
+            starts |= each.site().at().equals(method)
+                    && each.site().member().equals(STARTS_AN_ARRAY)
+                    && each.site().owner().equals(NAMES_A_PART);
+        }
+        if (!starts) {
+            return out;
+        }
+        for (Compiled.Site each : compiled()) {
+            if (each.at().equals(method) && each.how() == Compiled.How.READS
+                    && each.owner().equals(NAMES_A_PART)) {
+                out.add(DocumentPart.valueOf(each.member()).key());
+            }
+        }
+        return out;
+    }
+
+    /** The methods that start an array under {@code field}, read off the name written at the call
+     *  or off the part the call names. */
     private static Set<String> whereTheArrayIsStarted(String field) throws Exception {
         Set<String> out = new LinkedHashSet<>();
         for (Compiled.Invocation each : called()) {
             if (each.site().member().equals(STARTS_AN_ARRAY) && each.said().contains(field)) {
+                out.add(each.site().at());
+            }
+        }
+        for (Compiled.Invocation each : called()) {
+            if (each.site().member().equals(STARTS_AN_ARRAY)
+                    && namesStartedThrough(each.site().at()).contains(field)) {
                 out.add(each.site().at());
             }
         }

--- a/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -3,6 +3,8 @@ package souther.cli;
 import souther.cli.Main;
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.publish.RuleHandleSurface;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -111,10 +113,10 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                 out.add(point.role().againstTheLine()
                         ? "no row is at the " + point.role() + " point " + behavior + "/"
                                 + line.axis() + " = " + point.against()
-                                + " (" + line.describe(names, null) + ")"
+                                + " (" + line.describe(RuleHandleSurface.PROSE, names, null) + ")"
                         : "no row is at an " + point.role() + " point of " + behavior + "/"
                                 + line.axis() + ", " + point.against()
-                                + " (" + line.describe(names, null) + ")");
+                                + " (" + line.describe(RuleHandleSurface.PROSE, names, null) + ")");
             }
         }));
         return List.copyOf(out);

--- a/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -3,7 +3,7 @@ package souther.cli;
 import souther.cli.Main;
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -113,10 +113,10 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                 out.add(point.role().againstTheLine()
                         ? "no row is at the " + point.role() + " point " + behavior + "/"
                                 + line.axis() + " = " + point.against()
-                                + " (" + line.describe(RuleHandleSurface.PROSE, names, null) + ")"
+                                + " (" + RuleHandleProse.said(line.describe(), names, null) + ")"
                         : "no row is at an " + point.role() + " point of " + behavior + "/"
                                 + line.axis() + ", " + point.against()
-                                + " (" + line.describe(RuleHandleSurface.PROSE, names, null) + ")");
+                                + " (" + RuleHandleProse.said(line.describe(), names, null) + ")");
             }
         }));
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
@@ -1,8 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourceNameResolver;
-import souther.compiler.source.SourceId;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,29 +79,6 @@ public sealed interface RuleCitation {
     }
 
     /**
-     * How a report writes this, where it knows what to call a source.
-     *
-     * <p>The one formatter, shared with the borders a comparison draws — a rule and a line the same
-     * rule drew are found the same way, and two spellings of one place would read as two places.
-     * What is not shared is an identity: where a rule was read is
-     * {@link souther.compiler.partition.LineOrigin}'s and one rule has as many of those as it has
-     * readings.
-     *
-     * <p>Every word here is read off {@link #rule}. What goes in front of a place is what that rule
-     * is, so a kind of rule added to the seal is one this sentence has words for or one that stops
-     * the compile.
-     */
-    default String said(SourceNameResolver names, SourceId sectionSource) {
-        return switch (this) {
-            case Named it -> it.rule().citedName();
-            // Written here, and reached from somewhere else: a comparison inside a helper is one
-            // rule and a reader is sent to two places, which the citation already tells apart.
-            case WrittenAt it -> it.rule().whatItIs()
-                    + joining(it.at()) + it.at().said(names, sectionSource);
-        };
-    }
-
-    /**
      * Where a handle reaches its rule, which is nothing for a rule the author named.
      *
      * <p>The one place a handle is taken apart. What a fold over these keeps is the rule once and
@@ -146,15 +121,5 @@ public sealed interface RuleCitation {
             throw new IllegalArgumentException("a rule with no name is reached at a place and a rule"
                     + " with one is reached by it: " + rule + " at " + reachedAt);
         }
-    }
-
-    /**
-     * What goes between the construct and the place.
-     *
-     * <p>Shared with the borders the same rule drew, which is the whole of what those two have in
-     * common: a word, and how it joins to a place. Neither holds the other's identity.
-     */
-    static String joining(Citation at) {
-        return at instanceof Citation.Elsewhere ? " in " : "@";
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -107,7 +107,18 @@ public record AuthoredLine(WhichLine which, LineFacts facts,
      * in both places, the two spellings of one narrowing read as two.
      */
     public String said(String rule) {
-        return rule + (narrowedWithin.isEmpty() ? "" : " within " + naming(narrowedWithin));
+        return rule + narrowing();
+    }
+
+    /**
+     * What this reading adds after the rule, which is nothing where no declaration took an end in.
+     *
+     * <p>The words on their own, for a reader putting them after a handle it renders itself. A rule
+     * has one spelling and it is not this one's to write, so what is offered here is the rest of the
+     * sentence rather than the whole of it.
+     */
+    public String narrowing() {
+        return narrowedWithin.isEmpty() ? "" : " within " + naming(narrowedWithin);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -2,11 +2,13 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.NarrowedBounds;
+import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.Towards;
 import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -420,9 +422,8 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
 
     /** The rule that drew this line, as the surface {@code surface} names writes it in a report
      *  about {@code sectionSource}. */
-    public String describe(RuleHandleSurface surface,
-                           souther.compiler.diag.SourceNameResolver names,
-                           souther.compiler.source.SourceId sectionSource) {
+    public String describe(RuleHandleSurface surface, SourceNameResolver names,
+                           SourceId sectionSource) {
         return origin.describe(surface, names, sectionSource);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -2,13 +2,11 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.NarrowedBounds;
-import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.Towards;
-import souther.compiler.publish.RuleHandleSurface;
-import souther.compiler.source.SourceId;
+import souther.compiler.publish.PublishedSentence;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -420,11 +418,9 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
         return criterion == null ? null : criterion.written(cut.of());
     }
 
-    /** The rule that drew this line, as the surface {@code surface} names writes it in a report
-     *  about {@code sectionSource}. */
-    public String describe(RuleHandleSurface surface, SourceNameResolver names,
-                           SourceId sectionSource) {
-        return origin.describe(surface, names, sectionSource);
+    /** The rule that drew this line, as what a report writes about it. */
+    public PublishedSentence describe() {
+        return origin.describe();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -6,6 +6,7 @@ import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.Towards;
+import souther.compiler.publish.RuleHandleSurface;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -417,10 +418,12 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
         return criterion == null ? null : criterion.written(cut.of());
     }
 
-    /** The rule that drew this line, as a report about {@code sectionSource} writes it. */
-    public String describe(souther.compiler.diag.SourceNameResolver names,
+    /** The rule that drew this line, as the surface {@code surface} names writes it in a report
+     *  about {@code sectionSource}. */
+    public String describe(RuleHandleSurface surface,
+                           souther.compiler.diag.SourceNameResolver names,
                            souther.compiler.source.SourceId sectionSource) {
-        return origin.describe(names, sectionSource);
+        return origin.describe(surface, names, sectionSource);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -7,6 +7,8 @@ import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
@@ -409,17 +411,16 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      * <p>A type and an invariant have names, and a name is the same wherever it is read, so they take
      * no resolver and are given one only because this is one question.
      */
-    default String describe(SourceNameResolver names, SourceId sectionSource) {
+    default String describe(RuleHandleSurface surface, SourceNameResolver names,
+                            SourceId sectionSource) {
+        // The handle of the rule this line came from, said the one way handles are said. A rule and
+        // a line it drew are found the same way, and two spellings of one handle read as two.
+        String handle = surface.render(PublishedRuleHandle.of(cited()), names, sectionSource);
         return switch (this) {
-            case InvariantOrigin i -> i.rule().citedName();
-            case EnsuresOrigin e -> e.rule().citedName();
-            // The same word and the same join a question about this rule is written with. A rule
-            // and a line it drew are found the same way, and two spellings of one place read as two
-            // places.
-            case ComparisonOrigin g -> g.read().written().said(names, sectionSource);
-            // The declarations that took the end in, said the way the line itself says them.
-            case NarrowedOrigin n ->
-                    n.authoredLine().said(n.bound().describe(names, sectionSource));
+            case InvariantOrigin _, EnsuresOrigin _, ComparisonOrigin _ -> handle;
+            // The declarations that took the end in, said the way the line itself says them. The
+            // handle underneath is the bound's, which is what this origin cites.
+            case NarrowedOrigin n -> n.authoredLine().said(handle);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -1,14 +1,12 @@
 package souther.compiler.partition;
 
-import souther.compiler.source.SourceId;
 
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.publish.PublishedRuleHandle;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.PublishedSentence;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
@@ -394,33 +392,27 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
     }
 
     /**
-     * Where this came from, as a report writes it, with the sources under the names {@code names}
-     * gives them and the section it is printed under being about {@code sectionSource}.
+     * Where this came from, as what a report writes rather than as the words themselves.
      *
-     * <p>A comparison has no name, so what identifies it is where it is written — and that is a
-     * place, so it is said the way every other place a report names is said. Its own file where that
-     * is not the section's, and the declaration it is written in where this compile has no source for
-     * it. Built from the place instead, one compile reported a comparison of {@code Int.abs} as
-     * {@code comparison@7:22} two lines under an arm of that same body saying where it was.
+     * <p>The handle of the rule this line came from, and no words of this reading's own about it. How
+     * a reader is sent to a rule is one question with one answer
+     * ({@link souther.compiler.publish.PublishedRuleHandle}), and a line saying it a second way here
+     * is a second spelling that can come apart from the one a question about the same rule writes.
      *
-     * <p>One word goes in front of the place, and it says what the rule is. It was the construct the
-     * comparison stood in — three of them draw a line this way and one is spelled {@code guard} — and
-     * a word for the thing around a rule is a word the rule can lose: a comparison given a name a
-     * line above the fork stands in no construct that draws anything.
-     *
-     * <p>A type and an invariant have names, and a name is the same wherever it is read, so they take
-     * no resolver and are given one only because this is one question.
+     * <p>What this adds is what is true of the line rather than of the rule: the declarations that
+     * took an end of it in. A bound narrowed by another declaration is not the line that bound would
+     * have drawn alone, and the rule is the same rule either way — so those words go around the
+     * handle rather than into it.
      */
-    default String describe(RuleHandleSurface surface, SourceNameResolver names,
-                            SourceId sectionSource) {
-        // The handle of the rule this line came from, said the one way handles are said. A rule and
-        // a line it drew are found the same way, and two spellings of one handle read as two.
-        String handle = surface.render(PublishedRuleHandle.of(cited()), names, sectionSource);
+    default PublishedSentence describe() {
+        PublishedRuleHandle handle = PublishedRuleHandle.of(cited());
         return switch (this) {
-            case InvariantOrigin _, EnsuresOrigin _, ComparisonOrigin _ -> handle;
+            case InvariantOrigin _, EnsuresOrigin _, ComparisonOrigin _ ->
+                    PublishedSentence.AroundAHandle.alone(handle);
             // The declarations that took the end in, said the way the line itself says them. The
             // handle underneath is the bound's, which is what this origin cites.
-            case NarrowedOrigin n -> n.authoredLine().said(handle);
+            case NarrowedOrigin n -> new PublishedSentence.AroundAHandle(
+                    "", handle, n.authoredLine().narrowing());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentArray.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentArray.java
@@ -11,26 +11,38 @@ import tools.jackson.databind.node.ArrayNode;
  * meant. That is how the fields carrying a rule handle came to be a list of the ones somebody
  * registered rather than the ones a document has.
  *
- * <p>So the schema's own name for the part is carried beside the node, and a field that has a
- * declared place ({@link RuleHandleSurface}) is written by comparing the two. The array's name and
- * not the item's: items are what a schema declares under {@code items}, and a writer that named each
- * one would be writing the same answer once per row.
- *
- * <p>The name is the definition being filled rather than the place it is used from. A part reached
- * through {@code $ref} is one shape however many fields refer to it, and what a row of it must look
- * like is written where the definition is.
+ * <p>Made by {@link DocumentPart} and nowhere else, which is what keeps the name and the place one
+ * answer. Handed both as arguments, a caller could put an array under one name and claim the place
+ * of another, and the comparison a field is written by would hold while the field it wrote sat
+ * somewhere the contract does not describe.
  */
-public record DocumentArray(ArrayNode node, String schemaPath) {
+public final class DocumentArray {
 
-    public DocumentArray {
+    private final ArrayNode node;
+
+    private final String schemaPath;
+
+    private DocumentArray(ArrayNode node, String schemaPath) {
+        this.node = node;
+        this.schemaPath = schemaPath;
+    }
+
+    /** One of these, for the part of the document that knows which part it is. */
+    static DocumentArray of(ArrayNode node, String schemaPath) {
         if (node == null || schemaPath == null || !schemaPath.startsWith("/")) {
             throw new IllegalArgumentException("a repeated part of the document is a node and what"
                     + " the schema calls it: " + schemaPath);
         }
+        return new DocumentArray(node, schemaPath);
+    }
+
+    /** Where the schema declares this part. */
+    public String schemaPath() {
+        return schemaPath;
     }
 
     /** A row of it, which the schema declares under {@code items}. */
     public DocumentItem addObject() {
-        return new DocumentItem(node.addObject(), schemaPath + "/items");
+        return DocumentItem.at(node.addObject(), schemaPath + "/items");
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentArray.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentArray.java
@@ -1,0 +1,36 @@
+package souther.compiler.publish;
+
+import tools.jackson.databind.node.ArrayNode;
+
+/**
+ * A repeated part of the document being written, together with what the schema says it is.
+ *
+ * <p>A node on its own says nothing about where it sits, so a field written into one is a field
+ * nothing can be held to: the writer knows which part of the contract it is filling in and the node
+ * does not, and a check that could only ask the node was reduced to trusting whatever the writer
+ * meant. That is how the fields carrying a rule handle came to be a list of the ones somebody
+ * registered rather than the ones a document has.
+ *
+ * <p>So the schema's own name for the part is carried beside the node, and a field that has a
+ * declared place ({@link RuleHandleSurface}) is written by comparing the two. The array's name and
+ * not the item's: items are what a schema declares under {@code items}, and a writer that named each
+ * one would be writing the same answer once per row.
+ *
+ * <p>The name is the definition being filled rather than the place it is used from. A part reached
+ * through {@code $ref} is one shape however many fields refer to it, and what a row of it must look
+ * like is written where the definition is.
+ */
+public record DocumentArray(ArrayNode node, String schemaPath) {
+
+    public DocumentArray {
+        if (node == null || schemaPath == null || !schemaPath.startsWith("/")) {
+            throw new IllegalArgumentException("a repeated part of the document is a node and what"
+                    + " the schema calls it: " + schemaPath);
+        }
+    }
+
+    /** A row of it, which the schema declares under {@code items}. */
+    public DocumentItem addObject() {
+        return new DocumentItem(node.addObject(), schemaPath + "/items");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentItem.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentItem.java
@@ -1,0 +1,26 @@
+package souther.compiler.publish;
+
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * One object of the document being written, together with what the schema says it is.
+ *
+ * <p>What {@link DocumentArray} hands out, and what a field with a declared place is written into.
+ * Everything else about writing a document stays as it was: a node takes whatever keys the writer
+ * puts on it, and this is not a second way to do that. It exists so that the one field kind whose
+ * place the contract names can be checked against the place it was actually written.
+ */
+public record DocumentItem(ObjectNode node, String schemaPath) {
+
+    public DocumentItem {
+        if (node == null || schemaPath == null || !schemaPath.startsWith("/")) {
+            throw new IllegalArgumentException("an object of the document is a node and what the"
+                    + " schema calls it: " + schemaPath);
+        }
+    }
+
+    /** Where the schema declares a field this object writes under {@code key}. */
+    String fieldPath(String key) {
+        return schemaPath + "/properties/" + key;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentItem.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentItem.java
@@ -9,14 +9,32 @@ import tools.jackson.databind.node.ObjectNode;
  * Everything else about writing a document stays as it was: a node takes whatever keys the writer
  * puts on it, and this is not a second way to do that. It exists so that the one field kind whose
  * place the contract names can be checked against the place it was actually written.
+ *
+ * <p>Made where a row of a part is made, for the reason {@link DocumentArray} gives.
  */
-public record DocumentItem(ObjectNode node, String schemaPath) {
+public final class DocumentItem {
 
-    public DocumentItem {
+    private final ObjectNode node;
+
+    private final String schemaPath;
+
+    private DocumentItem(ObjectNode node, String schemaPath) {
+        this.node = node;
+        this.schemaPath = schemaPath;
+    }
+
+    /** One of these, for a row of a part that knows which part it is. */
+    static DocumentItem at(ObjectNode node, String schemaPath) {
         if (node == null || schemaPath == null || !schemaPath.startsWith("/")) {
             throw new IllegalArgumentException("an object of the document is a node and what the"
                     + " schema calls it: " + schemaPath);
         }
+        return new DocumentItem(node, schemaPath);
+    }
+
+    /** The object being written, for the fields that have no declared place of their own. */
+    public ObjectNode node() {
+        return node;
     }
 
     /** Where the schema declares a field this object writes under {@code key}. */

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentPart.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentPart.java
@@ -1,0 +1,68 @@
+package souther.compiler.publish;
+
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * A repeated part of the adequacy document that carries a rule handle, as the schema declares it.
+ *
+ * <p>What a part is called and where the schema declares it are one fact, so they are one value.
+ * Written as two — a key handed to {@code putArray} and a path handed beside it — a writer could
+ * fill an array under one name while claiming the place of another, and every check would agree:
+ * the surface's place would match what the writer claimed, the claim would match nothing, and the
+ * handle would be published under a field the contract says nothing about. That is the shape this
+ * whole issue is about, arrived at from the naming side, and it is why nothing here takes a key.
+ *
+ * <p>The path is the definition the rows conform to and not the property the array hangs from. Two
+ * sections publish obligations and two publish findings, each through a {@code $ref}, and what a row
+ * of either must look like is written once where the definition is. Which places may hold such an
+ * array is the schema's own business and is checked against it
+ * ({@code EveryFormOfARuleHandleIsOneTheContractDescribes}).
+ *
+ * <p>Only the parts that carry a handle are here. The rest of the document is written as it always
+ * was: this exists so the one field kind whose place the contract names can be held to it.
+ */
+public enum DocumentPart {
+
+    /** The questions a behavior's rules raise that nothing answered. */
+    UNANSWERED("unanswered", "/$defs/partition/properties/unanswered"),
+
+    /** What a reading could not read. */
+    NOT_READ("notRead", "/$defs/partition/properties/notRead"),
+
+    /** The lines a behavior's rules drew. */
+    BOUNDARIES("boundaries", "/$defs/partition/properties/boundaries"),
+
+    /** What a set of lines is owed a row for, published by two sections through one definition. */
+    OBLIGATIONS("obligations", "/$defs/obligations"),
+
+    /** What a measure found, published by two sections through one definition. */
+    FINDINGS("findings", "/$defs/findings");
+
+    private final String key;
+    private final String schemaPath;
+
+    DocumentPart(String key, String schemaPath) {
+        this.key = key;
+        this.schemaPath = schemaPath;
+    }
+
+    /** What the part is called wherever it is written. */
+    public String key() {
+        return key;
+    }
+
+    /** Where the schema declares what a row of it looks like. */
+    public String schemaPath() {
+        return schemaPath;
+    }
+
+    /**
+     * This part of {@code parent}, made and named together.
+     *
+     * <p>The one way to get one. A caller cannot put the array under a name of its own and hand the
+     * place of this one along with it, because it never says either.
+     */
+    public DocumentArray putArray(ObjectNode parent) {
+        return DocumentArray.of(parent.putArray(key), schemaPath);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
@@ -1,18 +1,26 @@
 package souther.compiler.publish;
 
 import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 
 import java.util.Optional;
 
 /**
- * How a document sends a reader to a rule, as the things a document's words for it are made of.
+ * How a document sends a reader to a rule, as one of the sentences a document writes.
  *
- * <p>The projection of a {@link RuleCitation} onto what varies in the sentence a report writes: the
- * name where the author gave one, and otherwise what the rule is, whether the code is here or
- * reached from here, where it is, and what it is reached by. Everything else a citation carries is
- * how this compiler came to be holding it.
+ * <p>The projection of a {@link RuleCitation} onto what varies in that sentence: the name where the
+ * author gave one, and otherwise what the rule is, whether the code is here or reached from here,
+ * and where it is. Everything else a citation carries is how this compiler came to be holding it.
+ *
+ * <p><b>The arms are the published grammar and not the internal seal.</b> Which sentence a document
+ * writes does not divide the way {@link RuleRef} divides: an invariant clause the author named and
+ * one they left to be counted are two sentences under one arm of that seal, and a citation and a
+ * place are two seals whose product is not the grammar either. Walked for the internal division,
+ * the population of forms a contract has to describe comes out short by exactly the forms a value
+ * decides — which is how a schema came to promise one shape for a field that writes several. So the
+ * division here is by sentence, and a form nothing spells stops the compile.
  *
  * <p><b>Made so that two handles a document writes alike are one value.</b> Choosing one of several
  * takes a comparison, and a comparison over what a citation is rather than over what is written of
@@ -21,50 +29,89 @@ import java.util.Optional;
  * have removed.
  *
  * <p>So this and never {@link RuleCitation} is what the order is over, and what it must keep is one
- * property: two of these that are equal are two a document writes the same sentence for. A rule's
- * kind is in the sentence, so it is here — left out, a comparison and a predicate written at one
- * place would come to one value and be printed two ways.
+ * property: two of these that are equal are two a document writes the same sentence for.
  *
- * <p>Three and not one with a field that is sometimes absent, because they are three kinds of
- * evidence. A name is what the author called the rule; a place is where this document's own source
- * has it; and a reach is a place in code out of sight together with what reaches it, which is what
- * makes the place mean something. Read back out of an absent field, the third would be the second
- * with something extra, and every consumer would rebuild the distinction from the absence.
+ * <p><b>The spelling is this layer's and is reached through a surface.</b> What the sentence reads
+ * as is {@link RuleHandleSentence}, and what may ask for it is {@link RuleHandleSurface} — so every
+ * place a rule handle reaches a reader is a place that named itself, and the surfaces a document has
+ * are a set a check can hold against the schema rather than a habit callers keep.
  */
 public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHandle> {
 
-    /** The author gave it a name, and that is what a reader is told. */
-    record Named(String name) implements PublishedRuleHandle {
+    /** A clause of an invariant the author gave a name. */
+    record NamedInvariant(String declaredOn, String clause) implements PublishedRuleHandle {
 
-        public Named {
-            if (name == null || name.isEmpty()) {
-                throw new IllegalArgumentException("a rule called nothing is reached by where it is");
+        public NamedInvariant {
+            if (declaredOn == null || declaredOn.isEmpty() || clause == null || clause.isEmpty()) {
+                throw new IllegalArgumentException("a named clause of an invariant is written on a"
+                        + " declaration and called something: " + declaredOn + " (" + clause + ")");
+            }
+        }
+    }
+
+    /**
+     * A clause of an invariant the author named nothing, which a reader counts to.
+     *
+     * <p>Counted from one, as somebody reading the declaration counts them. Its own form and not a
+     * name that happens to be a number: a reader looking for a clause called {@code #2} is looking
+     * for something the author never wrote, and a contract that described only the named form left
+     * this one undescribed.
+     */
+    record NumberedInvariant(String declaredOn, int number) implements PublishedRuleHandle {
+
+        public NumberedInvariant {
+            if (declaredOn == null || declaredOn.isEmpty() || number < 1) {
+                throw new IllegalArgumentException("a clause nobody named is the nth of some"
+                        + " declaration, counted from one: " + declaredOn + " #" + number);
+            }
+        }
+    }
+
+    /** A clause of an {@code ensures} the author gave words to — a name, or the case an arm names. */
+    record NamedEnsures(String behavior, String clause) implements PublishedRuleHandle {
+
+        public NamedEnsures {
+            if (behavior == null || behavior.isEmpty() || clause == null || clause.isEmpty()) {
+                throw new IllegalArgumentException("a clause of an ensures belongs to a behavior and"
+                        + " is called something: " + behavior + " (" + clause + ")");
+            }
+        }
+    }
+
+    /** A clause stating one rule over every answer, which the behavior's own name is the whole of. */
+    record WholeEnsures(String behavior) implements PublishedRuleHandle {
+
+        public WholeEnsures {
+            if (behavior == null || behavior.isEmpty()) {
+                throw new IllegalArgumentException("a clause over every answer is some behavior's");
             }
         }
     }
 
     /** It has no name and is written where a reader can be sent, so what is said is what it is and
      *  where. */
-    record Written(String kind, Place at) implements PublishedRuleHandle {
+    record Written(PublishedRuleKind kind, Place at) implements PublishedRuleHandle {
 
         public Written {
-            if (kind == null || kind.isEmpty() || at == null) {
+            if (kind == null || at == null || at instanceof Place.Nowhere) {
                 throw new IllegalArgumentException("a rule with no name is said as what it is and"
                         + " where: " + kind + " at " + at);
             }
         }
     }
 
-    /** It has no name and the code is out of sight, so what is said is what it is, where it came
-     *  from, and what reaches it. */
-    record Reached(String kind, Place at, String reachedBy) implements PublishedRuleHandle {
+    /**
+     * It has no name and the code is out of sight, so what is said is what it is, what reaches it,
+     * and where it came from if this compile met it at a place.
+     */
+    record Reached(PublishedRuleKind kind, Place at, String reachedBy)
+            implements PublishedRuleHandle {
 
         public Reached {
-            if (kind == null || kind.isEmpty() || at == null
-                    || reachedBy == null || reachedBy.isEmpty()) {
-                throw new IllegalArgumentException("code out of sight is said as what it is, where"
-                        + " it came from and what reaches it: " + kind + " at " + at + " by "
-                        + reachedBy);
+            if (kind == null || reachedBy == null || reachedBy.isEmpty() || at == null) {
+                throw new IllegalArgumentException("code out of sight is said as what it is, what"
+                        + " reaches it and where it came from: " + kind + " in " + reachedBy
+                        + " at " + at);
             }
         }
     }
@@ -122,14 +169,42 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
         }
     }
 
-    /** How a document would write {@code cited}. */
+    /**
+     * How a document would write {@code cited}.
+     *
+     * <p>The one projection, and total over both seals it reads: which sentence a rule with a name
+     * takes is the clause's own answer, and which one a rule without takes is the citation's.
+     */
     static PublishedRuleHandle of(RuleCitation cited) {
         return switch (cited) {
-            case RuleCitation.Named it -> new Named(it.rule().citedName());
+            case RuleCitation.Named it -> named(it.rule());
             case RuleCitation.WrittenAt it -> it.at() instanceof Citation.Elsewhere out
-                    ? new Reached(it.rule().whatItIs(), placeOf(it.at()),
+                    ? new Reached(PublishedRuleKind.of(it.rule()), placeOf(it.at()),
                             out.provenance().reachedBy())
-                    : new Written(it.rule().whatItIs(), placeOf(it.at()));
+                    : new Written(PublishedRuleKind.of(it.rule()), placeOf(it.at()));
+        };
+    }
+
+    /**
+     * Which sentence a rule the author named is written as.
+     *
+     * <p>Two kinds of named rule and two sentences each, because in both the author may have left
+     * the words to be filled in: a clause with no name of its own is counted, and a clause stating
+     * one rule over every answer is the behavior's name alone.
+     */
+    private static PublishedRuleHandle named(RuleRef.Named rule) {
+        return switch (rule) {
+            case RuleRef.Invariant it -> {
+                String declaredOn = it.clause().id().declaredOn().name();
+                yield it.clause().name()
+                        .<PublishedRuleHandle>map(name ->
+                                new NamedInvariant(declaredOn, name.toString()))
+                        .orElseGet(() -> new NumberedInvariant(
+                                declaredOn, it.clause().id().ordinal() + 1));
+            }
+            case RuleRef.Ensures it -> it.clause().isEmpty()
+                    ? new WholeEnsures(it.rule().behavior().name())
+                    : new NamedEnsures(it.rule().behavior().name(), it.clause());
         };
     }
 
@@ -180,7 +255,22 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
             return kind;
         }
         return switch (this) {
-            case Named it -> it.name().compareTo(((Named) other).name());
+            case NamedInvariant it -> {
+                NamedInvariant also = (NamedInvariant) other;
+                int on = it.declaredOn().compareTo(also.declaredOn());
+                yield on != 0 ? on : it.clause().compareTo(also.clause());
+            }
+            case NumberedInvariant it -> {
+                NumberedInvariant also = (NumberedInvariant) other;
+                int on = it.declaredOn().compareTo(also.declaredOn());
+                yield on != 0 ? on : Integer.compare(it.number(), also.number());
+            }
+            case NamedEnsures it -> {
+                NamedEnsures also = (NamedEnsures) other;
+                int of = it.behavior().compareTo(also.behavior());
+                yield of != 0 ? of : it.clause().compareTo(also.clause());
+            }
+            case WholeEnsures it -> it.behavior().compareTo(((WholeEnsures) other).behavior());
             case Written it -> {
                 Written also = (Written) other;
                 int word = it.kind().compareTo(also.kind());
@@ -198,13 +288,16 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
         };
     }
 
-    /** Which of the three kinds of sentence comes first, written out rather than read off how the
-     *  arms happen to be declared. */
+    /** Which of the sentences comes first, written out rather than read off how the arms happen to
+     *  be declared. */
     private static int rank(PublishedRuleHandle handle) {
         return switch (handle) {
-            case Named _ -> 0;
-            case Written _ -> 1;
-            case Reached _ -> 2;
+            case NamedInvariant _ -> 0;
+            case NumberedInvariant _ -> 1;
+            case NamedEnsures _ -> 2;
+            case WholeEnsures _ -> 3;
+            case Written _ -> 4;
+            case Reached _ -> 5;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
@@ -5,8 +5,6 @@ import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 
-import java.util.Optional;
-
 /**
  * How a document sends a reader to a rule, as one of the sentences a document writes.
  *
@@ -93,7 +91,7 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
     record Written(PublishedRuleKind kind, Place at) implements PublishedRuleHandle {
 
         public Written {
-            if (kind == null || at == null || at instanceof Place.Nowhere) {
+            if (kind == null || at == null) {
                 throw new IllegalArgumentException("a rule with no name is said as what it is and"
                         + " where: " + kind + " at " + at);
             }
@@ -101,17 +99,36 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
     }
 
     /**
-     * It has no name and the code is out of sight, so what is said is what it is, what reaches it,
-     * and where it came from if this compile met it at a place.
+     * It has no name, the code is out of sight, and this compile met it at a place: what is said is
+     * what it is, what reaches it, and where it came from.
      */
     record Reached(PublishedRuleKind kind, Place at, String reachedBy)
             implements PublishedRuleHandle {
 
         public Reached {
             if (kind == null || reachedBy == null || reachedBy.isEmpty() || at == null) {
-                throw new IllegalArgumentException("code out of sight is said as what it is, what"
-                        + " reaches it and where it came from: " + kind + " in " + reachedBy
-                        + " at " + at);
+                throw new IllegalArgumentException("code out of sight met at a place is said as what"
+                        + " it is, what reaches it and where it came from: " + kind + " in "
+                        + reachedBy + " at " + at);
+            }
+        }
+    }
+
+    /**
+     * The same with no place at all, which is what a report says of code it never met a position in.
+     *
+     * <p>Its own form rather than a place that says nothing. Carried as an arm of {@link Place}, the
+     * one thing a report cannot write would be the one thing every reader of a place has to handle,
+     * and what the sentence does about it — leave the place out — would be a case the spelling
+     * refuses at a point the types said it could reach.
+     */
+    record ReachedOutOfSight(PublishedRuleKind kind, String reachedBy)
+            implements PublishedRuleHandle {
+
+        public ReachedOutOfSight {
+            if (kind == null || reachedBy == null || reachedBy.isEmpty()) {
+                throw new IllegalArgumentException("code with no position is said as what it is and"
+                        + " what reaches it: " + kind + " in " + reachedBy);
             }
         }
     }
@@ -119,12 +136,14 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
     /**
      * Where a report says the rule is, as it says it.
      *
-     * <p>Three and not two. A place in a file this compile holds is what a reader can be sent to;
-     * a position in a text it cannot name is still printed, line and column, because whoever is
-     * showing the report knows which text it is; and code out of sight has no position at all.
+     * <p>Two, and every one of them is somewhere a sentence can put. A place in a file this compile
+     * holds is what a reader can be sent to; a position in a text it cannot name is still printed,
+     * line and column, because whoever is showing the report knows which text it is. Code this
+     * compile met no position in has no place, and says so by being a form of its own
+     * ({@link ReachedOutOfSight}) rather than by holding a place that is not one.
      *
      * <p>Not {@link PublishedAt} alone, which is the shape the document's own {@code at} field
-     * takes and so has nothing for the middle one. Borrowed for this, two rules the report prints
+     * takes and so has nothing for the second one. Borrowed for this, two rules the report prints
      * at different lines of an unnamed text came out as one value — and the choice between them
      * fell back to whichever the set of them iterated first.
      */
@@ -137,16 +156,12 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
          *  reader's to know. */
         record Unplaced(int line, int column) implements Place {}
 
-        /** No position at all, which is what a report says of code out of sight. */
-        record Nowhere() implements Place {}
-
-        /** A place a reader can be sent to first, then one only whoever is showing the report can
-         *  use, and last none — which is how much a reader is given, most first. */
+        /** A place a reader can be sent to before one only whoever is showing the report can use,
+         *  which is how much a reader is given, most first. */
         private int rank() {
             return switch (this) {
                 case InSource _ -> 0;
                 case Unplaced _ -> 1;
-                case Nowhere _ -> 2;
             };
         }
 
@@ -164,7 +179,6 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
                     int line = Integer.compare(it.line(), also.line());
                     yield line != 0 ? line : Integer.compare(it.column(), also.column());
                 }
-                case Nowhere _ -> 0;
             };
         }
     }
@@ -178,10 +192,29 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
     static PublishedRuleHandle of(RuleCitation cited) {
         return switch (cited) {
             case RuleCitation.Named it -> named(it.rule());
-            case RuleCitation.WrittenAt it -> it.at() instanceof Citation.Elsewhere out
-                    ? new Reached(PublishedRuleKind.of(it.rule()), placeOf(it.at()),
-                            out.provenance().reachedBy())
-                    : new Written(PublishedRuleKind.of(it.rule()), placeOf(it.at()));
+            case RuleCitation.WrittenAt it -> written(it.rule(), it.at());
+        };
+    }
+
+    /**
+     * Which sentence a rule the author wrote rather than named is written as.
+     *
+     * <p>Where the code is, and whether this compile met a position in it. The two questions are the
+     * citation's and are asked here rather than left to a place that answers the second by being
+     * something a sentence cannot write.
+     */
+    private static PublishedRuleHandle written(RuleRef.Written rule, Citation cited) {
+        PublishedRuleKind kind = PublishedRuleKind.of(rule);
+        return switch (cited) {
+            case Citation.Written it -> new Written(kind, placeOf(it, it.at()));
+            case Citation.Unplaced it -> new Written(kind, placeOf(it, it.at()));
+            case Citation.Reached it ->
+                    new Reached(kind, placeOf(it, it.at()), it.provenance().reachedBy());
+            // Out of sight, and where this compiler met it is no part of what a reader is shown:
+            // such code is said as what reaches it, whether or not there was a position to drop.
+            case Citation.UnplacedElsewhere it ->
+                    new ReachedOutOfSight(kind, it.provenance().reachedBy());
+            case Citation.OutOfSight it -> new ReachedOutOfSight(kind, it.provenance().reachedBy());
         };
     }
 
@@ -212,27 +245,13 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
      * Where a report says that code is: the place a reader can be sent to where there is one, and
      * otherwise the numbers it prints instead.
      *
-     * <p>The numbers are asked of the citation and not of the place, because a place is what the
-     * document's own field is made of and there is none for a position in a text this compilation
-     * cannot name — while the sentence about the rule prints one all the same.
+     * <p>{@code at} is handed in rather than read back out of {@code cited}, because which arms have
+     * a position is what the caller has just answered — asked again here, the two answers could
+     * come apart, and the one that decides the sentence would be whichever this happened to use.
      */
-    private static Place placeOf(Citation cited) {
-        Optional<PublishedAt> held = PublishedAt.of(cited);
-        if (held.isPresent()) {
-            return new Place.InSource(held.get());
-        }
-        // Asked of what a report prints and not of what the citation holds. Code out of sight is
-        // said as where it came from and nothing else, whether or not this compiler met it at a
-        // position — so the numbers are no part of what a reader is shown, and a projection that
-        // kept them would tell apart two handles a document writes alike.
-        SourcePos where = switch (cited) {
-            case Citation.Written it -> it.at();
-            case Citation.Unplaced it -> it.at();
-            case Citation.Reached it -> it.at();
-            case Citation.UnplacedElsewhere _, Citation.OutOfSight _ -> null;
-        };
-        return where == null ? new Place.Nowhere()
-                : new Place.Unplaced(where.line(), where.column());
+    private static Place placeOf(Citation cited, SourcePos at) {
+        return PublishedAt.of(cited).<Place>map(Place.InSource::new)
+                .orElseGet(() -> new Place.Unplaced(at.line(), at.column()));
     }
 
     /**
@@ -285,6 +304,11 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
                 int by = it.reachedBy().compareTo(also.reachedBy());
                 yield by != 0 ? by : it.at().compareTo(also.at());
             }
+            case ReachedOutOfSight it -> {
+                ReachedOutOfSight also = (ReachedOutOfSight) other;
+                int word = it.kind().compareTo(also.kind());
+                yield word != 0 ? word : it.reachedBy().compareTo(also.reachedBy());
+            }
         };
     }
 
@@ -298,6 +322,7 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
             case WholeEnsures _ -> 3;
             case Written _ -> 4;
             case Reached _ -> 5;
+            case ReachedOutOfSight _ -> 6;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleKind.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleKind.java
@@ -1,0 +1,49 @@
+package souther.compiler.publish;
+
+import souther.compiler.check.RuleRef;
+
+/**
+ * The word a document uses for a rule the author wrote rather than named.
+ *
+ * <p>A published word, so it is spelled here and not read off the class that happens to hold such a
+ * rule today. Generated from the internal seal, renaming {@code RuleRef.Comparison} would widen or
+ * move what a consumer must handle without anybody deciding to — which is the mistake the schema's
+ * enumerated fields are held against rather than generated from.
+ *
+ * <p>What keeps this in step with the rest is that the projection below is total. A kind of written
+ * rule added to the seal and left without a word stops the compile, at the one place a word is
+ * chosen.
+ */
+public enum PublishedRuleKind {
+
+    /** A rule that puts a line on the order the values at a position are counted on. */
+    COMPARISON("comparison"),
+
+    /** A rule that tells a set of the values at a position from the rest, and draws no line. */
+    PREDICATE("predicate");
+
+    private final String word;
+
+    PublishedRuleKind(String word) {
+        this.word = word;
+    }
+
+    /** What a document writes. */
+    public String word() {
+        return word;
+    }
+
+    /**
+     * The word for {@code rule}.
+     *
+     * <p>No {@code default} arm, so a kind of written rule added to the seal is one somebody gives a
+     * published word rather than one that arrives in a document under a word that already meant
+     * something else.
+     */
+    public static PublishedRuleKind of(RuleRef.Written rule) {
+        return switch (rule) {
+            case RuleRef.Comparison _ -> COMPARISON;
+            case RuleRef.Predicate _ -> PREDICATE;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedSentence.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedSentence.java
@@ -1,0 +1,49 @@
+package souther.compiler.publish;
+
+/**
+ * What a field of a document says, for the fields that sometimes say it about a rule.
+ *
+ * <p>A sum and not a string, because whether a handle is in there is what the schema says of the
+ * field and what a reader acts on. Handed the finished words, a field could carry a sentence with a
+ * handle spelled by whoever built it — which is the shape this whole issue is about, one layer down:
+ * the sentence would be right today and free to come apart from the one every other field writes.
+ *
+ * <p>So the handle is handed over as a handle and the words around it as words, and what puts them
+ * together is {@link RuleHandleSurface}. A field that carries one is then a field that carries one
+ * because there was no way to write it otherwise.
+ */
+public sealed interface PublishedSentence {
+
+    /** Words about something that is not a rule — a class, an arm, a case of an input. */
+    record Words(String said) implements PublishedSentence {
+
+        public Words {
+            if (said == null || said.isEmpty()) {
+                throw new IllegalArgumentException("a field a document writes says something");
+            }
+        }
+    }
+
+    /**
+     * A rule handle with words of the field's own around it.
+     *
+     * <p>Either side may be empty, which is a field that says the handle and nothing else. Empty is
+     * the words there are and not a missing answer: what a border writes after the handle is the
+     * declarations that took an end of its line in, and a line nothing narrowed has none of those.
+     */
+    record AroundAHandle(String before, PublishedRuleHandle handle, String after)
+            implements PublishedSentence {
+
+        public AroundAHandle {
+            if (before == null || handle == null || after == null) {
+                throw new IllegalArgumentException("a sentence about a rule is words, a handle and"
+                        + " words: " + before + " " + handle + " " + after);
+            }
+        }
+
+        /** The handle by itself, for a field whose whole sentence it is. */
+        public static AroundAHandle alone(PublishedRuleHandle handle) {
+            return new AroundAHandle("", handle, "");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleProse.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleProse.java
@@ -1,0 +1,37 @@
+package souther.compiler.publish;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.source.SourceId;
+
+/**
+ * What a rule handle reads as in the report a person reads.
+ *
+ * <p>The same sentence a document writes, because a reader meeting a rule in the report and a
+ * consumer meeting it in the document are meeting one rule, and two spellings of one handle read as
+ * two handles.
+ *
+ * <p>Apart from {@link RuleHandleSurface} rather than an arm of it. What a person is shown is held
+ * to nothing in the schema, so it is not one of the fields a check counts — and a renderer that
+ * handed back a string a document writer could put anywhere would leave that count a list of the
+ * places somebody remembered. Which classes may name this is written down
+ * ({@code WhoMaySayWhatARuleHandleReadsAs}).
+ */
+public final class RuleHandleProse {
+
+    private RuleHandleProse() {
+    }
+
+    /** {@code handle} in a report about {@code sectionSource}, with the sources under the names
+     *  {@code names} gives them. */
+    public static String said(PublishedRuleHandle handle, SourceNameResolver names,
+                              SourceId sectionSource) {
+        return RuleHandleSentence.said(handle, names, sectionSource);
+    }
+
+    /** The same for a sentence with a handle in it, so that the words around one are put together
+     *  the one way wherever they are read. */
+    public static String said(PublishedSentence sentence, SourceNameResolver names,
+                              SourceId sectionSource) {
+        return RuleHandleSentence.of(sentence, names, sectionSource);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSentence.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSentence.java
@@ -1,0 +1,78 @@
+package souther.compiler.publish;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.source.SourceId;
+
+/**
+ * What a rule handle reads as, which is one sentence per form of {@link PublishedRuleHandle}.
+ *
+ * <p>The one spelling. A rule and a line the same rule drew and a question about it are found the
+ * same way, and two spellings of one handle read as two handles — which is what a border and a
+ * standing question had between them until this, one of them writing the word for the rule and the
+ * other reading it off the construct the rule stood in.
+ *
+ * <p>Reached only through {@link RuleHandleSurface}, which is why nothing here is public. A handle
+ * written into a document under a field nobody declared is a surface no check knows about, and a
+ * check that has to find such a field by looking for a call is a check that guesses. Held to a
+ * surface, a new one cannot be written without being named.
+ */
+final class RuleHandleSentence {
+
+    private RuleHandleSentence() {
+    }
+
+    /**
+     * {@code handle} as a report about {@code sectionSource} writes it, with the sources under the
+     * names {@code names} gives them.
+     *
+     * <p>No {@code default} arm, so a form added to the grammar is one somebody spells rather than
+     * one that arrives at a reader as a sentence about something else.
+     */
+    static String said(PublishedRuleHandle handle, SourceNameResolver names,
+                       SourceId sectionSource) {
+        return switch (handle) {
+            case PublishedRuleHandle.NamedInvariant it ->
+                    "invariant " + it.declaredOn() + " (" + it.clause() + ")";
+            // Counted from one, as somebody reading the declaration counts them.
+            case PublishedRuleHandle.NumberedInvariant it ->
+                    "invariant " + it.declaredOn() + " #" + it.number();
+            case PublishedRuleHandle.NamedEnsures it ->
+                    "ensures " + it.behavior() + " (" + it.clause() + ")";
+            case PublishedRuleHandle.WholeEnsures it -> "ensures " + it.behavior();
+            case PublishedRuleHandle.Written it ->
+                    it.kind().word() + "@" + place(it.at(), names, sectionSource);
+            // Written somewhere else and reached from here: the rule is one and the reader is sent
+            // to two places, which the sentence keeps apart. Where this compile met no position
+            // there is nothing to send them to but the declaration.
+            case PublishedRuleHandle.Reached it -> it.kind().word() + " in `" + it.reachedBy() + "`"
+                    + (it.at() instanceof PublishedRuleHandle.Place.Nowhere ? ""
+                            : ", reached at " + place(it.at(), names, sectionSource));
+        };
+    }
+
+    /**
+     * A place as the sentence writes it.
+     *
+     * <p>A line and a column are a place only beside a file. They are written on their own where the
+     * section already names the file, and with the file where it does not — a position from another
+     * source, printed bare, points at whatever happens to sit at those numbers in the one the reader
+     * has in mind.
+     */
+    private static String place(PublishedRuleHandle.Place at, SourceNameResolver names,
+                                SourceId sectionSource) {
+        return switch (at) {
+            case PublishedRuleHandle.Place.InSource it -> {
+                PublishedAt where = it.at();
+                String numbers = where.line() + ":" + where.column();
+                yield where.source().equals(sectionSource) ? numbers
+                        : names.nameOf(where.source()) + ":" + numbers;
+            }
+            case PublishedRuleHandle.Place.Unplaced it -> it.line() + ":" + it.column();
+            // Refused rather than spelled as nothing. The one form that reaches here without a
+            // position says so in its own sentence, and a place written as an empty string would be
+            // a reader sent to a file with no line in it.
+            case PublishedRuleHandle.Place.Nowhere _ -> throw new IllegalStateException(
+                    "code out of sight is said by what reaches it and not by where it is");
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSentence.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSentence.java
@@ -28,6 +28,15 @@ final class RuleHandleSentence {
      * <p>No {@code default} arm, so a form added to the grammar is one somebody spells rather than
      * one that arrives at a reader as a sentence about something else.
      */
+    static String of(PublishedSentence sentence, SourceNameResolver names,
+                     SourceId sectionSource) {
+        return switch (sentence) {
+            case PublishedSentence.Words it -> it.said();
+            case PublishedSentence.AroundAHandle it ->
+                    it.before() + said(it.handle(), names, sectionSource) + it.after();
+        };
+    }
+
     static String said(PublishedRuleHandle handle, SourceNameResolver names,
                        SourceId sectionSource) {
         return switch (handle) {
@@ -42,11 +51,12 @@ final class RuleHandleSentence {
             case PublishedRuleHandle.Written it ->
                     it.kind().word() + "@" + place(it.at(), names, sectionSource);
             // Written somewhere else and reached from here: the rule is one and the reader is sent
-            // to two places, which the sentence keeps apart. Where this compile met no position
-            // there is nothing to send them to but the declaration.
+            // to two places, which the sentence keeps apart.
             case PublishedRuleHandle.Reached it -> it.kind().word() + " in `" + it.reachedBy() + "`"
-                    + (it.at() instanceof PublishedRuleHandle.Place.Nowhere ? ""
-                            : ", reached at " + place(it.at(), names, sectionSource));
+                    + ", reached at " + place(it.at(), names, sectionSource);
+            // And with no position to send them to, the declaration is the whole of it.
+            case PublishedRuleHandle.ReachedOutOfSight it ->
+                    it.kind().word() + " in `" + it.reachedBy() + "`";
         };
     }
 
@@ -68,11 +78,6 @@ final class RuleHandleSentence {
                         : names.nameOf(where.source()) + ":" + numbers;
             }
             case PublishedRuleHandle.Place.Unplaced it -> it.line() + ":" + it.column();
-            // Refused rather than spelled as nothing. The one form that reaches here without a
-            // position says so in its own sentence, and a place written as an empty string would be
-            // a reader sent to a file with no line in it.
-            case PublishedRuleHandle.Place.Nowhere _ -> throw new IllegalStateException(
-                    "code out of sight is said by what reaches it and not by where it is");
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
@@ -6,129 +6,104 @@ import souther.compiler.source.SourceId;
 import tools.jackson.databind.node.ObjectNode;
 
 /**
- * Where a rule handle reaches a reader.
+ * A field of the adequacy document that carries a rule handle.
  *
- * <p>Every sentence about a rule is written through one of these, which is what makes the places a
- * document publishes one a set rather than a habit. A check can then ask the schema which fields
- * carry a handle and ask this which fields the compiler writes one into, and compare the two —
- * where a check that went looking for the calls would be reading a key out of a string literal and
- * calling two fields of one name one field.
+ * <p>An enum, so the fields a document publishes a handle into are what the compiler has rather than
+ * a list somebody keeps. Each names the field by where the schema declares it, which is what tells
+ * two fields of one name apart: {@code rule} is written under three parents, and a set of keys would
+ * have said there were fewer fields than there are and gone on saying it as more were added.
  *
- * <p>Held as an API and not as a convention. {@link RuleHandleSentence} is not public, so a handle
- * cannot reach a reader without a surface: adding a field that carries one means adding a constant
- * here, and a constant here with nothing to match it in the schema is a document field nobody
- * declared.
+ * <p><b>Writing is the whole of what this offers.</b> There is no way to ask one of these what a
+ * handle reads as, because a renderer that handed a string back is a renderer whose answer can be
+ * put under a field nobody declared — and the count of fields would then be the count of the ones
+ * somebody remembered to register. What a person's report shows is
+ * {@link RuleHandleProse}, and which classes may name that is written down
+ * ({@code WhoMaySayWhatARuleHandleReadsAs}).
+ *
+ * <p>A field whose sentence has words of its own takes {@link PublishedSentence} rather than the
+ * finished words, so that the handle inside it is one this put together.
  */
-public sealed interface RuleHandleSurface {
+public enum RuleHandleSurface {
 
-    /** {@code handle} as this surface writes it. */
-    default String render(PublishedRuleHandle handle, SourceNameResolver names,
-                          SourceId sectionSource) {
-        return RuleHandleSentence.said(handle, names, sectionSource);
+    /** The rule a standing question is about. */
+    UNANSWERED_RULE("/$defs/partition/properties/unanswered/items/properties/rule",
+            "rule", Carries.THE_HANDLE_ALONE),
+
+    /** The rule a reading could not turn into a line. */
+    NOT_READ_RULE("/$defs/partition/properties/notRead/items/properties/rule",
+            "rule", Carries.THE_HANDLE_ALONE),
+
+    /** The rule that drew the line a point is owed for. */
+    OBLIGATION_RULE("/$defs/obligations/items/properties/rule",
+            "rule", Carries.THE_HANDLE_ALONE),
+
+    /** The rule a boundary came from, together with whatever narrowed the line. */
+    BOUNDARY_ORIGIN("/$defs/partition/properties/boundaries/items/properties/origin",
+            "origin", Carries.A_SENTENCE_AROUND_IT),
+
+    /** What a finding is about, which names the rule among other things. */
+    FINDING_SUBJECT("/$defs/findings/items/properties/subject",
+            "subject", Carries.A_SENTENCE_AROUND_IT);
+
+    private final String schemaPath;
+    private final String key;
+    private final Carries carries;
+
+    RuleHandleSurface(String schemaPath, String key, Carries carries) {
+        this.schemaPath = schemaPath;
+        this.key = key;
+        this.carries = carries;
+    }
+
+    /** Where the schema declares this field, as a pointer into the schema this compiler ships. */
+    public String schemaPath() {
+        return schemaPath;
+    }
+
+    /** What the field is called, taken from here so that no writer spells it again. */
+    public String key() {
+        return key;
+    }
+
+    /** Whether the field is the handle or a sentence with one in it. */
+    public Carries carries() {
+        return carries;
     }
 
     /**
-     * A field of the adequacy document.
+     * Write {@code handle} into {@code into} under this field.
      *
-     * <p>An enum, so the population is what the compiler has rather than a list somebody keeps.
-     * Each names the field by where the schema declares it, which is what tells two fields of one
-     * name apart: {@code rule} is written under three parents, and a set of keys would have said
-     * there were fewer surfaces than there are and gone on saying it as more were added.
+     * <p>Only where the field is the handle. A field with words of its own has a sentence to put
+     * together, and handed a bare handle it would carry the shortest true answer and lose the rest.
      */
-    enum InADocument implements RuleHandleSurface {
-
-        /** The rule a standing question is about. */
-        UNANSWERED_RULE("/$defs/partition/properties/unanswered/items/properties/rule",
-                "rule", Carries.THE_HANDLE_ALONE),
-
-        /** The rule a reading could not turn into a line. */
-        NOT_READ_RULE("/$defs/partition/properties/notRead/items/properties/rule",
-                "rule", Carries.THE_HANDLE_ALONE),
-
-        /** The rule that drew the line a point is owed for. */
-        OBLIGATION_RULE("/$defs/obligations/items/properties/rule",
-                "rule", Carries.THE_HANDLE_ALONE),
-
-        /** The rule a boundary came from, together with whatever narrowed it. */
-        BOUNDARY_ORIGIN("/$defs/partition/properties/boundaries/items/properties/origin",
-                "origin", Carries.A_SENTENCE_AROUND_IT),
-
-        /** What a finding is about, which names the rule among other things. */
-        FINDING_SUBJECT("/$defs/findings/items/properties/subject",
-                "subject", Carries.A_SENTENCE_AROUND_IT);
-
-        private final String schemaPath;
-        private final String key;
-        private final Carries carries;
-
-        InADocument(String schemaPath, String key, Carries carries) {
-            this.schemaPath = schemaPath;
-            this.key = key;
-            this.carries = carries;
+    public void put(ObjectNode into, PublishedRuleHandle handle, SourceNameResolver names,
+                    SourceId sectionSource) {
+        if (carries != Carries.THE_HANDLE_ALONE) {
+            throw new IllegalStateException(
+                    "this field writes a sentence with a handle in it: " + this);
         }
-
-        /** Where the schema declares this field, as a pointer into the schema this compiler ships. */
-        public String schemaPath() {
-            return schemaPath;
-        }
-
-        /** What the field is called, taken from here so that no writer spells it again. */
-        public String key() {
-            return key;
-        }
-
-        /** Whether the field is the handle or a sentence with one in it. */
-        public Carries carries() {
-            return carries;
-        }
-
-        /**
-         * Write {@code handle} into {@code into} under this field.
-         *
-         * <p>Only where the field is the handle. A field that writes a sentence around one has words
-         * of its own to put together, and they are the caller's — so it says what it wrote rather
-         * than being handed a handle and left to add to it.
-         */
-        public void put(ObjectNode into, PublishedRuleHandle handle, SourceNameResolver names,
-                        SourceId sectionSource) {
-            if (carries != Carries.THE_HANDLE_ALONE) {
-                throw new IllegalStateException(
-                        "this field writes a sentence with a handle in it: " + this);
-            }
-            into.put(key, render(handle, names, sectionSource));
-        }
-
-        /**
-         * Write {@code sentence} into {@code into} under this field.
-         *
-         * <p>For the fields that put words around a handle. The key still comes from here, so that
-         * a field carrying a handle is one this names however it is written.
-         */
-        public void putSentence(ObjectNode into, String sentence) {
-            if (carries != Carries.A_SENTENCE_AROUND_IT) {
-                throw new IllegalStateException("this field is the handle and nothing else: " + this);
-            }
-            into.put(key, sentence);
-        }
+        into.put(key, RuleHandleSentence.said(handle, names, sectionSource));
     }
 
     /**
-     * The report a person reads.
+     * Write {@code sentence} into {@code into} under this field.
      *
-     * <p>Beside the document's fields rather than among them, because it is held to nothing in the
-     * schema: what a person is shown is not a contract a consumer builds against. It is a surface
-     * all the same, so that the sentence has one spelling wherever it is read.
+     * <p>Only where the field has words of its own. A field that is the handle would carry words
+     * beside it that a consumer reading it as a handle cannot take apart.
      */
-    record InTheReportAPersonReads() implements RuleHandleSurface {}
-
-    /** The report a person reads, which there is one of. */
-    RuleHandleSurface PROSE = new InTheReportAPersonReads();
+    public void put(ObjectNode into, PublishedSentence sentence, SourceNameResolver names,
+                    SourceId sectionSource) {
+        if (carries != Carries.A_SENTENCE_AROUND_IT) {
+            throw new IllegalStateException("this field is the handle and nothing else: " + this);
+        }
+        into.put(key, RuleHandleSentence.of(sentence, names, sectionSource));
+    }
 
     /** How much of the field a handle is. */
-    enum Carries {
+    public enum Carries {
         /** The field is the handle. */
         THE_HANDLE_ALONE,
-        /** The field is a sentence with a handle in it. */
+        /** The field is a sentence that may have a handle in it. */
         A_SENTENCE_AROUND_IT
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
@@ -3,8 +3,6 @@ package souther.compiler.publish;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.source.SourceId;
 
-import tools.jackson.databind.node.ObjectNode;
-
 /**
  * A field of the adequacy document that carries a rule handle.
  *
@@ -76,13 +74,13 @@ public enum RuleHandleSurface {
      * <p>Only where the field is the handle. A field with words of its own has a sentence to put
      * together, and handed a bare handle it would carry the shortest true answer and lose the rest.
      */
-    public void put(ObjectNode into, PublishedRuleHandle handle, SourceNameResolver names,
+    public void put(DocumentItem into, PublishedRuleHandle handle, SourceNameResolver names,
                     SourceId sectionSource) {
         if (carries != Carries.THE_HANDLE_ALONE) {
             throw new IllegalStateException(
                     "this field writes a sentence with a handle in it: " + this);
         }
-        into.put(key, RuleHandleSentence.said(handle, names, sectionSource));
+        into.node().put(here(into), RuleHandleSentence.said(handle, names, sectionSource));
     }
 
     /**
@@ -91,12 +89,29 @@ public enum RuleHandleSurface {
      * <p>Only where the field has words of its own. A field that is the handle would carry words
      * beside it that a consumer reading it as a handle cannot take apart.
      */
-    public void put(ObjectNode into, PublishedSentence sentence, SourceNameResolver names,
+    public void put(DocumentItem into, PublishedSentence sentence, SourceNameResolver names,
                     SourceId sectionSource) {
         if (carries != Carries.A_SENTENCE_AROUND_IT) {
             throw new IllegalStateException("this field is the handle and nothing else: " + this);
         }
-        into.put(key, RuleHandleSentence.of(sentence, names, sectionSource));
+        into.node().put(here(into), RuleHandleSentence.of(sentence, names, sectionSource));
+    }
+
+    /**
+     * The key, once the object being written is the one the schema declares this field on.
+     *
+     * <p>Where a field is written is half of what it is, and it was the half nothing compared. The
+     * place this names and the place the writer reached are two answers arrived at apart — the
+     * contract says where the field lives, the writer says which part of the document it is
+     * building — so a handle put into some other object is a field the schema declares nothing
+     * about, whatever the check that counts these constants had to say.
+     */
+    private String here(DocumentItem into) {
+        if (!schemaPath.equals(into.fieldPath(key))) {
+            throw new IllegalStateException("this field is declared at " + schemaPath
+                    + " and was written into " + into.fieldPath(key));
+        }
+        return key;
     }
 
     /** How much of the field a handle is. */

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
@@ -1,0 +1,134 @@
+package souther.compiler.publish;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.source.SourceId;
+
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Where a rule handle reaches a reader.
+ *
+ * <p>Every sentence about a rule is written through one of these, which is what makes the places a
+ * document publishes one a set rather than a habit. A check can then ask the schema which fields
+ * carry a handle and ask this which fields the compiler writes one into, and compare the two —
+ * where a check that went looking for the calls would be reading a key out of a string literal and
+ * calling two fields of one name one field.
+ *
+ * <p>Held as an API and not as a convention. {@link RuleHandleSentence} is not public, so a handle
+ * cannot reach a reader without a surface: adding a field that carries one means adding a constant
+ * here, and a constant here with nothing to match it in the schema is a document field nobody
+ * declared.
+ */
+public sealed interface RuleHandleSurface {
+
+    /** {@code handle} as this surface writes it. */
+    default String render(PublishedRuleHandle handle, SourceNameResolver names,
+                          SourceId sectionSource) {
+        return RuleHandleSentence.said(handle, names, sectionSource);
+    }
+
+    /**
+     * A field of the adequacy document.
+     *
+     * <p>An enum, so the population is what the compiler has rather than a list somebody keeps.
+     * Each names the field by where the schema declares it, which is what tells two fields of one
+     * name apart: {@code rule} is written under three parents, and a set of keys would have said
+     * there were fewer surfaces than there are and gone on saying it as more were added.
+     */
+    enum InADocument implements RuleHandleSurface {
+
+        /** The rule a standing question is about. */
+        UNANSWERED_RULE("/$defs/partition/properties/unanswered/items/properties/rule",
+                "rule", Carries.THE_HANDLE_ALONE),
+
+        /** The rule a reading could not turn into a line. */
+        NOT_READ_RULE("/$defs/partition/properties/notRead/items/properties/rule",
+                "rule", Carries.THE_HANDLE_ALONE),
+
+        /** The rule that drew the line a point is owed for. */
+        OBLIGATION_RULE("/$defs/obligations/items/properties/rule",
+                "rule", Carries.THE_HANDLE_ALONE),
+
+        /** The rule a boundary came from, together with whatever narrowed it. */
+        BOUNDARY_ORIGIN("/$defs/partition/properties/boundaries/items/properties/origin",
+                "origin", Carries.A_SENTENCE_AROUND_IT),
+
+        /** What a finding is about, which names the rule among other things. */
+        FINDING_SUBJECT("/$defs/findings/items/properties/subject",
+                "subject", Carries.A_SENTENCE_AROUND_IT);
+
+        private final String schemaPath;
+        private final String key;
+        private final Carries carries;
+
+        InADocument(String schemaPath, String key, Carries carries) {
+            this.schemaPath = schemaPath;
+            this.key = key;
+            this.carries = carries;
+        }
+
+        /** Where the schema declares this field, as a pointer into the schema this compiler ships. */
+        public String schemaPath() {
+            return schemaPath;
+        }
+
+        /** What the field is called, taken from here so that no writer spells it again. */
+        public String key() {
+            return key;
+        }
+
+        /** Whether the field is the handle or a sentence with one in it. */
+        public Carries carries() {
+            return carries;
+        }
+
+        /**
+         * Write {@code handle} into {@code into} under this field.
+         *
+         * <p>Only where the field is the handle. A field that writes a sentence around one has words
+         * of its own to put together, and they are the caller's — so it says what it wrote rather
+         * than being handed a handle and left to add to it.
+         */
+        public void put(ObjectNode into, PublishedRuleHandle handle, SourceNameResolver names,
+                        SourceId sectionSource) {
+            if (carries != Carries.THE_HANDLE_ALONE) {
+                throw new IllegalStateException(
+                        "this field writes a sentence with a handle in it: " + this);
+            }
+            into.put(key, render(handle, names, sectionSource));
+        }
+
+        /**
+         * Write {@code sentence} into {@code into} under this field.
+         *
+         * <p>For the fields that put words around a handle. The key still comes from here, so that
+         * a field carrying a handle is one this names however it is written.
+         */
+        public void putSentence(ObjectNode into, String sentence) {
+            if (carries != Carries.A_SENTENCE_AROUND_IT) {
+                throw new IllegalStateException("this field is the handle and nothing else: " + this);
+            }
+            into.put(key, sentence);
+        }
+    }
+
+    /**
+     * The report a person reads.
+     *
+     * <p>Beside the document's fields rather than among them, because it is held to nothing in the
+     * schema: what a person is shown is not a contract a consumer builds against. It is a surface
+     * all the same, so that the sentence has one spelling wherever it is read.
+     */
+    record InTheReportAPersonReads() implements RuleHandleSurface {}
+
+    /** The report a person reads, which there is one of. */
+    RuleHandleSurface PROSE = new InTheReportAPersonReads();
+
+    /** How much of the field a handle is. */
+    enum Carries {
+        /** The field is the handle. */
+        THE_HANDLE_ALONE,
+        /** The field is a sentence with a handle in it. */
+        A_SENTENCE_AROUND_IT
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -7,6 +7,7 @@ import souther.compiler.partition.BoundaryTarget;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.LineOrigin;
 import souther.compiler.partition.PointRole;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.source.SourceId;
 
 import java.util.Map;
@@ -122,9 +123,11 @@ public record BorderAssessment(Border border, Map<DomainPoint, ItemAssessment> i
         return border.cut().shape();
     }
 
-    /** The rule that drew the line, as a report about {@code sectionSource} writes it. */
-    public String describe(SourceNameResolver names, SourceId sectionSource) {
-        return border.describe(names, sectionSource);
+    /** The rule that drew the line, as the surface {@code surface} names writes it in a report about
+     *  {@code sectionSource}. */
+    public String describe(RuleHandleSurface surface, SourceNameResolver names,
+                           SourceId sectionSource) {
+        return border.describe(surface, names, sectionSource);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -1,14 +1,12 @@
 package souther.compiler.query;
 
-import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.partition.Border;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.BoundaryTarget;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.LineOrigin;
 import souther.compiler.partition.PointRole;
-import souther.compiler.publish.RuleHandleSurface;
-import souther.compiler.source.SourceId;
+import souther.compiler.publish.PublishedSentence;
 
 import java.util.Map;
 
@@ -123,11 +121,9 @@ public record BorderAssessment(Border border, Map<DomainPoint, ItemAssessment> i
         return border.cut().shape();
     }
 
-    /** The rule that drew the line, as the surface {@code surface} names writes it in a report about
-     *  {@code sectionSource}. */
-    public String describe(RuleHandleSurface surface, SourceNameResolver names,
-                           SourceId sectionSource) {
-        return border.describe(surface, names, sectionSource);
+    /** The rule that drew the line, as what a report writes about it. */
+    public PublishedSentence describe() {
+        return border.describe();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -5,6 +5,10 @@ import souther.compiler.partition.BorderQuantity;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.PointRole;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -264,9 +268,19 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * author named is found by that name wherever it is read, and a comparison by the place it is
      * written.
      */
-    public String describe(souther.compiler.diag.SourceNameResolver names,
-                           souther.compiler.source.SourceId sectionSource) {
-        return cited.said(names, sectionSource);
+    public String describe(RuleHandleSurface surface, SourceNameResolver names,
+                           SourceId sectionSource) {
+        return surface.render(handle(), names, sectionSource);
+    }
+
+    /**
+     * How a document sends a reader to the rule that drew this line.
+     *
+     * <p>The handle rather than what it reads as, for the field that is the handle and nothing
+     * else. What that field says is the surface's to write.
+     */
+    public PublishedRuleHandle handle() {
+        return PublishedRuleHandle.of(cited);
     }
 
     /**
@@ -599,8 +613,8 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * be at two places, and two runs beside one line can stop in two places, and this says the
      * same of both — a consumer joins on {@code obligationId} and shows this.
      */
-    public String said(souther.compiler.diag.SourceNameResolver names,
-                       souther.compiler.source.SourceId sectionSource) {
-        return role() + " point of " + describe(names, sectionSource);
+    public String said(RuleHandleSurface surface, SourceNameResolver names,
+                       SourceId sectionSource) {
+        return role() + " point of " + describe(surface, names, sectionSource);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -5,10 +5,8 @@ import souther.compiler.partition.BorderQuantity;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.PointRole;
-import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.publish.PublishedRuleHandle;
-import souther.compiler.publish.RuleHandleSurface;
-import souther.compiler.source.SourceId;
+import souther.compiler.publish.PublishedSentence;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -268,9 +266,8 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * author named is found by that name wherever it is read, and a comparison by the place it is
      * written.
      */
-    public String describe(RuleHandleSurface surface, SourceNameResolver names,
-                           SourceId sectionSource) {
-        return surface.render(handle(), names, sectionSource);
+    public PublishedSentence describe() {
+        return PublishedSentence.AroundAHandle.alone(handle());
     }
 
     /**
@@ -613,8 +610,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * be at two places, and two runs beside one line can stop in two places, and this says the
      * same of both — a consumer joins on {@code obligationId} and shows this.
      */
-    public String said(RuleHandleSurface surface, SourceNameResolver names,
-                       SourceId sectionSource) {
-        return role() + " point of " + describe(surface, names, sectionSource);
+    public PublishedSentence said() {
+        return new PublishedSentence.AroundAHandle(role() + " point of ", handle(), "");
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -75,6 +75,8 @@ import souther.compiler.publish.PublicationOrders;
 import souther.compiler.publish.PublishedAt;
 import souther.compiler.publish.PublishedIncompleteness;
 import souther.compiler.publish.PublishedOpening;
+import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.publish.WeakeningVocabulary;
 import souther.compiler.publish.WeakeningWord;
 import souther.compiler.partition.CompositionBudget;
@@ -579,7 +581,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // of a point nobody read as much as of one nothing could show writable.
         for (Adequacy.DeclaredDebt each : account.undecided()) {
             for (String said : undecidedBecause(each.debt().owed().disposition(),
-                    pointOf(each, each.debt().describe(names, null)))) {
+                    pointOf(each, each.debt().describe(RuleHandleSurface.PROSE, names, null)))) {
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, each.debt(), _ -> true, at -> whatWasTried(
@@ -1455,7 +1457,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // alone a reader is told a difference with nothing under it to act on.
         for (BorderObligationPointAssessment point : owed.undecided()) {
             for (String said : undecidedBecause(point.owed().disposition(),
-                    point.role() + " point (" + point.describe(names, declaredIn) + ")")) {
+                    point.role() + " point (" + point.describe(RuleHandleSurface.PROSE, names, declaredIn) + ")")) {
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, point, _ -> true, at -> whatWasTried(
@@ -1497,7 +1499,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     // and neither of them said which value was being asked for.
                     out.append(String.format("      %s no row is at %s %s point%s (%s)%n",
                             mark(f), againstTheLine ? "the" : "an", point.role(),
-                            point.whichSide(), point.describe(names, declaredIn)));
+                            point.whichSide(), point.describe(RuleHandleSurface.PROSE, names, declaredIn)));
                     readings(out, point, _ -> true, _ -> "");
                 }
             }
@@ -1511,7 +1513,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     at -> !at.owedAt(point.at()).hasRowWitness())) {
                 out.append(String.format("      · the %s point (%s) is answered, and not at every"
                                 + " reading of the line%n",
-                        point.role(), point.describe(names, declaredIn)));
+                        point.role(), point.describe(RuleHandleSurface.PROSE, names, declaredIn)));
                 readings(out, point, at -> !at.owedAt(point.at()).hasRowWitness(), _ -> "");
             }
         }
@@ -1522,7 +1524,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             if (p.item() instanceof ItemAssessment.NotOwed not) {
                 out.append(String.format("      · no %s point%s is owed at %s (%s): %s%n",
                         p.role(), p.border().border().whichSide(p.at()), p.border().label(),
-                        p.border().describe(names, declaredIn), whyNotOwed(not.reason())));
+                        p.border().describe(RuleHandleSurface.PROSE, names, declaredIn), whyNotOwed(not.reason())));
             }
         }
         // And a word of the technique this line has no point in at all, which is not the same news.
@@ -1533,7 +1535,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             line.border().inEachRole().forEach((role, answer) -> {
                 if (answer instanceof RoleAnswer.NoPoint none) {
                     out.append(String.format("      · no %s point exists at %s (%s): %s%n",
-                            role, line.label(), line.describe(names, declaredIn),
+                            role, line.label(), line.describe(RuleHandleSurface.PROSE, names, declaredIn),
                             whyNoPoint(none.why())));
                 }
             });
@@ -2486,7 +2488,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     private static String cited(Set<RuleCitation> offered,
                                 SourceNameResolver names,
                                 SourceId declaredIn) {
-        return handle(offered).said(names, declaredIn);
+        return RuleHandleSurface.PROSE.render(
+                PublishedRuleHandle.of(handle(offered)), names, declaredIn);
     }
 
     /**
@@ -3098,7 +3101,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // needs to open a file wants the second rather than a string to take apart.
                 // The same handle the border prints for a line the comparison drew, through the
                 // table of sources this document carries.
-                one.put("rule", handle(each.cited()).said(sources::written, null));
+                RuleHandleSurface.InADocument.UNANSWERED_RULE.put(
+                        one, PublishedRuleHandle.of(handle(each.cited())), sources::written, null);
                 // What tells one rule from another, beside the words for finding it. A handle is a
                 // projection of the rule and not the rule: two arms of one `ensures` clause may
                 // name the same case, so the author's words for them are the same words, and two
@@ -3157,7 +3161,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a place written without its source is a line and a column belonging to nothing —
             // and where a boundary is the only place a report points at, the `sources` table has
             // no other entry to guess from.
-            b.put("origin", boundary.describe(sources::written, null));
+            RuleHandleSurface.InADocument.BOUNDARY_ORIGIN.putSentence(b,
+                    boundary.describe(RuleHandleSurface.InADocument.BOUNDARY_ORIGIN,
+                            sources::written, null));
             // What the line is a line at, said rather than left to be inferred from the text beside
             // it. A line between two positions writes the other position where a line at a count
             // writes the count, and the two read alike.
@@ -3265,11 +3271,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // what tells one rule from another, and the two are not in step wherever a rule has no
             // name of its own.
             if (each instanceof PartitionEvidence.NotRead.ARule rule) {
-                said.put("rule", handle(rule.cited()).said(sources::written, null));
+                RuleHandleSurface.InADocument.NOT_READ_RULE.put(
+                        said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
             if (each instanceof PartitionEvidence.NotRead.AnUnclassifiedRule rule) {
-                said.put("rule", handle(rule.cited()).said(sources::written, null));
+                RuleHandleSurface.InADocument.NOT_READ_RULE.put(
+                        said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
         });
@@ -3458,7 +3466,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a person reads, and two obligations can share every one of them.
             obligationId(o.putObject("obligationId"), point.point());
             o.put("point", word(point.role()));
-            o.put("rule", point.describe(sources::written, null));
+            RuleHandleSurface.InADocument.OBLIGATION_RULE.put(
+                    o, point.handle(), sources::written, null);
             ruleId(o.putObject("ruleId"), point.id().provenance());
             o.put("relation", point.operator());
             // What the line is on, where the author wrote a word for it. A body's line has none,
@@ -3574,7 +3583,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ObjectNode f = out.addObject();
             f.put("kind", word(finding.kind()));
             f.put("disposition", word(finding.disposition(held)));
-            f.put("subject", subject(finding, sources));
+            RuleHandleSurface.InADocument.FINDING_SUBJECT.putSentence(f, subject(finding, sources));
             // Which rule this is about, where the finding is about one. The words in `subject` are
             // how a reader finds it, and two rules an author named alike have the same words — so a
             // consumer joining findings to the questions they came from wants this.
@@ -3695,7 +3704,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // The handle, and what tells this rule from another beside it: two arms of one clause
             // may name the same case, so the words alone joined two questions into one row.
             case About.AQuestionNothingAnswered(var asked) ->
-                    handle(asked.cited()).said(sources::written, null)
+                    RuleHandleSurface.InADocument.FINDING_SUBJECT.render(
+                                    PublishedRuleHandle.of(handle(asked.cited())),
+                                    sources::written, null)
                             + " — " + asked(asked.asked())
                             + " " + subjectOf(asked);
             case About.ACaseNoRowAppliesItTo(var input, var missing) ->
@@ -3703,7 +3714,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // The point and the line, and no quantity: a body's line is owed once wherever it is
             // read, so what joins this to a `partition.obligations` entry is the role, where on
             // the line, and the rule — the same three that entry is keyed on.
-            case About.APointOfABorder(var point) -> point.said(sources::written, null);
+            case About.APointOfABorder(var point) -> point.said(
+                    RuleHandleSurface.InADocument.FINDING_SUBJECT, sources::written, null);
             // The same sentence, on what the declaration wrote. A line owed once over every reading
             // of it is named by the terms the author used and not by the position some behavior met
             // it at, which is what the debt is (issue #1062).

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -75,6 +75,8 @@ import souther.compiler.publish.PublicationOrders;
 import souther.compiler.publish.PublishedAt;
 import souther.compiler.publish.PublishedIncompleteness;
 import souther.compiler.publish.PublishedOpening;
+import souther.compiler.publish.DocumentArray;
+import souther.compiler.publish.DocumentItem;
 import souther.compiler.publish.PublishedRuleHandle;
 import souther.compiler.publish.PublishedSentence;
 import souther.compiler.publish.RuleHandleProse;
@@ -3098,9 +3100,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // inside one. Every measure here is a reader of them, and a position no axis came back for
         // still has whatever was written about it.
         if (!partition.unanswered().isEmpty()) {
-            ArrayNode standing = out.putArray("unanswered");
+            DocumentArray standing = new DocumentArray(out.putArray("unanswered"),
+                    "/$defs/partition/properties/unanswered");
             for (PartitionEvidence.Unanswered each : partition.unanswered()) {
-                ObjectNode one = standing.addObject();
+                DocumentItem said = standing.addObject();
+                ObjectNode one = said.node();
                 one.put("at", each.at());
                 // The rendered label, which is what this key has always been. What it is rendered
                 // from is beside it: a name is a name, and a place is a place, and a consumer that
@@ -3108,7 +3112,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // The same handle the border prints for a line the comparison drew, through the
                 // table of sources this document carries.
                 RuleHandleSurface.UNANSWERED_RULE.put(
-                        one, PublishedRuleHandle.of(handle(each.cited())), sources::written, null);
+                        said, PublishedRuleHandle.of(handle(each.cited())), sources::written, null);
                 // What tells one rule from another, beside the words for finding it. A handle is a
                 // projection of the rule and not the rule: two arms of one `ensures` clause may
                 // name the same case, so the author's words for them are the same words, and two
@@ -3154,9 +3158,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 c.put("why", word(said.why()));
             }
         }
-        ArrayNode boundaries = out.putArray("boundaries");
+        DocumentArray boundaries = new DocumentArray(out.putArray("boundaries"),
+                "/$defs/partition/properties/boundaries");
         for (BorderAssessment boundary : lines.made().orElseGet(List::of)) {
-            ObjectNode b = boundaries.addObject();
+            DocumentItem drawn = boundaries.addObject();
+            ObjectNode b = drawn.node();
             b.put("axis", boundary.axis());
             // The identity, and never left out. This document says what it is about with the
             // ids the caller handed its sources over as, and `sources` explains each one; a
@@ -3167,7 +3173,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a place written without its source is a line and a column belonging to nothing —
             // and where a boundary is the only place a report points at, the `sources` table has
             // no other entry to guess from.
-            RuleHandleSurface.BOUNDARY_ORIGIN.put(b, boundary.describe(), sources::written, null);
+            RuleHandleSurface.BOUNDARY_ORIGIN.put(
+                    drawn, boundary.describe(), sources::written, null);
             // What the line is a line at, said rather than left to be inferred from the text beside
             // it. A line between two positions writes the other position where a line at a count
             // writes the count, and the two read alike.
@@ -3245,7 +3252,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // to a reader that checks whether the field is there, and this document's shape is what the
         // schema is written against.
         ArrayNode undivided = out.putArray("notDerivable");
-        ArrayNode unread = out.putArray("notRead");
+        DocumentArray unread = new DocumentArray(out.putArray("notRead"),
+                "/$defs/partition/properties/notRead");
         // Only the positions the model divides no way. The list is what a consumer reads for that
         // claim, and the other two answers are about a reading that stopped and about a rule this
         // measure has no line for — neither of which is the model saying nothing.
@@ -3265,7 +3273,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // measure — which a person reading the report was shown and a consumer keyed on this
         // document was not.
         partition.notRead().forEach(each -> {
-            ObjectNode said = unread.addObject();
+            DocumentItem row = unread.addObject();
+            ObjectNode said = row.node();
             said.put("position", each.at());
             said.put("reason", word(each.reason()));
             // And which rule, where one was read and could not be used. Absent where the reading
@@ -3276,12 +3285,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // name of its own.
             if (each instanceof PartitionEvidence.NotRead.ARule rule) {
                 RuleHandleSurface.NOT_READ_RULE.put(
-                        said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
+                        row, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
             if (each instanceof PartitionEvidence.NotRead.AnUnclassifiedRule rule) {
                 RuleHandleSurface.NOT_READ_RULE.put(
-                        said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
+                        row, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
         });
@@ -3461,17 +3470,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      *             that has such words. Null for a body's own lines, which have none: a reading
      *             names the position it met the line at and no reading can stand for the rest
      */
-    private void obligations(ArrayNode out, List<BorderObligationPointAssessment> account,
+    private void obligations(ArrayNode written, List<BorderObligationPointAssessment> account,
                              Map<BorderObligationPoint, String> axes,
                              DocumentSources sources) {
+        // The definition being filled in and not the field it is reached through. Two sections write
+        // this shape, and what a row of it must look like is written where the definition is.
+        DocumentArray out = new DocumentArray(written, "/$defs/obligations");
         for (BorderObligationPointAssessment point : account) {
-            ObjectNode o = out.addObject();
+            DocumentItem owed = out.addObject();
+            ObjectNode o = owed.node();
             // The identity first, because it is what a finding joins on. The words below are what
             // a person reads, and two obligations can share every one of them.
             obligationId(o.putObject("obligationId"), point.point());
             o.put("point", word(point.role()));
             RuleHandleSurface.OBLIGATION_RULE.put(
-                    o, point.handle(), sources::written, null);
+                    owed, point.handle(), sources::written, null);
             ruleId(o.putObject("ruleId"), point.id().provenance());
             o.put("relation", point.operator());
             // What the line is on, where the author wrote a word for it. A body's line has none,
@@ -3582,12 +3595,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * Written twice, a consumer joining on the fields would find them agreeing until one of the two
      * was edited.
      */
-    private void findings(ArrayNode out, List<Adequacy.Finding> written, DocumentSources sources) {
+    private void findings(ArrayNode into, List<Adequacy.Finding> written, DocumentSources sources) {
+        // The definition, for the reason `obligations` gives: two sections write this shape.
+        DocumentArray out = new DocumentArray(into, "/$defs/findings");
         for (Adequacy.Finding finding : written) {
-            ObjectNode f = out.addObject();
+            DocumentItem found = out.addObject();
+            ObjectNode f = found.node();
             f.put("kind", word(finding.kind()));
             f.put("disposition", word(finding.disposition(held)));
-            RuleHandleSurface.FINDING_SUBJECT.put(f, subject(finding), sources::written, null);
+            RuleHandleSurface.FINDING_SUBJECT.put(found, subject(finding), sources::written, null);
             // Which rule this is about, where the finding is about one. The words in `subject` are
             // how a reader finds it, and two rules an author named alike have the same words — so a
             // consumer joining findings to the questions they came from wants this.

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -77,6 +77,7 @@ import souther.compiler.publish.PublishedIncompleteness;
 import souther.compiler.publish.PublishedOpening;
 import souther.compiler.publish.DocumentArray;
 import souther.compiler.publish.DocumentItem;
+import souther.compiler.publish.DocumentPart;
 import souther.compiler.publish.PublishedRuleHandle;
 import souther.compiler.publish.PublishedSentence;
 import souther.compiler.publish.RuleHandleProse;
@@ -3100,8 +3101,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // inside one. Every measure here is a reader of them, and a position no axis came back for
         // still has whatever was written about it.
         if (!partition.unanswered().isEmpty()) {
-            DocumentArray standing = new DocumentArray(out.putArray("unanswered"),
-                    "/$defs/partition/properties/unanswered");
+            DocumentArray standing = DocumentPart.UNANSWERED.putArray(out);
             for (PartitionEvidence.Unanswered each : partition.unanswered()) {
                 DocumentItem said = standing.addObject();
                 ObjectNode one = said.node();
@@ -3158,8 +3158,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 c.put("why", word(said.why()));
             }
         }
-        DocumentArray boundaries = new DocumentArray(out.putArray("boundaries"),
-                "/$defs/partition/properties/boundaries");
+        DocumentArray boundaries = DocumentPart.BOUNDARIES.putArray(out);
         for (BorderAssessment boundary : lines.made().orElseGet(List::of)) {
             DocumentItem drawn = boundaries.addObject();
             ObjectNode b = drawn.node();
@@ -3236,7 +3235,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // two entries there and one here. A consumer joining a finding to what it is about joins
         // here, on the point, where on the line and the rule; and every reading is published, so
         // nothing a text report left out for room is missing from the document.
-        obligations(out.putArray("obligations"), account, null, sources);
+        obligations(DocumentPart.OBLIGATIONS.putArray(out), account, null, sources);
         ObjectNode pairs = out.putObject("pairs");
         // The size of the space is the model's and is written whether or not anybody counted. The
         // counts are the measurement's and are written only where one was made; `truncated` is gone
@@ -3252,8 +3251,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // to a reader that checks whether the field is there, and this document's shape is what the
         // schema is written against.
         ArrayNode undivided = out.putArray("notDerivable");
-        DocumentArray unread = new DocumentArray(out.putArray("notRead"),
-                "/$defs/partition/properties/notRead");
+        DocumentArray unread = DocumentPart.NOT_READ.putArray(out);
         // Only the positions the model divides no way. The list is what a consumer reads for that
         // claim, and the other two answers are about a reading that stopped and about a rule this
         // measure has no line for — neither of which is the model saying nothing.
@@ -3455,7 +3453,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * line or a class, that coordinate is not where the reader would go.
      */
     private void findings(ObjectNode behavior, BehaviorReport of, DocumentSources sources) {
-        findings(behavior.putArray("findings"), of.findings(), sources);
+        findings(DocumentPart.FINDINGS.putArray(behavior), of.findings(), sources);
     }
 
     /**
@@ -3470,12 +3468,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      *             that has such words. Null for a body's own lines, which have none: a reading
      *             names the position it met the line at and no reading can stand for the rest
      */
-    private void obligations(ArrayNode written, List<BorderObligationPointAssessment> account,
+    private void obligations(DocumentArray out, List<BorderObligationPointAssessment> account,
                              Map<BorderObligationPoint, String> axes,
                              DocumentSources sources) {
-        // The definition being filled in and not the field it is reached through. Two sections write
-        // this shape, and what a row of it must look like is written where the definition is.
-        DocumentArray out = new DocumentArray(written, "/$defs/obligations");
         for (BorderObligationPointAssessment point : account) {
             DocumentItem owed = out.addObject();
             ObjectNode o = owed.node();
@@ -3557,12 +3552,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ArrayNode declared = one.putArray("owners");
             owners.forEach(each -> typeId(declared.addObject(), each));
             one.put("name", entry.named(owners));
-            obligations(one.putArray("obligations"),
+            obligations(DocumentPart.OBLIGATIONS.putArray(one),
                     entry.owed.stream().map(Adequacy.DeclaredDebt::debt).toList(),
                     entry.owed.stream().collect(Collectors.toMap(
                             each -> each.debt().point(), Adequacy.DeclaredDebt::axis, (a, _) -> a)),
                     sources);
-            findings(one.putArray("findings"), entry.found, sources);
+            findings(DocumentPart.FINDINGS.putArray(one), entry.found, sources);
         });
     }
 
@@ -3595,9 +3590,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * Written twice, a consumer joining on the fields would find them agreeing until one of the two
      * was edited.
      */
-    private void findings(ArrayNode into, List<Adequacy.Finding> written, DocumentSources sources) {
-        // The definition, for the reason `obligations` gives: two sections write this shape.
-        DocumentArray out = new DocumentArray(into, "/$defs/findings");
+    private void findings(DocumentArray out, List<Adequacy.Finding> written,
+                          DocumentSources sources) {
         for (Adequacy.Finding finding : written) {
             DocumentItem found = out.addObject();
             ObjectNode f = found.node();

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -76,6 +76,8 @@ import souther.compiler.publish.PublishedAt;
 import souther.compiler.publish.PublishedIncompleteness;
 import souther.compiler.publish.PublishedOpening;
 import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.PublishedSentence;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.publish.WeakeningVocabulary;
 import souther.compiler.publish.WeakeningWord;
@@ -581,7 +583,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // of a point nobody read as much as of one nothing could show writable.
         for (Adequacy.DeclaredDebt each : account.undecided()) {
             for (String said : undecidedBecause(each.debt().owed().disposition(),
-                    pointOf(each, each.debt().describe(RuleHandleSurface.PROSE, names, null)))) {
+                    pointOf(each, RuleHandleProse.said(each.debt().describe(), names, null)))) {
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, each.debt(), _ -> true, at -> whatWasTried(
@@ -1457,7 +1459,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // alone a reader is told a difference with nothing under it to act on.
         for (BorderObligationPointAssessment point : owed.undecided()) {
             for (String said : undecidedBecause(point.owed().disposition(),
-                    point.role() + " point (" + point.describe(RuleHandleSurface.PROSE, names, declaredIn) + ")")) {
+                    point.role() + " point ("
+                            + RuleHandleProse.said(point.describe(), names, declaredIn) + ")")) {
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, point, _ -> true, at -> whatWasTried(
@@ -1499,7 +1502,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     // and neither of them said which value was being asked for.
                     out.append(String.format("      %s no row is at %s %s point%s (%s)%n",
                             mark(f), againstTheLine ? "the" : "an", point.role(),
-                            point.whichSide(), point.describe(RuleHandleSurface.PROSE, names, declaredIn)));
+                            point.whichSide(),
+                            RuleHandleProse.said(point.describe(), names, declaredIn)));
                     readings(out, point, _ -> true, _ -> "");
                 }
             }
@@ -1513,7 +1517,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     at -> !at.owedAt(point.at()).hasRowWitness())) {
                 out.append(String.format("      · the %s point (%s) is answered, and not at every"
                                 + " reading of the line%n",
-                        point.role(), point.describe(RuleHandleSurface.PROSE, names, declaredIn)));
+                        point.role(),
+                        RuleHandleProse.said(point.describe(), names, declaredIn)));
                 readings(out, point, at -> !at.owedAt(point.at()).hasRowWitness(), _ -> "");
             }
         }
@@ -1524,7 +1529,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             if (p.item() instanceof ItemAssessment.NotOwed not) {
                 out.append(String.format("      · no %s point%s is owed at %s (%s): %s%n",
                         p.role(), p.border().border().whichSide(p.at()), p.border().label(),
-                        p.border().describe(RuleHandleSurface.PROSE, names, declaredIn), whyNotOwed(not.reason())));
+                        RuleHandleProse.said(p.border().describe(), names, declaredIn),
+                        whyNotOwed(not.reason())));
             }
         }
         // And a word of the technique this line has no point in at all, which is not the same news.
@@ -1535,7 +1541,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             line.border().inEachRole().forEach((role, answer) -> {
                 if (answer instanceof RoleAnswer.NoPoint none) {
                     out.append(String.format("      · no %s point exists at %s (%s): %s%n",
-                            role, line.label(), line.describe(RuleHandleSurface.PROSE, names, declaredIn),
+                            role, line.label(),
+                            RuleHandleProse.said(line.describe(), names, declaredIn),
                             whyNoPoint(none.why())));
                 }
             });
@@ -2488,8 +2495,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     private static String cited(Set<RuleCitation> offered,
                                 SourceNameResolver names,
                                 SourceId declaredIn) {
-        return RuleHandleSurface.PROSE.render(
-                PublishedRuleHandle.of(handle(offered)), names, declaredIn);
+        return RuleHandleProse.said(PublishedRuleHandle.of(handle(offered)), names, declaredIn);
     }
 
     /**
@@ -3101,7 +3107,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // needs to open a file wants the second rather than a string to take apart.
                 // The same handle the border prints for a line the comparison drew, through the
                 // table of sources this document carries.
-                RuleHandleSurface.InADocument.UNANSWERED_RULE.put(
+                RuleHandleSurface.UNANSWERED_RULE.put(
                         one, PublishedRuleHandle.of(handle(each.cited())), sources::written, null);
                 // What tells one rule from another, beside the words for finding it. A handle is a
                 // projection of the rule and not the rule: two arms of one `ensures` clause may
@@ -3161,9 +3167,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a place written without its source is a line and a column belonging to nothing —
             // and where a boundary is the only place a report points at, the `sources` table has
             // no other entry to guess from.
-            RuleHandleSurface.InADocument.BOUNDARY_ORIGIN.putSentence(b,
-                    boundary.describe(RuleHandleSurface.InADocument.BOUNDARY_ORIGIN,
-                            sources::written, null));
+            RuleHandleSurface.BOUNDARY_ORIGIN.put(b, boundary.describe(), sources::written, null);
             // What the line is a line at, said rather than left to be inferred from the text beside
             // it. A line between two positions writes the other position where a line at a count
             // writes the count, and the two read alike.
@@ -3271,12 +3275,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // what tells one rule from another, and the two are not in step wherever a rule has no
             // name of its own.
             if (each instanceof PartitionEvidence.NotRead.ARule rule) {
-                RuleHandleSurface.InADocument.NOT_READ_RULE.put(
+                RuleHandleSurface.NOT_READ_RULE.put(
                         said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
             if (each instanceof PartitionEvidence.NotRead.AnUnclassifiedRule rule) {
-                RuleHandleSurface.InADocument.NOT_READ_RULE.put(
+                RuleHandleSurface.NOT_READ_RULE.put(
                         said, PublishedRuleHandle.of(handle(rule.cited())), sources::written, null);
                 ruleId(said.putObject("ruleId"), rule.rule());
             }
@@ -3466,7 +3470,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a person reads, and two obligations can share every one of them.
             obligationId(o.putObject("obligationId"), point.point());
             o.put("point", word(point.role()));
-            RuleHandleSurface.InADocument.OBLIGATION_RULE.put(
+            RuleHandleSurface.OBLIGATION_RULE.put(
                     o, point.handle(), sources::written, null);
             ruleId(o.putObject("ruleId"), point.id().provenance());
             o.put("relation", point.operator());
@@ -3583,7 +3587,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ObjectNode f = out.addObject();
             f.put("kind", word(finding.kind()));
             f.put("disposition", word(finding.disposition(held)));
-            RuleHandleSurface.InADocument.FINDING_SUBJECT.putSentence(f, subject(finding, sources));
+            RuleHandleSurface.FINDING_SUBJECT.put(f, subject(finding), sources::written, null);
             // Which rule this is about, where the finding is about one. The words in `subject` are
             // how a reader finds it, and two rules an author named alike have the same words — so a
             // consumer joining findings to the questions they came from wants this.
@@ -3671,30 +3675,35 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * with it, because two parameters of one type give two findings a class name alone cannot tell
      * apart — and a class of a position carries its position for exactly that reason, which this
      * used to say of the inputs and not of the axes.
+     *
+     * <p>What the field says rather than the words it says, because some of these are about a rule
+     * and the handle for one is not this method's to spell. Handed the finished words, this field
+     * would be the one place a handle reached a reader without the layer that owns the sentence
+     * being asked ({@link RuleHandleSurface}).
      */
-    private static String subject(Adequacy.Finding finding, DocumentSources sources) {
+    private static PublishedSentence subject(Adequacy.Finding finding) {
         return switch (finding.about()) {
             // The label and not the arm, and the same label `branch.obligations` writes: this field
             // exists to join to that entry, and a value spelled a second way here would join to
             // nothing.
-            case About.AnArmNoRowGoesThrough(var arm) -> ArmVocabulary.label(arm);
-            case About.ACaseNoRowExpects(var missing) -> missing.name();
-            case About.ACaseNothingWasSeenToProduce(var missing) -> missing.name();
+            case About.AnArmNoRowGoesThrough(var arm) -> words(ArmVocabulary.label(arm));
+            case About.ACaseNoRowExpects(var missing) -> words(missing.name());
+            case About.ACaseNothingWasSeenToProduce(var missing) -> words(missing.name());
             case About.AClassNoRowIsIn(var missing) ->
-                    missing.name() + " (at " + missing.axis().name() + ")";
-            case About.APositionNoLineDivides(var position) -> position.at().toString();
-            case About.APositionThisCouldNotRead(var it) -> it.at();
-            case About.ARuleWithoutALine(var it) -> it.at();
+                    words(missing.name() + " (at " + missing.axis().name() + ")");
+            case About.APositionNoLineDivides(var position) -> words(position.at().toString());
+            case About.APositionThisCouldNotRead(var it) -> words(it.at());
+            case About.ARuleWithoutALine(var it) -> words(it.at());
             // Where a reader is sent to look at the rule, which is what such a finding has instead
             // of a subject: what the rule states there is what nothing worked out.
-            case About.ARuleNothingClassified(var it) -> it.at();
+            case About.ARuleNothingClassified(var it) -> words(it.at());
             // The position and not a number measured of it: which of this position's rules went
             // unread is a fact about the location, and the measures on it are as many as the rules
             // name numbers there.
-            case About.APositionWhoseRulesWereNotReached(var gap) -> gap.at().toString();
+            case About.APositionWhoseRulesWereNotReached(var gap) -> words(gap.at().toString());
             // The position, as the two above write it. What is said of it is the kind's; there is
             // no rule to name and no class this is about, so the position is the whole subject.
-            case About.APositionReadWiderThanItsRules(var it) -> it.at().toString();
+            case About.APositionReadWiderThanItsRules(var it) -> words(it.at().toString());
             // The rule and what it was left saying. Named by the position alone, two rules nothing
             // took in at one position serialised as two identical objects, and the human line named
             // them while a consumer of the document could not tell them apart.
@@ -3703,24 +3712,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // for a rule with a name and broke for every rule found by where it is written.
             // The handle, and what tells this rule from another beside it: two arms of one clause
             // may name the same case, so the words alone joined two questions into one row.
-            case About.AQuestionNothingAnswered(var asked) ->
-                    RuleHandleSurface.InADocument.FINDING_SUBJECT.render(
-                                    PublishedRuleHandle.of(handle(asked.cited())),
-                                    sources::written, null)
-                            + " — " + asked(asked.asked())
-                            + " " + subjectOf(asked);
+            case About.AQuestionNothingAnswered(var asked) -> new PublishedSentence.AroundAHandle(
+                    "", PublishedRuleHandle.of(handle(asked.cited())),
+                    " — " + asked(asked.asked()) + " " + subjectOf(asked));
             case About.ACaseNoRowAppliesItTo(var input, var missing) ->
-                    missing.name() + " (in #" + (input.at() + 1) + ")";
+                    words(missing.name() + " (in #" + (input.at() + 1) + ")");
             // The point and the line, and no quantity: a body's line is owed once wherever it is
             // read, so what joins this to a `partition.obligations` entry is the role, where on
             // the line, and the rule — the same three that entry is keyed on.
-            case About.APointOfABorder(var point) -> point.said(
-                    RuleHandleSurface.InADocument.FINDING_SUBJECT, sources::written, null);
+            case About.APointOfABorder(var point) -> point.said();
             // The same sentence, on what the declaration wrote. A line owed once over every reading
             // of it is named by the terms the author used and not by the position some behavior met
             // it at, which is what the debt is (issue #1062).
-            case About.APointOfADeclaredBorder(var debt) -> debt.said();
+            case About.APointOfADeclaredBorder(var debt) -> words(debt.said());
         };
+    }
+
+    /** What a finding about something other than a rule says, which is words and no handle. */
+    private static PublishedSentence words(String said) {
+        return new PublishedSentence.Words(said);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -4,7 +4,7 @@ import souther.compiler.coverage.ArmProbe;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.fmt.Formatter;
 import souther.compiler.publish.PublishedIncompleteness;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.GenerationOutcome;
@@ -649,7 +649,7 @@ public final class GeneratedRows {
             // the role: a point away from the line was written as the value the line is at, which
             // is the one place in reach that such a point is not.
             case About.APointOfABorder(var point) ->
-                    point.said(RuleHandleSurface.PROSE, SourceId::value, null);
+                    RuleHandleProse.said(point.said(), SourceId::value, null);
             // The same words on what the declaration wrote. Nothing composes a row for one of
             // these yet — the search walks one behavior's inputs and this line is owed once over
             // all of them — so what is printed beside it is that, in its own sentence.

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -4,6 +4,7 @@ import souther.compiler.coverage.ArmProbe;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.fmt.Formatter;
 import souther.compiler.publish.PublishedIncompleteness;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.GenerationOutcome;
@@ -648,7 +649,7 @@ public final class GeneratedRows {
             // the role: a point away from the line was written as the value the line is at, which
             // is the one place in reach that such a point is not.
             case About.APointOfABorder(var point) ->
-                    point.said(SourceId::value, null);
+                    point.said(RuleHandleSurface.PROSE, SourceId::value, null);
             // The same words on what the declaration wrote. Nothing composes a row for one of
             // these yet — the search walks one behavior's inputs and this line is owed once over
             // all of them — so what is printed beside it is that, in its own sentence.

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-10.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-10.json
@@ -1438,7 +1438,7 @@
           },
           "subject": {
             "type": "string",
-            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
           },
           "code": {
             "type": "string",
@@ -1816,7 +1816,7 @@
               },
               "origin": {
                 "type": "string",
-                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
+                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
               },
               "kind": {
                 "enum": [
@@ -2140,7 +2140,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
+                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId"
@@ -2289,7 +2289,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId",

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-11.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-11.json
@@ -1473,7 +1473,7 @@
           },
           "subject": {
             "type": "string",
-            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
           },
           "code": {
             "type": "string",
@@ -1994,7 +1994,7 @@
               },
               "origin": {
                 "type": "string",
-                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
+                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
               },
               "kind": {
                 "enum": [
@@ -2318,7 +2318,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
+                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId"
@@ -2467,7 +2467,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId",

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-12.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-12.json
@@ -1596,7 +1596,7 @@
           },
           "subject": {
             "type": "string",
-            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
           },
           "code": {
             "type": "string",
@@ -2117,7 +2117,7 @@
               },
               "origin": {
                 "type": "string",
-                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
+                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
               },
               "kind": {
                 "enum": [
@@ -2441,7 +2441,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
+                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId"
@@ -2606,7 +2606,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId",

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-13.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-13.json
@@ -88,6 +88,26 @@
     }
   },
   "$defs": {
+    "ruleHandle": {
+      "type": "string",
+      "description": "How a reader finds a rule, written once here for every field that carries one. A rule the author named is found by that name: a clause of an invariant they called something is `invariant Amount (cap)`, one they named nothing is counted from the top of the declaration as `invariant Amount #2`, a clause of an `ensures` is `ensures charge (refunded)`, and a clause stating one rule over every answer is `ensures charge`. A rule they wrote rather than named has no name to look up and is found by where it is: `comparison@billing.sou:14:22` in a source this document's `sources` table names, and `comparison@7:3` where the file is the reader's to know. Code this compile reads from somewhere it holds no file for is said by what reaches it — `comparison in `Money`, reached at billing.sou:14:22`, or `comparison in `Money`, reached at 7:3`, or `comparison in `Money`` where there was no position to give. The word in front of a place says what kind of rule it is, and is one of the words `ruleId.kind` uses for a rule with no name: `predicate@billing.sou:14:22`, `predicate@7:3`, `predicate in `Money`, reached at billing.sou:14:22`, `predicate in `Money`, reached at 7:3`, `predicate in `Money``. These words are how an author acts on a rule and never what tells one rule from another — two arms of one `ensures` clause may name the same case — which is `ruleId`.",
+      "examples": [
+        "invariant Amount (cap)",
+        "invariant Amount #2",
+        "ensures charge (refunded)",
+        "ensures charge",
+        "comparison@billing.sou:14:22",
+        "comparison@7:3",
+        "comparison in `Money`, reached at billing.sou:14:22",
+        "comparison in `Money`, reached at 7:3",
+        "comparison in `Money`",
+        "predicate@billing.sou:14:22",
+        "predicate@7:3",
+        "predicate in `Money`, reached at billing.sou:14:22",
+        "predicate in `Money`, reached at 7:3",
+        "predicate in `Money`"
+      ]
+    },
     "runSensitivity": {
       "enum": [
         "may_change",
@@ -783,8 +803,8 @@
             ]
           },
           "rule": {
-            "type": "string",
-            "description": "The rule that drew the line, as `boundaries[].origin` writes it."
+            "$ref": "#/$defs/ruleHandle",
+            "description": "The rule that drew the line this point is owed for. The handle and nothing else, where the `boundaries` entry for the same line writes the declarations that took its ends in beside it."
           },
           "ruleId": {
             "$ref": "#/$defs/ruleId"
@@ -1603,7 +1623,8 @@
           },
           "subject": {
             "type": "string",
-            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+            "x-souther-contains": "#/$defs/ruleHandle",
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — the rule as a `ruleHandle`, and a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. A finding about a question nothing answered leads with the same handle and says what was asked after it. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
           },
           "code": {
             "type": "string",
@@ -2185,7 +2206,8 @@
               },
               "origin": {
                 "type": "string",
-                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
+                "x-souther-contains": "#/$defs/ruleHandle",
+                "description": "The rule that drew this line, as a `ruleHandle`, and after it the declarations that took an end of the line in where any did. The handle alone where none did, which is what the `obligations` entry for a point of this line carries. Not itself a handle, because those words are about the line rather than about the rule; what a consumer keys on is the `ruleId` under that entry."
               },
               "kind": {
                 "enum": [
@@ -2515,8 +2537,8 @@
                 "$ref": "#/$defs/answerRealizationStoppedReason"
               },
               "rule": {
-                "type": "string",
-                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
+                "$ref": "#/$defs/ruleHandle",
+                "description": "How a reader finds the rule this question is about. The same handle the `boundaries` entry for a line the same rule drew carries, and the same one a `notRead` entry carries for a rule it could not read. What the forms are is `ruleHandle`; what tells one rule from another is `ruleId` beside this, because two arms of one `ensures` clause may name the same case and a handle is what an author acts on rather than what a consumer groups by."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId"
@@ -2680,8 +2702,8 @@
                 "$ref": "#/$defs/notReadReason"
               },
               "rule": {
-                "type": "string",
-                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+                "$ref": "#/$defs/ruleHandle",
+                "description": "How a reader finds the rule this could not turn into a line. The same handle an `unanswered` entry and a `boundaries` entry carry for the same rule, and its forms are `ruleHandle`. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId",

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-5.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-5.json
@@ -336,7 +336,7 @@
             "additionalProperties": false,
             "properties": {
               "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
               "kind": {
                 "enum": ["at_value", "between_positions", "over_a_form"],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. `over_a_form` is a rule over an arithmetic form across several positions: the line is where the form comes to `value`, `axis` names the form as an author would write it and `value` is a number the form takes rather than a value any position holds. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
@@ -430,7 +430,7 @@
             "additionalProperties": false,
             "properties": {
               "at": { "type": "string", "description": "The position the rule is written about, as a report names it." },
-              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
+              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
               "ruleId": { "$ref": "#/$defs/ruleId" },
               "question": { "$ref": "#/$defs/coverageQuestion" },
               "subject": {
@@ -486,7 +486,7 @@
             "properties": {
               "position": { "type": "string" },
               "reason": { "$ref": "#/$defs/notReadReason" },
-              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
+              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
               "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one." }
             }
           }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-6.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-6.json
@@ -336,7 +336,7 @@
             "additionalProperties": false,
             "properties": {
               "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
               "kind": {
                 "enum": ["at_value", "between_positions", "over_a_form"],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. `over_a_form` is a rule over an arithmetic form across several positions: the line is where the form comes to `value`, `axis` names the form as an author would write it and `value` is a number the form takes rather than a value any position holds. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
@@ -430,7 +430,7 @@
             "additionalProperties": false,
             "properties": {
               "at": { "type": "string", "description": "The position the rule is written about, as a report names it." },
-              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
+              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
               "ruleId": { "$ref": "#/$defs/ruleId" },
               "question": { "$ref": "#/$defs/coverageQuestion" },
               "subject": {
@@ -486,7 +486,7 @@
             "properties": {
               "position": { "type": "string" },
               "reason": { "$ref": "#/$defs/notReadReason" },
-              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
+              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
               "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one." }
             }
           }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -354,7 +354,7 @@
             "additionalProperties": false,
             "properties": {
               "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
               "kind": {
                 "enum": ["at_value", "between_positions", "over_a_form"],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. `over_a_form` is a rule over an arithmetic form across several positions: the line is where the form comes to `value`, `axis` names the form as an author would write it and `value` is a number the form takes rather than a value any position holds. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
@@ -474,7 +474,7 @@
             "additionalProperties": false,
             "properties": {
               "at": { "type": "string", "description": "The position the rule is written about, as a report names it." },
-              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
+              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
               "ruleId": { "$ref": "#/$defs/ruleId" },
               "question": { "$ref": "#/$defs/coverageQuestion" },
               "subject": {
@@ -530,7 +530,7 @@
             "properties": {
               "position": { "type": "string" },
               "reason": { "$ref": "#/$defs/notReadReason" },
-              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
+              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
               "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one." }
             }
           }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-8.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-8.json
@@ -368,7 +368,7 @@
             "additionalProperties": false,
             "properties": {
               "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
               "kind": {
                 "enum": ["at_value", "between_positions", "over_a_form"],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. `over_a_form` is a rule over an arithmetic form across several positions: the line is where the form comes to `value`, `axis` names the form as an author would write it and `value` is a number the form takes rather than a value any position holds. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
@@ -495,7 +495,7 @@
                 "uniqueItems": true,
                 "items": { "$ref": "#/$defs/questionStoppedReason" }
               },
-              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
+              "rule": { "type": "string", "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two." },
               "ruleId": { "$ref": "#/$defs/ruleId" },
               "question": { "$ref": "#/$defs/coverageQuestion" },
               "subject": {
@@ -551,7 +551,7 @@
             "properties": {
               "position": { "type": "string" },
               "reason": { "$ref": "#/$defs/notReadReason" },
-              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
+              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
               "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one." }
             }
           }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-9.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-9.json
@@ -1416,7 +1416,7 @@
           },
           "subject": {
             "type": "string",
-            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
           },
           "code": {
             "type": "string",
@@ -1794,7 +1794,7 @@
               },
               "origin": {
                 "type": "string",
-                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
+                "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or a comparison a body wrote, named by what the rule is and where. Prose rather than a word list: which rules there are is the model's question, not this document's."
               },
               "kind": {
                 "enum": [
@@ -2144,7 +2144,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause called `if`. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
+                "description": "How a reader finds the rule: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. A comparison in a body is written rather than named, so a document that spelled every rule as a name would send an author looking for a clause that was never given one. The same handle a `boundaries` entry writes for a line the same rule drew. Not what tells one rule from another: two arms of one `ensures` clause may name the same case, and `ruleId` beside this is what says they are two."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId"
@@ -2293,7 +2293,7 @@
               },
               "rule": {
                 "type": "string",
-                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+                "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `comparison@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
               },
               "ruleId": {
                 "$ref": "#/$defs/ruleId",

--- a/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
@@ -7,7 +7,7 @@ import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.publish.PublishedRuleHandle;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
@@ -91,7 +91,7 @@ class AGuardsQuestionIsCitedByWhereItIsWrittenTest {
                 .map(each -> (RuleCitation.WrittenAt) each).findFirst()
                 .orElseThrow(() -> new AssertionError("a comparison has no name, so it is cited by"
                         + " where it is written: " + one.cited()));
-        String said = RuleHandleSurface.PROSE.render(
+        String said = RuleHandleProse.said(
                 PublishedRuleHandle.of(written), SourceNameResolver.identity(), null);
         assertTrue(said.startsWith("comparison@"),
                 () -> "what the rule is and where it is written: " + said);

--- a/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
@@ -6,6 +6,8 @@ import souther.compiler.check.RuleCitation;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
@@ -89,9 +91,10 @@ class AGuardsQuestionIsCitedByWhereItIsWrittenTest {
                 .map(each -> (RuleCitation.WrittenAt) each).findFirst()
                 .orElseThrow(() -> new AssertionError("a comparison has no name, so it is cited by"
                         + " where it is written: " + one.cited()));
-        assertTrue(written.said(SourceNameResolver.identity(), null).startsWith("comparison@"),
-                () -> "what the rule is and where it is written: "
-                        + written.said(SourceNameResolver.identity(), null));
+        String said = RuleHandleSurface.PROSE.render(
+                PublishedRuleHandle.of(written), SourceNameResolver.identity(), null);
+        assertTrue(said.startsWith("comparison@"),
+                () -> "what the rule is and where it is written: " + said);
     }
 
     /** The invariant beside it keeps its name, which is the other half of the same rule. */

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.observe.MeasurementStatus;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.ArmObligation;
 import souther.compiler.query.Compilation;
@@ -224,7 +224,7 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                             .made().orElseGet(List::of)) {
                 if (point.item().coverage().settled() && !point.owed().hasRowWitness()) {
                     wrong.add("boundary "
-                            + point.said(RuleHandleSurface.PROSE,
+                            + RuleHandleProse.said(point.said(),
                                     souther.compiler.source.SourceId::value, null));
                 }
             }

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.ArmObligation;
 import souther.compiler.query.Compilation;
@@ -223,7 +224,8 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                             .made().orElseGet(List::of)) {
                 if (point.item().coverage().settled() && !point.owed().hasRowWitness()) {
                     wrong.add("boundary "
-                            + point.said(souther.compiler.source.SourceId::value, null));
+                            + point.said(RuleHandleSurface.PROSE,
+                                    souther.compiler.source.SourceId::value, null));
                 }
             }
             if (partition.pairs().counted() instanceof Measurement.Complete<?>

--- a/souther-compiler/src/test/java/souther/compiler/DocumentShape.java
+++ b/souther-compiler/src/test/java/souther/compiler/DocumentShape.java
@@ -56,7 +56,13 @@ public final class DocumentShape {
             "type", "enum", "const", "minimum", "pattern", "minItems", "maxItems",
             "uniqueItems", "contains", "minContains", "maxContains",
             // prose and plumbing
-            "description", "title", "$schema", "$id", "$defs");
+            "description", "title", "$schema", "$id", "$defs", "examples",
+            // and one annotation of this compiler's, which says that a string has a handle inside
+            // it rather than being one. No part of what a document must satisfy — a reader that
+            // does not know the word ignores it, which is what makes it safe to write here — and
+            // what holds it to the writer is the check that reads it
+            // (`EveryFormOfARuleHandleIsOneTheContractDescribes`)
+            "x-souther-contains");
 
     /** What a walk of one document came to: how much of it was reached, and what the schema
      *  refuses. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.report.AdequacyReport;
 
 import java.util.stream.Collectors;
@@ -211,7 +212,8 @@ class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
                 .map(each -> each.at() + " " + each.reason())
                 .collect(Collectors.joining(", "))
                 + "] points [" + read.account().stream()
-                .map(point -> point.said(souther.compiler.source.SourceId::value, null))
+                .map(point -> point.said(RuleHandleSurface.PROSE,
+                        souther.compiler.source.SourceId::value, null))
                 .collect(Collectors.joining(", ")) + "]";
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
@@ -3,7 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.report.AdequacyReport;
 
 import java.util.stream.Collectors;
@@ -212,7 +212,7 @@ class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
                 .map(each -> each.at() + " " + each.reason())
                 .collect(Collectors.joining(", "))
                 + "] points [" + read.account().stream()
-                .map(point -> point.said(RuleHandleSurface.PROSE,
+                .map(point -> RuleHandleProse.said(point.said(),
                         souther.compiler.source.SourceId::value, null))
                 .collect(Collectors.joining(", ")) + "]";
     }

--- a/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
@@ -272,6 +272,87 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
     }
 
     /**
+     * Every part a handle is written into is a part the schema declares under that name.
+     *
+     * <p>What ties a name to a place. The two are one value so that no writer can put an array under
+     * one name and claim the place of another — but a value is still a claim until something reads
+     * it, and what reads it is the schema: the place has to be an array of objects, and the name has
+     * to be the name of a property that leads there. Left unread, a part could name a field the
+     * contract has never heard of and every check between the writer and the surface would still
+     * agree with every other.
+     *
+     * <p>Reached from the property, because that is the direction a document is written in. A part
+     * two sections publish is reached from each of them and is one definition, so what is asked is
+     * that every property leading to it is called what this part is called, and that there is one.
+     */
+    @Test
+    void everyPartAHandleIsWrittenIntoIsOneTheSchemaDeclaresUnderThatName() {
+        for (DocumentPart part : DocumentPart.values()) {
+            JsonNode declared = at(schema(), part.schemaPath());
+            assertEquals("array", declared.get("type").asString(),
+                    () -> "the schema declares a repeated part at " + part.schemaPath());
+            assertNotNull(declared.get("items"),
+                    () -> "and says what a row of it looks like: " + part.schemaPath());
+
+            assertEquals(Set.of(part.key()), namesLeadingTo(part.schemaPath()),
+                    () -> "and every property that leads there is what this part is called: "
+                            + part);
+        }
+    }
+
+    /**
+     * The names of the properties that lead to {@code path}, whether by sitting there or by
+     * referring to it.
+     *
+     * <p>Both, because a definition is reached through {@code $ref} and a part written in place is
+     * not, and a document writer cannot tell which of the two it is filling in.
+     */
+    private static Set<String> namesLeadingTo(String path) {
+        Set<String> found = new LinkedHashSet<>();
+        leadingTo(schema(), "", "#" + path, path, found);
+        return found;
+    }
+
+    private static void leadingTo(JsonNode at, String here, String reference, String path,
+                                  Set<String> found) {
+        if (at.isObject()) {
+            at.propertyNames().forEach(key -> {
+                String below = here + "/" + key;
+                JsonNode under = at.get(key);
+                if (here.endsWith("/properties")
+                        && (below.equals(path) || refersTo(under, reference))) {
+                    found.add(key);
+                }
+                leadingTo(under, below, reference, path, found);
+            });
+        } else if (at.isArray()) {
+            for (int i = 0; i < at.size(); i++) {
+                leadingTo(at.get(i), here + "/" + i, reference, path, found);
+            }
+        }
+    }
+
+    /** Whether {@code said} is that reference, or a composition one branch of which is. */
+    private static boolean refersTo(JsonNode said, String reference) {
+        if (!said.isObject()) {
+            return false;
+        }
+        if (said.has("$ref") && reference.equals(said.get("$ref").asString())) {
+            return true;
+        }
+        JsonNode all = said.get("allOf");
+        if (all == null) {
+            return false;
+        }
+        for (JsonNode each : all) {
+            if (refersTo(each, reference)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * A field is written into the object the schema declares it on, and refused anywhere else.
      *
      * <p>What a field is includes where it lives, and that was the half nothing compared: the
@@ -286,7 +367,7 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
         PublishedSentence sentence = PublishedSentence.AroundAHandle.alone(handle);
         for (RuleHandleSurface each : RuleHandleSurface.values()) {
             DocumentItem elsewhere =
-                    new DocumentItem(JSON.createObjectNode(), "/$defs/somewhereElse/items");
+                    DocumentItem.at(JSON.createObjectNode(), "/$defs/somewhereElse/items");
 
             assertThrows(IllegalStateException.class,
                     () -> {
@@ -313,7 +394,7 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
      */
     private static DocumentItem whereItBelongs(RuleHandleSurface surface) {
         String path = surface.schemaPath();
-        return new DocumentItem(JSON.createObjectNode(),
+        return DocumentItem.at(JSON.createObjectNode(),
                 path.substring(0, path.length() - "/properties/".length() - surface.key().length()));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
@@ -11,7 +11,6 @@ import souther.compiler.types.WrittenOwner;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.node.ObjectNode;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -252,24 +251,70 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
         PublishedRuleHandle handle = new PublishedRuleHandle.NamedInvariant("Amount", "cap");
         PublishedSentence sentence = PublishedSentence.AroundAHandle.alone(handle);
         for (RuleHandleSurface each : RuleHandleSurface.values()) {
-            ObjectNode into = JSON.createObjectNode();
+            DocumentItem into = whereItBelongs(each);
             switch (each.carries()) {
                 case THE_HANDLE_ALONE -> {
                     each.put(into, handle, SourceId::value, null);
                     assertThrows(IllegalStateException.class,
-                            () -> each.put(JSON.createObjectNode(), sentence, SourceId::value, null),
+                            () -> each.put(whereItBelongs(each), sentence, SourceId::value, null),
                             () -> "a field that is the handle is not told a sentence: " + each);
                 }
                 case A_SENTENCE_AROUND_IT -> {
                     each.put(into, sentence, SourceId::value, null);
                     assertThrows(IllegalStateException.class,
-                            () -> each.put(JSON.createObjectNode(), handle, SourceId::value, null),
+                            () -> each.put(whereItBelongs(each), handle, SourceId::value, null),
                             () -> "a field with words of its own is not handed a handle: " + each);
                 }
             }
-            assertTrue(into.has(each.key()),
+            assertTrue(into.node().has(each.key()),
                     () -> "and either way the field is written under the key this names: " + each);
         }
+    }
+
+    /**
+     * A field is written into the object the schema declares it on, and refused anywhere else.
+     *
+     * <p>What a field is includes where it lives, and that was the half nothing compared: the
+     * contract said where each of these sits and the writer said which part of the document it was
+     * building, and the two answers never met. A handle written into some other object is a field
+     * the schema declares nothing about, however carefully the surfaces themselves are counted —
+     * which is this issue's own defect, arrived at from the writing side.
+     */
+    @Test
+    void aFieldIsRefusedWhereTheSchemaDoesNotDeclareIt() {
+        PublishedRuleHandle handle = new PublishedRuleHandle.NamedInvariant("Amount", "cap");
+        PublishedSentence sentence = PublishedSentence.AroundAHandle.alone(handle);
+        for (RuleHandleSurface each : RuleHandleSurface.values()) {
+            DocumentItem elsewhere =
+                    new DocumentItem(JSON.createObjectNode(), "/$defs/somewhereElse/items");
+
+            assertThrows(IllegalStateException.class,
+                    () -> {
+                        switch (each.carries()) {
+                            case THE_HANDLE_ALONE ->
+                                    each.put(elsewhere, handle, SourceId::value, null);
+                            case A_SENTENCE_AROUND_IT ->
+                                    each.put(elsewhere, sentence, SourceId::value, null);
+                        }
+                    },
+                    () -> "a handle written into an object the schema does not declare this field"
+                            + " on: " + each);
+            assertTrue(elsewhere.node().isEmpty(),
+                    () -> "and nothing was written there: " + each);
+        }
+    }
+
+    /**
+     * An object at the place the schema declares {@code surface} on.
+     *
+     * <p>Read off the surface, which is what makes the pair above say something: what is asked is
+     * whether writing anywhere else is refused, and an object built from some other answer would be
+     * refused for being that other answer rather than for being elsewhere.
+     */
+    private static DocumentItem whereItBelongs(RuleHandleSurface surface) {
+        String path = surface.schemaPath();
+        return new DocumentItem(JSON.createObjectNode(),
+                path.substring(0, path.length() - "/properties/".length() - surface.key().length()));
     }
 
     /** The same, read off the schema: a field that is a handle refers to the canonical definition,

--- a/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
@@ -2,11 +2,16 @@ package souther.compiler.publish;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.RuleRef;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.source.SourceId;
+import souther.compiler.types.SourceConstruct;
+import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.WrittenOwner;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -20,6 +25,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -79,8 +85,7 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
             out.add(new PublishedRuleHandle.Written(kind, inATextWithNoName()));
             out.add(new PublishedRuleHandle.Reached(kind, inASourceThisCompileHolds(), "Money"));
             out.add(new PublishedRuleHandle.Reached(kind, inATextWithNoName(), "Money"));
-            out.add(new PublishedRuleHandle.Reached(kind, new PublishedRuleHandle.Place.Nowhere(),
-                    "Money"));
+            out.add(new PublishedRuleHandle.ReachedOutOfSight(kind, "Money"));
         }
         return List.copyOf(out);
     }
@@ -127,6 +132,46 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
     }
 
     /**
+     * Every published word for a rule with no name is one some rule of the model is called by.
+     *
+     * <p>The projection read the other way round. Every kind of written rule has a word because the
+     * switch that chooses one is total, and what is not total by anything the compiler checks is the
+     * far side: a word added here that no rule projects to is a word the contract would go on
+     * promising and no document could ever carry — which is this issue's own defect, in the one
+     * place the population above is taken from a declaration rather than from what is produced.
+     */
+    @Test
+    void everyPublishedWordIsOneSomeRuleIsCalledBy() {
+        assertEquals(
+                Set.of(PublishedRuleKind.values()),
+                everyKindOfWrittenRule().stream().map(PublishedRuleKind::of)
+                        .collect(Collectors.toSet()),
+                "the words a rule of the model is called by, and the words the contract has");
+    }
+
+    /**
+     * One rule of every kind the author writes rather than names.
+     *
+     * <p>From the seal, so the day a third kind of written rule exists this is asked about it. Walked
+     * to the leaves: what {@code RuleRef.Written} permits is what a document names, and a half of the
+     * seal above it is nothing an author writes.
+     */
+    private static List<RuleRef.Written> everyKindOfWrittenRule() {
+        WrittenOwner.Body body = new WrittenOwner.Body("m", "b");
+        List<RuleRef.Written> out = List.of(
+                new RuleRef.Comparison("b",
+                        new SourceConstructOrigin(body, 0, 0, SourceConstruct.BINARY)),
+                new RuleRef.Predicate("b",
+                        new SourceConstructOrigin(body, 1, 0, SourceConstruct.CALL)));
+
+        assertEquals(
+                Set.of(RuleRef.Written.class.getPermittedSubclasses()),
+                out.stream().map(each -> (Class<?>) each.getClass()).collect(Collectors.toSet()),
+                "one of each kind of rule an author writes rather than names, and no other");
+        return out;
+    }
+
+    /**
      * What the compiler writes and what the contract gives as examples are the same set.
      *
      * <p>Rendered through the surface a person's report writes, which is the same spelling every
@@ -161,7 +206,7 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
     /** The sentences this compiler writes, one per form. */
     private static Set<String> rendered() {
         return everyForm().stream()
-                .map(each -> RuleHandleSurface.PROSE.render(each, SourceId::value, null))
+                .map(each -> RuleHandleProse.said(each, SourceId::value, null))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
@@ -184,13 +229,47 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
     @Test
     void everyFieldTheCompilerWritesAHandleIntoIsOneTheSchemaSaysCarriesOne() {
         Map<String, RuleHandleSurface.Carries> written = new LinkedHashMap<>();
-        for (RuleHandleSurface.InADocument each : RuleHandleSurface.InADocument.values()) {
+        for (RuleHandleSurface each : RuleHandleSurface.values()) {
             written.put(each.schemaPath(), each.carries());
         }
 
         assertEquals(declaredInTheSchema(), written,
                 "the fields the schema says carry a handle and the fields the compiler writes one"
                         + " into");
+    }
+
+    /**
+     * A field that is a handle writes one, and a field that puts words around one writes those.
+     *
+     * <p>The two are not interchangeable and the surface is what says which: handed a handle, a
+     * field whose sentence has more in it would carry a document's shortest true answer and lose the
+     * rest, and told a sentence, a field a consumer reads as a handle would carry words it cannot
+     * take apart. Which each is, is already the pair the check above compares, so this asks that the
+     * writing side act on it rather than carry it.
+     */
+    @Test
+    void aFieldIsWrittenTheWayItSaysItCarriesAHandle() {
+        PublishedRuleHandle handle = new PublishedRuleHandle.NamedInvariant("Amount", "cap");
+        PublishedSentence sentence = PublishedSentence.AroundAHandle.alone(handle);
+        for (RuleHandleSurface each : RuleHandleSurface.values()) {
+            ObjectNode into = JSON.createObjectNode();
+            switch (each.carries()) {
+                case THE_HANDLE_ALONE -> {
+                    each.put(into, handle, SourceId::value, null);
+                    assertThrows(IllegalStateException.class,
+                            () -> each.put(JSON.createObjectNode(), sentence, SourceId::value, null),
+                            () -> "a field that is the handle is not told a sentence: " + each);
+                }
+                case A_SENTENCE_AROUND_IT -> {
+                    each.put(into, sentence, SourceId::value, null);
+                    assertThrows(IllegalStateException.class,
+                            () -> each.put(JSON.createObjectNode(), handle, SourceId::value, null),
+                            () -> "a field with words of its own is not handed a handle: " + each);
+                }
+            }
+            assertTrue(into.has(each.key()),
+                    () -> "and either way the field is written under the key this names: " + each);
+        }
     }
 
     /** The same, read off the schema: a field that is a handle refers to the canonical definition,
@@ -209,13 +288,7 @@ class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
             if (at.has(EMBEDS) && REFERENCE.equals(at.get(EMBEDS).asString())) {
                 out.put(path, RuleHandleSurface.Carries.A_SENTENCE_AROUND_IT);
             }
-            // Under the canonical definition itself there is nothing to find, and walking into it
-            // would name the definition as a field that carries a handle.
-            at.propertyNames().forEach(key -> {
-                if (!(path + "/" + key).equals(CANONICAL)) {
-                    walk(at.get(key), path + "/" + key, out);
-                }
-            });
+            at.propertyNames().forEach(key -> walk(at.get(key), path + "/" + key, out));
         } else if (at.isArray()) {
             for (int i = 0; i < at.size(); i++) {
                 walk(at.get(i), path + "/" + i, out);

--- a/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/EveryFormOfARuleHandleIsOneTheContractDescribesTest.java
@@ -1,0 +1,244 @@
+package souther.compiler.publish;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.report.AdequacyReport;
+import souther.compiler.source.SourceId;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every form of sentence a document sends a reader to a rule by is one the shipped schema describes.
+ *
+ * <p>The third contract surface. Which keys a document may carry is held elsewhere, and so is every
+ * enumerated word it may carry; what a field of free text is written as was held nowhere, and a
+ * description is where a consumer reads it. The schema promised a handle spelled {@code if@…} from
+ * the first version that shipped, three days after the word stopped being {@code if} and before any
+ * document of any version carried one — nine versions, each copied from the one before, and nothing
+ * ever read the sentence against the writer.
+ *
+ * <p>Held as a correspondence and not by generating one side from the other, for the reason the
+ * enumerated words are: what a document may carry is a decision about the contract, and moving a
+ * word inside the compiler is not. A generated description would move with the compiler, and the
+ * only thing left to notice would be a consumer.
+ *
+ * <p>The population is the published grammar rather than the seals underneath it. A citation and a
+ * place are two internal sums whose product is not the set of sentences: a clause the author named
+ * and one a reader counts to are one arm of {@code RuleRef} and two sentences, and two arms of the
+ * citation write one. Walked for the internal division, the forms a contract has to describe come
+ * out short by exactly the ones a value decides.
+ */
+class EveryFormOfARuleHandleIsOneTheContractDescribesTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** Where the handle's forms are described, once, for every field that carries one. */
+    private static final String CANONICAL = "/$defs/ruleHandle";
+
+    /** What the canonical definition is referred to as from the fields that carry a handle. */
+    private static final String REFERENCE = "#/$defs/ruleHandle";
+
+    /** The annotation a field that writes a sentence with a handle in it carries. Beside the
+     *  reference rather than instead of it: such a field is not a handle, and a reader validating a
+     *  document must not be told it is. */
+    private static final String EMBEDS = "x-souther-contains";
+
+    private static final SourceId IN = new SourceId("billing.sou");
+
+    /**
+     * One handle of every form the grammar has.
+     *
+     * <p>The product of what decides a sentence: which form it is, which of the published words goes
+     * in front of a place where one does, and what kind of place there is. Written out rather than
+     * gathered from a compilation — a model states the rules it states, and a form no fixture
+     * happens to write is one a document may carry the day something does.
+     */
+    private static List<PublishedRuleHandle> everyForm() {
+        List<PublishedRuleHandle> out = new ArrayList<>(List.of(
+                new PublishedRuleHandle.NamedInvariant("Amount", "cap"),
+                new PublishedRuleHandle.NumberedInvariant("Amount", 2),
+                new PublishedRuleHandle.NamedEnsures("charge", "refunded"),
+                new PublishedRuleHandle.WholeEnsures("charge")));
+        for (PublishedRuleKind kind : PublishedRuleKind.values()) {
+            out.add(new PublishedRuleHandle.Written(kind, inASourceThisCompileHolds()));
+            out.add(new PublishedRuleHandle.Written(kind, inATextWithNoName()));
+            out.add(new PublishedRuleHandle.Reached(kind, inASourceThisCompileHolds(), "Money"));
+            out.add(new PublishedRuleHandle.Reached(kind, inATextWithNoName(), "Money"));
+            out.add(new PublishedRuleHandle.Reached(kind, new PublishedRuleHandle.Place.Nowhere(),
+                    "Money"));
+        }
+        return List.copyOf(out);
+    }
+
+    private static PublishedRuleHandle.Place inASourceThisCompileHolds() {
+        return new PublishedRuleHandle.Place.InSource(
+                new PublishedAt(IN, 14, 22, new PublishedAt.Where.Here()));
+    }
+
+    private static PublishedRuleHandle.Place inATextWithNoName() {
+        return new PublishedRuleHandle.Place.Unplaced(7, 3);
+    }
+
+    /**
+     * That the population above is the grammar and not a list somebody kept up by hand.
+     *
+     * <p>Each axis on its own, because a form is a point of the product: an arm nobody built and a
+     * kind of place nobody paired with an arm are both forms the contract would go on describing
+     * nothing about.
+     */
+    @Test
+    void thePopulationIsEveryFormTheGrammarHas() {
+        assertEquals(
+                Set.of(PublishedRuleHandle.class.getPermittedSubclasses()),
+                everyForm().stream().map(each -> (Class<?>) each.getClass())
+                        .collect(Collectors.toSet()),
+                "one of each form of sentence the grammar has, and no other");
+        assertEquals(
+                Set.of(PublishedRuleKind.values()),
+                everyForm().stream().flatMap(each -> switch (each) {
+                    case PublishedRuleHandle.Written it -> Stream.of(it.kind());
+                    case PublishedRuleHandle.Reached it -> Stream.of(it.kind());
+                    default -> Stream.<PublishedRuleKind>of();
+                }).collect(Collectors.toSet()),
+                "and every published word a rule with no name is called by");
+        assertEquals(
+                Set.of(PublishedRuleHandle.Place.class.getPermittedSubclasses()),
+                everyForm().stream().flatMap(each -> switch (each) {
+                    case PublishedRuleHandle.Written it -> Stream.of(it.at());
+                    case PublishedRuleHandle.Reached it -> Stream.of(it.at());
+                    default -> Stream.<PublishedRuleHandle.Place>of();
+                }).map(each -> (Class<?>) each.getClass()).collect(Collectors.toSet()),
+                "and every kind of place a report says such a rule is at");
+    }
+
+    /**
+     * What the compiler writes and what the contract gives as examples are the same set.
+     *
+     * <p>Rendered through the surface a person's report writes, which is the same spelling every
+     * surface writes: a form that reads one way in a document and another in a report is two forms,
+     * and this asks about the grammar rather than about one field.
+     *
+     * <p>Not against a fixture, which would tie the contract to a line number some model happens to
+     * be written at. Against the renderer, so the contract moves exactly when the sentence does.
+     */
+    @Test
+    void theContractGivesAnExampleOfEveryFormAndOfNothingElse() {
+        assertEquals(rendered(), examples(),
+                "the sentences this compiler writes and the ones the schema gives as examples");
+    }
+
+    /**
+     * And the prose beside them says each of those sentences.
+     *
+     * <p>The examples are what a check can read and the description is what a person reads, and a
+     * contract whose machine-readable half is right while its sentence is nine versions old is the
+     * failure this exists for, spelled a second way.
+     */
+    @Test
+    void everyExampleTheContractGivesIsInTheProseBesideIt() {
+        String said = at(schema(), CANONICAL).get("description").asString();
+        for (String example : rendered()) {
+            assertTrue(said.contains(example),
+                    () -> "the prose a reader builds against says this form: " + example);
+        }
+    }
+
+    /** The sentences this compiler writes, one per form. */
+    private static Set<String> rendered() {
+        return everyForm().stream()
+                .map(each -> RuleHandleSurface.PROSE.render(each, SourceId::value, null))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /** The sentences the contract gives as examples of a handle. */
+    private static Set<String> examples() {
+        JsonNode said = at(schema(), CANONICAL).get("examples");
+        assertNotNull(said, "the canonical definition gives examples of what a handle reads as");
+        Set<String> out = new LinkedHashSet<>();
+        said.forEach(each -> out.add(each.asString()));
+        return out;
+    }
+
+    /**
+     * Every field of the document that carries a handle, as the schema says so.
+     *
+     * <p>By where the schema declares the field and not by what it is called. {@code rule} is
+     * written under three parents, so a set of names would say there were fewer fields than there
+     * are and go on saying it as more were added.
+     */
+    @Test
+    void everyFieldTheCompilerWritesAHandleIntoIsOneTheSchemaSaysCarriesOne() {
+        Map<String, RuleHandleSurface.Carries> written = new LinkedHashMap<>();
+        for (RuleHandleSurface.InADocument each : RuleHandleSurface.InADocument.values()) {
+            written.put(each.schemaPath(), each.carries());
+        }
+
+        assertEquals(declaredInTheSchema(), written,
+                "the fields the schema says carry a handle and the fields the compiler writes one"
+                        + " into");
+    }
+
+    /** The same, read off the schema: a field that is a handle refers to the canonical definition,
+     *  and one that writes a sentence around a handle says which definition it embeds. */
+    private static Map<String, RuleHandleSurface.Carries> declaredInTheSchema() {
+        Map<String, RuleHandleSurface.Carries> out = new LinkedHashMap<>();
+        walk(schema(), "", out);
+        return out;
+    }
+
+    private static void walk(JsonNode at, String path, Map<String, RuleHandleSurface.Carries> out) {
+        if (at.isObject()) {
+            if (at.has("$ref") && REFERENCE.equals(at.get("$ref").asString())) {
+                out.put(path, RuleHandleSurface.Carries.THE_HANDLE_ALONE);
+            }
+            if (at.has(EMBEDS) && REFERENCE.equals(at.get(EMBEDS).asString())) {
+                out.put(path, RuleHandleSurface.Carries.A_SENTENCE_AROUND_IT);
+            }
+            // Under the canonical definition itself there is nothing to find, and walking into it
+            // would name the definition as a field that carries a handle.
+            at.propertyNames().forEach(key -> {
+                if (!(path + "/" + key).equals(CANONICAL)) {
+                    walk(at.get(key), path + "/" + key, out);
+                }
+            });
+        } else if (at.isArray()) {
+            for (int i = 0; i < at.size(); i++) {
+                walk(at.get(i), path + "/" + i, out);
+            }
+        }
+    }
+
+    private static JsonNode at(JsonNode schema, String pointer) {
+        JsonNode found = schema;
+        for (String step : pointer.substring(1).split("/")) {
+            found = found.get(step);
+            assertNotNull(found, () -> "the schema declares " + pointer);
+        }
+        return found;
+    }
+
+    private static JsonNode schema() {
+        try (InputStream said = AdequacyReport.class
+                .getResourceAsStream(AdequacyReport.SCHEMA_RESOURCE)) {
+            assertNotNull(said, "the schema this compiler ships");
+            return JSON.readTree(said);
+        } catch (Exception e) {
+            throw new AssertionError("the schema this compiler ships is readable", e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
@@ -107,21 +107,38 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
      */
     @Test
     void twoHandlesAreOneValueExactlyWhereADocumentWritesThemAlike() {
-        List<RuleCitation> population = everyShapeOfSentence();
-        for (RuleCitation one : population) {
-            for (RuleCitation other : population) {
-                PublishedRuleHandle here = PublishedRuleHandle.of(one);
-                PublishedRuleHandle there = PublishedRuleHandle.of(other);
-                boolean written = said(one).equals(said(other));
+        List<PublishedRuleHandle> population = everyHandle();
+        for (PublishedRuleHandle here : population) {
+            for (PublishedRuleHandle there : population) {
+                boolean written = said(here).equals(said(there));
 
                 assertEquals(written, here.equals(there),
                         () -> "one value exactly where a document writes them alike: "
-                                + said(one) + " and " + said(other));
+                                + said(here) + " and " + said(there));
                 assertEquals(written, here.compareTo(there) == 0,
                         () -> "and the order agrees with the equality: "
-                                + said(one) + " and " + said(other));
+                                + said(here) + " and " + said(there));
             }
         }
+    }
+
+    /**
+     * The handles the property above is asked over.
+     *
+     * <p>What a compilation offers, and beside it the one form no compilation here writes: code out
+     * of sight with no position at all is met where a body is put back together out of what a module
+     * published, which none of these fixtures does. Left to the fixtures, that arm would be the one
+     * whose ordering nothing asks about — and it was, while it was an arm of the place instead of a
+     * sentence of its own and the checks below were satisfied by the placed one beside it.
+     */
+    private static List<PublishedRuleHandle> everyHandle() {
+        List<PublishedRuleHandle> out = new ArrayList<>(
+                everyShapeOfSentence().stream().map(PublishedRuleHandle::of).toList());
+        for (PublishedRuleKind kind : PublishedRuleKind.values()) {
+            out.add(new PublishedRuleHandle.ReachedOutOfSight(kind, "Int.clamp"));
+            out.add(new PublishedRuleHandle.ReachedOutOfSight(kind, "Int.abs"));
+        }
+        return List.copyOf(out);
     }
 
     /**
@@ -321,9 +338,8 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
         return out;
     }
 
-    private static String said(RuleCitation cited) {
-        return RuleHandleSurface.PROSE.render(
-                PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null);
+    private static String said(PublishedRuleHandle handle) {
+        return RuleHandleProse.said(handle, SourceNameResolver.identity(), null);
     }
 
     /**
@@ -336,11 +352,9 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
      */
     @Test
     void thePopulationHoldsEveryKindOfSentenceADocumentWrites() {
-        List<PublishedRuleHandle> handles = everyShapeOfSentence().stream()
-                .map(PublishedRuleHandle::of).toList();
+        List<PublishedRuleHandle> handles = everyHandle();
 
-        assertTrue(everyShapeOfSentence().stream().map(
-                        TwoHandlesADocumentWritesApartAreTwoValuesTest::said)
+        assertTrue(handles.stream().map(TwoHandlesADocumentWritesApartAreTwoValuesTest::said)
                 .distinct().count() > 1,
                 "a population a document writes one sentence for says nothing about telling two"
                         + " apart");
@@ -350,7 +364,8 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
                         PublishedRuleHandle.NamedEnsures.class,
                         PublishedRuleHandle.WholeEnsures.class,
                         PublishedRuleHandle.Written.class,
-                        PublishedRuleHandle.Reached.class),
+                        PublishedRuleHandle.Reached.class,
+                        PublishedRuleHandle.ReachedOutOfSight.class),
                 Set.of(PublishedRuleHandle.class.getPermittedSubclasses()),
                 "the kinds of sentence this type has");
         for (Class<?> each : PublishedRuleHandle.class.getPermittedSubclasses()) {

--- a/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.publish;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleCitation;
@@ -19,6 +20,7 @@ import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
 import souther.compiler.types.WrittenOwner;
 
 import java.util.ArrayList;
@@ -142,9 +144,22 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
         RuleRef.Named alsoNamed = new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 1),
                 Optional.of(new ClauseName("floor"))));
+        // A clause the author named nothing, which a reader counts to, and the two sentences an
+        // `ensures` has: the words the author gave the clause, and a clause over every answer that
+        // the behavior's name is the whole of.
+        RuleRef.Named counted = new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 2),
+                Optional.empty()));
+        RuleRef.Named clauseOfAnEnsures = new RuleRef.Ensures(
+                new BehaviorContract.RuleId(new ValueName.Behavior("m", "b"), 0, 0, null), "c");
+        RuleRef.Named everyAnswer = new RuleRef.Ensures(
+                new BehaviorContract.RuleId(new ValueName.Behavior("m", "b"), 0, 0, null), "");
         List<RuleCitation> out = new ArrayList<>(List.of(
                 new RuleCitation.Named(named),
                 new RuleCitation.Named(alsoNamed),
+                new RuleCitation.Named(counted),
+                new RuleCitation.Named(clauseOfAnEnsures),
+                new RuleCitation.Named(everyAnswer),
                 new RuleCitation.WrittenAt(COMPARISON, AT),
                 new RuleCitation.WrittenAt(PREDICATE, AT),
                 new RuleCitation.WrittenAt(COMPARISON,
@@ -198,20 +213,20 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
                 new PublishedRuleHandle.Place.Unplaced(1, 1);
         PublishedRuleHandle.Place there =
                 new PublishedRuleHandle.Place.Unplaced(2, 1);
-        PublishedRuleHandle.Reached said =
-                new PublishedRuleHandle.Reached("comparison", here, "Int.clamp");
+        PublishedRuleHandle.Reached said = new PublishedRuleHandle.Reached(
+                PublishedRuleKind.COMPARISON, here, "Int.clamp");
 
-        assertNotEquals(0, Integer.signum(said.compareTo(
-                        new PublishedRuleHandle.Reached("predicate", here, "Int.clamp"))),
+        assertNotEquals(0, Integer.signum(said.compareTo(new PublishedRuleHandle.Reached(
+                        PublishedRuleKind.PREDICATE, here, "Int.clamp"))),
                 "what the rule is");
-        assertNotEquals(0, Integer.signum(said.compareTo(
-                        new PublishedRuleHandle.Reached("comparison", there, "Int.clamp"))),
+        assertNotEquals(0, Integer.signum(said.compareTo(new PublishedRuleHandle.Reached(
+                        PublishedRuleKind.COMPARISON, there, "Int.clamp"))),
                 "where the code is");
-        assertNotEquals(0, Integer.signum(said.compareTo(
-                        new PublishedRuleHandle.Reached("comparison", here, "Int.abs"))),
+        assertNotEquals(0, Integer.signum(said.compareTo(new PublishedRuleHandle.Reached(
+                        PublishedRuleKind.COMPARISON, here, "Int.abs"))),
                 "and what reaches it");
-        assertEquals(0, said.compareTo(
-                        new PublishedRuleHandle.Reached("comparison", here, "Int.clamp")),
+        assertEquals(0, said.compareTo(new PublishedRuleHandle.Reached(
+                        PublishedRuleKind.COMPARISON, here, "Int.clamp")),
                 "and two alike in every part are one value");
     }
 
@@ -232,7 +247,7 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
 
         String of(PublishedRuleHandle.Reached said) {
             return switch (this) {
-                case WHAT_THE_RULE_IS -> said.kind();
+                case WHAT_THE_RULE_IS -> said.kind().word();
                 case WHERE_THE_CODE_IS -> said.at().toString();
                 case WHAT_REACHES_IT -> said.reachedBy();
             };
@@ -307,7 +322,8 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
     }
 
     private static String said(RuleCitation cited) {
-        return cited.said(SourceNameResolver.identity(), null);
+        return RuleHandleSurface.PROSE.render(
+                PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null);
     }
 
     /**
@@ -329,10 +345,14 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
                 "a population a document writes one sentence for says nothing about telling two"
                         + " apart");
         assertEquals(
-                Set.of(PublishedRuleHandle.Named.class, PublishedRuleHandle.Written.class,
+                Set.of(PublishedRuleHandle.NamedInvariant.class,
+                        PublishedRuleHandle.NumberedInvariant.class,
+                        PublishedRuleHandle.NamedEnsures.class,
+                        PublishedRuleHandle.WholeEnsures.class,
+                        PublishedRuleHandle.Written.class,
                         PublishedRuleHandle.Reached.class),
                 Set.of(PublishedRuleHandle.class.getPermittedSubclasses()),
-                "the three kinds of sentence this type has");
+                "the kinds of sentence this type has");
         for (Class<?> each : PublishedRuleHandle.class.getPermittedSubclasses()) {
             assertTrue(handles.stream().anyMatch(each::isInstance),
                     () -> "and each of them is in what the property above is asked over: " + each);

--- a/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
@@ -12,7 +12,7 @@ import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.publish.PublishedRuleHandle;
 import souther.compiler.publish.PublishedRuleKind;
-import souther.compiler.publish.RuleHandleSurface;
+import souther.compiler.publish.RuleHandleProse;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeKey;
@@ -119,7 +119,7 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
             }
             RuleCitation cited = new RuleCitation.WrittenAt(written,
                     Citation.of(new SourcePos(1, 1)));
-            String said = RuleHandleSurface.PROSE.render(
+            String said = RuleHandleProse.said(
                     PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null);
 
             assertEquals(AdequacyReport.schemaRuleKind(each),
@@ -151,7 +151,7 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
             }
             RuleCitation cited = new RuleCitation.Named(named);
 
-            assertEquals(named.citedName(), RuleHandleSurface.PROSE.render(
+            assertEquals(named.citedName(), RuleHandleProse.said(
                             PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null),
                     () -> "a rule with a name is cited by it: " + each);
             assertTrue(!named.citedName().isBlank(),

--- a/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
@@ -10,6 +10,9 @@ import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.publish.PublishedRuleHandle;
+import souther.compiler.publish.PublishedRuleKind;
+import souther.compiler.publish.RuleHandleSurface;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeKey;
@@ -116,12 +119,21 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
             }
             RuleCitation cited = new RuleCitation.WrittenAt(written,
                     Citation.of(new SourcePos(1, 1)));
-            String said = cited.said(SourceNameResolver.identity(), null);
+            String said = RuleHandleSurface.PROSE.render(
+                    PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null);
 
             assertEquals(AdequacyReport.schemaRuleKind(each),
                     said.substring(0, said.indexOf('@')),
                     () -> "the word a reader is shown and the word a document groups by, for "
                             + each);
+            assertEquals(AdequacyReport.schemaRuleKind(each),
+                    PublishedRuleKind.of(written).word(),
+                    () -> "and the word the handle is built from is that same word, for " + each);
+            // And the word a diagnostic says of the rule, which is a third surface: a reader met by
+            // a sentence about a comparison and sent to a handle that calls it something else is
+            // reading about two rules.
+            assertEquals(PublishedRuleKind.of(written).word(), written.whatItIs(),
+                    () -> "and the word a diagnostic says of it, for " + each);
         }
     }
 
@@ -139,7 +151,8 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
             }
             RuleCitation cited = new RuleCitation.Named(named);
 
-            assertEquals(named.citedName(), cited.said(SourceNameResolver.identity(), null),
+            assertEquals(named.citedName(), RuleHandleSurface.PROSE.render(
+                            PublishedRuleHandle.of(cited), SourceNameResolver.identity(), null),
                     () -> "a rule with a name is cited by it: " + each);
             assertTrue(!named.citedName().isBlank(),
                     () -> "and there is a name to cite it by: " + each);


### PR DESCRIPTION
Closes #1390.

The schema described the handle a document sends a reader to a rule by as
`if@<source>:<line>:<column>`. The writer stopped saying `if` before the
first schema version that shipped, so no document of any version could have
carried that shape. A field of free text was the one part of this contract
nothing was reading back: which keys a document may carry is held against the
writer, and so is every enumerated word, and what a rendered string reads as
was held nowhere. Two neighbouring fields carried the same false sentence,
each written out separately, and a new version is made by copying the file
before it.

Two other descriptions were false the same way, and for the same reason. A
finding's subject was given an example with no source in it, which no
document can write. A boundary's origin was said to be named by the construct
the author wrote the rule in, which stopped being how a rule is named in the
same change that took `if` out.

## What the handle is now

The sentence had two spellings and drew its words from three places: the
citation wrote the word and the join, a line's origin wrote its own version
of the same sentence for the border it drew, and the word in front of a place
came off the rule while the document's own word for the same kind came off
the report. The publishing layer owns the sentence now, and it is the only
thing that can write one.

Its forms divide the way the sentences divide rather than the way the
internal seal does. A clause the author named and a clause a reader counts to
are one arm of the rule and two sentences; so are a clause of an `ensures`
and one stating a rule over every answer. Walked for the internal division,
the forms a contract has to describe come out short by exactly the ones a
value decides — which is how the schema came to promise one shape for a field
that writes several. The word in front of a place is a published vocabulary
of its own, so renaming what holds such a rule inside the compiler moves
nothing a consumer reads.

## What holds it

A canonical definition says the forms once, with an example of each, and the
fields that carry a handle refer to it. A check renders one sentence per form
of the grammar and asks the contract for those examples and no others, and
asks its prose to say each of them — so a machine-readable half that is right
beside a sentence nine versions old fails here.

Which fields carry a handle is asked of the writer and of the schema and
compared by where the schema declares each field. Two fields of one name are
two fields, which a set of names could not say. Nothing outside the
publishing layer can spell a handle, so a field that carries one cannot be
added without naming itself.

## The earlier versions

They carry the same false sentence, and no document of any of them could have
matched it, so it is corrected where it stands rather than versioned. The
check reads the version this compiler writes: a word that moves with a
version leaves the older schema right about the documents it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)