### PR TITLE
Hand a counterfactual the machines the reading it comes from made

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.types.TypeKey;
-import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 
 import java.util.function.Supplier;
@@ -78,7 +77,8 @@ public interface DeclarationReadings {
      * declaration's own machines are {@code recorder}, so that what the reading builds is what the
      * answer comes to hold; every other declaration's are worked out by the reading itself, since
      * asking for another declaration's answer from inside this one is how two declarations that
-     * reach each other come to wait on each other.
+     * reach each other come to wait on each other. Worked out and kept: a reading of one of those
+     * is a reading like any other, and what it comes to is what its own counterfactual is handed.
      *
      * <p>And what it makes is kept, because the reading that answer is made by is the declaration's
      * canonical reading: the question that asked for the answer is the next to want it, and is
@@ -90,7 +90,7 @@ public interface DeclarationReadings {
 
             @Override
             public StringMachineAnswers of(TypeKey declaration) {
-                return declaration.equals(named) ? recorder : StringMachineAnswers.NONE;
+                return declaration.equals(named) ? recorder : StringMachineAnswers.unborrowed();
             }
 
             @Override
@@ -118,5 +118,5 @@ public interface DeclarationReadings {
      * counterfactual is handed. Handing out one shared object would make every such reading write
      * into the same maps.
      */
-    DeclarationReadings NONE = _ -> StringMachineAnswers.borrowing(StringFacts.NONE);
+    DeclarationReadings NONE = _ -> StringMachineAnswers.unborrowed();
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.types.TypeKey;
+import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 
 import java.util.function.Supplier;
@@ -109,6 +110,13 @@ public interface DeclarationReadings {
         };
     }
 
-    /** Nothing made anywhere, for a reading with no store to ask. */
-    DeclarationReadings NONE = _ -> StringMachineAnswers.NONE;
+    /**
+     * Nothing to borrow, for a reading with no store to ask.
+     *
+     * <p>A reading's own answers all the same, and a fresh one at each asking: a reading that
+     * borrows nothing still comes to the machines it built, and what it came to is what its own
+     * counterfactual is handed. Handing out one shared object would make every such reading write
+     * into the same maps.
+     */
+    DeclarationReadings NONE = _ -> StringMachineAnswers.borrowing(StringFacts.NONE);
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -390,10 +390,6 @@ public final class FieldDomains {
         // answers were being given away by treating it as a value with nothing to say.
         InvariantChecker.Seeded seeded =
                 InvariantChecker.seedFields(named, source, policy, settled, reach, machines);
-        // What the reading answered its string questions from, kept as the value it is so that a
-        // counterfactual of this reading is handed it. Taken after the reading, so that what one
-        // recording its own machines came to is here as well as what it borrowed.
-        StringFacts stringMachines = machines.of(named.key()).facts();
         Map<RuleKey, NumericDomain.Bounds> out = new LinkedHashMap<>();
         seeded.atoms().forEach((field, atom) -> {
             // The value itself is at no name of its own, and its range is the one thing not worth
@@ -448,7 +444,7 @@ public final class FieldDomains {
                 seeded.notGathered(), seeded.handedOn(), placeOf,
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
-                seeded.readBy(), seeded.spacing(), stringMachines);
+                seeded.readBy(), seeded.spacing(), seeded.stringMachines());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -764,8 +764,9 @@ public final class FieldDomains {
      * came to them, and nothing else.
      *
      * <p>This declaration's, because they are what is here. Another declaration's are a store's
-     * answer about it, and asking for one takes a store — which a reading standing inside a
-     * comparison has no way to reach, and which is not what this holds.
+     * answer about it, and asking for one takes a store, which a reading standing inside a
+     * comparison has no way to reach — so a reading of one of those borrows nothing and keeps what
+     * it builds, which is what {@link StringMachineAnswers#unborrowed()} is.
      *
      * <p>Nothing of the reading itself is lent. What a counterfactual is depends on what it leaves
      * out, so no counterfactual is the declaration's canonical reading and none is kept as one —
@@ -774,7 +775,7 @@ public final class FieldDomains {
      */
     private DeclarationReadings borrowingMachines() {
         return declaration -> declaration.equals(named.key())
-                ? StringMachineAnswers.borrowing(stringMachines) : StringMachineAnswers.NONE;
+                ? StringMachineAnswers.borrowing(stringMachines) : StringMachineAnswers.unborrowed();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -9,6 +9,7 @@ import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Rel;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.AdmissibleSet;
+import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.UnreadReason;
 import souther.compiler.values.ValueSet;
@@ -73,7 +74,7 @@ public final class FieldDomains {
                     NOTHING_NAMED,
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(),
                     Set.of(RuleKey.THE_VALUE),
-                    Map.of(), Map.of(), Map.of(), Map.of());
+                    Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE);
 
     private final Map<RuleKey, NumericDomain.Bounds> byName;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -171,6 +172,21 @@ public final class FieldDomains {
      *  the reading would have stated for it. */
     private final Map<FactSubject, souther.compiler.numeric.Granularity> spacing;
     /**
+     * The string machines this reading answered from and made.
+     *
+     * <p>A value, and the one a store keeps under the declaration. What it holds is a fact about a
+     * plan, a set or a language beside a stretch, and which reading built it does not enter into
+     * what it says — so a counterfactual of this reading is handed it rather than building the same
+     * machines again ({@link #counterfactual}). Leaving rules out changes which plans a reading
+     * meets, not what any one of them admits.
+     *
+     * <p>The facts and not the lender they came from. A lender asks a store, and this is reachable
+     * from an answer: what a {@link NarrowedBounds} defers its names to is a reading of this, so a
+     * store's capability kept here would be kept in an answer.
+     */
+    private final StringFacts stringMachines;
+
+    /**
      * The counterfactual readings this one has been asked for, kept under what each leaves out
      * ({@link #counterfactual}).
      *
@@ -200,7 +216,9 @@ public final class FieldDomains {
                          Set<RuleKey> unreadOfEveryValue,
                          Map<RuleKey, FactSubject> atomAt, Map<RuleKey, Counted> countAt,
                          Map<RuleRef.Invariant, Map<Core, InvariantChecker.PartRead>> readBy,
-                         Map<FactSubject, souther.compiler.numeric.Granularity> spacing) {
+                         Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
+                         StringFacts stringMachines) {
+        this.stringMachines = stringMachines;
         this.byName = byName;
         this.heldByName = heldByName;
         this.admittedByName = admittedByName;
@@ -372,6 +390,10 @@ public final class FieldDomains {
         // answers were being given away by treating it as a value with nothing to say.
         InvariantChecker.Seeded seeded =
                 InvariantChecker.seedFields(named, source, policy, settled, reach, machines);
+        // What the reading answered its string questions from, kept as the value it is so that a
+        // counterfactual of this reading is handed it. Taken after the reading, so that what one
+        // recording its own machines came to is here as well as what it borrowed.
+        StringFacts stringMachines = machines.of(named.key()).facts();
         Map<RuleKey, NumericDomain.Bounds> out = new LinkedHashMap<>();
         seeded.atoms().forEach((field, atom) -> {
             // The value itself is at no name of its own, and its range is the one thing not worth
@@ -426,7 +448,7 @@ public final class FieldDomains {
                 seeded.notGathered(), seeded.handedOn(), placeOf,
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
-                seeded.readBy(), seeded.spacing());
+                seeded.readBy(), seeded.spacing(), stringMachines);
     }
 
     /**
@@ -737,8 +759,25 @@ public final class FieldDomains {
      */
     private FieldDomains counterfactual(LeftOut omitted) {
         return counterfactuals.computeIfAbsent(omitted,
-                left -> of(named, data, source, policy, settled, left.reach(),
-                        DeclarationReadings.NONE));
+                left -> of(named, data, source, policy, settled, left.reach(), borrowingMachines()));
+    }
+
+    /**
+     * What a counterfactual of this reading borrows: this declaration's machines as this reading
+     * came to them, and nothing else.
+     *
+     * <p>This declaration's, because they are what is here. Another declaration's are a store's
+     * answer about it, and asking for one takes a store — which a reading standing inside a
+     * comparison has no way to reach, and which is not what this holds.
+     *
+     * <p>Nothing of the reading itself is lent. What a counterfactual is depends on what it leaves
+     * out, so no counterfactual is the declaration's canonical reading and none is kept as one —
+     * which is what {@link InvariantChecker#seedFields} settles by looking at the reach it was
+     * handed.
+     */
+    private DeclarationReadings borrowingMachines() {
+        return declaration -> declaration.equals(named.key())
+                ? StringMachineAnswers.borrowing(stringMachines) : StringMachineAnswers.NONE;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -750,7 +750,8 @@ public final class FieldDomains {
      * it.
      *
      * <p>The one place a counterfactual of this reading is stood up, so that what one is — the
-     * declaration, its source, what it may spend, and what it leaves out — is settled once. The
+     * declaration, its source, what it may spend, what it leaves out, and what it is handed rather
+     * than builds ({@link #borrowingMachines}) — is settled once. The
      * questions that leave the same rules out get the reading that was made: both ends of a
      * coordinate leave the same rules out, a declaration reaching several of a record's names
      * leaves them out again at each of them, and the questions {@link EndNarrowing} puts ask for

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.ConjoinedAdmissibleValues;
@@ -468,6 +469,10 @@ public final class InvariantChecker {
      *                 is handed every value with nothing saying why
      * @param notSeparated the names whose values this reading cannot show are the whole of what the
      *                 rules leave
+     * @param stringMachines what this reading answered its string questions from and what it made
+     *                 answering them. Carried by the reading because the reading is what came to
+     *                 them: asked of the lender afterwards, what comes back is what was there to
+     *                 borrow before this reading built anything
      */
     record Seeded(ConstraintState<FactSubject> constraints, Map<RuleKey, FactSubject> atoms,
                   Map<RuleKey, FactSubject> keys,
@@ -478,7 +483,8 @@ public final class InvariantChecker {
                   Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
                   Map<RuleKey, ValueSet> admitted,
                   Map<RuleKey, List<UnreadReason>> unreadAt,
-                  Set<RuleKey> notSeparated) {
+                  Set<RuleKey> notSeparated,
+                  StringFacts stringMachines) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
          *  which operation it is a count of. Projected rather than kept beside {@link #held()}: two
@@ -1072,7 +1078,8 @@ public final class InvariantChecker {
         }
         return new Seeded(constraints, atoms, keys, held, reading, took, read,
                 notGathered, unreadOfEveryValue, Set.copyOf(handedOn),
-                readBy, Map.copyOf(spacing), admitted, unreadAt, notSeparated);
+                readBy, Map.copyOf(spacing), admitted, unreadAt, notSeparated,
+                c.answers.facts());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -267,7 +267,7 @@ public final class InvariantChecker {
      * reading's to keep: it is asked of these, which answer from what the store keeps for the
      * declaration and work out the rest.
      */
-    private StringMachineAnswers answers = StringMachineAnswers.NONE;
+    private StringMachineAnswers answers = StringMachineAnswers.unborrowed();
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -108,8 +108,16 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
                 machines);
     }
 
-    /** The answers about the string machines of the declaration {@code read} names, or none
-     *  where it names no declaration of a module. */
+    /**
+     * The answers about the string machines of the declaration {@code read} names, or none where it
+     * names no declaration of a module.
+     *
+     * <p>What is lent to an allowance and to the questions {@link #answers()} serves, and not a
+     * reading's own answers — a reading makes those where it is made, and this is asked again each
+     * time because one of them is not a value and this is inside an answer. So the empty case is
+     * {@link StringMachineAnswers#NONE} and not a reading's: there is nothing here for anything to
+     * keep what it builds for.
+     */
     private static StringMachineAnswers answersFor(TypeSymbol read, DeclarationReadings machines) {
         return read instanceof TypeSymbol.AtModule at
                 ? machines.of(at.key()) : StringMachineAnswers.NONE;

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -189,11 +189,12 @@ public final class Db implements StoreWork {
 
 
     /** What this store answers about {@code declaration}'s string machines, for a reading to
-     *  borrow — nothing, where it has no answer for the declaration at all. */
+     *  borrow — nothing to borrow, where it has no answer for the declaration at all. Either way
+     *  the reading keeps what it builds: that is what its own counterfactual is handed. */
     private StringMachineAnswers machinesOf(TypeKey declaration) {
         Answer<StringFacts> facts = ask(new Machines.OfDeclaration(declaration));
         return facts.present()
-                ? StringMachineAnswers.borrowing(facts.value()) : StringMachineAnswers.NONE;
+                ? StringMachineAnswers.borrowing(facts.value()) : StringMachineAnswers.unborrowed();
     }
 
     private final Map<Key<?>, Memo> memos = new HashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Machines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Machines.java
@@ -54,7 +54,7 @@ public final class Machines {
             if (!source.present() || !policy.present()) {
                 return Answer.absent();
             }
-            StringMachineAnswers recorder = StringMachineAnswers.recording();
+            StringMachineAnswers recorder = StringMachineAnswers.borrowing(StringFacts.NONE);
             FieldDomains domains = FieldDomains.of(TypeSymbols.declared(named), source.value(),
                     policy.value(),
                     db.readings().whileTheAnswerIsMade(named, recorder));

--- a/souther-compiler/src/main/java/souther/compiler/query/Machines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Machines.java
@@ -54,7 +54,7 @@ public final class Machines {
             if (!source.present() || !policy.present()) {
                 return Answer.absent();
             }
-            StringMachineAnswers recorder = StringMachineAnswers.borrowing(StringFacts.NONE);
+            StringMachineAnswers recorder = StringMachineAnswers.unborrowed();
             FieldDomains domains = FieldDomains.of(TypeSymbols.declared(named), source.value(),
                     policy.value(),
                     db.readings().whileTheAnswerIsMade(named, recorder));

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -34,8 +34,14 @@ public final class StringMachineAnswers {
      * Answering from nothing and keeping nothing: every machine worked out on the spot.
      *
      * <p>For a question asked outside a reading — whether a state is bottom, whether a set meets a
-     * range — where there is nothing to borrow from and nothing that will be read again. Shared,
-     * which is why this one keeps nothing: a reading's answers are its own.
+     * range — where there is nothing to borrow from and nothing that will be asked again. Shared,
+     * which is why this one keeps nothing.
+     *
+     * <p><b>Never handed to a reading.</b> A reading's answers are its own and keep what they make,
+     * because what a reading came to is what its counterfactual is handed; handed this one, a
+     * reading would come to nothing and the counterfactual would build all of it again. A reading
+     * with nothing to borrow is {@link #unborrowed()}, which is a different thing from this and
+     * reads like it.
      */
     public static final StringMachineAnswers NONE = new StringMachineAnswers(StringFacts.NONE, false);
 
@@ -55,15 +61,26 @@ public final class StringMachineAnswers {
     /**
      * A reading's own answers, made from {@code facts} and keeping what it works out beside them.
      *
-     * <p>{@link StringFacts#NONE} for a reading with nothing to borrow, which is a reading that
-     * builds all of them and holds all of them — the canonical reading of a declaration, whose
-     * machines become the facts the store keeps, is one of those.
+     * <p>{@link #unborrowed()} where there is nothing to borrow, which is the same thing over no
+     * facts at all.
      */
     public static StringMachineAnswers borrowing(StringFacts facts) {
         if (facts == null) {
             throw new IllegalArgumentException("a reading borrows from some facts, or from none");
         }
         return new StringMachineAnswers(facts, true);
+    }
+
+    /**
+     * A reading's own answers with nothing to borrow: it builds every machine it meets and holds
+     * every one it built.
+     *
+     * <p>Which is what a reading with no lender is, and what a reading of a declaration the lender
+     * has nothing for is. Not {@link #NONE}: having nothing to borrow and keeping nothing are two
+     * things, and they parted when what a reading came to became what its counterfactual is handed.
+     */
+    public static StringMachineAnswers unborrowed() {
+        return new StringMachineAnswers(StringFacts.NONE, true);
     }
 
     /** What {@code plan} admits where somebody has made it, or null; asking makes nothing and

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -64,10 +64,12 @@ public final class StringMachineAnswers {
         if (known != null) {
             return known;
         }
-        MADE.incrementAndGet();
         TextExtent made = TextExtents.of(set);
-        if (recording && !(made instanceof TextExtent.NotBuilt)) {
-            extents.put(set, made);
+        if (!(made instanceof TextExtent.NotBuilt)) {
+            MADE.incrementAndGet();
+            if (recording) {
+                extents.put(set, made);
+            }
         }
         return made;
     }
@@ -84,10 +86,12 @@ public final class StringMachineAnswers {
         if (known != null) {
             return known;
         }
-        MADE.incrementAndGet();
         Emptiness made = TextExtents.inside(language, held, meter);
-        if (recording && made != Emptiness.UNDECIDED) {
-            inside.put(stretch, made);
+        if (made != Emptiness.UNDECIDED) {
+            MADE.incrementAndGet();
+            if (recording) {
+                inside.put(stretch, made);
+            }
         }
         return made;
     }
@@ -112,8 +116,11 @@ public final class StringMachineAnswers {
                     case AdmittedPlan.Pattern _, AdmittedPlan.Both _, AdmittedPlan.Either _ ->
                             true;
                 };
-                if (recording && machine && made instanceof Realization.Exact it) {
-                    realized.put(plan, it.set());
+                if (machine && made instanceof Realization.Exact it) {
+                    MADE.incrementAndGet();
+                    if (recording) {
+                        realized.put(plan, it.set());
+                    }
                 }
             }
         };
@@ -123,9 +130,14 @@ public final class StringMachineAnswers {
      * How many machines have been made rather than answered from the facts, for a test holding a
      * reading to what it borrows.
      *
-     * <p>Counted where the answer is not there to be had, which is the one place a machine is
-     * built. What a caller is held to is that a second reading of a declaration asks the same
-     * string questions and is answered from what the first came to — a shape, and not a speed.
+     * <p>All three of the questions this answers, counted where the answer was not there to be had
+     * and what was built came out: a plan realized into a set, the extent of a set, and whether a
+     * language has a string inside a stretch. Counted whatever this does with it afterwards, since
+     * keeping what was built is what a recording one does and building it is what any of them may
+     * have to do.
+     *
+     * <p>What a caller is held to is that a second reading of a declaration asks the same string
+     * questions and is answered from what the first came to — a shape, and not a speed.
      */
     public static long machinesMade() {
         return MADE.get();

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -13,9 +13,15 @@ import java.util.concurrent.atomic.AtomicLong;
  * has already made where there is such a thing, and worked out where there is not.
  *
  * <p>Held by the reading and by nothing that outlives it. It is not a value: what it answers from
- * is a value ({@link StringFacts}), but it also builds, and a reading that records what it built
- * ({@link #recording}) is a different object at the end from the one it was at the start. So it is
- * made where a reading is made, handed along with it, and never kept in an answer.
+ * is a value ({@link StringFacts}), but it also builds, and one that has answered a reading is a
+ * different object at the end from the one it was at the start. So it is made where a reading is
+ * made, handed along with it, and never kept in an answer — what leaves is {@link #facts()}.
+ *
+ * <p>One of these keeps what it made, whether or not it borrowed. What a reading came to is what it
+ * was handed and what it built on top, and the reading is the only place both are: asked of the
+ * lender afterwards, what comes back is what there was to borrow before the reading built anything.
+ * {@link #NONE} is the exception and is not a reading's — it is what a question asked outside one
+ * has to answer from.
  *
  * <p>What is borrowed is not spent. A machine answered from the facts was made under an allowance
  * of the reading that made it, so a reading whose allowance would have refused it is handed the
@@ -24,32 +30,40 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class StringMachineAnswers {
 
-    /** Answering from nothing and keeping nothing: every machine worked out on the spot. */
+    /**
+     * Answering from nothing and keeping nothing: every machine worked out on the spot.
+     *
+     * <p>For a question asked outside a reading — whether a state is bottom, whether a set meets a
+     * range — where there is nothing to borrow from and nothing that will be read again. Shared,
+     * which is why this one keeps nothing: a reading's answers are its own.
+     */
     public static final StringMachineAnswers NONE = new StringMachineAnswers(StringFacts.NONE, false);
 
     private final StringFacts borrowed;
-    private final boolean recording;
+    /** Whether what is made here is kept, which is what a reading's own answers do and what the
+     *  shared {@link #NONE} must not. */
+    private final boolean keeps;
     private final Map<AdmittedPlan, ValueSet> realized = new LinkedHashMap<>();
     private final Map<ValueSet, TextExtent> extents = new LinkedHashMap<>();
     private final Map<StringFacts.Stretch, Emptiness> inside = new LinkedHashMap<>();
 
-    private StringMachineAnswers(StringFacts borrowed, boolean recording) {
+    private StringMachineAnswers(StringFacts borrowed, boolean keeps) {
         this.borrowed = borrowed;
-        this.recording = recording;
+        this.keeps = keeps;
     }
 
-    /** Answering from {@code facts}, and working out the rest without keeping it. */
+    /**
+     * A reading's own answers, made from {@code facts} and keeping what it works out beside them.
+     *
+     * <p>{@link StringFacts#NONE} for a reading with nothing to borrow, which is a reading that
+     * builds all of them and holds all of them — the canonical reading of a declaration, whose
+     * machines become the facts the store keeps, is one of those.
+     */
     public static StringMachineAnswers borrowing(StringFacts facts) {
         if (facts == null) {
             throw new IllegalArgumentException("a reading borrows from some facts, or from none");
         }
-        return new StringMachineAnswers(facts, false);
-    }
-
-    /** Answering from nothing and keeping everything it works out, for the reading whose machines
-     *  become the facts the store keeps ({@link #facts}). */
-    public static StringMachineAnswers recording() {
-        return new StringMachineAnswers(StringFacts.NONE, true);
+        return new StringMachineAnswers(facts, true);
     }
 
     /** What {@code plan} admits where somebody has made it, or null; asking makes nothing and
@@ -67,7 +81,7 @@ public final class StringMachineAnswers {
         TextExtent made = TextExtents.of(set);
         if (!(made instanceof TextExtent.NotBuilt)) {
             MADE.incrementAndGet();
-            if (recording) {
+            if (keeps) {
                 extents.put(set, made);
             }
         }
@@ -89,7 +103,7 @@ public final class StringMachineAnswers {
         Emptiness made = TextExtents.inside(language, held, meter);
         if (made != Emptiness.UNDECIDED) {
             MADE.incrementAndGet();
-            if (recording) {
+            if (keeps) {
                 inside.put(stretch, made);
             }
         }
@@ -97,7 +111,7 @@ public final class StringMachineAnswers {
     }
 
     /** The same, as the lender an allowance takes; the block is not part of the question, and
-     *  what the allowance builds is kept here where this is recording. */
+     *  what the allowance builds is kept here. */
     public <A> Allowance.Known<A> lending() {
         return new Allowance.Known<>() {
             @Override
@@ -118,7 +132,7 @@ public final class StringMachineAnswers {
                 };
                 if (machine && made instanceof Realization.Exact it) {
                     MADE.incrementAndGet();
-                    if (recording) {
+                    if (keeps) {
                         realized.put(plan, it.set());
                     }
                 }
@@ -132,9 +146,8 @@ public final class StringMachineAnswers {
      *
      * <p>All three of the questions this answers, counted where the answer was not there to be had
      * and what was built came out: a plan realized into a set, the extent of a set, and whether a
-     * language has a string inside a stretch. Counted whatever this does with it afterwards, since
-     * keeping what was built is what a recording one does and building it is what any of them may
-     * have to do.
+     * language has a string inside a stretch. Counted whatever this does with it afterwards: what
+     * is at stake is whether the machine had to be built, and not whose maps it ends up in.
      *
      * <p>What a caller is held to is that a second reading of a declaration asks the same string
      * questions and is answered from what the first came to — a shape, and not a speed.
@@ -145,14 +158,14 @@ public final class StringMachineAnswers {
 
     private static final AtomicLong MADE = new AtomicLong();
 
-    /** Everything this answered from and everything it made, as the value a store keeps. */
+    /**
+     * Everything this answered from and everything it made: what the reading it belongs to came to.
+     *
+     * <p>What a store keeps under the declaration, and what a second reading of the same
+     * declaration is handed — including a counterfactual of the reading this answered, which meets
+     * the same string rules wherever what it leaves out is about something else.
+     */
     public StringFacts facts() {
-        if (realized.isEmpty() && extents.isEmpty() && inside.isEmpty()) {
-            // Nothing was made beside what was borrowed, and what was borrowed is already this
-            // value. A reading that only answered from the facts asks for them as often as it is
-            // read again, and a copy each time is a copy of everything the declaration came to.
-            return borrowed;
-        }
         Map<AdmittedPlan, ValueSet> plans = new LinkedHashMap<>(borrowed.realized());
         plans.putAll(realized);
         Map<ValueSet, TextExtent> stops = new LinkedHashMap<>(borrowed.extents());

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -6,6 +6,7 @@ import souther.compiler.regex.Meter;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * What a reading of one declaration asks about its string machines, answered from what somebody
@@ -63,6 +64,7 @@ public final class StringMachineAnswers {
         if (known != null) {
             return known;
         }
+        MADE.incrementAndGet();
         TextExtent made = TextExtents.of(set);
         if (recording && !(made instanceof TextExtent.NotBuilt)) {
             extents.put(set, made);
@@ -82,6 +84,7 @@ public final class StringMachineAnswers {
         if (known != null) {
             return known;
         }
+        MADE.incrementAndGet();
         Emptiness made = TextExtents.inside(language, held, meter);
         if (recording && made != Emptiness.UNDECIDED) {
             inside.put(stretch, made);
@@ -116,8 +119,28 @@ public final class StringMachineAnswers {
         };
     }
 
+    /**
+     * How many machines have been made rather than answered from the facts, for a test holding a
+     * reading to what it borrows.
+     *
+     * <p>Counted where the answer is not there to be had, which is the one place a machine is
+     * built. What a caller is held to is that a second reading of a declaration asks the same
+     * string questions and is answered from what the first came to — a shape, and not a speed.
+     */
+    public static long machinesMade() {
+        return MADE.get();
+    }
+
+    private static final AtomicLong MADE = new AtomicLong();
+
     /** Everything this answered from and everything it made, as the value a store keeps. */
     public StringFacts facts() {
+        if (realized.isEmpty() && extents.isEmpty() && inside.isEmpty()) {
+            // Nothing was made beside what was borrowed, and what was borrowed is already this
+            // value. A reading that only answered from the facts asks for them as often as it is
+            // read again, and a copy each time is a copy of everything the declaration came to.
+            return borrowed;
+        }
         Map<AdmittedPlan, ValueSet> plans = new LinkedHashMap<>(borrowed.realized());
         plans.putAll(realized);
         Map<ValueSet, TextExtent> stops = new LinkedHashMap<>(borrowed.extents());

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
@@ -4,13 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.numeric.EndSide;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.Machines;
 import souther.compiler.query.ReadAs;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -81,6 +84,43 @@ class ACounterfactualBorrowsTheMachinesTheReadingMadeTest {
                 "the floor under `hi` is held by whoever the counterfactual says, so one was taken");
         assertEquals(before, StringMachineAnswers.machinesMade(),
                 "and it answered its string questions out of the machines the reading holds");
+    }
+
+    /**
+     * The same, where what there was to borrow was only part of it.
+     *
+     * <p>What a counterfactual is handed is what the reading it comes from came to, which is what
+     * it borrowed and what it built on top. Handed instead what the lender answers afterwards, a
+     * counterfactual gets what there was to borrow before the reading built anything — and builds
+     * everything the reading built, one step away from where it was building it before.
+     *
+     * <p>The lender here answers with the plans and none of the extents, so the reading borrows
+     * some of its machines and makes the rest.
+     */
+    @Test
+    void whatTheReadingBuiltOnTopIsHandedOnToo() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        TypeKey held = new TypeKey("demo", "Held");
+        StringFacts whole = compilation.db().ask(new Machines.OfDeclaration(held)).value();
+        assertFalse(whole.extents().isEmpty(),
+                "the declaration's machines include extents, so leaving them out leaves work to do");
+        StringFacts part = new StringFacts(whole.realized(), Map.of(), Map.of());
+
+        long beforeReading = StringMachineAnswers.machinesMade();
+        FieldDomains reading = FieldDomains.of(TypeSymbols.declared(held),
+                RuleReadings.of(compilation, compilation.modules().get(0)),
+                ReadAs.THE_COMPILATION_DOES,
+                _ -> StringMachineAnswers.borrowing(part));
+        assertTrue(StringMachineAnswers.machinesMade() > beforeReading,
+                "the reading builds what the lender had nothing to say about");
+
+        long before = StringMachineAnswers.machinesMade();
+        assertFalse(AReadingOfAPosition.holding(reading.at(RuleKey.of("hi")), EndSide.LOWER)
+                        .isEmpty(),
+                "the floor under `hi` is attributed, so a counterfactual was taken");
+        assertEquals(before, StringMachineAnswers.machinesMade(),
+                "and it is handed what the reading borrowed and what the reading made");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
@@ -124,6 +124,35 @@ class ACounterfactualBorrowsTheMachinesTheReadingMadeTest {
     }
 
     /**
+     * The same, for a declaration read from inside another declaration's answer.
+     *
+     * <p>The machines a declaration's answer is made of are built by that declaration's own
+     * reading, its fields' declarations included, because asking the store for one of those from
+     * inside would be two declarations waiting on each other. A reading of one of those is a
+     * reading all the same: it borrows nothing, and what it builds is what its own counterfactual
+     * is handed. Handed answers that keep nothing, it comes to nothing — and it is handed on inside
+     * the revision, so what asks for that declaration next gets the reading that came to nothing.
+     */
+    @Test
+    void aDeclarationReadFromInsideAnothersAnswerKeepsWhatItBuilt() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        TypeKey inner = new TypeKey("demo", "Common");
+        compilation.db().ask(new Machines.OfDeclaration(new TypeKey("demo", "Held")));
+
+        FieldDomains reading = FieldDomains.of(TypeSymbols.declared(inner),
+                RuleReadings.of(compilation, compilation.modules().get(0)),
+                ReadAs.THE_COMPILATION_DOES,
+                compilation.db().readings());
+
+        long before = StringMachineAnswers.machinesMade();
+        assertFalse(AReadingOfAPosition.holding(reading.at(RuleKey.of("hi")), EndSide.LOWER)
+                        .isEmpty(),
+                "the floor under `hi` is attributed, so a counterfactual was taken");
+        assertEquals(before, StringMachineAnswers.machinesMade(),
+                "and the reading it comes from kept what it built, wherever it was read");
+    }
+
+    /**
      * The same reading, asked for what it holds rather than for who holds it.
      *
      * <p>A negative control on the count above: machines are made when this declaration is read at

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
@@ -124,35 +124,6 @@ class ACounterfactualBorrowsTheMachinesTheReadingMadeTest {
     }
 
     /**
-     * The same, for a declaration read from inside another declaration's answer.
-     *
-     * <p>The machines a declaration's answer is made of are built by that declaration's own
-     * reading, its fields' declarations included, because asking the store for one of those from
-     * inside would be two declarations waiting on each other. A reading of one of those is a
-     * reading all the same: it borrows nothing, and what it builds is what its own counterfactual
-     * is handed. Handed answers that keep nothing, it comes to nothing — and it is handed on inside
-     * the revision, so what asks for that declaration next gets the reading that came to nothing.
-     */
-    @Test
-    void aDeclarationReadFromInsideAnothersAnswerKeepsWhatItBuilt() {
-        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
-        TypeKey inner = new TypeKey("demo", "Common");
-        compilation.db().ask(new Machines.OfDeclaration(new TypeKey("demo", "Held")));
-
-        FieldDomains reading = FieldDomains.of(TypeSymbols.declared(inner),
-                RuleReadings.of(compilation, compilation.modules().get(0)),
-                ReadAs.THE_COMPILATION_DOES,
-                compilation.db().readings());
-
-        long before = StringMachineAnswers.machinesMade();
-        assertFalse(AReadingOfAPosition.holding(reading.at(RuleKey.of("hi")), EndSide.LOWER)
-                        .isEmpty(),
-                "the floor under `hi` is attributed, so a counterfactual was taken");
-        assertEquals(before, StringMachineAnswers.machinesMade(),
-                "and the reading it comes from kept what it built, wherever it was read");
-    }
-
-    /**
      * The same reading, asked for what it holds rather than for who holds it.
      *
      * <p>A negative control on the count above: machines are made when this declaration is read at

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
@@ -1,0 +1,106 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.EndSide;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.StringMachineAnswers;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A reading taken again with rules left out is answered out of the string machines the reading it
+ * was taken from came to.
+ *
+ * <p>A machine is a fact about a plan, a set, or a language beside a stretch, and which reading
+ * built it does not enter into what it says. Leaving a declaration's clauses out changes which
+ * plans a reading meets; it does not change what any one of them admits. So a counterfactual over
+ * clauses about numbers meets the same string rules as the reading it is taken from, and asks its
+ * string questions of what that reading already holds.
+ *
+ * <p>Two readings answered from the same facts is also what makes attributing an end a comparison.
+ * A borrowed machine is not paid for out of the borrower's allowance, so a counterfactual left to
+ * build its own would be the one reading of the two that could run out and answer a wider end —
+ * and the end it was compared against would read as one its own clauses had moved.
+ */
+class ACounterfactualBorrowsTheMachinesTheReadingMadeTest {
+
+    /**
+     * A record whose fields are a string with a pattern and two numbers, and two declarations
+     * putting a floor under one of the numbers.
+     *
+     * <p>The floor is what is attributed, and it is attributed by leaving clauses about numbers
+     * out. The pattern is reached either way, so the counterfactual asks the same string questions
+     * as the reading it comes from.
+     */
+    private static final String SOURCE = """
+            module demo exposing ( Held, keep )
+
+            data Code = String
+                invariant String.matches("[A-Z]{2}-[0-9]{4}", value)
+
+            data Common =
+                { code: Code
+                , lo: Int
+                , hi: Int
+                }
+                invariant based = lo >= 100
+                invariant far = hi >= lo + 10
+
+            data Held = { ...Common }
+                invariant near = hi >= lo + 5
+
+            behavior keep : (h: Held) -> Held
+
+            let keep (h) = h
+            """;
+
+    @Test
+    void theCounterfactualMakesNoMachineTheReadingItComesFromHolds() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        FieldDomains reading = FieldDomains.of(
+                TypeSymbols.declared(new TypeKey("demo", "Held")),
+                RuleReadings.of(compilation, compilation.modules().get(0)),
+                ReadAs.THE_COMPILATION_DOES,
+                compilation.db().readings());
+
+        long before = StringMachineAnswers.machinesMade();
+        List<TypeSymbol.AtModule> holding =
+                AReadingOfAPosition.holding(reading.at(RuleKey.of("hi")), EndSide.LOWER);
+
+        assertFalse(holding.isEmpty(),
+                "the floor under `hi` is held by whoever the counterfactual says, so one was taken");
+        assertEquals(before, StringMachineAnswers.machinesMade(),
+                "and it answered its string questions out of the machines the reading holds");
+    }
+
+    /**
+     * The same reading, asked for what it holds rather than for who holds it.
+     *
+     * <p>A negative control on the count above: machines are made when this declaration is read at
+     * all, so a count that never moves would say the reading asks no string questions rather than
+     * that the counterfactual borrows the answers.
+     */
+    @Test
+    void readingTheDeclarationMakesMachines() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+
+        long before = StringMachineAnswers.machinesMade();
+        FieldDomains.of(TypeSymbols.declared(new TypeKey("demo", "Held")),
+                RuleReadings.of(compilation, compilation.modules().get(0)),
+                ReadAs.THE_COMPILATION_DOES);
+
+        assertTrue(StringMachineAnswers.machinesMade() > before,
+                "a reading with nothing to borrow from builds the machines its rules come to");
+    }
+}


### PR DESCRIPTION
Closes #1431.

A reading taken again with some rules left out — which is how who holds an end is answered — was stood up with no lender, so it built every string machine it met, including the ones the reading it comes from already holds. It is handed them now.

The machines are not the reading. Each entry of `StringFacts` is a fact about a plan, a set, or a language beside a stretch, and which reading built it does not enter into what it says. Leaving a declaration's clauses out changes which plans a reading meets; it does not change what any one of them admits.

What is handed on is what the reading came to, and the reading is what carries it. `Seeded` holds what its answers object answered from and made, taken from the object the reading itself used. Asked of the lender afterwards instead, what comes back is what there was to borrow before the reading built anything — and everything the reading built on top would be built again by the counterfactual, which is the work this removes, one step from where it was.

So a reading's answers keep what they make, whether or not they borrowed: the flag that made keeping the privilege of one reading is gone, and the reading whose machines become the store's answer is now just the one that borrowed nothing.

Which leaves three things where there were two, and the names say which is which. `NONE` is shared and keeps nothing, for a question asked outside a reading — whether a state is bottom, whether a set meets a range. `unborrowed()` is a reading with nothing to borrow: its own, and it keeps what it builds. `borrowing(facts)` is a reading with something to borrow. Having nothing to borrow and keeping nothing were one thing while nothing was kept; they parted here, and every place that hands answers to a reading says the second rather than the first — a reading given no lender, a declaration the store has no answer for, the declarations a counterfactual reaches, and the reading a clause-discharge walk makes.

What a `FieldDomains` keeps is the facts and not the lender they came from. A lender asks a store, and a reading is reachable from an answer through the supplier a `NarrowedBounds` defers its names to, so a store's capability kept there would be kept in an answer.

There is a second reason beside the cost. A borrowed machine is not paid for out of the borrower's allowance, so the reading an end is compared against was handed machines the counterfactual had to afford for itself — and a counterfactual that could not afford one answers a wider end, which reads as an end its own clauses had moved. The two are answered from the same facts now.

Measured with `souther-bench` over the crm corpus, snapshotting each revision's classes and swapping the one classpath entry between alternating runs: the leaf edit comes down by about two fifths, and the edit of an imported module, the comment edit and the warm compile stay where they are. The count of readings an edit makes is unchanged — this is what a reading costs, not how many there are — and an edit now builds no string machine at all.

`ACounterfactualBorrowsTheMachinesTheReadingMadeTest` holds it, over a record whose fields are a string with a pattern and two numbers, with two declarations putting a floor under one of them, so that what the counterfactual leaves out is about numbers and the string questions it asks are the ones the reading it comes from answered. Handed the whole of the declaration's machines, the counterfactual builds none. Handed only part of them — the plans and none of the extents — the reading builds the rest and the counterfactual still builds none, which is what says the facts come from the reading rather than from the lender. The class carries the negative control as well: a reading with nothing to borrow from builds them. `StringMachineAnswers.machinesMade()` is the seam, counted at each of the three questions where a machine had to be built.

Both mutations were run: taking the facts from the lender after the reading turns the partial one red and leaves the others green, and handing the counterfactual nothing turns the first red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
