### PR TITLE
Read what a choice's width rests on off its alternatives, not off what they took in

### DIFF
--- a/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * <p>Two things are owed about it and they are not the same thing. A position has to be told that
  * it may be wider than the rules leave it, and the account of a rule has to send an author to the
- * choice they wrote. Both are projections of one decision — which alternative went unread and what
- * the one beside it left — and the decision can only be made where the alternatives are what stands
- * between the brackets, because a conjunction written beside a choice is distributed into both of
- * them before the values are worked out.
+ * choice they wrote. Both are projections of one decision — which alternative went unread and which
+ * of them the width of the choice rests on — and the decision can only be made where the
+ * alternatives are what stands between the brackets, because a conjunction written beside a choice
+ * is distributed into both of them before the values are worked out.
  *
  * <p>So each side receiving the answer is the shape being held. Read off the call sites, because
  * that is what the rule is about: nothing in a type stops a carrier that holds two branches and a
@@ -26,11 +26,14 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
 
     private static final String OPENING = "souther.compiler.check.StatedByClauses$AlternativeOpening";
 
+    private static final String OUTCOME = "souther.compiler.check.Settlement$OfAChoice";
+
     /** The one method that answers what a choice left open, out of what its alternatives took in. */
     private static final String AUTHORITY =
             "souther.compiler.check.StatedByClauses#opens"
