### PR TITLE
Read a counterfactual once per set of rules left out

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -15,6 +15,7 @@ import souther.compiler.values.ValueSet;
 
 import souther.compiler.numeric.Count;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import souther.compiler.types.ValueName;
@@ -179,6 +180,28 @@ public final class FieldDomains {
     /** How each atom's values are spaced, so that settling one afterwards states the same equality
      *  the reading would have stated for it. */
     private final Map<FactSubject, souther.compiler.numeric.Granularity> spacing;
+    /**
+     * The counterfactual readings this one has been asked for, kept under what was left out of each.
+     *
+     * <p>What a reading with rules taken away comes to is decided by which rules those are and by
+     * nothing else — not by the name the question was asked at, and not by which side of a
+     * coordinate is being attributed. So the readings are kept under what was left out, and the
+     * questions that ask for the same one get the one that was made: both ends of a coordinate ask
+     * the same set, a declaration that reaches several names asks it again at each of them, and the
+     * questions {@link EndNarrowing} puts ask for the reading without every candidate and the one
+     * without a single candidate, which where there is one candidate are the same reading.
+     *
+     * <p>Beside the state rather than part of it. These are the reading this already is, read out
+     * for what one rule did, so nothing here answers anything the rules of this value do not
+     * already say.
+     *
+     * <p>Kept under the lock of the reading they are of, because a reading is worked out on a
+     * thread of its own where one is given a deadline and the two ends of a coordinate are asked
+     * for separately.
+     */
+    private final Map<Set<TypeSymbol.AtModule>, FieldDomains> readWithoutTheClausesOf =
+            new HashMap<>();
+    private final Map<Set<PartId>, FieldDomains> readWithoutTheParts = new HashMap<>();
 
     private FieldDomains(Map<RuleKey, NumericDomain.Bounds> byName,
                          Map<RuleKey, NumericDomain.Bounds> heldByName,
@@ -674,14 +697,21 @@ public final class FieldDomains {
      * standing one up is a second place for that comparison to be written a different way round.
      */
     private Endpoint endWithout(Set<TypeSymbol.AtModule> removed, RuleKey path, boolean lower) {
-        NumericDomain.Bounds bounds = without(removed::contains).byName.get(path);
+        NumericDomain.Bounds bounds = without(removed).byName.get(path);
         return bounds == null ? null : lower ? bounds.min() : bounds.max();
     }
 
-    /** This value read again without the clauses of the declarations {@code skip} names. */
-    private FieldDomains without(java.util.function.Predicate<TypeSymbol> skip) {
-        return of(named, data, source, policy, settled,
-                InvariantChecker.Reach.withoutClausesOf(skip), DeclarationReadings.NONE);
+    /**
+     * This value read again without the clauses of the declarations {@code removed} names.
+     *
+     * <p>Asked for by the set left out, which is what the reading is of: the same set asked for
+     * twice is one reading, made when the first question reaches it.
+     */
+    private synchronized FieldDomains without(Set<TypeSymbol.AtModule> removed) {
+        return readWithoutTheClausesOf.computeIfAbsent(Set.copyOf(removed),
+                skip -> of(named, data, source, policy, settled,
+                        InvariantChecker.Reach.withoutClausesOf(skip::contains),
+                        DeclarationReadings.NONE));
     }
 
     /**
@@ -1217,7 +1247,7 @@ public final class FieldDomains {
     /** Where the coordinate stops on one side with these conjuncts taken away. */
     private Endpoint sideWithout(Set<AboutOneCoordinate> removed, NumberAt<RuleKey> at,
                                  boolean lower) {
-        NumericDomain.Bounds without = without(removed).leftAt(at.position(), at.of());
+        NumericDomain.Bounds without = withoutConjuncts(removed).leftAt(at.position(), at.of());
         return without == null ? null : lower ? without.min() : without.max();
     }
 
@@ -1350,13 +1380,19 @@ public final class FieldDomains {
                 .toList();
     }
 
-    /** This value read again without some conjuncts of its rules. */
-    private FieldDomains without(Set<AboutOneCoordinate> removed) {
-        return of(named, data, source, policy, settled,
-                InvariantChecker.Reach.withoutParts(removed.stream()
+    /**
+     * This value read again without some conjuncts of its rules.
+     *
+     * <p>Asked for by the conjuncts left out, which is what the reading is of: two sets of
+     * candidates naming the same conjuncts are one reading, and so are the same conjuncts asked for
+     * at both ends of a coordinate.
+     */
+    private synchronized FieldDomains withoutConjuncts(Set<AboutOneCoordinate> removed) {
+        return readWithoutTheParts.computeIfAbsent(removed.stream()
                         .map(AboutOneCoordinate::part)
-                        .collect(java.util.stream.Collectors.toSet())),
-                DeclarationReadings.NONE);
+                        .collect(java.util.stream.Collectors.toUnmodifiableSet()),
+                parts -> of(named, data, source, policy, settled,
+                        InvariantChecker.Reach.withoutParts(parts), DeclarationReadings.NONE));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -181,27 +181,14 @@ public final class FieldDomains {
      *  the reading would have stated for it. */
     private final Map<FactSubject, souther.compiler.numeric.Granularity> spacing;
     /**
-     * The counterfactual readings this one has been asked for, kept under what was left out of each.
+     * The counterfactual readings this one has been asked for, kept under what each leaves out
+     * ({@link #counterfactual}).
      *
-     * <p>What a reading with rules taken away comes to is decided by which rules those are and by
-     * nothing else — not by the name the question was asked at, and not by which side of a
-     * coordinate is being attributed. So the readings are kept under what was left out, and the
-     * questions that ask for the same one get the one that was made: both ends of a coordinate ask
-     * the same set, a declaration that reaches several names asks it again at each of them, and the
-     * questions {@link EndNarrowing} puts ask for the reading without every candidate and the one
-     * without a single candidate, which where there is one candidate are the same reading.
-     *
-     * <p>Beside the state rather than part of it. These are the reading this already is, read out
-     * for what one rule did, so nothing here answers anything the rules of this value do not
-     * already say.
-     *
-     * <p>Kept under the lock of the reading they are of, because a reading is worked out on a
-     * thread of its own where one is given a deadline and the two ends of a coordinate are asked
-     * for separately.
+     * <p>Beside the state rather than part of it. Each is the reading this already is, read out for
+     * what one rule did, so nothing here answers anything the rules of this value do not already
+     * say.
      */
-    private final Map<Set<TypeSymbol.AtModule>, FieldDomains> readWithoutTheClausesOf =
-            new HashMap<>();
-    private final Map<Set<PartId>, FieldDomains> readWithoutTheParts = new HashMap<>();
+    private final Map<LeftOut, FieldDomains> counterfactuals = new HashMap<>();
 
     private FieldDomains(Map<RuleKey, NumericDomain.Bounds> byName,
                          Map<RuleKey, NumericDomain.Bounds> heldByName,
@@ -697,20 +684,73 @@ public final class FieldDomains {
      * standing one up is a second place for that comparison to be written a different way round.
      */
     private Endpoint endWithout(Set<TypeSymbol.AtModule> removed, RuleKey path, boolean lower) {
-        NumericDomain.Bounds bounds = without(removed).byName.get(path);
+        NumericDomain.Bounds bounds = withoutClausesOf(removed).byName.get(path);
         return bounds == null ? null : lower ? bounds.min() : bounds.max();
     }
 
+    /** This value read again without the clauses of the declarations {@code removed} names. */
+    private FieldDomains withoutClausesOf(Set<TypeSymbol.AtModule> removed) {
+        return counterfactual(new LeftOut.ClausesOf(removed));
+    }
+
     /**
-     * This value read again without the clauses of the declarations {@code removed} names.
+     * What a counterfactual reading leaves out, which is the whole of what decides what it comes
+     * to.
      *
-     * <p>Asked for by the set left out, which is what the reading is of: the same set asked for
-     * twice is one reading, made when the first question reaches it.
+     * <p>Two kinds of omission and one identity. A declaration's clauses are left out to ask which
+     * declaration is holding an end, and authored conjuncts are left out to ask what those
+     * conjuncts were holding — and what either reading comes to is decided by which rules are gone:
+     * not by the name the question was asked at, and not by which side of a coordinate is being
+     * attributed. Said as a value, that is what a reading is kept under, and a third thing to leave
+     * out has to say what it leaves out before it can be one of these at all.
      */
-    private synchronized FieldDomains without(Set<TypeSymbol.AtModule> removed) {
-        return readWithoutTheClausesOf.computeIfAbsent(Set.copyOf(removed),
-                skip -> of(named, data, source, policy, settled,
-                        InvariantChecker.Reach.withoutClausesOf(skip::contains),
+    private sealed interface LeftOut {
+
+        /** How far the reading that leaves this out reaches. */
+        InvariantChecker.Reach reach();
+
+        /** Everything these declarations wrote, wherever it was read. */
+        record ClausesOf(Set<TypeSymbol.AtModule> declarations) implements LeftOut {
+
+            public ClausesOf {
+                declarations = Set.copyOf(declarations);
+            }
+
+            @Override
+            public InvariantChecker.Reach reach() {
+                return InvariantChecker.Reach.withoutClausesOf(declarations::contains);
+            }
+        }
+
+        /** These conjuncts of the rules, everything else the declaration says being read. */
+        record Conjuncts(Set<PartId> parts) implements LeftOut {
+
+            public Conjuncts {
+                parts = Set.copyOf(parts);
+            }
+
+            @Override
+            public InvariantChecker.Reach reach() {
+                return InvariantChecker.Reach.withoutParts(parts);
+            }
+        }
+    }
+
+    /**
+     * This value read again with {@code omitted} left out, made when the first question asks for
+     * it.
+     *
+     * <p>The one place a counterfactual of this reading is stood up, so that what one is — the
+     * declaration, its source, what it may spend, and what it leaves out — is settled once. The
+     * questions that leave the same rules out get the reading that was made: both ends of a
+     * coordinate leave the same rules out, a declaration reaching several of a record's names
+     * leaves them out again at each of them, and the questions {@link EndNarrowing} puts ask for
+     * the reading without every candidate and the one without a single candidate, which where
+     * there is one candidate are the same reading.
+     */
+    private FieldDomains counterfactual(LeftOut omitted) {
+        return counterfactuals.computeIfAbsent(omitted,
+                left -> of(named, data, source, policy, settled, left.reach(),
                         DeclarationReadings.NONE));
     }
 
@@ -1383,16 +1423,13 @@ public final class FieldDomains {
     /**
      * This value read again without some conjuncts of its rules.
      *
-     * <p>Asked for by the conjuncts left out, which is what the reading is of: two sets of
-     * candidates naming the same conjuncts are one reading, and so are the same conjuncts asked for
-     * at both ends of a coordinate.
+     * <p>Which conjuncts, and not which candidates named them: two sets of candidates writing the
+     * same conjuncts leave the same rules out, and are one reading.
      */
-    private synchronized FieldDomains withoutConjuncts(Set<AboutOneCoordinate> removed) {
-        return readWithoutTheParts.computeIfAbsent(removed.stream()
-                        .map(AboutOneCoordinate::part)
-                        .collect(java.util.stream.Collectors.toUnmodifiableSet()),
-                parts -> of(named, data, source, policy, settled,
-                        InvariantChecker.Reach.withoutParts(parts), DeclarationReadings.NONE));
+    private FieldDomains withoutConjuncts(Set<AboutOneCoordinate> removed) {
+        return counterfactual(new LeftOut.Conjuncts(removed.stream()
+                .map(AboutOneCoordinate::part)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet())));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualIsReadOncePerSetOfRulesLeftOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualIsReadOncePerSetOfRulesLeftOutTest.java
@@ -12,6 +12,7 @@ import souther.compiler.types.TypeSymbols;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -75,16 +76,53 @@ class ACounterfactualIsReadOncePerSetOfRulesLeftOutTest {
                 "and the same clauses left out is the same reading, made once");
     }
 
+    /**
+     * A number with an end either way, and a conjunct about it that places neither.
+     *
+     * <p>{@code hole} places no end, so what the conjuncts about {@code n} were holding is asked by
+     * leaving conjuncts out rather than read off the ends they placed. Both ends are asked, and
+     * they ask it of the same conjuncts: the reading without all three, and the reading without
+     * each one of them.
+     */
+    private static final String BOTH_ENDS = """
+            module demo exposing ( Bounded, keep )
+
+            data Bounded = { n: Int }
+                invariant floor = n >= 0
+                invariant hole = n /= 0
+                invariant ceiling = n <= 100
+
+            behavior keep : (b: Bounded) -> Bounded
+
+            let keep (b) = b
+            """;
+
+    @Test
+    void theSecondEndOfANumberLeavesTheSameConjunctsOutAsTheFirst() {
+        FieldDomains reading = reading(BOTH_ENDS, "Bounded");
+
+        long before = InvariantChecker.readingsMade();
+        assertFalse(reading.movedEnds().isEmpty(),
+                "the conjuncts about `n` are attributed by leaving them out");
+        assertEquals(4, InvariantChecker.readingsMade() - before,
+                "four sets are left out over the two ends — all three conjuncts, and each of them"
+                        + " alone — and the second end asks for the ones the first already made");
+    }
+
     /** The floor of a coordinate is held by whoever the reading says, asked with that floor. */
     private static List<TypeSymbol.AtModule> holding(NarrowedBounds narrowed) {
         return AReadingOfAPosition.holding(narrowed, EndSide.LOWER);
     }
 
     private static FieldDomains reading() {
-        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        return reading(SOURCE, "Held");
+    }
+
+    private static FieldDomains reading(String source, String declaration) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        TypeSymbol.AtModule held = TypeSymbols.declared(new TypeKey("demo", "Held"));
-        return FieldDomains.of(held,
+        TypeSymbol.AtModule of = TypeSymbols.declared(new TypeKey("demo", declaration));
+        return FieldDomains.of(of,
                 RuleReadings.of(compilation, compilation.modules().get(0)),
                 ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualIsReadOncePerSetOfRulesLeftOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualIsReadOncePerSetOfRulesLeftOutTest.java
@@ -1,0 +1,91 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.EndSide;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reading with rules taken away comes to is decided by which rules those are.
+ *
+ * <p>Not by the name the question was asked at. Which declarations hold an end is answered by
+ * leaving a declaration's clauses out and reading again, and a declaration writing about two of a
+ * record's names is asked the same counterfactuals at each of them — the same clauses left out, the
+ * same reading, twice. So the readings are kept under what was left out, and the second name is
+ * answered out of what the first made.
+ *
+ * <p>The names the two questions come to are compared as well as the readings they took. A question
+ * answered out of nothing takes no reading either, and the count alone would not tell that apart
+ * from a question answered out of the readings already made.
+ */
+class ACounterfactualIsReadOncePerSetOfRulesLeftOutTest {
+
+    /**
+     * Two declarations write a floor under each of two names, and neither holds one on its own:
+     * {@code Common} puts both ten above {@code lo} and {@code Held} puts both five above, so ten
+     * above is where each of them stops. Attributing that end asks for the reading without both
+     * candidates and for the reading without each of them, which is the same three readings at
+     * {@code hi} as at {@code also}.
+     */
+    private static final String SOURCE = """
+            module demo exposing ( Held, keep )
+
+            data Common =
+                { lo: Int
+                , hi: Int
+                , also: Int
+                }
+                invariant based = lo >= 100
+                invariant far = hi >= lo + 10
+                invariant alsoFar = also >= lo + 10
+
+            data Held = { ...Common }
+                invariant near = hi >= lo + 5
+                invariant alsoNear = also >= lo + 5
+
+            behavior keep : (h: Held) -> Held
+
+            let keep (h) = h
+            """;
+
+    @Test
+    void aSecondNameIsAnsweredOutOfTheReadingsTheFirstMade() {
+        FieldDomains reading = reading();
+        NarrowedBounds hi = reading.at(RuleKey.of("hi"));
+        NarrowedBounds also = reading.at(RuleKey.of("also"));
+
+        long beforeTheFirst = InvariantChecker.readingsMade();
+        List<TypeSymbol.AtModule> atHi = holding(hi);
+        assertTrue(InvariantChecker.readingsMade() > beforeTheFirst,
+                "the first name is answered by reading the declaration again without some of it");
+
+        long beforeTheSecond = InvariantChecker.readingsMade();
+        assertEquals(atHi, holding(also),
+                "the same declarations hold the floor under the other name");
+        assertEquals(beforeTheSecond, InvariantChecker.readingsMade(),
+                "and the same clauses left out is the same reading, made once");
+    }
+
+    /** The floor of a coordinate is held by whoever the reading says, asked with that floor. */
+    private static List<TypeSymbol.AtModule> holding(NarrowedBounds narrowed) {
+        return AReadingOfAPosition.holding(narrowed, EndSide.LOWER);
+    }
+
+    private static FieldDomains reading() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        TypeSymbol.AtModule held = TypeSymbols.declared(new TypeKey("demo", "Held"));
+        return FieldDomains.of(held,
+                RuleReadings.of(compilation, compilation.modules().get(0)),
+                ReadAs.THE_COMPILATION_DOES);
+    }
+}


### PR DESCRIPTION
Which declarations hold an end is answered by leaving a declaration's clauses out and reading the declaration again; what its authored conjuncts were holding is answered by leaving conjuncts out and reading again. What either reading comes to is decided by which rules are gone, and by nothing else: not by the name the question was asked at, and not by which side of a coordinate is being attributed.

Each was made afresh at every question. So both ends of a number read the same one over again, a declaration reaching several of a record's names read it again at each of them, and the questions put to a coordinate with a single candidate asked for the reading without every candidate and the reading without that one, which are the same reading.

What is left out is a value here, and the reading is kept under it. The value says how far the reading that leaves it out reaches, so the two kinds of omission are one identity rather than two caches with a copy each of what a counterfactual is, and a third kind has to say what it leaves out before it can be one at all.

An answer of the store is compared on every recompute, and comparing two of them asks who holds an end — so this is what an edit pays for a recheck of the module it touched. Measured with `souther-bench edit` over the crm corpus, interleaved against develop: the leaf edit comes down, and the edit of an imported module and the warm compile stay where they are, their readings coming from recomputing the module's inputs.

Both omissions are held, each with a negative control against develop: a second name answered out of the readings the first made, and a number whose second end leaves out the sets its first end already asked for.

What an answer's identity is stays as it was. The names are part of what `Adequacy.Inputs` says — they reach the lines the partition publishes — so `equals` still asks for them; it now asks for far less work to get them. What is left of #1411 is whether that is little enough, which the next profile answers.

Refs #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)