### PR TITLE
Read the next message while the one before it is being answered

### DIFF
--- a/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
+++ b/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
@@ -40,8 +40,10 @@ class TheLanguageServerIsOneThisCommandLineServesTest {
                 message(null, "textDocument/didOpen", Map.of(
                         "textDocument", Map.of("uri", "file:///t.sou",
                                 "text", "module demo\ndata M = { name: Missing }\n"))),
-                message(2, "shutdown", Map.of()),
-                message(null, "exit", Map.of())));
+                // Shut down and then the stream ends, which is a session ending the way a client
+                // that closes its editor ends one. No `exit`: that is a client saying stop now, and
+                // a server told to stop now has nothing more to publish.
+                message(2, "shutdown", Map.of())));
 
         assertEquals(0, answer.code(), "a session its client shut down is this command finishing");
 

--- a/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
+++ b/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
@@ -6,6 +6,10 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.UncheckedIOException;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -15,6 +19,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,17 +39,20 @@ class TheLanguageServerIsOneThisCommandLineServesTest {
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
     @Test
-    void aLineNamingTheCommandIsAnsweredWithTheHandshake() {
-        Answer answer = run(frames(
-                message(1, "initialize", Map.of()),
-                message(null, "initialized", Map.of()),
-                message(null, "textDocument/didOpen", Map.of(
-                        "textDocument", Map.of("uri", "file:///t.sou",
-                                "text", "module demo\ndata M = { name: Missing }\n"))),
-                // Shut down and then the stream ends, which is a session ending the way a client
-                // that closes its editor ends one. No `exit`: that is a client saying stop now, and
-                // a server told to stop now has nothing more to publish.
-                message(2, "shutdown", Map.of())));
+    void aLineNamingTheCommandIsAnsweredWithTheHandshake() throws Exception {
+        Answer answer = converse(said -> {
+            said.send(
+                    message(1, "initialize", Map.of()),
+                    message(null, "initialized", Map.of()),
+                    message(null, "textDocument/didOpen", Map.of(
+                            "textDocument", Map.of("uri", "file:///t.sou",
+                                    "text", "module demo\ndata M = { name: Missing }\n"))));
+            // Read what the analysis published before saying goodbye. Diagnostics are what the
+            // server does with a moment nothing was asked of it, so shutting it down in the same
+            // breath as opening the document is shutting it down before it has had one.
+            said.awaitNotification("textDocument/publishDiagnostics");
+            said.send(message(2, "shutdown", Map.of()), message(null, "exit", Map.of()));
+        });
 
         assertEquals(0, answer.code(), "a session its client shut down is this command finishing");
 
@@ -78,6 +87,106 @@ class TheLanguageServerIsOneThisCommandLineServesTest {
             return written.stream()
                     .filter(m -> m.has("method") && m.get("method").asString().equals(method))
                     .findFirst().orElseThrow(() -> new AssertionError("no " + method));
+        }
+    }
+
+    /**
+     * Runs {@code souther lsp} while {@code conversation} talks to it, on streams of this test's own.
+     *
+     * <p>A stream that stays open, because what is being watched for here is published rather than
+     * replied to, and this server publishes in a moment when nothing has been asked of it. A run of
+     * frames written all at once and then ended leaves no such moment.
+     */
+    private static Answer converse(Consumer<Said> conversation) throws Exception {
+        PipedOutputStream toServer = new PipedOutputStream();
+        PipedInputStream serverIn = new PipedInputStream(toServer, 1 << 16);
+        ByteArrayOutputStream wrote = new ByteArrayOutputStream();
+        ByteArrayOutputStream complained = new ByteArrayOutputStream();
+        InputStream in = System.in;
+        PrintStream out = System.out;
+        PrintStream err = System.err;
+        AtomicInteger code = new AtomicInteger(-1);
+        try {
+            System.setIn(serverIn);
+            System.setOut(new PrintStream(wrote, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(complained, true, StandardCharsets.UTF_8));
+            Thread serving = Thread.ofPlatform().name("souther-lsp-under-test")
+                    .start(() -> code.set(Main.dispatch(new String[] {"lsp"})));
+            conversation.accept(new Said(toServer, wrote));
+            toServer.close();
+            serving.join(WAIT_MILLIS);
+        } finally {
+            System.setIn(in);
+            System.setOut(out);
+            System.setErr(err);
+        }
+        return new Answer(code.get(), framesSoFar(wrote.toByteArray()),
+                complained.toString(StandardCharsets.UTF_8));
+    }
+
+    /** Long enough that a slow machine is not a failure, short enough to be a test. */
+    private static final long WAIT_MILLIS = 60_000;
+
+    /** What a test says to a session, and what it waits to hear back. */
+    private record Said(PipedOutputStream toServer, ByteArrayOutputStream wrote) {
+
+        void send(String... messages) {
+            try {
+                toServer.write(frames(messages));
+                toServer.flush();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        void awaitNotification(String method) {
+            long until = System.currentTimeMillis() + WAIT_MILLIS;
+            while (System.currentTimeMillis() < until) {
+                boolean heard = framesSoFar(wrote.toByteArray()).stream()
+                        .anyMatch(m -> m.has("method") && m.get("method").asString().equals(method));
+                if (heard) {
+                    return;
+                }
+                try {
+                    Thread.sleep(2);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            throw new AssertionError("the server never sent " + method);
+        }
+    }
+
+    /**
+     * The messages in {@code wrote} that can be read whole.
+     *
+     * <p>Read while the writing is going on, so the last frame may be a header with its body still
+     * to come. That one is not a message yet and is left for the next read.
+     */
+    private static List<JsonNode> framesSoFar(byte[] wrote) {
+        List<JsonNode> messages = new ArrayList<>();
+        int at = 0;
+        while (true) {
+            int blank = -1;
+            for (int i = at; i + 3 < wrote.length; i++) {
+                if (wrote[i] == '\r' && wrote[i + 1] == '\n'
+                        && wrote[i + 2] == '\r' && wrote[i + 3] == '\n') {
+                    blank = i;
+                    break;
+                }
+            }
+            if (blank < 0) {
+                return messages;
+            }
+            String header = new String(wrote, at, blank - at, StandardCharsets.US_ASCII);
+            int length = Integer.parseInt(header.substring(header.indexOf(':') + 1).trim());
+            int body = blank + 4;
+            if (body + length > wrote.length) {
+                return messages;
+            }
+            messages.add(JSON.readTree(new String(wrote, body, length, StandardCharsets.UTF_8)));
+            at = body + length;
         }
     }
 

--- a/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
+++ b/souther-cli/src/test/java/souther/cli/TheLanguageServerIsOneThisCommandLineServesTest.java
@@ -79,7 +79,9 @@ class TheLanguageServerIsOneThisCommandLineServesTest {
     private record Answer(int code, List<JsonNode> written, String said) {
 
         JsonNode replyTo(int id) {
-            return written.stream().filter(m -> m.has("id") && m.get("id").asInt() == id)
+            return written.stream()
+                    .filter(m -> m.has("id") && m.get("id").isNumber()
+                            && m.get("id").asInt() == id)
                     .findFirst().orElseThrow(() -> new AssertionError("no reply to request " + id));
         }
 

--- a/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
+++ b/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
@@ -50,8 +50,9 @@ class TheShippedBinaryServesTheLanguageServerIT {
                 message(null, "textDocument/didOpen", Map.of(
                         "textDocument", Map.of("uri", source.toUri().toString(),
                                 "text", Files.readString(source)))),
-                message(2, "shutdown", Map.of()),
-                message(null, "exit", Map.of())));
+                // No `exit` after it: the stream closing below is what ends the session, and a
+                // server told to stop now would have nothing more to publish.
+                message(2, "shutdown", Map.of())));
         process.getOutputStream().close();
         byte[] wrote = process.getInputStream().readAllBytes();
         String said = new String(process.getErrorStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);

--- a/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
+++ b/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
@@ -61,7 +61,7 @@ class TheShippedBinaryServesTheLanguageServerIT {
         String frame;
         while (published == null && (frame = answers.read()) != null) {
             JsonNode m = JSON.readTree(frame);
-            if (m.has("id") && m.get("id").asInt() == 1) {
+            if (m.has("id") && m.get("id").isNumber() && m.get("id").asInt() == 1) {
                 capabilities = m.get("result").get("capabilities");
             } else if (m.has("method")
                     && m.get("method").asString().equals("textDocument/publishDiagnostics")) {

--- a/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
+++ b/souther-cli/src/test/java/souther/cli/TheShippedBinaryServesTheLanguageServerIT.java
@@ -11,12 +11,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -44,32 +43,44 @@ class TheShippedBinaryServesTheLanguageServerIT {
         Files.writeString(source, "module trip\n\ndata Draft = { who: Approver }\n");
 
         Process process = new ProcessBuilder(binary.toString(), "lsp").start();
+        MessageConnection answers = new MessageConnection(
+                process.getInputStream(), OutputStream.nullOutputStream());
         process.getOutputStream().write(frames(
                 message(1, "initialize", Map.of("rootUri", source.getParent().toUri().toString())),
                 message(null, "initialized", Map.of()),
                 message(null, "textDocument/didOpen", Map.of(
                         "textDocument", Map.of("uri", source.toUri().toString(),
-                                "text", Files.readString(source)))),
-                // No `exit` after it: the stream closing below is what ends the session, and a
-                // server told to stop now would have nothing more to publish.
-                message(2, "shutdown", Map.of())));
+                                "text", Files.readString(source))))));
+        process.getOutputStream().flush();
+
+        // Read until the analysis arrives, and only then say goodbye. Diagnostics are what the
+        // server does with a moment nothing was asked of it, so asking it to stop in the same breath
+        // as opening the document is asking it to stop before it has had one.
+        JsonNode capabilities = null;
+        JsonNode published = null;
+        String frame;
+        while (published == null && (frame = answers.read()) != null) {
+            JsonNode m = JSON.readTree(frame);
+            if (m.has("id") && m.get("id").asInt() == 1) {
+                capabilities = m.get("result").get("capabilities");
+            } else if (m.has("method")
+                    && m.get("method").asString().equals("textDocument/publishDiagnostics")) {
+                published = m;
+            }
+        }
+
+        process.getOutputStream().write(frames(
+                message(2, "shutdown", Map.of()),
+                message(null, "exit", Map.of())));
         process.getOutputStream().close();
-        byte[] wrote = process.getInputStream().readAllBytes();
         String said = new String(process.getErrorStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
 
         assertEquals(0, process.waitFor(), "a client that shut the server down leaves it zero: " + said);
 
-        List<JsonNode> answers = readFrames(wrote);
-        JsonNode capabilities = answers.stream()
-                .filter(m -> m.has("id") && m.get("id").asInt() == 1).findFirst().orElseThrow()
-                .get("result").get("capabilities");
+        assertNotNull(capabilities, "the handshake was answered");
         assertTrue(capabilities.has("definitionProvider"),
                 "the server the launcher carries is the whole one, not a fragment the shade kept");
-
-        JsonNode published = answers.stream()
-                .filter(m -> m.has("method")
-                        && m.get("method").asString().equals("textDocument/publishDiagnostics"))
-                .findFirst().orElseThrow(() -> new AssertionError("no diagnostics were published"));
+        assertNotNull(published, "no diagnostics were published");
         assertEquals("E1023", published.get("params").get("diagnostics").get(0).get("code").asString(),
                 "and the analysis it needs came with it");
     }
@@ -95,14 +106,4 @@ class TheShippedBinaryServesTheLanguageServerIT {
         return buffer.toByteArray();
     }
 
-    private static List<JsonNode> readFrames(byte[] bytes) {
-        MessageConnection reader = new MessageConnection(
-                new ByteArrayInputStream(bytes), OutputStream.nullOutputStream());
-        List<JsonNode> read = new ArrayList<>();
-        String s;
-        while ((s = reader.read()) != null) {
-            read.add(JSON.readTree(s));
-        }
-        return read;
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Abandoned.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Abandoned.java
@@ -1,0 +1,21 @@
+package souther.compiler.query;
+
+/**
+ * Thrown out of a walk that was asked to stop before it had an answer.
+ *
+ * <p>An {@link Error} and not an exception, because the callers above catch {@code RuntimeException}
+ * and {@code StackOverflowError} to turn a fault into a marker in the file the author is reading. A
+ * walk that was stopped has no fault to report and nothing to say about any file: it was told to
+ * stop, and only whoever told it is entitled to read that. Passing through those catches is what the
+ * type is for.
+ *
+ * <p>No stack trace and no suppression. It is control flow on a path that is taken as often as an
+ * author types, and where it was thrown from says nothing that the reason it was thrown does not.
+ */
+public final class Abandoned extends Error {
+    private static final long serialVersionUID = 1L;
+
+    public Abandoned() {
+        super("the walk was asked to stop before it answered", null, false, false);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Abandonment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Abandonment.java
@@ -13,6 +13,11 @@ import java.util.function.BooleanSupplier;
  * <p>Asking is not a place to do anything else. A supplier that throws is throwing what the work
  * should stop for, and this passes it through: the caller that built this decides both what stopping
  * means and what stopping raises.
+ *
+ * <p>Where to ask is once per turn of a walk, and not once per operation that looks expensive. What
+ * costs is enumerating, and a walk enumerating a thousand things that each cost nothing costs as
+ * much as one enumerating a thousand that each cost something. A step that goes on to call something
+ * which asks is covered; a step that may do nothing at all is not, and is where the asking has to be.
  */
 public final class Abandonment {
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Abandonment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Abandonment.java
@@ -1,0 +1,39 @@
+package souther.compiler.query;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * What long work asks between its steps: whether whoever set it going still wants the answer.
+ *
+ * <p>One value rather than a boolean passed down, because the two ends of it are not alike. What
+ * makes work stop is a question only its caller can answer — a client that cancelled a request, a
+ * keystroke that arrived while a diagnose was walking — and every step in between should be able to
+ * ask it without being told which of those it is. A step asks {@link #stopIfAsked} and goes on.
+ *
+ * <p>Asking is not a place to do anything else. A supplier that throws is throwing what the work
+ * should stop for, and this passes it through: the caller that built this decides both what stopping
+ * means and what stopping raises.
+ */
+public final class Abandonment {
+
+    /** Work that runs to the end whatever else happens — a batch compile, a test. */
+    public static final Abandonment NEVER = new Abandonment(() -> false);
+
+    private final BooleanSupplier asked;
+
+    public Abandonment(BooleanSupplier asked) {
+        this.asked = asked;
+    }
+
+    /** Whether the answer is still wanted. */
+    public boolean asked() {
+        return asked.getAsBoolean();
+    }
+
+    /** Stops the work here when the answer is no longer wanted. */
+    public void stopIfAsked() {
+        if (asked.getAsBoolean()) {
+            throw new Abandoned();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -482,6 +482,11 @@ public final class Compilation {
         return db;
     }
 
+    /** What makes a walk of this compilation stop short of an answer — {@link Db#abandonWhen}. */
+    public void abandonWhen(Abandonment abandonment) {
+        db.abandonWhen(abandonment);
+    }
+
     /** The names of the modules these sources declare, in the order the sources were given. */
     public List<String> modules() {
         List<String> declared = db.ask(new Front.Declared()).value();

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -198,6 +198,17 @@ public final class Db implements StoreWork {
     }
 
     private final Map<Key<?>, Memo> memos = new HashMap<>();
+    /**
+     * Whether whoever set this walk going has since stopped wanting the answer. Asked where a
+     * question is about to be answered and nowhere else, so a walk stops between two questions and
+     * never inside one.
+     *
+     * <p>Being asked to stop is not an input changing. The answers already reached are answers of
+     * this revision and stay: nothing can move an input while a walk is running, because the walk is
+     * what the one thread holding this store is doing. Only the key that never returned a value is
+     * left without a memo, which is what {@link #ask} does with a throw either way.
+     */
+    private Abandonment abandonment = Abandonment.NEVER;
     /** The keys being answered right now, outermost first — the chain a cycle is found on. */
     private final Set<Key<?>> inProgress = new LinkedHashSet<>();
     /** The reads of each in-progress key, innermost frame last. */
@@ -306,6 +317,19 @@ public final class Db implements StoreWork {
         spoke.removeIf(key -> !memos.containsKey(key));
     }
 
+    /**
+     * Says what makes a walk of this store stop short: while {@code asked} answers true, the next
+     * question that has to be answered raises {@link Abandoned} instead.
+     *
+     * <p>What is left behind is what was answered. A key whose computation was cut through leaves no
+     * memo — it never returned a value — while every key that answered inside it keeps one, because
+     * an answer of this revision is an answer of this revision however the walk that wanted it
+     * ended. The next walk pays for what this one did not finish and for nothing else.
+     */
+    public void abandonWhen(Abandonment abandonment) {
+        this.abandonment = abandonment;
+    }
+
     /** Answers {@code key}, computing it if nothing kept from before still holds. */
     @SuppressWarnings("unchecked")
     public <T> Answer<T> ask(Key<T> key) {
@@ -323,6 +347,7 @@ public final class Db implements StoreWork {
             memos.put(key, memo.verifiedAt(revision));
             return (Answer<T>) memo.answer();
         }
+        abandonment.stopIfAsked();
         inProgress.add(key);
         frames.push(new LinkedHashSet<>());
         Answer<T> answer;

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -343,11 +343,16 @@ public final class Db implements StoreWork {
             throughCycle.addAll(inProgress);
             return key.onCycle(List.copyOf(inProgress));
         }
+        // Before either of the two things that cost anything, and after the one that does not. An
+        // answer already verified at this revision is a lookup and a return; checking what is left
+        // is a walk of everything the answer read, and working one out is a walk of whatever it
+        // reaches. A store told to stop while it is re-verifying a graph nothing moved is a store
+        // being asked its cheapest question over and over, and that is the question an edit asks.
+        abandonment.stopIfAsked();
         if (memo != null && stillHolds(memo)) {
             memos.put(key, memo.verifiedAt(revision));
             return (Answer<T>) memo.answer();
         }
-        abandonment.stopIfAsked();
         inProgress.add(key);
         frames.push(new LinkedHashSet<>());
         Answer<T> answer;
@@ -385,6 +390,10 @@ public final class Db implements StoreWork {
      * Whether {@code memo}'s answer can be kept: everything it read still answers what it did when
      * this answer was made. Asking each of them is what settles that, and each of those may settle
      * the same way without running anything.
+     *
+     * <p>Every step of it is an {@link #ask}, which is where a store that was told to stop stops. So
+     * a verification walk is abandoned wherever it has got to, without this loop asking again on its
+     * own account.
      */
     private boolean stillHolds(Memo memo) {
         // Verification is not a read: a key being checked is not a dependency of whoever happened to

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -391,9 +391,10 @@ public final class Db implements StoreWork {
      * this answer was made. Asking each of them is what settles that, and each of those may settle
      * the same way without running anything.
      *
-     * <p>Every step of it is an {@link #ask}, which is where a store that was told to stop stops. So
-     * a verification walk is abandoned wherever it has got to, without this loop asking again on its
-     * own account.
+     * <p>Told to stop, it stops where it has got to. What it walks is a graph and what it does at
+     * each step may be nothing at all — a dependency another question has already verified is a
+     * lookup — so the step is this loop's, and asking is left to this loop rather than to what it
+     * calls.
      */
     private boolean stillHolds(Memo memo) {
         // Verification is not a read: a key being checked is not a dependency of whoever happened to
@@ -401,6 +402,11 @@ public final class Db implements StoreWork {
         frames.push(new LinkedHashSet<>());
         try {
             for (Key<?> read : memo.reads()) {
+                // Here, and not left to the ask below. A dependency already verified at this
+                // revision is answered before that one gets as far as asking, so a walk over a graph
+                // that another question has already been through would go the whole way without
+                // being asked once — which is the walk this is, most of the time.
+                abandonment.stopIfAsked();
                 ask(read);
                 Memo dependency = memos.get(read);
                 if (dependency == null || dependency.changedAt() > memo.verifiedAt()) {
@@ -436,6 +442,7 @@ public final class Db implements StoreWork {
     public List<Found> allReports() {
         Map<Told, Found> found = new LinkedHashMap<>();
         for (Key<?> key : spoke) {
+            abandonment.stopIfAsked();
             Memo memo = memos.get(key);
             if (memo == null || memo.verifiedAt() != revision) {
                 continue;

--- a/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,8 +82,57 @@ class AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest {
         assertEquals(1, INNER_RUNS.get(), "nor was anything under it");
     }
 
+    @Test
+    void theWalkIsStoppedPartWayThroughEvenWhereEveryStepLeftIsALookup() {
+        Db db = new Db();
+        db.set(new Untouched(), "first");
+        // Two questions over the same dependencies. Asking the second at a new revision is what
+        // leaves those dependencies verified there, so the first one's walk over them is a walk of
+        // lookups — the case where a stop that waited for something to be worked out never comes.
+        db.ask(new OverManyThings(1));
+        db.ask(new OverManyThings(2));
+        db.set(new Untouched(), "second");
+        db.ask(new OverManyThings(2));
+
+        db.abandonWhen(new Abandonment(new BooleanSupplier() {
+            private boolean walkHasBegun;
+
+            @Override
+            public boolean getAsBoolean() {
+                boolean wasAskedBefore = walkHasBegun;
+                walkHasBegun = true;
+                return wasAskedBefore;   // not yet as the walk begins; yes once it is under way
+            }
+        }));
+
+        assertThrows(Abandoned.class, () -> db.ask(new OverManyThings(1)),
+                "a walk of a graph another question has already been through is still a walk");
+    }
+
     /** An input this graph does not read, so setting it moves the revision and nothing else. */
     private record Untouched() implements Input<String> {
+    }
+
+    /** A question over enough dependencies that walking them is the work, and each is a lookup. */
+    private record OverManyThings(int which) implements Key<String> {
+
+        @Override
+        public Answer<String> compute(Db db) {
+            StringBuilder read = new StringBuilder();
+            for (int i = 0; i < 8; i++) {
+                read.append(db.ask(new OneThing(i)).value());
+            }
+            return Answer.of(read.toString());
+        }
+    }
+
+    /** Answers without reading anything, so it is verified by being looked at and nothing else. */
+    private record OneThing(int which) implements Key<String> {
+
+        @Override
+        public Answer<String> compute(Db db) {
+            return Answer.of("thing " + which);
+        }
     }
 
     /** Asks the inner question, and then a second one — which is where the stop falls. */

--- a/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
@@ -1,0 +1,86 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What a store is left holding when the walk over it was told to stop.
+ *
+ * <p>Two halves, and each is worth nothing without the other. The question the walk was inside when
+ * it stopped never returned a value, so nothing may be kept for it: a store that kept one would hand
+ * the next asker an answer that was never worked out. The questions that did return a value inside
+ * it are answers of the revision they were asked at, and being told to stop is not an input moving —
+ * nothing can move an input while a walk is running, because the walk is what the one thread holding
+ * the store is doing. Those are kept, and the walk that follows pays only for what this one left.
+ *
+ * <p>Counting both is what makes this say anything. A store that threw everything away would satisfy
+ * the first half on its own, and one that kept everything would satisfy the second.
+ */
+class AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest {
+
+    /** Whether the store is under a stop at all. The stop itself falls where the inner question
+     * has answered and the outer one has not, which is the only place worth looking at. */
+    private static final AtomicBoolean ARMED = new AtomicBoolean();
+
+    private static final AtomicInteger OUTER_RUNS = new AtomicInteger();
+
+    private static final AtomicInteger INNER_RUNS = new AtomicInteger();
+
+    @Test
+    void theQuestionItStoppedInsideIsAskedAgainAndTheOnesThatAnsweredAreNot() {
+        ARMED.set(true);
+        OUTER_RUNS.set(0);
+        INNER_RUNS.set(0);
+
+        Db db = new Db();
+        db.abandonWhen(new Abandonment(() -> ARMED.get() && INNER_RUNS.get() > 0));
+
+        assertThrows(Abandoned.class, () -> db.ask(new Outer()),
+                "a walk told to stop stops, rather than answering with whatever it had");
+        assertEquals(1, OUTER_RUNS.get(), "the outer question was entered once");
+        assertEquals(1, INNER_RUNS.get(), "and the inner one answered once inside it");
+
+        ARMED.set(false);
+        assertEquals("inner", db.ask(new Outer()).value(),
+                "asked again with nothing stopping it, the walk answers");
+        assertEquals(2, OUTER_RUNS.get(),
+                "the question that never returned a value left nothing behind to be handed over");
+        assertEquals(1, INNER_RUNS.get(),
+                "the one that did is an answer of this revision, and was not worked out twice");
+    }
+
+    /** Asks the inner question, and then a second one — which is where the stop falls. */
+    private record Outer() implements Key<String> {
+
+        @Override
+        public Answer<String> compute(Db db) {
+            OUTER_RUNS.incrementAndGet();
+            String inner = db.ask(new Inner()).value();
+            db.ask(new Beside());
+            return Answer.of(inner);
+        }
+    }
+
+    private record Inner() implements Key<String> {
+
+        @Override
+        public Answer<String> compute(Db db) {
+            INNER_RUNS.incrementAndGet();
+            return Answer.of("inner");
+        }
+    }
+
+    /** Asked after the inner one, so that asking for it is where a stop is met. */
+    private record Beside() implements Key<String> {
+
+        @Override
+        public Answer<String> compute(Db db) {
+            return Answer.of("beside");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest.java
@@ -20,6 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * <p>Counting both is what makes this say anything. A store that threw everything away would satisfy
  * the first half on its own, and one that kept everything would satisfy the second.
+ *
+ * <p>And a walk is not only what a question is worked out by. An edit moves the revision, and what
+ * the next question does with a graph nothing else touched is walk all of it to find that out — no
+ * answer is worked out anywhere, and that walk is most of what an editor's store does. A stop that
+ * only reached the working-out would be a stop that never came where it was most wanted.
  */
 class AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest {
 
@@ -52,6 +57,32 @@ class AWalkThatWasStoppedKeepsWhatItAnsweredAndNothingElseTest {
                 "the question that never returned a value left nothing behind to be handed over");
         assertEquals(1, INNER_RUNS.get(),
                 "the one that did is an answer of this revision, and was not worked out twice");
+    }
+
+    @Test
+    void theWalkThatOnlyCheckedWhatWasKeptIsStoppedToo() {
+        ARMED.set(false);
+        OUTER_RUNS.set(0);
+        INNER_RUNS.set(0);
+
+        Db db = new Db();
+        db.abandonWhen(new Abandonment(ARMED::get));
+        db.set(new Untouched(), "first");
+        assertEquals("inner", db.ask(new Outer()).value(), "the graph is answered and kept");
+
+        // An edit somewhere else. Nothing this graph read has moved, so every question in it will
+        // be kept — and finding that out is a walk of all of them.
+        db.set(new Untouched(), "second");
+        ARMED.set(true);
+
+        assertThrows(Abandoned.class, () -> db.ask(new Outer()),
+                "checking what is still good is a walk, and a walk that was told to stop stops");
+        assertEquals(1, OUTER_RUNS.get(), "nothing was worked out again");
+        assertEquals(1, INNER_RUNS.get(), "nor was anything under it");
+    }
+
+    /** An input this graph does not read, so setting it moves the revision and nothing else. */
+    private record Untouched() implements Input<String> {
     }
 
     /** Asks the inner question, and then a second one — which is where the stop falls. */

--- a/souther-lsp/src/main/java/souther/lsp/Cancellation.java
+++ b/souther-lsp/src/main/java/souther/lsp/Cancellation.java
@@ -1,0 +1,31 @@
+package souther.lsp;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Whether the client has said it no longer wants the answer to one request.
+ *
+ * <p>One of these per request, made where the frame is read and handed over with it, so that saying
+ * so and reading it are the same object seen from two threads. A request is registered under its id
+ * before it is put where the analysis thread can see it, which is what makes a cancel that arrives
+ * while the request is still queued reach the same value as one that arrives while it is running.
+ *
+ * <p>When it is read is what settles the request: the read taken after the work is done and before
+ * the outcome is decided is the moment the request either was cancelled or was not. A cancel that
+ * lands after that read does not change what the client is sent, and nothing here pretends
+ * otherwise — there is no state to move it to.
+ */
+final class Cancellation {
+
+    private final AtomicBoolean asked = new AtomicBoolean();
+
+    /** Says the client has given up on this request. */
+    void ask() {
+        asked.set(true);
+    }
+
+    /** Whether the client had given up as of this read. */
+    boolean asked() {
+        return asked.get();
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/ConnectionLost.java
+++ b/souther-lsp/src/main/java/souther/lsp/ConnectionLost.java
@@ -1,0 +1,16 @@
+package souther.lsp;
+
+/**
+ * Raised on the thread that owns a session when the thread reading its frames could not go on.
+ *
+ * <p>An {@link Error}, so that the catch which turns a fault into a failed request does not turn
+ * this into one. A request that cannot be answered costs that request; a connection that cannot be
+ * read costs the session, and there is nothing left to write the failure to.
+ */
+final class ConnectionLost extends Error {
+    private static final long serialVersionUID = 1L;
+
+    ConnectionLost(Throwable cause) {
+        super("the connection could not be read", cause);
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/Inbound.java
+++ b/souther-lsp/src/main/java/souther/lsp/Inbound.java
@@ -1,0 +1,28 @@
+package souther.lsp;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * What the thread reading frames hands the thread that carries them out.
+ *
+ * <p>Three things and not one, because a session ends in more than one way and each way has to reach
+ * the analysis thread through the same queue. Putting them in the queue is what makes the order they
+ * happened in the order they are seen in, and it is what wakes a thread that is waiting for work.
+ */
+sealed interface Inbound {
+
+    /** A message to carry out, and whether the client has since given up on it. */
+    record Message(JsonNode body, Cancellation cancellation) implements Inbound {}
+
+    /** The client closed the stream. Whether that is an orderly end is the exit code's question. */
+    record EndOfInput() implements Inbound {}
+
+    /**
+     * The reading thread stopped on something it could not read past.
+     *
+     * <p>Carried rather than reported where it happened: the thread that reads frames is not the one
+     * that owns the session, and a failure of the reader is a failure of the session. It is raised
+     * again on the thread that can end one.
+     */
+    record ReaderFailed(Throwable cause) implements Inbound {}
+}

--- a/souther-lsp/src/main/java/souther/lsp/Inbox.java
+++ b/souther-lsp/src/main/java/souther/lsp/Inbox.java
@@ -78,9 +78,17 @@ final class Inbox {
         return readerFailure.get();
     }
 
-    /** Whether anything is waiting to be carried out — what makes a diagnose give way. */
-    boolean anyWaiting() {
-        return !waiting.isEmpty();
+    /**
+     * Whether a client is waiting to be answered — what makes a diagnose give way.
+     *
+     * <p>A message, and not anything at all. The end of the stream and a failure of the reading
+     * thread are also things in this queue, and neither is a client asking for something: giving way
+     * to the end of the stream would abandon a diagnose that has nothing left to give way to, only
+     * to be asked for again a moment later. Reading the head is enough to tell, because the reading
+     * thread adds one of those two and then stops, so a queue whose head is one holds nothing else.
+     */
+    boolean aMessageIsWaiting() {
+        return waiting.peek() instanceof Inbound.Message;
     }
 
     /** The next thing to carry out, or null if nothing is waiting. */

--- a/souther-lsp/src/main/java/souther/lsp/Inbox.java
+++ b/souther-lsp/src/main/java/souther/lsp/Inbox.java
@@ -1,0 +1,114 @@
+package souther.lsp;
+
+import tools.jackson.databind.JsonNode;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * What has been read off the connection and not yet carried out.
+ *
+ * <p>The one place the two threads of a session meet. The reading thread only ever adds to it; the
+ * analysis thread takes from it, and owns everything a message is carried out against.
+ *
+ * <p>A request is registered under its id before it is queued, and not when it is taken off the
+ * queue. That order is what a cancel depends on: a client that sends a request and cancels it in the
+ * same breath is naming something the analysis thread has not looked at yet, and the name has to
+ * already mean something. Where the request is when the cancel arrives — queued, running, or done —
+ * is then not a distinction anything has to make.
+ *
+ * <p>A failure of the reading thread is published twice, and the two are not copies. The queue
+ * carries it so a thread waiting for work is woken and meets it in the order it happened; the slot
+ * carries it so a thread that is in the middle of a long answer can be told at its next checkpoint,
+ * which it cannot be by a queue it is not reading.
+ */
+final class Inbox {
+
+    private final BlockingQueue<Inbound> waiting = new LinkedBlockingQueue<>();
+
+    /** The requests read but not yet answered, by the id the client named them with. */
+    private final Map<String, Cancellation> outstanding = new ConcurrentHashMap<>();
+
+    private final AtomicReference<Throwable> readerFailure = new AtomicReference<>();
+
+    /** Hands over one message, registering it first if it is a request the client may cancel. */
+    void hand(JsonNode body) {
+        Cancellation cancellation = new Cancellation();
+        String id = nameOf(body.get("id"));
+        if (id != null) {
+            outstanding.put(id, cancellation);
+        }
+        waiting.add(new Inbound.Message(body, cancellation));
+    }
+
+    /** Says the client has given up on the request {@code id} names, wherever it has got to. */
+    void cancel(JsonNode id) {
+        String name = nameOf(id);
+        if (name == null) {
+            return;
+        }
+        Cancellation cancellation = outstanding.get(name);
+        if (cancellation != null) {
+            cancellation.ask();
+        }
+    }
+
+    /** Says {@code id} has been answered, so a cancel naming it from now on names nothing. */
+    void answered(JsonNode id) {
+        String name = nameOf(id);
+        if (name != null) {
+            outstanding.remove(name);
+        }
+    }
+
+    void readerEnded() {
+        waiting.add(new Inbound.EndOfInput());
+    }
+
+    void readerFailed(Throwable cause) {
+        readerFailure.compareAndSet(null, cause);
+        waiting.add(new Inbound.ReaderFailed(cause));
+    }
+
+    /** What stopped the reading thread, or null while it is reading. */
+    Throwable readerFailure() {
+        return readerFailure.get();
+    }
+
+    /** Whether anything is waiting to be carried out — what makes a diagnose give way. */
+    boolean anyWaiting() {
+        return !waiting.isEmpty();
+    }
+
+    /** The next thing to carry out, or null if nothing is waiting. */
+    Inbound take() {
+        return waiting.poll();
+    }
+
+    /** The next thing to carry out, waiting for one to arrive. */
+    Inbound await() {
+        try {
+            return waiting.take();
+        } catch (InterruptedException _) {
+            // Nothing here interrupts this thread, so someone outside the session did. A session
+            // that was interrupted did not end the way the protocol ends one, and the exit code
+            // says so.
+            Thread.currentThread().interrupt();
+            return new Inbound.EndOfInput();
+        }
+    }
+
+    /**
+     * What a request is registered under: the id as it was written, brackets and quotes and all.
+     *
+     * <p>The protocol lets an id be a number or a string, and {@code 1} and {@code "1"} are two
+     * requests. Taking the text of the node keeps them apart, where reading either as a string would
+     * let a cancel for one end the other.
+     */
+    private static String nameOf(JsonNode id) {
+        return id == null || id.isNull() ? null : id.toString();
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/Inbox.java
+++ b/souther-lsp/src/main/java/souther/lsp/Inbox.java
@@ -79,16 +79,14 @@ final class Inbox {
     }
 
     /**
-     * Whether a client is waiting to be answered — what makes a diagnose give way.
+     * Whether anything is waiting — what makes a diagnose give way.
      *
-     * <p>A message, and not anything at all. The end of the stream and a failure of the reading
-     * thread are also things in this queue, and neither is a client asking for something: giving way
-     * to the end of the stream would abandon a diagnose that has nothing left to give way to, only
-     * to be asked for again a moment later. Reading the head is enough to tell, because the reading
-     * thread adds one of those two and then stops, so a queue whose head is one holds nothing else.
+     * <p>Anything, and not only a message. What is in here is either a client asking for something
+     * or a session ending, and both are reasons to stop diagnosing: the first because answering is
+     * what a diagnose steps aside for, the second because there is nobody left to publish to.
      */
-    boolean aMessageIsWaiting() {
-        return waiting.peek() instanceof Inbound.Message;
+    boolean anyWaiting() {
+        return !waiting.isEmpty();
     }
 
     /** The next thing to carry out, or null if nothing is waiting. */

--- a/souther-lsp/src/main/java/souther/lsp/LspMethod.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspMethod.java
@@ -22,6 +22,10 @@ import java.util.Optional;
  * <p>What a method is advertised by is not a name derived from the method's own: three notifications
  * share one capability, one method is registered after the handshake instead, and the lifecycle is
  * announced by nothing. Each of those is a value here rather than a row missing from a table.
+ *
+ * <p>Answered is what this is a set of. {@code $/cancelRequest} is not among them and is not missing
+ * from them: it is not answered, it says something about another message while that message is being
+ * worked on, and it is acted on where the frames are read.
  */
 public enum LspMethod {
 

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -208,11 +208,14 @@ public final class LspServer {
     /**
      * Carries out what arrives, and diagnoses the workspace whenever nothing else is waiting.
      *
-     * <p>Which is the whole of the scheduling. A diagnose is what this thread does with a moment in
-     * which no client is waiting to be answered: it gives way to any message, and a run of keystrokes
-     * therefore costs one diagnose at the end of it rather than one each. What it does not do is
-     * guarantee it ever runs — a client that never stopped asking would never be told anything, and
-     * that is what asking without pause means, not a case to write a threshold for.
+     * <p>Which is the whole of the scheduling, and it has no exception in it. A diagnose is what this
+     * thread does with a moment in which nothing is waiting: it gives way to whatever arrives, so a
+     * run of keystrokes costs one diagnose at the end of it rather than one each, and once the stream
+     * has ended nothing more is published, because the end of a stream is something that arrived.
+     *
+     * <p>What it does not do is guarantee a diagnose ever runs — a client that never stopped asking
+     * would never be told anything, and that is what asking without pause means, not a case to write
+     * a threshold for.
      */
     private int carryOutWhatArrives() {
         while (true) {
@@ -227,13 +230,6 @@ public final class LspServer {
             switch (next) {
                 case Inbound.ReaderFailed failed -> throw new ConnectionLost(failed.cause());
                 case Inbound.EndOfInput _ -> {
-                    // The end of the stream asks for nothing, so a diagnose does not give way to it
-                    // and one that is still owed is carried out before the session ends. `exit` is
-                    // not this: that is a client saying stop now, and a server told to stop now has
-                    // nothing more to publish.
-                    if (diagnosticsAreStale) {
-                        diagnose();
-                    }
                     return exitCode();
                 }
                 case Inbound.Message message -> {
@@ -976,7 +972,7 @@ public final class LspServer {
      */
     private void diagnose() {
         diagnosticsAreStale = false;
-        stopWhen = inbox::aMessageIsWaiting;
+        stopWhen = inbox::anyWaiting;
         try {
             publishAll();
         } catch (Abandoned _) {

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -5,6 +5,8 @@ import souther.lsp.analysis.Analyzer;
 import souther.lsp.analysis.DocumentStore;
 import souther.lsp.analysis.ModuleGraph;
 import souther.lsp.analysis.Workspace;
+import souther.compiler.query.Abandoned;
+import souther.compiler.query.Abandonment;
 import souther.compiler.query.Adequacy;
 import souther.lsp.protocol.CodeAction;
 import souther.lsp.protocol.CodeLens;
@@ -31,6 +33,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 /**
  * A hand-rolled LSP server over a {@link MessageConnection}. It reads JSON-RPC messages, dispatches
@@ -41,6 +44,25 @@ import java.util.Map;
 public final class LspServer {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** JSON-RPC's, and the protocol's for a request the client gave up on. */
+    private static final int METHOD_NOT_FOUND = -32601;
+    private static final int INTERNAL_ERROR = -32603;
+    private static final int REQUEST_CANCELLED = -32800;
+
+    /**
+     * The one method carried out where the frames are read rather than where they are answered.
+     *
+     * <p>It is not in {@link LspMethod} because it is not answered: it says something about another
+     * message, and it says it while that message is being worked on. Handed over like the rest, it
+     * would be read after the request it names had been answered — which is every request it could
+     * have stopped.
+     */
+    private static final String CANCEL_REQUEST = "$/cancelRequest";
+
+    /** Nothing to write. Held once because it says nothing and every message that says it says the
+     * same nothing. */
+    private static final Outcome NOTHING = new Outcome.Nothing();
 
     private final MessageConnection conn;
     private final DocumentStore documents = new DocumentStore();
@@ -53,8 +75,49 @@ public final class LspServer {
     private final Workspace workspace = new Workspace();
     private int nextRequestId = 1;
 
+    /** What has been read and not yet carried out. The only thing both threads touch. */
+    private final Inbox inbox = new Inbox();
+
+    /** Whether what was published still says what the documents say. */
+    private boolean diagnosticsAreStale;
+
+    /**
+     * What would make the unit of work in hand stop short of its answer.
+     *
+     * <p>It is the unit of work that decides, and the two units this server has are stopped by
+     * different things: a request by the client saying it no longer wants the answer, a diagnose by
+     * anything at all arriving, because a diagnose is what this thread does when it has nothing else
+     * to do. Written as each unit begins and read through {@link #abandonment}.
+     */
+    private BooleanSupplier stopWhen = () -> false;
+
+    /**
+     * What every step of the work in hand asks. One value, held by the analyzer and the workspace
+     * from the start, so that the reason work stops is settled in one place and not carried down
+     * through each of them.
+     */
+    private final Abandonment abandonment = new Abandonment(this::stopNow);
+
     public LspServer(MessageConnection conn) {
         this.conn = conn;
+        analyzer.abandonWhen(abandonment);
+        workspace.abandonWhen(abandonment);
+    }
+
+    /**
+     * Whether the work in hand should stop, and where a failure of the reading thread is met.
+     *
+     * <p>In that order, and the order is the point. A session whose connection cannot be read has
+     * nobody left to answer, so whether this particular answer is still wanted is no longer a
+     * question. It is asked here because a thread in the middle of a long answer is not reading the
+     * queue the failure is also published to.
+     */
+    private boolean stopNow() {
+        Throwable failed = inbox.readerFailure();
+        if (failed != null) {
+            throw new ConnectionLost(failed);
+        }
+        return stopWhen.getAsBoolean();
     }
 
     public static void main(String[] args) {
@@ -79,66 +142,172 @@ public final class LspServer {
     }
 
     /**
-     * Reads and dispatches messages until end of input or an {@code exit} notification, and answers
-     * with the code the protocol asks the process to end under.
+     * Serves one session, and answers with the code the protocol asks the process to end under.
+     *
+     * <p>A thread beside this one reads frames; this one owns the documents, the workspace and the
+     * analyzer, and carries the frames out in the order they arrived. The store a compile is made of
+     * is asked by one thread only, which is the sentence it is written under, and what the second
+     * thread buys is not a second question being answered — it is that a question can be read while
+     * the one before it is still being answered, and so that it can be given up on.
+     *
+     * <p>This way round, and not the other. Whoever owns the store owns the session: an error
+     * nothing here is entitled to recover from ends this thread, and ending this thread ends the
+     * process, because the thread that reads is a daemon. A server that had lost its analysis and
+     * gone on reading would answer nothing and say nothing about it.
      */
     public int run() {
-        String message;
-        while ((message = conn.read()) != null) {
-            JsonNode m;
-            try {
-                m = JSON.readTree(message);
-            } catch (RuntimeException _) {
-                continue;   // a malformed frame is dropped, not fatal
-            }
-            JsonNode methodNode = m.get("method");
-            if (methodNode == null || methodNode.isNull()) {
-                continue;   // a response to a server-initiated request; nothing to do
-            }
-            boolean stop;
-            try {
-                stop = dispatch(methodNode.asString(), m.get("id"), m.get("params"));
-            } catch (RuntimeException | StackOverflowError e) {
-                // One request the server cannot answer must cost that request, not the session. The
-                // analysis layer catches what it can so it can publish a marker instead, but that is
-                // a promise made inside it; this is the one that holds whatever it does. A request
-                // gets an error reply so the client stops waiting; a notification has no reply to
-                // send, so it is simply dropped and the loop reads on.
-                failed(m.get("id"), e);
-                continue;
-            }
-            if (stop) {
-                break;      // exit
-            }
-        }
-        return askedToShutDown ? 0 : 1;
-    }
-
-    /** Replies to a request the server could not answer. A notification (no id) has no reply. */
-    private void failed(JsonNode id, Throwable cause) {
-        if (id == null || id.isNull()) {
-            return;
-        }
-        respondError(id, -32603,   // JSON-RPC InternalError
-                "the request could not be completed (" + cause.getClass().getSimpleName() + ")");
+        Thread.ofPlatform().daemon().name("souther-lsp-reader").start(this::read);
+        return carryOutWhatArrives();
     }
 
     /**
-     * Returns true when the server should stop (on {@code exit}).
+     * Reads frames and hands them over until the stream ends or reading cannot go on.
+     *
+     * <p>Nothing is answered here. What this thread decides is the order things happened in, and the
+     * one thing it acts on itself is a cancel, which has to reach a request that is already being
+     * worked on.
+     */
+    private void read() {
+        try {
+            String message;
+            while ((message = conn.read()) != null) {
+                JsonNode m;
+                try {
+                    m = JSON.readTree(message);
+                } catch (RuntimeException _) {
+                    continue;   // a malformed frame is dropped, not fatal
+                }
+                JsonNode methodNode = m.get("method");
+                if (methodNode == null || methodNode.isNull()) {
+                    continue;   // a response to a server-initiated request; nothing to do
+                }
+                if (CANCEL_REQUEST.equals(methodNode.asString())) {
+                    JsonNode params = m.get("params");
+                    inbox.cancel(params == null ? null : params.get("id"));
+                    continue;
+                }
+                inbox.hand(m);
+            }
+            inbox.readerEnded();
+        } catch (Throwable t) {
+            // Caught to be carried, not to be recovered from: this thread cannot end a session and
+            // the one that can is not reading the stream. It is raised again there.
+            inbox.readerFailed(t);
+        }
+    }
+
+    /**
+     * Carries out what arrives, and diagnoses the workspace whenever nothing else is waiting.
+     *
+     * <p>Which is the whole of the scheduling. A diagnose is what this thread does with an idle
+     * moment: it gives way to anything at all, and a run of keystrokes therefore costs one diagnose
+     * at the end of it rather than one each. What it does not do is guarantee it ever runs — a client
+     * that never stopped asking would never be told anything, and that is what asking without pause
+     * means, not a case to write a threshold for.
+     */
+    private int carryOutWhatArrives() {
+        while (true) {
+            Inbound next = inbox.take();
+            if (next == null && diagnosticsAreStale) {
+                diagnose();
+                continue;
+            }
+            if (next == null) {
+                next = inbox.await();
+            }
+            switch (next) {
+                case Inbound.ReaderFailed failed -> throw new ConnectionLost(failed.cause());
+                case Inbound.EndOfInput _ -> {
+                    // Not something to give way to. Everything else in this queue is a client
+                    // asking for something, and a diagnose steps aside for those; the end of the
+                    // stream asks for nothing, so what was already asked for is finished first. A
+                    // diagnose is the only thing that can still be owed at this point.
+                    if (diagnosticsAreStale) {
+                        diagnose();
+                    }
+                    return exitCode();
+                }
+                case Inbound.Message message -> {
+                    if (carryOut(message)) {
+                        return exitCode();
+                    }
+                }
+            }
+        }
+    }
+
+    /** What the protocol asks the process to end under: whether the client shut the server down. */
+    private int exitCode() {
+        return askedToShutDown ? 0 : 1;
+    }
+
+    /**
+     * Carries out one message, writes the one reply it is owed, and says whether the session ends.
+     *
+     * <p>Where a request is settled. The read of the cancellation taken here is what decides it: a
+     * client that gave up before this read is sent the reply that says so, and one that gave up
+     * after it is sent the answer, because by then there was an answer and nothing to be gained by
+     * throwing it away. Which of the two happened is not a thing the client can be told apart from
+     * the reply it gets, and the protocol asks for one reply either way.
+     */
+    private boolean carryOut(Inbound.Message message) {
+        JsonNode id = message.body().get("id");
+        stopWhen = message.cancellation()::asked;
+        Outcome outcome;
+        try {
+            outcome = dispatch(message.body());
+        } catch (Abandoned _) {
+            outcome = new Outcome.Cancelled();
+        } catch (RuntimeException | StackOverflowError e) {
+            // One request the server cannot answer must cost that request, not the session. The
+            // analysis layer catches what it can so it can publish a marker instead, but that is a
+            // promise made inside it; this is the one that holds whatever it does.
+            outcome = new Outcome.Failed(INTERNAL_ERROR,
+                    "the request could not be completed (" + e.getClass().getSimpleName() + ")");
+        }
+        if (outcome instanceof Outcome.Answered && message.cancellation().asked()) {
+            outcome = new Outcome.Cancelled();
+        }
+        inbox.answered(id);
+        write(id, outcome);
+        return outcome instanceof Outcome.Stop;
+    }
+
+    /**
+     * The one place a reply to a client's message is written.
+     *
+     * <p>A notification asked nothing, so nothing is written for one — an unknown notification
+     * included, which is what makes naming a method the way a client learns the server does not
+     * answer it without making an unnamed notification an error.
+     */
+    private void write(JsonNode id, Outcome outcome) {
+        if (id == null || id.isNull()) {
+            return;
+        }
+        switch (outcome) {
+            case Outcome.Answered answered -> respond(id, answered.result());
+            case Outcome.Cancelled _ ->
+                    respondError(id, REQUEST_CANCELLED, "the request was cancelled");
+            case Outcome.Failed failed -> respondError(id, failed.code(), failed.message());
+            case Outcome.Nothing _ -> { }
+            case Outcome.Stop _ -> { }
+        }
+    }
+
+    /**
+     * What one message comes to.
      *
      * <p>Naming the method is where a client learns the server does not answer it: nothing below
      * this point takes a spelling, so there is no second place a method could be refused, and none
      * where one could be answered without being declared.
      */
-    private boolean dispatch(String method, JsonNode id, JsonNode params) {
+    private Outcome dispatch(JsonNode body) {
+        String method = body.get("method").asString();
         LspMethod named = LspMethod.of(method).orElse(null);
         if (named == null) {
-            if (id != null && !id.isNull()) {
-                respondError(id, -32601, "method not found: " + method);
-            }
-            return false;   // a notification has no reply, so an unknown one is simply dropped
+            return new Outcome.Failed(METHOD_NOT_FOUND, "method not found: " + method);
         }
-        return answer(named, id, params);
+        return answer(named, body.get("id"), body.get("params"));
     }
 
     /**
@@ -148,58 +317,57 @@ public final class LspServer {
      * unhandled here does not compile. That is what makes the set of methods the server answers the
      * set written there, and so the set the handshake is built from.
      */
-    private boolean answer(LspMethod method, JsonNode id, JsonNode params) {
+    private Outcome answer(LspMethod method, JsonNode id, JsonNode params) {
         return switch (method) {
-            case INITIALIZE -> { captureRoots(params); respond(id, initializeResult()); yield false; }
-            case INITIALIZED -> { registerDynamically(); yield false; }
-            case SET_TRACE, DID_CHANGE_CONFIGURATION -> false;   // no-op
+            case INITIALIZE -> { captureRoots(params); yield new Outcome.Answered(initializeResult()); }
+            case INITIALIZED -> { registerDynamically(); yield NOTHING; }
+            case SET_TRACE, DID_CHANGE_CONFIGURATION -> NOTHING;   // no-op
             case DID_OPEN -> {
                 InboundDecoders.decode(InboundDecoders.DID_OPEN, params)
-                        .ifPresent(p -> { documents.open(p.uri(), p.text()); publishAll(); });
-                yield false;
+                        .ifPresent(p -> { documents.open(p.uri(), p.text()); diagnosticsAreStale = true; });
+                yield NOTHING;
             }
             case DID_CHANGE -> {
                 InboundDecoders.decode(InboundDecoders.DID_CHANGE, params)
-                        .ifPresent(p -> { documents.change(p.uri(), p.text()); publishAll(); });
-                yield false;
+                        .ifPresent(p -> { documents.change(p.uri(), p.text()); diagnosticsAreStale = true; });
+                yield NOTHING;
             }
             case DID_CLOSE -> {
                 InboundDecoders.decode(InboundDecoders.DOC_REF, params)
                         .ifPresent(p -> { documents.close(p.uri()); clearDiagnostics(p.uri()); });
-                yield false;
+                yield NOTHING;
             }
             case DID_CHANGE_WATCHED_FILES -> {
                 workspace.markChanged();   // a file changed on disk; drop the cached scan and re-read
-                publishAll();
-                yield false;
+                diagnosticsAreStale = true;
+                yield NOTHING;
             }
-            case DOCUMENT_SYMBOL -> { respond(id, documentSymbols(params)); yield false; }
-            case SEMANTIC_TOKENS_FULL -> { respond(id, semanticTokens(params)); yield false; }
-            case HOVER -> { respond(id, hover(params)); yield false; }
-            case DEFINITION -> { respond(id, definition(params)); yield false; }
-            case REFERENCES -> { respond(id, references(params)); yield false; }
-            case COMPLETION -> { respond(id, completion(params)); yield false; }
-            case INLAY_HINT -> { respond(id, inlayHints(params)); yield false; }
-            case DOCUMENT_HIGHLIGHT -> { respond(id, documentHighlights(params)); yield false; }
-            case SELECTION_RANGE -> { respond(id, selectionRanges(params)); yield false; }
-            case WORKSPACE_SYMBOL -> { respond(id, workspaceSymbols(params)); yield false; }
-            case SIGNATURE_HELP -> { respond(id, signatureHelp(params)); yield false; }
-            case CODE_ACTION -> { respond(id, codeActions(params)); yield false; }
-            case CODE_ACTION_RESOLVE -> { respond(id, codeActionResolve(params)); yield false; }
-            case CODE_LENS -> { respond(id, codeLenses(params)); yield false; }
-            case RENAME -> { respond(id, rename(params)); yield false; }
-            case FORMATTING -> { respond(id, formatting(params)); yield false; }
+            case DOCUMENT_SYMBOL -> new Outcome.Answered(documentSymbols(params));
+            case SEMANTIC_TOKENS_FULL -> new Outcome.Answered(semanticTokens(params));
+            case HOVER -> new Outcome.Answered(hover(params));
+            case DEFINITION -> new Outcome.Answered(definition(params));
+            case REFERENCES -> new Outcome.Answered(references(params));
+            case COMPLETION -> new Outcome.Answered(completion(params));
+            case INLAY_HINT -> new Outcome.Answered(inlayHints(params));
+            case DOCUMENT_HIGHLIGHT -> new Outcome.Answered(documentHighlights(params));
+            case SELECTION_RANGE -> new Outcome.Answered(selectionRanges(params));
+            case WORKSPACE_SYMBOL -> new Outcome.Answered(workspaceSymbols(params));
+            case SIGNATURE_HELP -> new Outcome.Answered(signatureHelp(params));
+            case CODE_ACTION -> new Outcome.Answered(codeActions(params));
+            case CODE_ACTION_RESOLVE -> new Outcome.Answered(codeActionResolve(params));
+            case CODE_LENS -> new Outcome.Answered(codeLenses(params));
+            case RENAME -> new Outcome.Answered(rename(params));
+            case FORMATTING -> new Outcome.Answered(formatting(params));
             // Only as the request it is. A `shutdown` written as a notification asked nothing, so
-            // there is nothing to reply to and nothing the exit code can hold the client to; the
-            // session still stops, because a client that wrote it is leaving either way.
+            // there is nothing to reply to and nothing the exit code can hold the client to.
             case SHUTDOWN -> {
-                if (id != null && !id.isNull()) {
-                    askedToShutDown = true;
-                    respond(id, null);
+                if (id == null || id.isNull()) {
+                    yield NOTHING;
                 }
-                yield false;
+                askedToShutDown = true;
+                yield new Outcome.Answered(null);
             }
-            case EXIT -> true;
+            case EXIT -> new Outcome.Stop();
         };
     }
 
@@ -784,12 +952,46 @@ public final class LspServer {
 
     // --- diagnostics ---
 
-    /** Recomputes diagnostics for the whole workspace and publishes each open document's set — an edit
-     * to one module can change what its importers report, so every open file is refreshed together. */
+    /**
+     * Brings the published diagnostics up to date with what the documents now say, giving way to
+     * anything that arrives while it runs.
+     *
+     * <p>Giving way costs nothing that was worth keeping. What a diagnose reaches is kept in the
+     * compile's store — an answer of this revision is an answer of this revision, however the walk
+     * that wanted it ended — so the diagnose that follows pays for what this one did not finish and
+     * for nothing else.
+     *
+     * <p>A diagnose that could not be carried out at all is not asked for again. The same documents
+     * would fail the same way, and a server retrying it would do nothing else for as long as they
+     * stood.
+     */
+    private void diagnose() {
+        diagnosticsAreStale = false;
+        stopWhen = inbox::anyWaiting;
+        try {
+            publishAll();
+        } catch (Abandoned _) {
+            diagnosticsAreStale = true;
+        } catch (RuntimeException | StackOverflowError _) {
+            // nothing to publish and nobody to tell: a diagnose is not a request
+        }
+    }
+
+    /**
+     * Recomputes diagnostics for the whole workspace and publishes each open document's set — an edit
+     * to one module can change what its importers report, so every open file is refreshed together.
+     *
+     * <p>Asked before each document whether what it is about to publish is still what the documents
+     * say. It stops short of promising the published set is never behind: what a client is told is
+     * decided here and read there, and nothing between the two is held. What it does hold is that a
+     * set published behind is followed by one that is not, because the diagnose that gave way is
+     * asked for again.
+     */
     private void publishAll() {
         ModuleGraph graph = workspace.snapshot(documents.openDocuments());
         Map<String, List<LspDiagnostic>> byUri = analyzer.diagnostics(graph, workspace.modulePath());
         for (String uri : documents.uris()) {
+            abandonment.stopIfAsked();
             publish(uri, byUri.getOrDefault(uri, List.of()));
         }
     }

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -40,6 +40,10 @@ import java.util.function.BooleanSupplier;
  * by method, and answers requests / publishes diagnostics. Inbound payloads are decoded with Raoh
  * ({@link InboundDecoders}); outbound trees are built as maps and serialised with Jackson. The
  * language work is delegated to the {@link Analyzer}, which knows nothing of the protocol.
+ *
+ * <p>Two threads, and one of them owns everything: a session reads frames on a thread of its own and
+ * carries them out on the thread it was started on, which holds the documents, the workspace and the
+ * analyzer. {@link #run} says what that buys and why it is that way round.
  */
 public final class LspServer {
 
@@ -57,6 +61,10 @@ public final class LspServer {
      * message, and it says it while that message is being worked on. Handed over like the rest, it
      * would be read after the request it names had been answered — which is every request it could
      * have stopped.
+     *
+     * <p>Acted on only where it is a notification, which is what the protocol says it is. Written
+     * with an id it is a request, and every request is owed a reply; this server has no reply for
+     * one, so it goes on to be answered the way a method nobody declared is.
      */
     private static final String CANCEL_REQUEST = "$/cancelRequest";
 
@@ -181,7 +189,8 @@ public final class LspServer {
                 if (methodNode == null || methodNode.isNull()) {
                     continue;   // a response to a server-initiated request; nothing to do
                 }
-                if (CANCEL_REQUEST.equals(methodNode.asString())) {
+                JsonNode id = m.get("id");
+                if (CANCEL_REQUEST.equals(methodNode.asString()) && (id == null || id.isNull())) {
                     JsonNode params = m.get("params");
                     inbox.cancel(params == null ? null : params.get("id"));
                     continue;

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -172,8 +172,8 @@ public final class LspServer {
      * Reads frames and hands them over until the stream ends or reading cannot go on.
      *
      * <p>Nothing is answered here. What this thread decides is the order things happened in, and the
-     * one thing it acts on itself is a cancel, which has to reach a request that is already being
-     * worked on.
+     * one thing it acts on itself is a cancel — which has to reach a request that has already been
+     * handed over, whether or not the session has got to it yet.
      */
     private void read() {
         try {
@@ -208,11 +208,11 @@ public final class LspServer {
     /**
      * Carries out what arrives, and diagnoses the workspace whenever nothing else is waiting.
      *
-     * <p>Which is the whole of the scheduling. A diagnose is what this thread does with an idle
-     * moment: it gives way to anything at all, and a run of keystrokes therefore costs one diagnose
-     * at the end of it rather than one each. What it does not do is guarantee it ever runs — a client
-     * that never stopped asking would never be told anything, and that is what asking without pause
-     * means, not a case to write a threshold for.
+     * <p>Which is the whole of the scheduling. A diagnose is what this thread does with a moment in
+     * which no client is waiting to be answered: it gives way to any message, and a run of keystrokes
+     * therefore costs one diagnose at the end of it rather than one each. What it does not do is
+     * guarantee it ever runs — a client that never stopped asking would never be told anything, and
+     * that is what asking without pause means, not a case to write a threshold for.
      */
     private int carryOutWhatArrives() {
         while (true) {
@@ -227,10 +227,10 @@ public final class LspServer {
             switch (next) {
                 case Inbound.ReaderFailed failed -> throw new ConnectionLost(failed.cause());
                 case Inbound.EndOfInput _ -> {
-                    // Not something to give way to. Everything else in this queue is a client
-                    // asking for something, and a diagnose steps aside for those; the end of the
-                    // stream asks for nothing, so what was already asked for is finished first. A
-                    // diagnose is the only thing that can still be owed at this point.
+                    // The end of the stream asks for nothing, so a diagnose does not give way to it
+                    // and one that is still owed is carried out before the session ends. `exit` is
+                    // not this: that is a client saying stop now, and a server told to stop now has
+                    // nothing more to publish.
                     if (diagnosticsAreStale) {
                         diagnose();
                     }
@@ -976,7 +976,7 @@ public final class LspServer {
      */
     private void diagnose() {
         diagnosticsAreStale = false;
-        stopWhen = inbox::anyWaiting;
+        stopWhen = inbox::aMessageIsWaiting;
         try {
             publishAll();
         } catch (Abandoned _) {

--- a/souther-lsp/src/main/java/souther/lsp/Outcome.java
+++ b/souther-lsp/src/main/java/souther/lsp/Outcome.java
@@ -1,0 +1,31 @@
+package souther.lsp;
+
+/**
+ * What carrying out one message came to, and so what is written back for it.
+ *
+ * <p>Returned rather than written where the work finishes, so that one place writes and every
+ * message leaves through it. That a request is answered exactly once is then a property of that
+ * place and not a habit of eighteen handlers.
+ */
+sealed interface Outcome {
+
+    /** The answer to a request. Null is an answer: {@code shutdown} is replied to with nothing. */
+    record Answered(Object result) implements Outcome {}
+
+    /**
+     * The client gave up on this request before it was answered.
+     *
+     * <p>An outcome and not a failure. The work was asked for and then unasked for, which is a thing
+     * that happens on every keystroke, and the reply the protocol asks for says exactly that.
+     */
+    record Cancelled() implements Outcome {}
+
+    /** The request could not be carried out. */
+    record Failed(int code, String message) implements Outcome {}
+
+    /** Nothing to write. A notification, or a request written as one. */
+    record Nothing() implements Outcome {}
+
+    /** Nothing to write, and the session ends here. */
+    record Stop() implements Outcome {}
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -173,8 +173,15 @@ public final class Analyzer {
      */
     private Abandonment abandonment = Abandonment.NEVER;
 
-    /** What makes the work this analyzer does from now on stop short of its answer. Set as a unit of
-     * work begins, and read by everything that unit reaches — the compile's walk included. */
+    /**
+     * What makes the work this analyzer does from now on stop short of its answer. Set as a unit of
+     * work begins, and read by everything that unit reaches — the compile's walk included.
+     *
+     * <p>Asked at the turn of every walk over the workspace here, and not left to the store's own
+     * asking. A question already answered at this revision comes back without the store getting as
+     * far as asking, so a loop over every file that reads one each time would go the whole way
+     * without being asked once — and a loop over every file that parses one is the work itself.
+     */
     public void abandonWhen(Abandonment abandonment) {
         this.abandonment = abandonment;
     }
@@ -412,6 +419,7 @@ public final class Analyzer {
         Map<String, String> joining = new LinkedHashMap<>();
         Set<String> broken = new HashSet<>();
         for (String uri : graph.uris()) {
+            abandonment.stopIfAsked();
             String text = graph.text(uri);
             Reading reading = readingOf(uri, text);
             if (reading.parses()) {
@@ -1102,6 +1110,7 @@ public final class Analyzer {
 
         List<Location> out = new ArrayList<>();
         for (String u : graph.uris()) {
+            abandonment.stopIfAsked();
             String t = graph.text(u);
             boolean owns = definingModule.equals(moduleOf(compilation, graph, u));
             if (!owns && !definingModule.equals(importedFrom(t, name))) {
@@ -1391,6 +1400,7 @@ public final class Analyzer {
             declarationOf(compilation, target, graph).ifPresent(out::add);
         }
         for (String module : compilation.modules()) {
+            abandonment.stopIfAsked();
             String moduleUri = uriOf(compilation.sourceIdOf(module));
             for (Resolve.TypeUse use
                     : compilation.db().ask(new Names.UsesOf(module, target)).value()) {
@@ -1423,6 +1433,7 @@ public final class Analyzer {
             out.addAll(valueDeclarationsOf(compilation, target, uri, graph));
         }
         for (String module : compilation.modules()) {
+            abandonment.stopIfAsked();
             String moduleUri = uriOf(compilation.sourceIdOf(module));
             for (Resolve.ValueUse use
                     : compilation.db().ask(new Names.ValueUsesOf(module, target)).value()) {
@@ -1442,6 +1453,7 @@ public final class Analyzer {
                                            String definingModule, ModuleGraph graph,
                                            Map<String, List<Range>> byUri) {
         for (String u : graph.uris()) {
+            abandonment.stopIfAsked();
             String t = graph.text(u);
             SyntaxNode root = CstParser.parse(t).root();
             LineIndex lines = new LineIndex(t);
@@ -1723,6 +1735,7 @@ public final class Analyzer {
     public List<WorkspaceSymbol> workspaceSymbols(String query, ModuleGraph graph) {
         List<WorkspaceSymbol> found = new ArrayList<>();
         for (String uri : graph.uris()) {
+            abandonment.stopIfAsked();
             String text = graph.text(uri);
             if (text == null) {
                 continue;
@@ -2497,6 +2510,7 @@ public final class Analyzer {
             return declared;
         }
         for (String uri : graph.uris()) {
+            abandonment.stopIfAsked();
             if (moduleName.equals(Compiler.moduleNameFromHeader(graph.text(uri)))) {
                 return uri;
             }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -10,6 +10,7 @@ import souther.compiler.check.Sig;
 import souther.compiler.check.Resolve;
 import souther.compiler.check.SpecImplementation;
 import souther.compiler.examples.ExampleProvisioning;
+import souther.compiler.query.Abandonment;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.ArmSummary;
 import souther.compiler.query.Measurement;
@@ -162,6 +163,22 @@ public final class Analyzer {
      */
     private boolean resolvesActions;
 
+    /**
+     * What stops the work this analyzer is doing now, short of the answer.
+     *
+     * <p>Held rather than passed, because what makes the work stop is a property of the unit of work
+     * the caller is carrying out and not of any one question inside it: the same value covers the
+     * files this reads, the walk the compile makes, and the markers it lays out afterwards. One
+     * caller sets it as it begins a unit of work, and every step of that unit asks the same value.
+     */
+    private Abandonment abandonment = Abandonment.NEVER;
+
+    /** What makes the work this analyzer does from now on stop short of its answer. Set as a unit of
+     * work begins, and read by everything that unit reaches — the compile's walk included. */
+    public void abandonWhen(Abandonment abandonment) {
+        this.abandonment = abandonment;
+    }
+
     /** Whether anything is being measured, which is what decides if an offer can exist where there
      * is no diagnostic to fix. */
     public boolean measuring() {
@@ -271,6 +288,7 @@ public final class Analyzer {
         Set<String> brokenModules = new HashSet<>();   // names of files held out for their syntax errors
 
         for (String uri : graph.uris()) {
+            abandonment.stopIfAsked();   // between two files, before this one is parsed
             String text = graph.text(uri);
             LineIndex lines = new LineIndex(text);
             List<LspDiagnostic> syntax = new ArrayList<>();
@@ -314,6 +332,7 @@ public final class Analyzer {
             });
         };
         for (Map.Entry<SourceId, List<Located>> e : byUri.entrySet()) {
+            abandonment.stopIfAsked();   // between two files' markers, before this one is laid out
             List<LspDiagnostic> list = out.get(e.getKey().value());
             if (list == null) {
                 continue;
@@ -361,6 +380,9 @@ public final class Analyzer {
         } else {
             workspaceCompile.update(sources, broken);
         }
+        // Told here rather than where the compile is made: what stops the walk is whichever unit of
+        // work reached it, and a compile outlives every one of them.
+        workspaceCompile.abandonWhen(abandonment);
         return workspaceCompile;
     }
 
@@ -1567,7 +1589,8 @@ public final class Analyzer {
         // The buffer as it stands where it parses, and finished off where it does not: a call is
         // asked about while its closing bracket is not typed, which is most of the time.
         SemanticProbe.Reading reading =
-                probe.of(rest, sorted.broken(), pathCompiledAgainst(), uri, text, cursor);
+                probe.of(rest, sorted.broken(), pathCompiledAgainst(), uri, text, cursor,
+                        abandonment);
         Compilation compilation = reading == null ? compileOf(graph) : reading.compilation();
         String parsed = reading == null ? text : reading.repaired();
         String module = moduleOf(compilation, graph, uri);
@@ -1879,7 +1902,8 @@ public final class Analyzer {
         Map<String, String> rest = new LinkedHashMap<>(sorted.joining());
         rest.remove(uri);
         SemanticProbe.Reading reading =
-                probe.of(rest, sorted.broken(), pathCompiledAgainst(), uri, text, cursor);
+                probe.of(rest, sorted.broken(), pathCompiledAgainst(), uri, text, cursor,
+                        abandonment);
         if (reading == null) {
             return List.of();
         }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/SemanticProbe.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/SemanticProbe.java
@@ -8,6 +8,7 @@ import souther.compiler.cst.SyntaxKind;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Abandonment;
 import souther.compiler.query.Compilation;
 import souther.compiler.source.SourceId;
 
@@ -235,7 +236,7 @@ final class SemanticProbe {
      * reading of it here would be a second answer free to differ.
      */
     Reading of(Map<String, String> joining, Set<String> broken, ModulePath path, String uri,
-               String text, int cursor) {
+               String text, int cursor, Abandonment abandonment) {
         Repair repair = repair(text, cursor);
         if (repair == null) {
             return null;
@@ -248,6 +249,7 @@ final class SemanticProbe {
         } else {
             compile.update(sources, broken);
         }
+        compile.abandonWhen(abandonment);
         // In the document it was inserted into, and said so: a place that names no text is in the
         // same text as nothing, and every extent would compare as being somewhere else — which
         // reads as "the author wrote this" about all of them.

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Workspace.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Workspace.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Abandonment;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +24,15 @@ public final class Workspace {
     private static final String SUFFIX = ".sou";
 
     private final List<Path> roots = new ArrayList<>();
+
+    /** What stops a walk of the workspace short. Reading the files under a root is not a question
+     * put to a store, so what abandons the compile does not reach it; this is where it is asked. */
+    private Abandonment abandonment = Abandonment.NEVER;
+
+    /** What makes reading this workspace stop short of an answer. */
+    public void abandonWhen(Abandonment abandonment) {
+        this.abandonment = abandonment;
+    }
 
     /** The last on-disk scan ({@code uri -> text}), or {@code null} when it must be re-read. Cached so
      * an edit to an open buffer does not re-walk and re-read the whole workspace on every keystroke. */
@@ -83,7 +93,10 @@ public final class Workspace {
                 continue;
             }
             try (Stream<Path> walk = Files.walk(root, CLASS_OUTPUT_DEPTH)) {
-                walk.filter(Files::isDirectory).filter(Workspace::isClassOutput).forEach(outputs::add);
+                walk.filter(Files::isDirectory).filter(Workspace::isClassOutput).forEach(dir -> {
+                    abandonment.stopIfAsked();
+                    outputs.add(dir);
+                });
             } catch (IOException _) {
                 // a root that cannot be walked contributes nothing; the workspace still works
             }
@@ -112,7 +125,10 @@ public final class Workspace {
             try (Stream<Path> walk = Files.walk(root)) {
                 walk.filter(Files::isRegularFile)
                         .filter(p -> p.getFileName().toString().endsWith(SUFFIX))
-                        .forEach(p -> sources.put(p.toUri().toString(), readOrEmpty(p)));
+                        .forEach(p -> {
+                            abandonment.stopIfAsked();
+                            sources.put(p.toUri().toString(), readOrEmpty(p));
+                        });
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Workspace.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Workspace.java
@@ -25,8 +25,9 @@ public final class Workspace {
 
     private final List<Path> roots = new ArrayList<>();
 
-    /** What stops a walk of the workspace short. Reading the files under a root is not a question
-     * put to a store, so what abandons the compile does not reach it; this is where it is asked. */
+    /** What stops a walk of the workspace short. Reading the files under a root is not a question put
+     * to a store, so what abandons the compile does not reach it; this is where it is asked, at every
+     * path a walk reaches rather than at the ones it was looking for. */
     private Abandonment abandonment = Abandonment.NEVER;
 
     /** What makes reading this workspace stop short of an answer. */
@@ -93,9 +94,14 @@ public final class Workspace {
                 continue;
             }
             try (Stream<Path> walk = Files.walk(root, CLASS_OUTPUT_DEPTH)) {
-                walk.filter(Files::isDirectory).filter(Workspace::isClassOutput).forEach(dir -> {
+                // Asked of every path the walk reaches, and not of the ones that turn out to be
+                // what is wanted. What costs time is the walk, and a root with no class output in
+                // it is a root this would read to the end after being told to stop.
+                walk.forEach(path -> {
                     abandonment.stopIfAsked();
-                    outputs.add(dir);
+                    if (Files.isDirectory(path) && isClassOutput(path)) {
+                        outputs.add(path);
+                    }
                 });
             } catch (IOException _) {
                 // a root that cannot be walked contributes nothing; the workspace still works
@@ -123,12 +129,14 @@ public final class Workspace {
                 continue;
             }
             try (Stream<Path> walk = Files.walk(root)) {
-                walk.filter(Files::isRegularFile)
-                        .filter(p -> p.getFileName().toString().endsWith(SUFFIX))
-                        .forEach(p -> {
-                            abandonment.stopIfAsked();
-                            sources.put(p.toUri().toString(), readOrEmpty(p));
-                        });
+                // Every path, as above: the walk is what a workspace of a hundred thousand files
+                // spends its time on, and how many of them end in `.sou` says nothing about that.
+                walk.forEach(path -> {
+                    abandonment.stopIfAsked();
+                    if (Files.isRegularFile(path) && path.getFileName().toString().endsWith(SUFFIX)) {
+                        sources.put(path.toUri().toString(), readOrEmpty(path));
+                    }
+                });
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/souther-lsp/src/test/java/souther/lsp/AConnectionThatCannotBeReadEndsTheSessionTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AConnectionThatCannotBeReadEndsTheSessionTest.java
@@ -1,0 +1,34 @@
+package souther.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A session whose frames cannot be read stops being a session.
+ *
+ * <p>Reading happens on a thread of its own, which is a thread that cannot end a session: it holds
+ * nothing, answers nothing, and a failure it kept to itself would leave the session waiting for a
+ * message that is never coming, with everything the client already asked for still owed. So what
+ * stopped it is carried to the thread that owns the session and raised there.
+ *
+ * <p>Raised, and not turned into a failed request. A request the server cannot answer costs that
+ * request; a connection that cannot be read costs the session, and there is nowhere left to write
+ * the failure to.
+ */
+class AConnectionThatCannotBeReadEndsTheSessionTest {
+
+    @Test
+    void aHeaderThatSaysNoLengthIsMetOnTheThreadThatOwnsTheSession() {
+        ByteArrayInputStream unreadable = new ByteArrayInputStream(
+                "Content-Length: as long as it takes\r\n\r\n{}".getBytes(StandardCharsets.US_ASCII));
+
+        assertThrows(ConnectionLost.class,
+                () -> LspServer.serve(unreadable, new ByteArrayOutputStream()),
+                "what stopped the reading thread is what the session stops on");
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/ADiagnoseIsWhatTheServerDoesWithAnIdleMomentTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/ADiagnoseIsWhatTheServerDoesWithAnIdleMomentTest.java
@@ -1,0 +1,124 @@
+package souther.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static souther.lsp.Session.message;
+import static souther.lsp.Session.publishedFor;
+import static souther.lsp.Session.replyTo;
+
+/**
+ * When the workspace is diagnosed, and what that costs a client that is typing.
+ *
+ * <p>Diagnostics are what this server does with a moment in which nothing has been asked of it. That
+ * one sentence is the whole of the scheduling, and both things worth holding it to follow from it. A
+ * run of keystrokes costs one diagnose rather than one each, because the second keystroke arrives
+ * while the first one's diagnose has not been started or has not finished, and either way it gives
+ * way. And a question asked after a keystroke is answered before the keystroke's diagnostics are
+ * published, because the question is something asked and the diagnose is what there is to do
+ * instead.
+ *
+ * <p>Nothing here holds the server to diagnosing at all while a client keeps asking. It does not:
+ * a client that never stops asking is a client that never leaves an idle moment, and that is what
+ * asking without pause means rather than a case to write a threshold for.
+ */
+class ADiagnoseIsWhatTheServerDoesWithAnIdleMomentTest {
+
+    @Test
+    void aRunOfEditsCostsOneDiagnoseAndNotOneEach() throws Exception {
+        Path dir = aWorkspace();
+        String uri = dir.resolve("m0.sou").toUri().toString();
+        try (Session session = new Session()) {
+            session.send(opening(dir, uri));
+            session.await(publishedFor(uri), "the diagnostics of the document as it was opened");
+            session.awaitQuiet();
+            long published = session.count(publishedFor(uri));
+
+            session.send(
+                    message(null, "textDocument/didChange", changedTo(uri, edited("Amount0"))),
+                    message(null, "textDocument/didChange", changedTo(uri, edited("Missing"))),
+                    message(null, "textDocument/didChange", changedTo(uri, edited("Amount0"))));
+            session.awaitAtLeast(published + 1, publishedFor(uri),
+                    "diagnostics for the document as the last of the edits left it");
+            session.awaitQuiet();
+
+            assertEquals(published + 1, session.count(publishedFor(uri)),
+                    "three edits in a row are one thing to say about the document, said once");
+        }
+    }
+
+    @Test
+    void aQuestionAskedAfterAnEditIsAnsweredBeforeTheEditIsDiagnosed() throws Exception {
+        Path dir = aWorkspace();
+        String uri = dir.resolve("m0.sou").toUri().toString();
+        try (Session session = new Session()) {
+            session.send(opening(dir, uri));
+            session.await(publishedFor(uri), "the diagnostics of the document as it was opened");
+            session.awaitQuiet();
+            long published = session.count(publishedFor(uri));
+
+            session.send(
+                    message(null, "textDocument/didChange", changedTo(uri, edited("Missing"))),
+                    message(2, "textDocument/hover", somewhereIn(uri)));
+            session.await(replyTo(2), "the answer to the question asked after the edit");
+
+            assertEquals(published, session.count(publishedFor(uri)),
+                    "the question was answered while what the edit provoked was still owed");
+        }
+    }
+
+    /** The handshake and one open document. */
+    private static String[] opening(Path dir, String uri) throws IOException {
+        return new String[] {
+            message(1, "initialize", Map.of("rootUri", dir.toUri().toString())),
+            message(null, "initialized", Map.of()),
+            message(null, "textDocument/didOpen",
+                    Map.of("textDocument", Map.of("uri", uri, "text", Files.readString(dir.resolve("m0.sou"))))),
+        };
+    }
+
+    private static Map<String, Object> changedTo(String uri, String text) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("textDocument", Map.of("uri", uri));
+        params.put("contentChanges", java.util.List.of(Map.of("text", text)));
+        return params;
+    }
+
+    private static Map<String, Object> somewhereIn(String uri) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("textDocument", Map.of("uri", uri));
+        params.put("position", Map.of("line", 1, "character", 6));
+        return params;
+    }
+
+    /** The opened document with the field's type named {@code type}, which one edit is as good as. */
+    private static String edited(String type) {
+        return moduleNamed(0).replace("of: Int", "of: " + type);
+    }
+
+    private static String moduleNamed(int i) {
+        return """
+                module m%d
+                data Amount%d = { of: Int }
+                behavior twice%d : (a: Amount%d) -> Amount%d
+                let twice%d (a) = Amount%d { of = a.of + a.of }
+                example twice%d
+                  | (Amount%d { of = 2 }) -> Amount%d { of = 4 }
+                """.formatted(i, i, i, i, i, i, i, i, i, i);
+    }
+
+    /** Enough modules that a diagnose is long enough to be interrupted by the next frame. */
+    private static Path aWorkspace() throws IOException {
+        Path dir = Files.createTempDirectory("lsp-idle");
+        for (int i = 0; i < 24; i++) {
+            Files.writeString(dir.resolve("m" + i + ".sou"), moduleNamed(i));
+        }
+        return dir;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/ARequestTheClientGaveUpOnIsAnsweredWithThatAndNothingElseTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/ARequestTheClientGaveUpOnIsAnsweredWithThatAndNothingElseTest.java
@@ -1,0 +1,140 @@
+package souther.lsp;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static souther.lsp.Session.message;
+import static souther.lsp.Session.replyTo;
+
+/**
+ * What a client is sent for a request it stopped waiting for.
+ *
+ * <p>A reply, and one — the protocol has no way to say nothing, and a client that never hears back
+ * about a request it sent is a client holding an entry open for the rest of the session. What the
+ * reply says is that the request was cancelled, which is the thing that happened.
+ *
+ * <p>Where the request had got to when the cancel arrived is not a distinction anything makes, and
+ * the cases here are written so that it cannot be one. The first names a request that had certainly
+ * not been looked at, because the reply to the request in front of it shows that one was still being
+ * answered; the second names a request with nothing in front of it at all. Both rest on a request
+ * being registered under its id before it is put where the thread that answers it can see it —
+ * registered afterwards, the first would find nothing to cancel and be answered with a hover.
+ *
+ * <p>What is not written here is a cancel that arrives after the answer was settled, which is
+ * answered with the answer. Which side of that a cancel falls on is decided by one read, and a test
+ * that tried to land on the far side of it would be a test of how long a compile happens to take.
+ */
+class ARequestTheClientGaveUpOnIsAnsweredWithThatAndNothingElseTest {
+
+    private static final int REQUEST_CANCELLED = -32800;
+
+    @Test
+    void oneQueuedBehindWorkAlreadyUnderWayIsAnsweredWithTheCancellation() throws Exception {
+        Path dir = aWorkspaceWorthCompiling();
+        String uri = dir.resolve("m0.sou").toUri().toString();
+        try (Session session = new Session()) {
+            session.send(afterOpening(dir, uri,
+                    message(2, "textDocument/hover", somewhereIn(uri)),
+                    message(3, "textDocument/hover", somewhereIn(uri)),
+                    message(null, "$/cancelRequest", Map.of("id", 3))));
+
+            assertCancelled(session, 3);
+            assertTrue(session.await(replyTo(2), "a reply to the request it did wait for").has("result"),
+                    "the request in front of it was not the one given up on, and was answered");
+        }
+    }
+
+    @Test
+    void oneAlreadyBeingWorkedOnIsAnsweredWithTheCancellation() throws Exception {
+        Path dir = aWorkspaceWorthCompiling();
+        String uri = dir.resolve("m0.sou").toUri().toString();
+        try (Session session = new Session()) {
+            session.send(afterOpening(dir, uri,
+                    message(2, "textDocument/hover", somewhereIn(uri)),
+                    message(null, "$/cancelRequest", Map.of("id", 2))));
+
+            assertCancelled(session, 2);
+        }
+    }
+
+    @Test
+    void oneNobodyGaveUpOnIsAnsweredWithWhatItAsked() throws Exception {
+        Path dir = aWorkspaceWorthCompiling();
+        String uri = dir.resolve("m0.sou").toUri().toString();
+        try (Session session = new Session()) {
+            session.send(afterOpening(dir, uri,
+                    message(2, "textDocument/hover", somewhereIn(uri))));
+
+            JsonNode reply = session.await(replyTo(2), "a reply to the hover");
+            assertTrue(reply.has("result"), "a request nobody cancelled is answered with its answer");
+            assertFalse(reply.has("error"), "and not with a cancellation");
+        }
+    }
+
+    private static void assertCancelled(Session session, int id) {
+        JsonNode reply = session.await(replyTo(id), "a reply to the request it gave up on");
+        assertFalse(reply.has("result"),
+                "a client that gave up is not sent the answer it stopped waiting for");
+        assertEquals(REQUEST_CANCELLED, reply.get("error").get("code").asInt(),
+                "it is sent what the protocol says a cancelled request is answered with");
+        session.awaitQuiet();
+        assertEquals(1, session.count(replyTo(id)), "and is sent it once");
+    }
+
+    /**
+     * The handshake, one open document, and then {@code then} — as one run of frames.
+     *
+     * <p>One run, and not a handshake sent and waited on first. A session that had been left to
+     * itself for a moment has diagnosed the workspace, and a compile that has answered once answers
+     * the next question about it too quickly to be a question in flight.
+     */
+    private static String[] afterOpening(Path dir, String uri, String... then) throws IOException {
+        List<String> frames = new ArrayList<>(List.of(
+                message(1, "initialize", Map.of("rootUri", dir.toUri().toString())),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of("textDocument",
+                        Map.of("uri", uri, "text", Files.readString(dir.resolve("m0.sou")))))));
+        frames.addAll(List.of(then));
+        return frames.toArray(String[]::new);
+    }
+
+    private static Map<String, Object> somewhereIn(String uri) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("textDocument", Map.of("uri", uri));
+        params.put("position", Map.of("line", 1, "character", 6));
+        return params;
+    }
+
+    /**
+     * Enough modules that answering one question about them takes long enough to cancel.
+     *
+     * <p>Each carries an example, so answering means running it. What is being tested is what
+     * happens while work is in flight, and work that is over before the next frame is read is not
+     * work in flight.
+     */
+    private static Path aWorkspaceWorthCompiling() throws IOException {
+        Path dir = Files.createTempDirectory("lsp-cancel");
+        for (int i = 0; i < 24; i++) {
+            Files.writeString(dir.resolve("m" + i + ".sou"), """
+                    module m%d
+                    data Amount%d = { of: Int }
+                    behavior twice%d : (a: Amount%d) -> Amount%d
+                    let twice%d (a) = Amount%d { of = a.of + a.of }
+                    example twice%d
+                      | (Amount%d { of = 2 }) -> Amount%d { of = 4 }
+                    """.formatted(i, i, i, i, i, i, i, i, i, i));
+        }
+        return dir;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
@@ -87,7 +87,8 @@ class LspServerTest {
         new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
 
         JsonNode caps = readFrames(out.toByteArray()).stream()
-                .filter(m -> m.has("id") && m.get("id").asInt() == 1).findFirst().orElseThrow()
+                .filter(m -> m.has("id") && m.get("id").isNumber() && m.get("id").asInt() == 1)
+                .findFirst().orElseThrow()
                 .get("result").get("capabilities");
         assertTrue(caps.get("referencesProvider").asBoolean(), "references is advertised");
     }
@@ -120,7 +121,8 @@ class LspServerTest {
         new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
 
         JsonNode caps = readFrames(out.toByteArray()).stream()
-                .filter(m -> m.has("id") && m.get("id").asInt() == 1).findFirst().orElseThrow()
+                .filter(m -> m.has("id") && m.get("id").isNumber() && m.get("id").asInt() == 1)
+                .findFirst().orElseThrow()
                 .get("result").get("capabilities");
         assertTrue(caps.get("documentFormattingProvider").asBoolean(), "formatting is advertised");
         assertTrue(caps.get("renameProvider").asBoolean(), "rename is advertised");

--- a/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
@@ -20,40 +20,38 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Drives the server end to end over an in-memory connection: an initialize handshake and an opened
- * document with a syntax error, checking the capabilities response and the published diagnostics. */
+/**
+ * Drives the server end to end over a connection: an initialize handshake and an opened document with
+ * a syntax error, checking the capabilities response and the published diagnostics.
+ *
+ * <p>What is asked and answered in one breath is handed over as a stream that ends. What is published
+ * because the workspace was left alone for a moment is not: diagnostics are what this server does
+ * with an idle moment, and a stream that is already at its end never leaves one. Those cases run
+ * against a {@link Session}, which holds the connection open and waits for what comes back.
+ */
 class LspServerTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
     @Test
     void initializeAndDiagnosticsFlowOverTheConnection() {
-        String didOpen = message(null, "textDocument/didOpen", Map.of(
-                "textDocument", Map.of("uri", "file:///t.sou",
-                        "text", "module demo\ndata M = { name String }\n")));   // missing `:`
+        String uri = "file:///t.sou";
+        try (Session session = new Session()) {
+            session.send(
+                    Session.message(1, "initialize", Map.of()),
+                    Session.message(null, "initialized", Map.of()),
+                    Session.message(null, "textDocument/didOpen", Map.of(
+                            "textDocument", Map.of("uri", uri,
+                                    "text", "module demo\ndata M = { name String }\n"))));   // missing `:`
 
-        byte[] input = frames(
-                message(1, "initialize", Map.of()),
-                message(null, "initialized", Map.of()),
-                didOpen);
+            JsonNode initResult = session.await(Session.replyTo(1), "an answer to initialize");
+            assertTrue(initResult.get("result").get("capabilities").has("textDocumentSync"));
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
-
-        List<JsonNode> messages = readFrames(out.toByteArray());
-
-        JsonNode initResult = messages.stream()
-                .filter(m -> m.has("id") && m.get("id").asInt() == 1).findFirst().orElseThrow();
-        assertTrue(initResult.get("result").get("capabilities").has("textDocumentSync"));
-
-        JsonNode publish = messages.stream()
-                .filter(m -> m.has("method")
-                        && m.get("method").asString().equals("textDocument/publishDiagnostics"))
-                .findFirst().orElse(null);
-        assertNotNull(publish, "expected a publishDiagnostics notification");
-        JsonNode diagnostics = publish.get("params").get("diagnostics");
-        assertTrue(diagnostics.size() > 0, "expected at least one diagnostic");
-        assertEquals("souther", diagnostics.get(0).get("source").asString());
+            JsonNode publish = session.await(Session.publishedFor(uri), "diagnostics for the document");
+            JsonNode diagnostics = publish.get("params").get("diagnostics");
+            assertTrue(diagnostics.size() > 0, "expected at least one diagnostic");
+            assertEquals("souther", diagnostics.get(0).get("source").asString());
+        }
     }
 
     @Test
@@ -67,25 +65,19 @@ class LspServerTest {
         Files.writeString(b, bText);
         String bUri = b.toUri().toString();
 
-        byte[] input = frames(
-                message(1, "initialize", Map.of("rootUri", dir.toUri().toString())),
-                message(null, "initialized", Map.of()),
-                message(null, "textDocument/didOpen", Map.of(
-                        "textDocument", Map.of("uri", bUri, "text", bText))));
+        try (Session session = new Session()) {
+            session.send(
+                    Session.message(1, "initialize", Map.of("rootUri", dir.toUri().toString())),
+                    Session.message(null, "initialized", Map.of()),
+                    Session.message(null, "textDocument/didOpen", Map.of(
+                            "textDocument", Map.of("uri", bUri, "text", bText))));
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
-
-        // the importing module used to bail; now it resolves a against the root and reports E1905
-        JsonNode publish = readFrames(out.toByteArray()).stream()
-                .filter(m -> m.has("method")
-                        && m.get("method").asString().equals("textDocument/publishDiagnostics"))
-                .filter(m -> m.get("params").get("uri").asString().equals(bUri))
-                .reduce((first, second) -> second).orElse(null);   // the latest publish for b
-        assertNotNull(publish, "expected a publishDiagnostics for b");
-        JsonNode diagnostics = publish.get("params").get("diagnostics");
-        assertTrue(diagnostics.size() > 0, "the cross-module compile surfaces the failing example");
-        assertEquals("E1905", diagnostics.get(0).get("code").asString());
+            // the importing module used to bail; now it resolves a against the root and reports E1905
+            JsonNode publish = session.await(Session.publishedFor(bUri), "diagnostics for b");
+            JsonNode diagnostics = publish.get("params").get("diagnostics");
+            assertTrue(diagnostics.size() > 0, "the cross-module compile surfaces the failing example");
+            assertEquals("E1905", diagnostics.get(0).get("code").asString());
+        }
     }
 
     @Test

--- a/souther-lsp/src/test/java/souther/lsp/Session.java
+++ b/souther-lsp/src/test/java/souther/lsp/Session.java
@@ -1,0 +1,205 @@
+package souther.lsp;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * A server running against a connection that stays open, for the tests about when it answers what.
+ *
+ * <p>The other protocol tests hand the server every frame at once and read what it wrote afterwards,
+ * which is enough while the answer to a message depends only on the messages before it. It is not
+ * enough here: what this server does with an idle moment is the thing being tested, and a stream
+ * that is already at its end never has one. So the frames go in through a pipe the test holds open,
+ * and the test waits on what comes back rather than on the session ending.
+ */
+final class Session implements AutoCloseable {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** Long enough that a slow machine is not a failure, short enough to be a test. */
+    private static final long WAIT_MILLIS = 60_000;
+
+    /** How long nothing may arrive before the server is taken to have finished what it was doing. */
+    private static final long QUIET_MILLIS = 400;
+
+    private final PipedOutputStream toServer = new PipedOutputStream();
+
+    private final ByteArrayOutputStream fromServer = new ByteArrayOutputStream();
+
+    private final Thread serving;
+
+    private volatile int code = -1;
+
+    private volatile Throwable stopped;
+
+    Session() {
+        PipedInputStream in;
+        try {
+            in = new PipedInputStream(toServer, 1 << 16);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        serving = Thread.ofPlatform().name("souther-lsp-under-test").start(() -> {
+            try {
+                code = LspServer.serve(in, fromServer);
+            } catch (Throwable t) {
+                stopped = t;
+            }
+        });
+    }
+
+    /** Writes the messages as one run of frames, the way a client that pipelines them would. */
+    void send(String... messages) {
+        try {
+            for (String message : messages) {
+                byte[] body = message.getBytes(StandardCharsets.UTF_8);
+                toServer.write(("Content-Length: " + body.length + "\r\n\r\n")
+                        .getBytes(StandardCharsets.US_ASCII));
+                toServer.write(body);
+            }
+            toServer.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** Everything the server has written so far that can be read as a whole frame. */
+    List<JsonNode> heard() {
+        byte[] wrote = fromServer.toByteArray();
+        List<JsonNode> messages = new ArrayList<>();
+        int at = 0;
+        while (true) {
+            int blank = indexOf(wrote, at);
+            if (blank < 0) {
+                return messages;
+            }
+            String header = new String(wrote, at, blank - at, StandardCharsets.US_ASCII);
+            int length = Integer.parseInt(header.substring(header.indexOf(':') + 1).trim());
+            int body = blank + 4;
+            if (body + length > wrote.length) {
+                return messages;   // the frame is still being written
+            }
+            messages.add(JSON.readTree(new String(wrote, body, length, StandardCharsets.UTF_8)));
+            at = body + length;
+        }
+    }
+
+    /** How many of the messages written so far {@code what} holds of. */
+    long count(Predicate<JsonNode> what) {
+        return heard().stream().filter(what).count();
+    }
+
+    /** Waits for a message the server writes that {@code what} holds of, and answers with it. */
+    JsonNode await(Predicate<JsonNode> what, String wanted) {
+        long until = System.currentTimeMillis() + WAIT_MILLIS;
+        while (System.currentTimeMillis() < until) {
+            JsonNode found = heard().stream().filter(what).findFirst().orElse(null);
+            if (found != null) {
+                return found;
+            }
+            pause();
+        }
+        throw new AssertionError("the server never wrote " + wanted);
+    }
+
+    /** Waits until the server has written at least {@code many} messages that {@code what} holds of. */
+    void awaitAtLeast(long many, Predicate<JsonNode> what, String wanted) {
+        long until = System.currentTimeMillis() + WAIT_MILLIS;
+        while (System.currentTimeMillis() < until) {
+            if (count(what) >= many) {
+                return;
+            }
+            pause();
+        }
+        throw new AssertionError("the server never wrote " + wanted);
+    }
+
+    /** Waits until the server has written nothing for long enough to have finished what it had. */
+    void awaitQuiet() {
+        long lastChange = System.currentTimeMillis();
+        int seen = fromServer.size();
+        while (System.currentTimeMillis() - lastChange < QUIET_MILLIS) {
+            pause();
+            if (fromServer.size() != seen) {
+                seen = fromServer.size();
+                lastChange = System.currentTimeMillis();
+            }
+        }
+    }
+
+    /** What the session ended with, once the stream has been closed. */
+    int code() {
+        return code;
+    }
+
+    @Override
+    public void close() {
+        try {
+            toServer.close();
+            serving.join(WAIT_MILLIS);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+        if (stopped != null) {
+            throw new AssertionError("the session did not end the way a session ends", stopped);
+        }
+    }
+
+    private static void pause() {
+        try {
+            Thread.sleep(2);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    /** Where the blank line that ends a frame's header block begins, or -1 if it is not there yet. */
+    private static int indexOf(byte[] wrote, int from) {
+        for (int i = from; i + 3 < wrote.length; i++) {
+            if (wrote[i] == '\r' && wrote[i + 1] == '\n' && wrote[i + 2] == '\r' && wrote[i + 3] == '\n') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** One JSON-RPC message: a request when {@code id} is given, a notification when it is not. */
+    static String message(Integer id, String method, Object params) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("jsonrpc", "2.0");
+        if (id != null) {
+            message.put("id", id);
+        }
+        message.put("method", method);
+        message.put("params", params);
+        return JSON.writeValueAsString(message);
+    }
+
+    /** Whether {@code message} is the reply to the request numbered {@code id}. */
+    static Predicate<JsonNode> replyTo(int id) {
+        return m -> m.has("id") && !m.has("method") && m.get("id").asInt() == id;
+    }
+
+    /** Whether {@code message} publishes diagnostics for {@code uri}. */
+    static Predicate<JsonNode> publishedFor(String uri) {
+        return m -> m.has("method")
+                && m.get("method").asString().equals("textDocument/publishDiagnostics")
+                && m.get("params").get("uri").asString().equals(uri);
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/Session.java
+++ b/souther-lsp/src/test/java/souther/lsp/Session.java
@@ -40,8 +40,6 @@ final class Session implements AutoCloseable {
 
     private final Thread serving;
 
-    private volatile int code = -1;
-
     private volatile Throwable stopped;
 
     Session() {
@@ -53,7 +51,7 @@ final class Session implements AutoCloseable {
         }
         serving = Thread.ofPlatform().name("souther-lsp-under-test").start(() -> {
             try {
-                code = LspServer.serve(in, fromServer);
+                LspServer.serve(in, fromServer);
             } catch (Throwable t) {
                 stopped = t;
             }
@@ -137,11 +135,6 @@ final class Session implements AutoCloseable {
                 lastChange = System.currentTimeMillis();
             }
         }
-    }
-
-    /** What the session ended with, once the stream has been closed. */
-    int code() {
-        return code;
     }
 
     @Override

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AQuestionAboutTheWholeWorkspaceIsStoppedPartWayThroughItTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AQuestionAboutTheWholeWorkspaceIsStoppedPartWayThroughItTest.java
@@ -1,0 +1,64 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Abandoned;
+import souther.compiler.query.Abandonment;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A question about every file in the workspace stops part way through the files.
+ *
+ * <p>Some of what an editor asks is a walk of the workspace that this layer does itself, rather than
+ * a question put to the store: what a name is used in, what declarations match what the author is
+ * typing, which file declares a module. Each turn of those reads a file and parses it, and none of
+ * it reaches the store — so a stop that only the store asked about would never come, however long
+ * the walk.
+ *
+ * <p>The compile is warmed first, and that is what makes this say anything. Everything the store
+ * could be asked here is already answered at this revision, so an answer comes back without the
+ * store getting as far as asking whether the work is still wanted. What is left to stop the walk is
+ * the walk asking on its own account, which is the thing under test.
+ */
+class AQuestionAboutTheWholeWorkspaceIsStoppedPartWayThroughItTest {
+
+    @Test
+    void lookingForDeclarationsAcrossTheWorkspaceIsStopped() {
+        Analyzer analyzer = new Analyzer();
+        ModuleGraph graph = aWorkspace();
+        assertEquals(24, analyzer.workspaceSymbols("Amount", graph).size(),
+                "warm: every module declares one type the query names");
+
+        analyzer.abandonWhen(new Abandonment(() -> true));
+
+        assertThrows(Abandoned.class, () -> analyzer.workspaceSymbols("Amount", graph),
+                "a walk of every file in the workspace is a walk that can be given up on");
+    }
+
+    @Test
+    void whatTheStoreAlreadyAnsweredDoesNotHoldTheWalkOpen() {
+        Analyzer analyzer = new Analyzer();
+        ModuleGraph graph = aWorkspace();
+        analyzer.diagnostics(graph);   // the compile, so nothing below has to be worked out again
+
+        analyzer.abandonWhen(new Abandonment(() -> true));
+
+        assertThrows(Abandoned.class, () -> analyzer.diagnostics(graph),
+                "a diagnose over answers it already has is still a walk of the workspace");
+    }
+
+    private static ModuleGraph aWorkspace() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < 24; i++) {
+            sources.put("file:///m" + i + ".sou", """
+                    module m%d
+                    data Amount%d = { of: Int }
+                    """.formatted(i, i));
+        }
+        return ModuleGraph.of(sources);
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AWalkOfTheWorkspaceIsStoppedWhereItIsReadingTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AWalkOfTheWorkspaceIsStoppedWhereItIsReadingTest.java
@@ -1,0 +1,62 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Abandoned;
+import souther.compiler.query.Abandonment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Reading a workspace stops where the reading is, not where what it was looking for turns out to be.
+ *
+ * <p>What a walk of a root costs is the paths it goes through, and how many of them are Souther
+ * sources says nothing about that. A workspace is mostly not Souther sources: it is a repository,
+ * with a build directory and a history and whatever else is checked into it. Asked only at the paths
+ * that turn out to be sources, a walk of a hundred thousand files reads all of them after being told
+ * to stop — and a root holding none reads to the end without being asked once.
+ *
+ * <p>So the roots here hold nothing the walk is looking for. That is the case where a stop placed at
+ * what was found never comes, and it is not a corner: a workspace that has not been built has no
+ * class output anywhere in it, which is the second of these every time.
+ */
+class AWalkOfTheWorkspaceIsStoppedWhereItIsReadingTest {
+
+    @Test
+    void aRootWithNoSourceInItIsStillARootBeingRead() throws IOException {
+        Workspace workspace = readingOnly(aRootOfOtherPeoplesFiles());
+
+        assertThrows(Abandoned.class, () -> workspace.snapshot(Map.of()),
+                "a root with nothing to find in it is a root this walked to the end");
+    }
+
+    @Test
+    void aRootWithNothingBuiltInItIsStillARootBeingRead() throws IOException {
+        Workspace workspace = readingOnly(aRootOfOtherPeoplesFiles());
+
+        assertThrows(Abandoned.class, workspace::modulePath,
+                "and looking for what a build left is the same walk over the same paths");
+    }
+
+    /** A workspace over {@code root} that has already been told to stop. */
+    private static Workspace readingOnly(Path root) {
+        Workspace workspace = new Workspace();
+        workspace.setRoots(List.of(root.toUri().toString()));
+        workspace.abandonWhen(new Abandonment(() -> true));
+        return workspace;
+    }
+
+    /** A root with files in it, none of which is a Souther source or anything a build left. */
+    private static Path aRootOfOtherPeoplesFiles() throws IOException {
+        Path root = Files.createTempDirectory("workspace-walk");
+        Files.writeString(root.resolve("README.md"), "not a source\n");
+        Files.createDirectories(root.resolve("docs").resolve("pictures"));
+        Files.writeString(root.resolve("docs").resolve("why.md"), "nor is this\n");
+        return root;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/SemanticProbeBenchmark.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/SemanticProbeBenchmark.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import souther.compiler.ast.Hir;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Abandonment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 
@@ -147,7 +148,7 @@ class SemanticProbeBenchmark {
         rest.remove(edited);
         String text = byId.get(edited) + halfWritten(round);
         SemanticProbe.Reading reading = probe.of(rest, Set.of(), ModulePath.EMPTY, edited, text,
-                text.length());
+                text.length(), Abandonment.NEVER);
         if (reading == null) {
             throw new IllegalStateException("the half-written line is one the probe finishes off");
         }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsAskedOfAHalfWrittenLineIsAskedOfWhatItSaysNowTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsAskedOfAHalfWrittenLineIsAskedOfWhatItSaysNowTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.ast.Hir;
 import souther.compiler.cst.LineIndex;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Abandonment;
 import souther.compiler.query.Names;
 import souther.compiler.sites.MemberReceiver;
 import souther.compiler.sites.SemanticSnapshot;
@@ -139,7 +140,8 @@ class WhatIsAskedOfAHalfWrittenLineIsAskedOfWhatItSaysNowTest {
     private static Reading reading(SemanticProbe probe, String text) {
         Map<String, String> joining = new LinkedHashMap<>();
         Reading reading = probe.of(joining, Set.of(), ModulePath.EMPTY, URI, text,
-                text.indexOf(".\n") < 0 ? text.length() : text.lastIndexOf(".\n") + 1);
+                text.indexOf(".\n") < 0 ? text.length() : text.lastIndexOf(".\n") + 1,
+                Abandonment.NEVER);
         assertNotNull(reading, "the half-written line is one this knows how to finish");
         return reading;
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
@@ -3,6 +3,7 @@ package souther.lsp.analysis;
 import org.junit.jupiter.api.Test;
 import souther.compiler.cst.LineIndex;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Abandonment;
 import souther.compiler.sites.Evidence;
 import souther.compiler.sites.MemberReceiver;
 import souther.compiler.sites.SemanticSnapshot;
@@ -141,7 +142,7 @@ class WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest {
         joining.put(LIB_URI, LIB);
         int cursor = text.lastIndexOf(".\n") + 1;
         SemanticProbe.Reading reading = new SemanticProbe().of(joining, Set.of(), ModulePath.EMPTY,
-                MODEL_URI, text, cursor);
+                MODEL_URI, text, cursor, Abandonment.NEVER);
         if (reading == null) {
             throw new AssertionError("the half-written line is one the probe finishes off");
         }


### PR DESCRIPTION
The language server read a frame, answered it and wrote the reply on one thread, and the diagnose an
edit provokes ran inside that. While it ran, the completion the author's next keystroke asked for sat
unread in the pipe, and a request the client had given up on was still carried out and still
answered. Closes #1435.

## What owns what

A thread beside the session reads frames and hands them over. The session keeps the documents, the
workspace and the analyzer, so the store a compile is made of is still asked by one thread, which is
the sentence it is written under. What the second thread buys is not a second question being answered
at once — it is that a question can arrive while one is being answered, and so that it can be given
up on.

The session owns the process rather than the reader. An error nothing is entitled to recover from
ends the thread that owns the store, and the reader is a daemon, so it cannot go on reading for a
server that has stopped answering. A failure of the reader is carried the other way, on a slot a
thread in the middle of a long answer can see as well as on the queue, and raised where a session can
be ended.

## When the workspace is diagnosed

A diagnose is what the session does with a moment in which nothing has been asked of it. It gives way
to whatever arrives and is asked for again, so a run of keystrokes costs one diagnose at the end of
it rather than one each, and a hover behind an edit is answered before the edit is published.

It carries no promise of running while a client keeps asking. A client that never pauses leaves no
moment to run in, and that is what asking without pause means rather than a case to write a threshold
for. What is held instead is that the last thing asked for is followed by the diagnostics of the
document as it now stands.

## Where a walk may be left

A store's walk can be told to stop where a question is about to be answered, and nowhere else: it
stops between two questions and never inside one. What it leaves is what it answered — the key that
never returned a value leaves no memo, and the keys that answered inside it keep theirs, because
being told to stop is not an input moving and nothing can move an input while the one thread holding
the store is walking it. The file walk and the parse loop ask the same value, so a diagnose gives way
while it is reading the workspace and not only while it is compiling it.

## What a client is sent

A request is registered under its id where the frame is read, before it is handed over, so a cancel
names something whether or not the session has looked at it yet. What settles the request is the read
of that registration taken once the work is done: a client that gave up before it is sent what the
protocol asks for, and one that gave up after is sent the answer. Every reply is written in one
place, from what carrying the message out came to.

A stale set of diagnostics is not ruled out — what a client is told is decided in one place and read
in another, and nothing between the two is held. What is held is that a set published behind is
followed by one that is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)