-                    + "(Lsouther/compiler/check/ChoiceId;Lsouther/compiler/check/Adoption;"
-                    + "Lsouther/compiler/check/Adoption;)"
+                    + "(Lsouther/compiler/check/ChoiceId;"
+                    + "Lsouther/compiler/check/Settlement$WidthDependency;"
+                    + "Lsouther/compiler/check/Adoption;Lsouther/compiler/check/Adoption;)"
                     + "Lsouther/compiler/check/StatedByClauses$AlternativeOpening;";
 
     /**
@@ -42,16 +45,75 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
      */
     @Test
     void oneMethodDecidesWhatAChoiceLeftOpen() throws Exception {
-        List<String> made = new ArrayList<>();
-        for (Compiled.Site site : Compiled.sites()) {
-            if (site.makesA(OPENING)) {
-                made.add(site.at());
-            }
-        }
-
-        assertEquals(List.of(AUTHORITY), made.stream().distinct().sorted().toList(),
+        assertEquals(List.of(AUTHORITY), whatMakes(OPENING),
                 "which positions a choice left open is answered somewhere else as well, or nowhere"
                         + " — and a second answer holds only until a conjunction stands beside a"
                         + " choice and the two are asked of different branches");
+    }
+
+    /**
+     * And the fate of a choice's branches and what its width rests on are made together.
+     *
+     * <p>The two are read by one caller about one pair of branches, and a place making one of them
+     * without the other is a place that has decided something about a choice on its own. Made at
+     * one site, a reader holding an outcome holds both — including in the branch of the settlement
+     * where the descriptions decide a choice before anything is worked out, which is where the
+     * second answer would have been.
+     *
+     * <p>Taking one more occurrence of the same choice in is the other, and it decides nothing: it
+     * is handed two outcomes about the two branches and joins each side with the same side.
+     */
+    @Test
+    void aFateAndTheWidthItGoesWithAreMadeAtOneSite() throws Exception {
+        assertEquals(List.of(
+                        "souther.compiler.check.Settlement$OfAChoice#alsoSeen"
+                                + "(Lsouther/compiler/check/Settlement$OfAChoice;)"
+                                + "Lsouther/compiler/check/Settlement$OfAChoice;",
+                        "souther.compiler.check.StatedByClauses$Reading#outcome"
+                                + "(Lsouther/compiler/check/StatedTogether$Said;"
+                                + "Lsouther/compiler/check/Settlement$Sided;"
+                                + "Lsouther/compiler/check/StatedTogether$Said;"
+                                + "Lsouther/compiler/check/Settlement$Sided;)"
+                                + "Lsouther/compiler/check/Settlement$OfAChoice;"),
+                whatMakes(OUTCOME),
+                "a choice's outcome is made somewhere else as well, and there is nothing to make"
+                        + " one of them carry the other's answer about the same two branches");
+    }
+
+    /**
+     * And nothing outside the answer itself works out which alternative a width rests on.
+     *
+     * <p>The comparison is four lines over two descriptions, which is exactly what a caller holding
+     * two branches would write for itself — and a second one of them would be read as the same fact
+     * while resting on whichever pair of branches its writer had in hand. Held here, the account
+     * takes the answer and asks nothing about values.
+     */
+    @Test
+    void whatAWidthRestsOnIsWorkedOutNowhereElse() throws Exception {
+        assertEquals(List.of(
+                        "souther.compiler.check.Settlement$WidthDependency#alsoSeen"
+                                + "(Lsouther/compiler/check/Settlement$WidthDependency;)"
+                                + "Lsouther/compiler/check/Settlement$WidthDependency;",
+                        "souther.compiler.check.Settlement$WidthDependency#none"
+                                + "()Lsouther/compiler/check/Settlement$WidthDependency;",
+                        "souther.compiler.check.Settlement$WidthDependency#of"
+                                + "(Lsouther/compiler/values/Emptiness;"
+                                + "Lsouther/compiler/values/PlannedValues;"
+                                + "Lsouther/compiler/values/Emptiness;"
+                                + "Lsouther/compiler/values/PlannedValues;)"
+                                + "Lsouther/compiler/check/Settlement$WidthDependency;"),
+                whatMakes("souther.compiler.check.Settlement$WidthDependency"),
+                "somewhere else makes one, and what it made is not what the settlement compared");
+    }
+
+    /** Every method that makes a value of {@code type}, each named once. */
+    private static List<String> whatMakes(String type) throws Exception {
+        List<String> made = new ArrayList<>();
+        for (Compiled.Site site : Compiled.sites()) {
+            if (site.makesA(type)) {
+                made.add(site.at());
+            }
+        }
+        return made.stream().distinct().sorted().toList();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -64,55 +64,64 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
     }
 
     /**
-     * Which positions a choice is as wide as it is because of one of its alternatives.
+     * Which positions a choice may be as wide as it is at because of one of its alternatives.
      *
      * <p>A relation between two branches and not an attribute of one, which is why it is here
-     * rather than in {@link Sided}: {@code onLeft} is read off what the <em>right</em> branch
-     * leaves, and the other way round.
+     * rather than in {@link Sided}: what may rest on the left is read off what the <em>right</em>
+     * branch leaves, and the other way round.
      *
-     * <p>A position is on a branch where the choice without that branch is not what the choice
-     * with it is. Since a choice admits whatever either of its branches admits, the one is
-     * contained in the other, and being different is being narrower — so this is asked as an
-     * equality of what the two descriptions were normalised to and needs no set arithmetic of its
-     * own. Descriptions that state one thing two ways come out different and the position is kept:
-     * what this is read for is whether a branch that may turn out to hold nothing is why an answer
-     * is as wide as it is, and keeping a position no branch was really answerable for costs a
-     * reading that could have spoken for it, while dropping one hands out an answer as exact when
-     * it is not.
+     * <p><b>What a member and a non-member each say, which is not the same strength.</b> Write
+     * {@code D} for the positions where the choice without a branch truly leaves less than the
+     * choice with it. A position left out is one where the two are the same set and dropping the
+     * branch changes nothing — that is proven. A position kept is one where nothing here proved
+     * them the same, which is weaker than their differing: two descriptions of one set written
+     * differently are kept apart. So {@code D} is contained in what is held and is not what is
+     * held, and a reader may take a non-member as a fact and a member only as a question nobody
+     * settled. Read the other way, a position no alternative was really answerable for would be
+     * published as one an author has to look at.
+     *
+     * <p>Which is what the comparison can be an equality of normalised descriptions and cost
+     * nothing. A choice admits whatever either of its branches admits, so what it leaves without
+     * one of them is contained in what it leaves with both, and equal descriptions are the same
+     * set — the proof runs in the direction a non-member is read in, and no machine is built to
+     * decide the other.
      *
      * <p><b>An occurrence at a time, and a union over them.</b> The same written choice stands
      * wherever a conjunction beside it was distributed in, and a branch dropped is dropped at every
-     * one of them — so a position any occurrence's width depends on is one the whole answer's does.
-     * Union is associative, commutative and idempotent, which is what lets the order the copies are
-     * met in stay out of the answer. An occurrence one branch of which admits nothing is not a
-     * choice there at all and contributes neither side.
+     * one of them — so a position any occurrence's width may rest on is one the whole answer's
+     * may. Union is associative, commutative and idempotent, which is what lets the order the
+     * copies are met in stay out of the answer, and it is the second reason a member is a question
+     * rather than a fact: an occurrence's own widening can be covered by what another occurrence
+     * leaves. An occurrence one branch of which admits nothing is not a choice there at all and
+     * contributes neither side.
      *
-     * @param onLeft  the positions the choice would leave narrower without its left alternative
-     * @param onRight the same for the right
+     * @param mayRestOnLeft  the positions where the choice without its left alternative was not
+     *                       shown to leave what the choice with it leaves
+     * @param mayRestOnRight the same for the right
      */
-    record WidthDependency(Set<FactSubject> onLeft, Set<FactSubject> onRight) {
+    record WidthDependency(Set<FactSubject> mayRestOnLeft, Set<FactSubject> mayRestOnRight) {
 
         WidthDependency {
-            onLeft = Set.copyOf(onLeft);
-            onRight = Set.copyOf(onRight);
+            mayRestOnLeft = Set.copyOf(mayRestOnLeft);
+            mayRestOnRight = Set.copyOf(mayRestOnRight);
         }
 
-        /** A choice whose width no alternative of it is answerable for. */
+        /** A choice shown to leave what it leaves without either of its alternatives. */
         static WidthDependency none() {
             return new WidthDependency(Set.of(), Set.of());
         }
 
         /**
-         * What one occurrence of a choice between these two branches is as wide as it is because
-         * of, read off the descriptions and building nothing.
+         * What one occurrence of a choice between these two branches may be as wide as it is
+         * because of, read off the descriptions and building nothing.
          *
          * <p>Over the positions either of them narrowed, since a position neither did is one both
          * of them leave at every value and so is the choice, with or without either.
          *
          * <p><b>Nothing where either branch admits nothing here.</b> There is no choice at such an
-         * occurrence — what it leaves is the branch beside the dead one — so neither alternative is
-         * why it is as wide as it is. Another occurrence of the same written choice may still be
-         * one both branches stand at, and what that one's width rests on is joined in beside this
+         * occurrence — what it leaves is the branch beside the dead one — so its width rests on
+         * neither alternative. Another occurrence of the same written choice may still be one both
+         * branches stand at, and what that one's width may rest on is joined in beside this
          * ({@link #alsoSeen}): a branch is dead for the author only where nobody can be in it
          * anywhere, and that is not this occurrence's to say.
          */
@@ -124,30 +133,33 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
                     || there == souther.compiler.values.Emptiness.EMPTY) {
                 return none();
             }
-            Set<FactSubject> onLeft = new LinkedHashSet<>();
-            Set<FactSubject> onRight = new LinkedHashSet<>();
+            Set<FactSubject> mayRestOnLeft = new LinkedHashSet<>();
+            Set<FactSubject> mayRestOnRight = new LinkedHashSet<>();
             Set<FactSubject> narrowed = new LinkedHashSet<>(one.adoptedAt());
             narrowed.addAll(other.adoptedAt());
             for (FactSubject position : narrowed) {
                 AdmittedPlan left = one.at(position);
                 AdmittedPlan right = other.at(position);
                 AdmittedPlan joined = AdmittedPlan.joining(List.of(left, right));
+                // Equal descriptions are one set, so this side of each is a proof that dropping
+                // the branch leaves the position where it was. Unequal ones are not a proof of
+                // anything, and the position is kept as one nobody settled.
                 if (!right.equals(joined)) {
-                    onLeft.add(position);
+                    mayRestOnLeft.add(position);
                 }
                 if (!left.equals(joined)) {
-                    onRight.add(position);
+                    mayRestOnRight.add(position);
                 }
             }
-            return new WidthDependency(onLeft, onRight);
+            return new WidthDependency(mayRestOnLeft, mayRestOnRight);
         }
 
         /** The width of one more occurrence of the same choice, taken in beside this. */
         WidthDependency alsoSeen(WidthDependency occurrence) {
-            Set<FactSubject> left = new LinkedHashSet<>(onLeft);
-            left.addAll(occurrence.onLeft());
-            Set<FactSubject> right = new LinkedHashSet<>(onRight);
-            right.addAll(occurrence.onRight());
+            Set<FactSubject> left = new LinkedHashSet<>(mayRestOnLeft);
+            left.addAll(occurrence.mayRestOnLeft());
+            Set<FactSubject> right = new LinkedHashSet<>(mayRestOnRight);
+            right.addAll(occurrence.mayRestOnRight());
             return new WidthDependency(left, right);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -1,9 +1,12 @@
 package souther.compiler.check;
 
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realized;
 import souther.compiler.values.UnreadReason;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,13 +45,110 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
         return confinement.made();
     }
 
-    /** Both branches of one written choice, each aggregated over its occurrences. */
-    record OfAChoice(Sided left, Sided right) {
+    /**
+     * Both branches of one written choice, each aggregated over its occurrences, and what the
+     * width of the choice depends on.
+     *
+     * <p>Made together and never apart. A fate says whether anybody can be in a branch; the
+     * dependency says which positions would be narrower without one. A reader deciding what an
+     * alternative nothing could read left open needs both about the same two branches, and made in
+     * two places they would be two answers to one question.
+     */
+    record OfAChoice(Sided left, Sided right, WidthDependency width) {
 
         /** This choice with one more occurrence of it taken in, side by side. */
         OfAChoice alsoSeen(OfAChoice occurrence) {
             return new OfAChoice(left.alsoSeen(occurrence.left()),
-                    right.alsoSeen(occurrence.right()));
+                    right.alsoSeen(occurrence.right()), width.alsoSeen(occurrence.width()));
+        }
+    }
+
+    /**
+     * Which positions a choice is as wide as it is because of one of its alternatives.
+     *
+     * <p>A relation between two branches and not an attribute of one, which is why it is here
+     * rather than in {@link Sided}: {@code onLeft} is read off what the <em>right</em> branch
+     * leaves, and the other way round.
+     *
+     * <p>A position is on a branch where the choice without that branch is not what the choice
+     * with it is. Since a choice admits whatever either of its branches admits, the one is
+     * contained in the other, and being different is being narrower — so this is asked as an
+     * equality of what the two descriptions were normalised to and needs no set arithmetic of its
+     * own. Descriptions that state one thing two ways come out different and the position is kept:
+     * what this is read for is whether a branch that may turn out to hold nothing is why an answer
+     * is as wide as it is, and keeping a position no branch was really answerable for costs a
+     * reading that could have spoken for it, while dropping one hands out an answer as exact when
+     * it is not.
+     *
+     * <p><b>An occurrence at a time, and a union over them.</b> The same written choice stands
+     * wherever a conjunction beside it was distributed in, and a branch dropped is dropped at every
+     * one of them — so a position any occurrence's width depends on is one the whole answer's does.
+     * Union is associative, commutative and idempotent, which is what lets the order the copies are
+     * met in stay out of the answer. An occurrence one branch of which admits nothing is not a
+     * choice there at all and contributes neither side.
+     *
+     * @param onLeft  the positions the choice would leave narrower without its left alternative
+     * @param onRight the same for the right
+     */
+    record WidthDependency(Set<FactSubject> onLeft, Set<FactSubject> onRight) {
+
+        WidthDependency {
+            onLeft = Set.copyOf(onLeft);
+            onRight = Set.copyOf(onRight);
+        }
+
+        /** A choice whose width no alternative of it is answerable for. */
+        static WidthDependency none() {
+            return new WidthDependency(Set.of(), Set.of());
+        }
+
+        /**
+         * What one occurrence of a choice between these two branches is as wide as it is because
+         * of, read off the descriptions and building nothing.
+         *
+         * <p>Over the positions either of them narrowed, since a position neither did is one both
+         * of them leave at every value and so is the choice, with or without either.
+         *
+         * <p><b>Nothing where either branch admits nothing here.</b> There is no choice at such an
+         * occurrence — what it leaves is the branch beside the dead one — so neither alternative is
+         * why it is as wide as it is. Another occurrence of the same written choice may still be
+         * one both branches stand at, and what that one's width rests on is joined in beside this
+         * ({@link #alsoSeen}): a branch is dead for the author only where nobody can be in it
+         * anywhere, and that is not this occurrence's to say.
+         */
+        static WidthDependency of(souther.compiler.values.Emptiness here,
+                                  PlannedValues<FactSubject> one,
+                                  souther.compiler.values.Emptiness there,
+                                  PlannedValues<FactSubject> other) {
+            if (here == souther.compiler.values.Emptiness.EMPTY
+                    || there == souther.compiler.values.Emptiness.EMPTY) {
+                return none();
+            }
+            Set<FactSubject> onLeft = new LinkedHashSet<>();
+            Set<FactSubject> onRight = new LinkedHashSet<>();
+            Set<FactSubject> narrowed = new LinkedHashSet<>(one.adoptedAt());
+            narrowed.addAll(other.adoptedAt());
+            for (FactSubject position : narrowed) {
+                AdmittedPlan left = one.at(position);
+                AdmittedPlan right = other.at(position);
+                AdmittedPlan joined = AdmittedPlan.joining(List.of(left, right));
+                if (!right.equals(joined)) {
+                    onLeft.add(position);
+                }
+                if (!left.equals(joined)) {
+                    onRight.add(position);
+                }
+            }
+            return new WidthDependency(onLeft, onRight);
+        }
+
+        /** The width of one more occurrence of the same choice, taken in beside this. */
+        WidthDependency alsoSeen(WidthDependency occurrence) {
+            Set<FactSubject> left = new LinkedHashSet<>(onLeft);
+            left.addAll(occurrence.onLeft());
+            Set<FactSubject> right = new LinkedHashSet<>(onRight);
+            right.addAll(occurrence.onRight());
+            return new WidthDependency(left, right);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -299,18 +299,19 @@ sealed interface StatedByClauses {
      * <p><b>Two sets and not one, because the two sides ask two questions of it.</b> An author has
      * to look at this choice wherever the alternative beside the unread one <em>reached</em> a
      * position, whether or not the answer there turned on it — that is a fact about clauses
-     * somebody wrote, and it is read off the tree that keeps their shape. A position is left wider
-     * than the rules only where the choice would be narrower without the unread alternative, which
-     * is a fact about values and is settled where the branches are. Made one,
+     * somebody wrote, and it is read off the tree that keeps their shape. A position is reported
+     * wider than the rules only where nothing showed the choice leaves it what it would without
+     * the unread alternative, which is a fact about values and is settled where the branches are
+     * ({@link Settlement.WidthDependency}). Made one,
      * {@code (P(a) && f(b)) || (P(a) && f(b))} came out with {@code a} reported wider than the
-     * rules hold it: both alternatives reached {@code a} and neither is why the choice is as wide
-     * there as it is.
+     * rules hold it: both alternatives reached {@code a}, and dropping either was shown to leave
+     * it where it was.
      *
      * @param byTheLeftGoingUnread  the positions the right alternative reached, where the left is
      *                              one nothing could read. Empty where it was read
      * @param byTheRightGoingUnread the same the other way round
-     * @param positions             the positions the choice is as wide as it is at because of an
-     *                              alternative nothing could read
+     * @param positions             the positions an alternative nothing could read was not shown
+     *                              to leave where they were
      */
     record AlternativeOpening(ChoiceId choice, Set<FactSubject> byTheLeftGoingUnread,
                               Set<FactSubject> byTheRightGoingUnread, Set<FactSubject> positions) {
@@ -338,11 +339,17 @@ sealed interface StatedByClauses {
      *
      * <p>Two questions and two sources, and neither answers the other's. Which alternative nothing
      * could read is a fact about the clause somebody wrote and is read off the tree that keeps that
-     * shape ({@link Adoption#dropped}). Whether the choice would be narrower without an alternative
-     * is a fact about the values, is worked out where the branches were settled, and arrives here
-     * decided ({@link Settlement.WidthDependency}) — asked of the positions each branch took in
-     * instead, the answer would be that a branch narrowing a position its neighbour narrows the
-     * same way is why the choice is as wide as it is.
+     * shape ({@link Adoption#dropped}). Whether anything showed the choice leaves a position what
+     * it would without an alternative is a fact about the values, is worked out where the branches
+     * were settled, and arrives here decided ({@link Settlement.WidthDependency}) — asked of the
+     * positions each branch took in instead, the answer would be that a branch narrowing a position
+     * its neighbour narrows the same way is why the choice is as wide as it is.
+     *
+     * <p>What arrives is the side a reader may act on: a position left out of it is one dropping
+     * the alternative was shown not to narrow, and one kept is one nobody settled. So a position
+     * this opens may be one the rules hold exactly where the reading says, and the cost of that is
+     * a reading declining to speak for a position it could have — never an answer handed out as
+     * exact when it is not.
      *
      * <p>Of the reading of values alone, which is the one a choice is asked of. Where a position's
      * order stops is not what an alternative takes back — a range says nothing about which values
@@ -352,10 +359,10 @@ sealed interface StatedByClauses {
                                     Adoption<FactSubject> one, Adoption<FactSubject> other) {
         Set<FactSubject> opened = new LinkedHashSet<>();
         if (one.dropped()) {
-            opened.addAll(width.onLeft());
+            opened.addAll(width.mayRestOnLeft());
         }
         if (other.dropped()) {
-            opened.addAll(width.onRight());
+            opened.addAll(width.mayRestOnRight());
         }
         return new AlternativeOpening(choice,
                 one.dropped() ? reachedBy(other) : Set.of(),

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -298,18 +298,19 @@ sealed interface StatedByClauses {
      *
      * <p><b>Two sets and not one, because the two sides ask two questions of it.</b> An author has
      * to look at this choice wherever the alternative beside the unread one <em>reached</em> a
-     * position, whether or not the reading could promise anything there — that is a fact about
-     * clauses somebody wrote. A position is left wider than the rules only where that alternative
-     * <em>promised</em> it something the unread one takes back; an alternative holding a clause
-     * nothing could read promises nothing, so it has nothing to be taken back and the position
-     * keeps whatever account it already had. Made one, {@code (P(a) && f(b)) || (P(a) && f(b))}
-     * came out with {@code a} reported wider than the rules hold it.
+     * position, whether or not the answer there turned on it — that is a fact about clauses
+     * somebody wrote, and it is read off the tree that keeps their shape. A position is left wider
+     * than the rules only where the choice would be narrower without the unread alternative, which
+     * is a fact about values and is settled where the branches are. Made one,
+     * {@code (P(a) && f(b)) || (P(a) && f(b))} came out with {@code a} reported wider than the
+     * rules hold it: both alternatives reached {@code a} and neither is why the choice is as wide
+     * there as it is.
      *
      * @param byTheLeftGoingUnread  the positions the right alternative reached, where the left is
      *                              one nothing could read. Empty where it was read
      * @param byTheRightGoingUnread the same the other way round
-     * @param positions             the positions the unread alternative left open, which is what
-     *                              the one beside it promised
+     * @param positions             the positions the choice is as wide as it is at because of an
+     *                              alternative nothing could read
      */
     record AlternativeOpening(ChoiceId choice, Set<FactSubject> byTheLeftGoingUnread,
                               Set<FactSubject> byTheRightGoingUnread, Set<FactSubject> positions) {
@@ -332,42 +333,34 @@ sealed interface StatedByClauses {
     }
 
     /**
-     * What one choice left open, out of what its two alternatives took in.
+     * What one choice left open, out of which of its alternatives went unread and what its width
+     * depends on.
      *
-     * <p>Over what each of them reached and did not merely settle: a position a dead branch settled
-     * is an answer, and an alternative nothing could read widens a constraint rather than an
-     * answer.
+     * <p>Two questions and two sources, and neither answers the other's. Which alternative nothing
+     * could read is a fact about the clause somebody wrote and is read off the tree that keeps that
+     * shape ({@link Adoption#dropped}). Whether the choice would be narrower without an alternative
+     * is a fact about the values, is worked out where the branches were settled, and arrives here
+     * decided ({@link Settlement.WidthDependency}) — asked of the positions each branch took in
+     * instead, the answer would be that a branch narrowing a position its neighbour narrows the
+     * same way is why the choice is as wide as it is.
      *
      * <p>Of the reading of values alone, which is the one a choice is asked of. Where a position's
      * order stops is not what an alternative takes back — a range says nothing about which values
      * stand anywhere, so a branch nothing read leaves the ranges beside it saying what they said.
      */
-    static AlternativeOpening opens(ChoiceId choice, Adoption<FactSubject> one,
-                                    Adoption<FactSubject> other) {
+    static AlternativeOpening opens(ChoiceId choice, Settlement.WidthDependency width,
+                                    Adoption<FactSubject> one, Adoption<FactSubject> other) {
         Set<FactSubject> opened = new LinkedHashSet<>();
         if (one.dropped()) {
-            opened.addAll(promisedBy(other));
+            opened.addAll(width.onLeft());
         }
         if (other.dropped()) {
-            opened.addAll(promisedBy(one));
+            opened.addAll(width.onRight());
         }
         return new AlternativeOpening(choice,
                 one.dropped() ? reachedBy(other) : Set.of(),
                 other.dropped() ? reachedBy(one) : Set.of(),
                 opened);
-    }
-
-    /**
-     * The positions an alternative promised something at, which is what an unread one beside it
-     * takes back.
-     *
-     * <p>Nothing where it holds a clause this could not read. What a branch promises is what it
-     * promises having read everything it was given, and a conjunct nothing could read is exactly
-     * what it was not given — so there is nothing there for the alternative beside it to widen, and
-     * whatever account the position has is its own.
-     */
-    private static Set<FactSubject> promisedBy(Adoption<FactSubject> of) {
-        return of.dropped() ? Set.of() : of.read();
     }
 
     /** The positions a reading reached and did not merely settle: what it constrained, and what it
@@ -661,16 +654,16 @@ sealed interface StatedByClauses {
                 // the dead branch would widen the met-together tree for nothing.
                 //
                 if (a == souther.compiler.values.Emptiness.EMPTY && b == souther.compiler.values.Emptiness.EMPTY) {
-                    decided.put(choice.id(), settled(mine, theirs));
+                    decided.put(choice.id(), settled(here, mine, there, theirs));
                     return new StatedTogether.Said(here.confinement().bothDead(there.confinement(),
                             Confinement.Admission.bothShown(mine, theirs)));
                 }
                 if (a == souther.compiler.values.Emptiness.EMPTY) {
-                    decided.put(choice.id(), settled(mine, theirs));
+                    decided.put(choice.id(), settled(here, mine, there, theirs));
                     return other;
                 }
                 if (b == souther.compiler.values.Emptiness.EMPTY) {
-                    decided.put(choice.id(), settled(mine, theirs));
+                    decided.put(choice.id(), settled(here, mine, there, theirs));
                     return one;
                 }
                 // Two live branches are another matter: merging them is the one decision a clause
@@ -681,7 +674,7 @@ sealed interface StatedByClauses {
                 // read, which is what admitted the declaration as APART at all.
                 if (alternatives == Alternatives.MERGED
                         && a == souther.compiler.values.Emptiness.NONEMPTY && b == souther.compiler.values.Emptiness.NONEMPTY) {
-                    decided.put(choice.id(), settled(mine, theirs));
+                    decided.put(choice.id(), settled(here, mine, there, theirs));
                     return new StatedTogether.Said(
                             either(here.confinement(), there.confinement()));
                 }
@@ -692,10 +685,34 @@ sealed interface StatedByClauses {
         }
 
         /** The fate of a choice the descriptions alone decided, for the account to read. */
-        private static Settlement.OfAChoice settled(Confinement.Admission<FactSubject> one,
-                                                    Confinement.Admission<FactSubject> other) {
-            return new Settlement.OfAChoice(Settlement.Sided.settledAs(one),
-                    Settlement.Sided.settledAs(other));
+        private static Settlement.OfAChoice settled(StatedTogether.Said one,
+                                                    Confinement.Admission<FactSubject> mine,
+                                                    StatedTogether.Said other,
+                                                    Confinement.Admission<FactSubject> theirs) {
+            return outcome(one, Settlement.Sided.settledAs(mine),
+                    other, Settlement.Sided.settledAs(theirs));
+        }
+
+        /**
+         * What one occurrence of a choice came to: the fate of both branches and what the width of
+         * the choice depends on.
+         *
+         * <p>The one place either is made. Both are about the same two branches and a reader of one
+         * needs the other, so a second place making one of them would be a second answer to the
+         * question this compiler has just answered — which is what the fates are gathered here to
+         * avoid.
+         *
+         * <p>What the fates come to is the width's to read: an occurrence one branch of which
+         * admits nothing is no choice there, and what that leaves the width resting on is stated
+         * where the width is ({@link Settlement.WidthDependency#of}).
+         */
+        private static Settlement.OfAChoice outcome(StatedTogether.Said one,
+                                                    Settlement.Sided here,
+                                                    StatedTogether.Said other,
+                                                    Settlement.Sided there) {
+            return new Settlement.OfAChoice(here, there,
+                    Settlement.WidthDependency.of(here.emptiness(), one.confinement().values(),
+                            there.emptiness(), other.confinement().values()));
         }
 
         /**
@@ -733,7 +750,7 @@ sealed interface StatedByClauses {
                     StatedTogether.Said other = settling(it.right(), by, outcomes);
                     Settlement.Sided here = probed(one, by);
                     Settlement.Sided there = probed(other, by);
-                    outcomes.merge(it.id(), new Settlement.OfAChoice(here, there),
+                    outcomes.merge(it.id(), outcome(one, here, other, there),
                             Settlement.OfAChoice::alsoSeen);
                     yield decided(one, here, other, there);
                 }
@@ -1000,7 +1017,8 @@ sealed interface StatedByClauses {
                     Taken beside = keptAs(other, fate.right());
                     yield live.either(
                             new RuleShortfall.Site.AtAChoice(it.id(), it.writtenAt().pos()),
-                            opens(it.id(), live.took().byValues(), beside.took().byValues()),
+                            opens(it.id(), fate.width(), live.took().byValues(),
+                                    beside.took().byValues()),
                             beside);
                 }
             };

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -233,13 +233,15 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
      *
      * <p>Two answers of one decision, and they are not the same set. An author has to look at the
      * choice wherever the alternative beside the unread one reached a position; a position is
-     * reported wider than the rules only where that alternative promised it something. What neither
-     * of them holds is a position the alternative merely settled — a branch nobody can be in
-     * settles what it named, and a choice imposes nothing extra there.
+     * reported wider than the rules only where the choice would be narrower without the unread
+     * alternative, which is settled where the values are and arrives here. What neither of them
+     * holds is a position the alternative merely settled — a branch nobody can be in settles what
+     * it named, and a choice imposes nothing extra there.
      */
     @Test
-    void whatAChoiceLeftOpenIsWhatTheAlternativeBesideTheUnreadOneReachedAndPromised() {
+    void whatAChoiceLeftOpenIsWhatTheAlternativeBesideTheUnreadOneReachedAndWidened() {
         StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
+                new Settlement.WidthDependency(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
                 theBranchRead(java.util.Set.of()).byValues(),
                 theBranchNothingRead(java.util.Set.of()).byValues());
 
@@ -247,26 +249,48 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 "an author is sent here about the position the branch beside it constrained, and"
                         + " not about the one it settled");
         assertEquals(java.util.Set.of(CONSTRAINED), opened.positions(),
-                "and the position hears about it for the same reason");
+                "and the position hears about it, the width there being the unread branch's");
         assertEquals(java.util.Set.of(), opened.byTheLeftGoingUnread(),
                 "the left alternative was read, so nothing is open by its going unread");
     }
 
     /**
-     * And an alternative holding a clause nothing could read promises nothing.
+     * A position neither alternative is why the choice is wide at is one the choice can still speak
+     * for, however many of them went unread.
      *
-     * <p>What a branch promises is what it promises having read everything it was given, so a
-     * choice between two such branches leaves the positions whatever account they already had —
-     * {@code (P(a) && f(b)) || (P(a) && f(b))} holds {@code a} exactly where {@code P} does.
+     * <p>{@code (P(a) && f(b)) || (P(a) && f(b))} holds {@code a} exactly where {@code P} does:
+     * either branch dropped leaves the other saying the same thing there, so nothing about
+     * {@code a} rests on the branch that may hold nothing.
      */
     @Test
-    void anAlternativeHoldingSomethingUnreadPromisesNothingForTheOtherToTakeBack() {
+    void aPositionNoAlternativeWidenedIsNotOpenedByEitherOfThemGoingUnread() {
         StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
+                Settlement.WidthDependency.none(),
                 theBranchNothingRead(java.util.Set.of()).byValues(),
                 theBranchNothingRead(java.util.Set.of()).byValues());
 
         assertEquals(java.util.Set.of(), opened.positions(),
-                "neither alternative promised anything, so neither has anything taken back");
+                "the choice is as wide as it is at every position without either of them");
+    }
+
+    /**
+     * And where one of two unread alternatives is what the width rests on, the position is opened.
+     *
+     * <p>The rule holds of a choice neither alternative of which was read whole, as it holds of one
+     * where the branch beside the unread one was: {@code (a == A && f(b)) || f(b)} leaves {@code a}
+     * at every value only because the right branch is one this compiler cannot show anybody is in.
+     * Answered off what the branches took in, both of them holding a clause nothing read would say
+     * neither promised anything, and the reading would speak for {@code a}.
+     */
+    @Test
+    void whereTwoUnreadAlternativesAreOneTheWidthRestsOnThePositionIsStillOpened() {
+        StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
+                new Settlement.WidthDependency(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
+                theBranchNothingRead(java.util.Set.of()).byValues(),
+                theBranchNothingRead(java.util.Set.of()).byValues());
+
+        assertEquals(java.util.Set.of(CONSTRAINED), opened.positions(),
+                "the right alternative is why the choice is that wide, and nothing read it");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
@@ -43,6 +43,11 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
         return PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.allBut(A)));
     }
 
+    /** {@code other == A}. */
+    private static PlannedValues<FactSubject> otherIsA() {
+        return PlannedValues.at(OTHER, AdmittedPlan.of(ValueSet.just(A)));
+    }
+
     /** A rule this reading has no word for, naming the positions it is about. */
     private static PlannedValues<FactSubject> unread(Set<FactSubject> named) {
         return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
@@ -129,18 +134,21 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
     }
 
     /**
-     * A position neither alternative is about is on neither, whatever they do to the one they are
-     * about.
+     * The width is asked at each position on its own, and a branch answerable for one is not
+     * answerable for the next.
      *
-     * <p>It holds every value with or without either of them, so no alternative is why the choice
-     * says nothing there. Asked over the positions either branch narrowed, it is never asked at
-     * all.
+     * <p>Two alternatives that narrow one position apart and another alike: dropping either leaves
+     * the first wider than it was and the second exactly where it was. Answered for the branch
+     * rather than for each of its positions, a branch that is why a choice is wide anywhere would
+     * be why it is wide everywhere it spoke.
      */
     @Test
-    void aPositionNeitherAlternativeIsAboutIsOnNeither() {
-        Settlement.WidthDependency width = between(isA(), notA());
+    void aBranchAnswerableForOnePositionIsNotAnswerableForTheNext() {
+        Settlement.WidthDependency width = between(isA().meet(otherIsA()),
+                notA().meet(otherIsA()));
 
-        assertEquals(Set.of(VALUE), width.onLeft(), "the position they are about is on both");
+        assertEquals(Set.of(VALUE), width.onLeft(),
+                "other is A under either alternative, so neither is why the choice leaves it so");
         assertEquals(Set.of(VALUE), width.onRight());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
@@ -1,0 +1,192 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
+import souther.compiler.values.UnreadReason;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which of a choice's alternatives its width rests on is read off what they leave.
+ *
+ * <p>A choice admits whatever either of its alternatives admits, so what it leaves without one of
+ * them is contained in what it leaves with both: differing there is being narrower, and a position
+ * the two of them leave alike is one neither alternative is answerable for the width of. That is
+ * the whole rule, and it is the same rule whether one alternative was read whole, both were, or
+ * neither — which is what lets the account ask a single question of it.
+ *
+ * <p>Asked of the descriptions and answered by their normal forms. Nothing is built to answer it,
+ * so a choice costs no more for being asked; two descriptions of one set that were written
+ * differently come out apart, and the position is kept as one the width may rest on.
+ */
+class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
+
+    private static final Term.Interner NAMES = new Term.Interner();
+    private static final FactSubject VALUE = FactSubject.of(NAMES.written("value"));
+    private static final FactSubject OTHER = FactSubject.of(NAMES.written("other"));
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    /** {@code value == A}. */
+    private static PlannedValues<FactSubject> isA() {
+        return PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.just(A)));
+    }
+
+    /** {@code value /= A}. */
+    private static PlannedValues<FactSubject> notA() {
+        return PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.allBut(A)));
+    }
+
+    /** A rule this reading has no word for, naming the positions it is about. */
+    private static PlannedValues<FactSubject> unread(Set<FactSubject> named) {
+        return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
+    }
+
+    /** What a choice between two branches somebody can be in is as wide as it is because of. */
+    private static Settlement.WidthDependency between(PlannedValues<FactSubject> one,
+                                                      PlannedValues<FactSubject> other) {
+        return Settlement.WidthDependency.of(souther.compiler.values.Emptiness.UNDECIDED, one,
+                souther.compiler.values.Emptiness.UNDECIDED, other);
+    }
+
+    /**
+     * An alternative saying nothing about a position the other narrowed is why the choice says
+     * nothing there.
+     *
+     * <p>{@code value == A || f(other)}: the choice admits every value at {@code value} and would
+     * admit one without the right alternative, so the width there is the right's.
+     */
+    @Test
+    void anAlternativeThatSaysNothingIsWhyTheChoiceSaysNothing() {
+        Settlement.WidthDependency width = between(isA(), unread(Set.of(OTHER)));
+
+        assertEquals(Set.of(), width.onLeft(),
+                "without the left the choice still admits every value at value");
+        assertEquals(Set.of(VALUE), width.onRight(),
+                "without the right it admits one");
+    }
+
+    /**
+     * Two alternatives narrowing a position the same way leave the choice's width resting on
+     * neither.
+     *
+     * <p>{@code (value == A && f(other)) || (value == A && f(other))} holds {@code value} exactly
+     * where {@code value == A} does, with or without either branch. Read off what each branch took
+     * in rather than what it leaves, both would come out answerable for it.
+     */
+    @Test
+    void twoAlternativesNarrowingAPositionAlikeLeaveTheWidthOnNeither() {
+        Settlement.WidthDependency width = between(isA().meet(unread(Set.of(OTHER))),
+                isA().meet(unread(Set.of(OTHER))));
+
+        assertEquals(Settlement.WidthDependency.none(), width,
+                "either branch dropped leaves the other saying the same thing at every position");
+    }
+
+    /** And the same where only one of them holds a clause nothing read. */
+    @Test
+    void andTheSameWhereOnlyOneOfThemHoldsAClauseNothingRead() {
+        assertEquals(Settlement.WidthDependency.none(),
+                between(isA().meet(unread(Set.of(OTHER))), isA()),
+                "the redundant branch is not why the choice admits what it admits");
+    }
+
+    /**
+     * Alternatives that cover a position between them leave the width on neither.
+     *
+     * <p>{@code value == A || value /= A} admits every value at {@code value}, and so does either
+     * of them beside a third that says nothing — which is why a further unread alternative cannot
+     * be why the choice is that wide.
+     */
+    @Test
+    void alternativesCoveringAPositionBetweenThemLeaveTheWidthOnNeither() {
+        Settlement.WidthDependency width =
+                between(isA().joinLive(notA()), unread(Set.of(OTHER)));
+
+        assertEquals(Settlement.WidthDependency.none(), width,
+                "the covered position is every value without either alternative");
+    }
+
+    /**
+     * Alternatives narrowing one position to sets neither contains leave the width on both.
+     *
+     * <p>Neither {@code value == A} nor {@code value == B} is what the choice between them leaves,
+     * so dropping either narrows it and each is answerable for the width.
+     */
+    @Test
+    void alternativesNeitherOfWhichCoversTheOtherLeaveTheWidthOnBoth() {
+        Settlement.WidthDependency width = between(isA(),
+                PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.just(B))));
+
+        assertEquals(Set.of(VALUE), width.onLeft());
+        assertEquals(Set.of(VALUE), width.onRight());
+    }
+
+    /**
+     * A position neither alternative is about is on neither, whatever they do to the one they are
+     * about.
+     *
+     * <p>It holds every value with or without either of them, so no alternative is why the choice
+     * says nothing there. Asked over the positions either branch narrowed, it is never asked at
+     * all.
+     */
+    @Test
+    void aPositionNeitherAlternativeIsAboutIsOnNeither() {
+        Settlement.WidthDependency width = between(isA(), notA());
+
+        assertEquals(Set.of(VALUE), width.onLeft(), "the position they are about is on both");
+        assertEquals(Set.of(VALUE), width.onRight());
+    }
+
+    /**
+     * An occurrence one branch of which admits nothing leaves the width resting on neither, and the
+     * next occurrence of the same written choice still says what it says.
+     *
+     * <p>Distribution puts the same written choice wherever a conjunction beside it stands, and a
+     * branch impossible under one neighbour can be the branch somebody is in under another. What
+     * this occurrence leaves is the branch beside the dead one, so nothing here rests on an
+     * alternative — and read as an answer about the written choice, it would take back what the
+     * occurrence beside it found.
+     */
+    @Test
+    void anOccurrenceOneBranchOfWhichAdmitsNothingRestsOnNeitherAndDoesNotSpeakForTheRest() {
+        Settlement.WidthDependency dead = Settlement.WidthDependency.of(
+                souther.compiler.values.Emptiness.EMPTY, isA(),
+                souther.compiler.values.Emptiness.UNDECIDED, unread(Set.of(OTHER)));
+        Settlement.WidthDependency live = between(isA(), unread(Set.of(OTHER)));
+
+        assertEquals(Settlement.WidthDependency.none(), dead,
+                "the choice is the branch beside the dead one, and no alternative widened it");
+        assertEquals(live, dead.alsoSeen(live),
+                "and what the occurrence beside it found is what the written choice is left with");
+    }
+
+    /**
+     * One more occurrence of the same written choice adds what its width rests on and nothing else.
+     *
+     * <p>The same choice stands wherever a conjunction beside it was distributed in, and a branch
+     * dropped is dropped at every one of them — so the sides are joined by union, which cannot
+     * depend on the order the copies were met or on a copy being met twice.
+     */
+    @Test
+    void whatTheOccurrencesLeaveIsJoinedWithoutRegardToOrderOrRepetition() {
+        Settlement.WidthDependency here =
+                new Settlement.WidthDependency(Set.of(VALUE), Set.of());
+        Settlement.WidthDependency there =
+                new Settlement.WidthDependency(Set.of(), Set.of(OTHER));
+
+        assertEquals(here.alsoSeen(there), there.alsoSeen(here),
+                "the order the copies were met in is not in the answer");
+        assertEquals(here.alsoSeen(there), here.alsoSeen(there).alsoSeen(here),
+                "and neither is a copy met twice");
+        assertEquals(new Settlement.WidthDependency(Set.of(VALUE), Set.of(OTHER)),
+                here.alsoSeen(there),
+                "a position any occurrence's width rests on is one the whole answer's does");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
@@ -71,9 +71,9 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
     void anAlternativeThatSaysNothingIsWhyTheChoiceSaysNothing() {
         Settlement.WidthDependency width = between(isA(), unread(Set.of(OTHER)));
 
-        assertEquals(Set.of(), width.onLeft(),
+        assertEquals(Set.of(), width.mayRestOnLeft(),
                 "without the left the choice still admits every value at value");
-        assertEquals(Set.of(VALUE), width.onRight(),
+        assertEquals(Set.of(VALUE), width.mayRestOnRight(),
                 "without the right it admits one");
     }
 
@@ -129,8 +129,8 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
         Settlement.WidthDependency width = between(isA(),
                 PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.just(B))));
 
-        assertEquals(Set.of(VALUE), width.onLeft());
-        assertEquals(Set.of(VALUE), width.onRight());
+        assertEquals(Set.of(VALUE), width.mayRestOnLeft());
+        assertEquals(Set.of(VALUE), width.mayRestOnRight());
     }
 
     /**
@@ -147,9 +147,9 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
         Settlement.WidthDependency width = between(isA().meet(otherIsA()),
                 notA().meet(otherIsA()));
 
-        assertEquals(Set.of(VALUE), width.onLeft(),
+        assertEquals(Set.of(VALUE), width.mayRestOnLeft(),
                 "other is A under either alternative, so neither is why the choice leaves it so");
-        assertEquals(Set.of(VALUE), width.onRight());
+        assertEquals(Set.of(VALUE), width.mayRestOnRight());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -30,13 +30,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * that narrows only the positions the rule names. Two positions over a carrier of two values give
  * sixteen sets of records, so the whole of that can be enumerated rather than sampled.
  *
- * <p><b>Two assumptions of the reading are written into the model, because they are what a
- * conjunction's account of an unread rule rests on.</b> A rule this could not read narrows only the
- * positions it names, and leaves the type with a value in it. Without the first, a rule naming
- * nothing could narrow everything and no conjunction could speak for any position; without the
- * second, one could empty the type and every answer about every position would be wrong. Both are
- * what {@code AdmissibleValues} says of itself, and a model that let them go would be testing a
- * different language.
+ * <p><b>One assumption of the reading is written into the model, because it is what a conjunction's
+ * account of an unread rule rests on.</b> A rule this could not read narrows only the positions it
+ * names. Without it a rule naming nothing could narrow everything, and no conjunction could speak
+ * for any position. It is what {@code AdmissibleValues} says of itself, and a model that let it go
+ * would be testing a different language.
+ *
+ * <p><b>That the type is left with a value in it is asked of the whole and not of a rule.</b> The
+ * three questions above are about what stands at a position, which is a question about a type that
+ * has a value — a model leaving none is what {@code isBottom} is for. Required of each rule
+ * instead, a choice would be read only against models in all of which both its alternatives stand,
+ * and what a reading says on the strength of a branch nobody may be in would never be asked about.
  */
 class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
 
@@ -128,13 +132,20 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
     }
 
     /**
-     * A rule this reading has no word for: every set of records that narrows only what it names and
-     * leaves the type with a value in it.
+     * A rule this reading has no word for: every set of records that narrows only what it names,
+     * the empty one among them.
+     *
+     * <p>A rule nothing could read may be one nothing satisfies, and where it is an alternative of
+     * a choice the branch beside it is what the rules leave. Left out, every choice would be read
+     * against models in all of which both its alternatives stand, and what a reading says on the
+     * strength of a branch nobody may be in would never be asked about. What is asked of the
+     * positions is still asked of models that leave a value — {@link #heldAgainstItsModels} skips
+     * the empty one, since what stands at a position is a question about a type that has one.
      */
     private static Rule unread(String wrote, Set<String> names, UnreadReason why) {
         List<Integer> could = new ArrayList<>();
         for (int records = 0; records <= EVERY_RECORD; records++) {
-            if (records != 0 && narrowsOnly(names, records)) {
+            if (narrowsOnly(names, records)) {
                 could.add(records);
             }
         }
@@ -170,14 +181,25 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
     }
 
     /**
-     * What an alternative promised, which is what an unread one beside it takes back.
+     * The positions a choice between these two would be narrower at without {@code alternative},
+     * which is what an unread one takes back.
      *
-     * <p>Nothing where it holds a clause nothing read: what a rule promises is what it promises
-     * having read everything it was given, so there is nothing there for the alternative beside it
-     * to widen.
+     * <p>Read off what the branch beside it leaves against what the two of them leave together. A
+     * choice admits whatever either alternative admits, so the one is contained in the other and
+     * differing is being narrower — and a branch that narrows a position exactly as its neighbour
+     * does is not why the choice is as wide as it is there, whether or not either of them was read
+     * whole.
      */
-    private static Set<String> promisedBy(Rule alternative) {
-        return alternative.holdsSomethingUnread() ? Set.of() : alternative.readAbout();
+    private static Set<String> widthRestingOn(Rule alternative, Rule beside) {
+        Set<String> out = new LinkedHashSet<>();
+        for (String atom : List.of(VALUE, OTHER)) {
+            AdmittedPlan joined = AdmittedPlan.joining(
+                    List.of(alternative.planned().at(atom), beside.planned().at(atom)));
+            if (!beside.planned().at(atom).equals(joined)) {
+                out.add(atom);
+            }
+        }
+        return out;
     }
 
     private static Rule both(Rule left, Rule right) {
@@ -273,13 +295,13 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
         about.addAll(right.readAbout());
         Set<String> opened = new LinkedHashSet<>(left.opened());
         opened.addAll(right.opened());
-        // The positions the alternative beside an unread one reached, said where the two of them
-        // are what was written.
+        // The positions the choice is as wide as it is at because of an alternative nothing could
+        // read, said where the two of them are what was written.
         if (left.holdsSomethingUnread()) {
-            opened.addAll(promisedBy(right));
+            opened.addAll(widthRestingOn(left, right));
         }
         if (right.holdsSomethingUnread()) {
-            opened.addAll(promisedBy(left));
+            opened.addAll(widthRestingOn(right, left));
         }
         return new Answer(left.planned().joinLive(right.planned()), opened, about,
                 left.choicesOverOnePosition() && right.choicesOverOnePosition()

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -181,22 +181,31 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
     }
 
     /**
-     * The positions a choice between these two would be narrower at without {@code alternative},
+     * The positions a choice between these two is left narrower at without {@code alternative},
      * which is what an unread one takes back.
      *
-     * <p>Read off what the branch beside it leaves against what the two of them leave together. A
-     * choice admits whatever either alternative admits, so the one is contained in the other and
-     * differing is being narrower — and a branch that narrows a position exactly as its neighbour
-     * does is not why the choice is as wide as it is there, whether or not either of them was read
-     * whole.
+     * <p>Out of the record sets and nothing else. What the compiler does with this question it
+     * does by comparing descriptions, so a model side that compared descriptions too would be the
+     * compiler agreeing with itself — which is the one thing this file exists not to do. Here it
+     * is what the models say: a choice between two sets of records is their union, so the question
+     * is whether taking one side away leaves fewer values standing at the position.
+     *
+     * <p>Over every pair a model could be, since what is opened is said of the clause and not of
+     * one model of it. A pair leaving no record at all is passed over, as it is where the answers
+     * are asked: what stands at a position is a question about a type that has a value.
      */
     private static Set<String> widthRestingOn(Rule alternative, Rule beside) {
         Set<String> out = new LinkedHashSet<>();
-        for (String atom : List.of(VALUE, OTHER)) {
-            AdmittedPlan joined = AdmittedPlan.joining(
-                    List.of(alternative.planned().at(atom), beside.planned().at(atom)));
-            if (!beside.planned().at(atom).equals(joined)) {
-                out.add(atom);
+        for (int mine : alternative.leaves()) {
+            for (int theirs : beside.leaves()) {
+                if ((mine | theirs) == 0) {
+                    continue;
+                }
+                for (String atom : List.of(VALUE, OTHER)) {
+                    if (standingAt(atom, mine | theirs) != standingAt(atom, theirs)) {
+                        out.add(atom);
+                    }
+                }
             }
         }
         return out;
@@ -214,7 +223,7 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * The half of a rule that is this compiler's answer, as one value.
      *
      * <p>Held together because a choice settles all of it or none of it. What an alternative
-     * promised and whether it holds a clause nothing read are what the next choice out reads to
+     * leaves and whether it holds a clause nothing read are what the next choice out reads to
      * decide what it opened, so a settlement that took the branch that stands for the values and
      * left these as the two branches together would answer the outer choice out of a branch nobody
      * can be in. Built nowhere but in the two below, so a part of it added later has to be settled
@@ -267,12 +276,12 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * the other.
      *
      * <p><b>The whole of the answer follows the four cases and not the values alone.</b> Where one
-     * branch stands the choice is that branch, so what it promised, whether it holds a clause
+     * branch stands the choice is that branch, so what it leaves, whether it holds a clause
      * nothing read, and what its own choices reached are the standing branch's — these are what the
      * next choice out reads to decide what it opened, and taken from the two branches together it
      * would be answering out of a branch nobody can be in.
      *
-     * <p>A choice neither branch of which stands is neither of them. It promises nothing and its
+     * <p>A choice neither branch of which stands is neither of them. It leaves nothing and its
      * alternatives lost nothing, and what showed it empty is what showed both — which is why that
      * one keeps what either branch could not read.
      */
@@ -404,8 +413,8 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * <p>What the choice comes to is the branch that stands, which read everything it was given.
      * Answered with the two branches' accounts put together, it would say a clause of it went
      * unread — and the next choice out reads that to decide what an alternative beside an unread
-     * one promised, so the reading would take back a position on the strength of a branch nobody
-     * can be in.
+     * one leaves, so the reading would take back a position on the strength of a branch nobody can
+     * be in.
      *
      * <p>Three rules deep on one side, which is what it takes: a conjunction of two is dead only
      * where both were read, so the clause nothing read is the third.


### PR DESCRIPTION
Closes #1421.

`StatedByClauses.opens` decided what a choice left open out of what each alternative
took in, and a branch holding a clause nothing could read was taken to have promised
nothing. Where both alternatives held such a clause neither promised anything, nothing
was opened, and the reading answered that a position holds every value and that this is
exactly what the rules leave — on the strength of an alternative this compiler cannot
show anybody is in.

That case was not missing. It was written that way to keep `(P(a) && f(b)) || (P(a) &&
f(b))` from reporting `a` wider than the rules hold it, and which positions a branch
constrained cannot tell those two apart: in one the alternative beside the unread one
narrows the position the same way and nothing is taken back, in the other it narrows it
and the unread one takes it back.

So the question is answered where the values are, and it is answered one-sidedly. A
position is left out where the two descriptions the branches were normalised to are the
same — a choice admits whatever either alternative admits, so what it leaves without one
of them is contained in what it leaves with both, and equal descriptions are one set. A
position is kept where nothing showed that, which is weaker than their differing: two
descriptions of one set written differently stay apart, and an occurrence's own widening
can be covered by what another occurrence of the same written choice leaves. So a
non-member is a fact and a member is a question nobody settled, which is the direction
the reading can afford — the cost of a member is a position the reading declines to speak
for, and the cost of the other way round is an answer handed out as exact when it is not.
Nothing is built to ask it and no allowance is taken.

`Settlement.OfAChoice` now carries that beside the fate of both branches, made at one
place about the same two branches. It is a relation between two branches rather than an
attribute of one, so it does not live in `Sided`. An occurrence one branch of which
admits nothing is no choice there and rests on neither, while another occurrence of the
same written choice still says what it says; the sides join by union over occurrences, so
the order the copies are met in stays out of the answer.

`opens` reads that answer and asks nothing about values, and `promisedBy` is gone. Which
alternative went unread is still read off the tree that keeps the author's shape, and
where an author is sent is still what that alternative's neighbour reached — two
questions, two sources.

`Adoption.either` still does the same kind of inference for its own question: where one
branch is dropped it moves what the other narrowed into what the clause missed, which is
what `constrains` is then read by, and that is a values effect derived from which rules a
branch took in. It answers a different question — whether a conjunct held the values down,
which gates the finding about a rule read to the end without a line — and it is
conservative where this was not. It is left as it stands and is worth an issue of its own.

The architecture test that holds the opening to one decision now also holds the outcome
to one maker and the width to its own type.

## The models

`WhatIsReadIsHeldAgainstTheModelsItCouldBeTest` required every rule nothing could read to
leave the type with a value in it, which meant a choice was only ever read against models
in all of which both its alternatives stand. That is the case this is about, so the
requirement moves to where it belongs: what stands at a position is asked of models that
leave a value, and a rule may be one nothing satisfies. With that, restoring the old rule
in the model makes the oracle name the form this is about and say what the reading speaks
for and what the models leave.

What the model side opens is worked out from the record sets and nothing else — a choice
between two of them is their union, so the question is whether taking one side away leaves
fewer values standing. Composing descriptions there as well would be the compiler agreeing
with itself about the width by the arithmetic it already used.

## How it was checked

Each of the three rules was mutated back and the run watched: the opening ignoring the
width of a choice both alternatives of which went unread, the width read off which
positions a branch narrowed, and the dead occurrence contributing one. In each case the
tests written for that rule failed and nothing else did. Restoring the model's old rule
fails the oracle at the form the issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

