### PR TITLE
Walk where a set's strings stop once for the revision that met it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.types.TypeKey;
+import souther.compiler.values.KnownExtents;
 import souther.compiler.values.StringMachineAnswers;
 
 import java.util.function.Supplier;
@@ -30,6 +31,19 @@ public interface DeclarationReadings {
 
     /** The answers for a reading of {@code declaration}'s string machines. */
     StringMachineAnswers of(TypeKey declaration);
+
+    /**
+     * Where the sets met anywhere in this revision were found to stop.
+     *
+     * <p>Beside the two above and on a lifetime of its own, because it is about neither a
+     * declaration nor a reading. Where a set's strings stop is settled by the set and by an
+     * allowance minted for that set, so the answer is one the revision has rather than one a
+     * declaration came to — every reading made under the revision asks the same one, and a reading
+     * with no revision behind it has {@link KnownExtents#NONE} and walks what it meets.
+     */
+    default KnownExtents extents() {
+        return KnownExtents.NONE;
+    }
 
     /**
      * The declaration's canonical reading as {@code source} and {@code policy} decide it: the one
@@ -80,6 +94,11 @@ public interface DeclarationReadings {
      * reach each other come to wait on each other. Worked out and kept: a reading of one of those
      * is a reading like any other, and what it comes to is what its own counterfactual is handed.
      *
+     * <p>Worked out is not walked again. Where the sets those readings meet were found to stop is
+     * the revision's ({@link #extents}), and a set two declarations both reach is walked for the
+     * first of them — which is a fact about the set and about no declaration, so neither reading
+     * comes to anything it would not have come to alone.
+     *
      * <p>And what it makes is kept, because the reading that answer is made by is the declaration's
      * canonical reading: the question that asked for the answer is the next to want it, and is
      * handed this rather than making a second beside it.
@@ -90,7 +109,13 @@ public interface DeclarationReadings {
 
             @Override
             public StringMachineAnswers of(TypeKey declaration) {
-                return declaration.equals(named) ? recorder : StringMachineAnswers.unborrowed();
+                return declaration.equals(named)
+                        ? recorder : StringMachineAnswers.unborrowed(lender.extents());
+            }
+
+            @Override
+            public KnownExtents extents() {
+                return lender.extents();
             }
 
             @Override
@@ -118,5 +143,5 @@ public interface DeclarationReadings {
      * counterfactual is handed. Handing out one shared object would make every such reading write
      * into the same maps.
      */
-    DeclarationReadings NONE = _ -> StringMachineAnswers.unborrowed();
+    DeclarationReadings NONE = _ -> StringMachineAnswers.unborrowed(KnownExtents.NONE);
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -7,8 +7,10 @@ import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Rel;
+import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.AdmissibleSet;
+import souther.compiler.values.KnownExtents;
 import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.UnreadReason;
@@ -74,7 +76,7 @@ public final class FieldDomains {
                     NOTHING_NAMED,
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(),
                     Set.of(RuleKey.THE_VALUE),
-                    Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE);
+                    Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE, KnownExtents.NONE);
 
     private final Map<RuleKey, NumericDomain.Bounds> byName;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -187,6 +189,15 @@ public final class FieldDomains {
     private final StringFacts stringMachines;
 
     /**
+     * Where the sets met under this revision were found to stop, for the readings this one makes
+     * of what its rules would leave without a clause.
+     *
+     * <p>A capability and not facts, and here rather than in what a reading came to: it is the
+     * revision's and is dropped with it, while what a reading came to is a value a store keeps.
+     */
+    private final KnownExtents known;
+
+    /**
      * The counterfactual readings this one has been asked for, kept under what each leaves out
      * ({@link #counterfactual}).
      *
@@ -217,8 +228,9 @@ public final class FieldDomains {
                          Map<RuleKey, FactSubject> atomAt, Map<RuleKey, Counted> countAt,
                          Map<RuleRef.Invariant, Map<Core, InvariantChecker.PartRead>> readBy,
                          Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
-                         StringFacts stringMachines) {
+                         StringFacts stringMachines, KnownExtents known) {
         this.stringMachines = stringMachines;
+        this.known = known;
         this.byName = byName;
         this.heldByName = heldByName;
         this.admittedByName = admittedByName;
@@ -444,7 +456,7 @@ public final class FieldDomains {
                 seeded.notGathered(), seeded.handedOn(), placeOf,
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
-                seeded.readBy(), seeded.spacing(), seeded.stringMachines());
+                seeded.readBy(), seeded.spacing(), seeded.stringMachines(), machines.extents());
     }
 
     /**
@@ -766,7 +778,11 @@ public final class FieldDomains {
      * <p>This declaration's, because they are what is here. Another declaration's are a store's
      * answer about it, and asking for one takes a store, which a reading standing inside a
      * comparison has no way to reach — so a reading of one of those borrows nothing and keeps what
-     * it builds, which is what {@link StringMachineAnswers#unborrowed()} is.
+     * it builds, which is what {@link StringMachineAnswers#unborrowed} is.
+     *
+     * <p>What the revision has worked out about sets goes with it either way. A counterfactual
+     * meets the sets its reading met wherever what it leaves out is about something else, and where
+     * a set stops is settled by the set — so a walk here is one the revision has already made.
      *
      * <p>Nothing of the reading itself is lent. What a counterfactual is depends on what it leaves
      * out, so no counterfactual is the declaration's canonical reading and none is kept as one —
@@ -774,8 +790,20 @@ public final class FieldDomains {
      * handed.
      */
     private DeclarationReadings borrowingMachines() {
-        return declaration -> declaration.equals(named.key())
-                ? StringMachineAnswers.borrowing(stringMachines) : StringMachineAnswers.unborrowed();
+        return new DeclarationReadings() {
+
+            @Override
+            public StringMachineAnswers of(TypeKey declaration) {
+                return declaration.equals(named.key())
+                        ? StringMachineAnswers.borrowing(stringMachines, known)
+                        : StringMachineAnswers.unborrowed(known);
+            }
+
+            @Override
+            public KnownExtents extents() {
+                return known;
+            }
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -265,9 +265,10 @@ public final class InvariantChecker {
      * worked out by asking what the rules leave without it, and each of those readings meets the
      * same sets. Where a set stops does not turn on which reading is asking, so it is not this
      * reading's to keep: it is asked of these, which answer from what the store keeps for the
-     * declaration and work out the rest.
+     * declaration, from what the revision has worked out about the sets themselves, and walk what
+     * neither of them has.
      */
-    private StringMachineAnswers answers = StringMachineAnswers.unborrowed();
+    private StringMachineAnswers answers;
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 
@@ -285,6 +286,9 @@ public final class InvariantChecker {
         // declaration this check reads: a capability handed on to the engine, which hands it to
         // every reading made through it, and kept by nothing any of them answers with.
         this.engine = new PathEngine(symbols, dischargeInvariants, machines, contracts, policy);
+        // Borrowing nothing, since no declaration is being seeded yet, and knowing what the
+        // revision knows: where a set stops is the same answer whoever met it.
+        this.answers = StringMachineAnswers.unborrowed(machines.extents());
         // Named here because this check reads them directly and often. They are the engine's, not a
         // second copy: one engine builds them once and everything below sees those.
         this.symbols = engine.symbols();

--- a/souther-compiler/src/main/java/souther/compiler/check/LentReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LentReadings.java
@@ -1,7 +1,10 @@
 package souther.compiler.check;
 
 import souther.compiler.types.TypeKey;
+import souther.compiler.values.KnownExtents;
 import souther.compiler.values.StringMachineAnswers;
+import souther.compiler.values.TextExtent;
+import souther.compiler.values.ValueSet;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +26,11 @@ import java.util.function.Supplier;
  * the reading is of that world. {@code revision} is what says which one is current; when it moves,
  * what was lent under the old one is dropped rather than carried into a world it was not read from.
  *
+ * <p>What was worked out about the sets those readings met is held here on the same terms and under
+ * a key of its own. Where a set's strings stop is settled by the set, so it is not one declaration's
+ * to lend to another — it is what this revision has found out, and every reading made under the
+ * revision asks the one table.
+ *
  * <p>This shares work and not answers. Which questions are recomputed is settled before anything is
  * asked of this, and an answer is never kept here for a reader to find later.
  */
@@ -40,6 +48,10 @@ public final class LentReadings implements DeclarationReadings {
     private final LongSupplier revision;
     private final StoreWork work;
     private final Map<OfDeclarationUnder, Shared> lent = new HashMap<>();
+    /** Where the sets met under this revision were found to stop. Beside the readings because the
+     *  lifetime is the same one, and apart from them because it is keyed by the set and by nothing
+     *  about who met it. */
+    private final Map<ValueSet, TextExtent> extents = new HashMap<>();
 
     /** The revision the readings in hand were made under. */
     private long lentAt;
@@ -59,6 +71,33 @@ public final class LentReadings implements DeclarationReadings {
     public StringMachineAnswers of(TypeKey declaration) {
         return machines.of(declaration);
     }
+
+    @Override
+    public KnownExtents extents() {
+        return known;
+    }
+
+    /**
+     * What this revision has worked out about where sets stop, as the readings made under it ask
+     * and answer it.
+     *
+     * <p>One object over a table that is dropped when the revision moves, rather than one made per
+     * revision: what holds it is the reading a question was handed long before anybody asks it
+     * anything, and a lender that handed out the table itself would have handed out one the next
+     * revision no longer keeps.
+     */
+    private final KnownExtents known = new KnownExtents() {
+
+        @Override
+        public TextExtent of(ValueSet set) {
+            return currentExtents().get(set);
+        }
+
+        @Override
+        public void remember(ValueSet set, TextExtent extent) {
+            currentExtents().put(set, extent);
+        }
+    };
 
     @Override
     public InvariantChecker.Seeded reading(TypeKey declaration, RuleReadingSource source,
@@ -93,11 +132,23 @@ public final class LentReadings implements DeclarationReadings {
      * lent at all.
      */
     private Map<OfDeclarationUnder, Shared> current() {
+        atTheCurrentRevision();
+        return lent;
+    }
+
+    /** The same for what was worked out about sets, which is dropped by the same move. */
+    private Map<ValueSet, TextExtent> currentExtents() {
+        atTheCurrentRevision();
+        return extents;
+    }
+
+    /** Drops what was shared under a revision that has been left behind. */
+    private void atTheCurrentRevision() {
         long now = revision.getAsLong();
         if (now != lentAt) {
             lent.clear();
+            extents.clear();
             lentAt = now;
         }
-        return lent;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -194,7 +194,8 @@ public final class Db implements StoreWork {
     private StringMachineAnswers machinesOf(TypeKey declaration) {
         Answer<StringFacts> facts = ask(new Machines.OfDeclaration(declaration));
         return facts.present()
-                ? StringMachineAnswers.borrowing(facts.value()) : StringMachineAnswers.unborrowed();
+                ? StringMachineAnswers.borrowing(facts.value(), readings().extents())
+                : StringMachineAnswers.unborrowed(readings().extents());
     }
 
     private final Map<Key<?>, Memo> memos = new HashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Machines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Machines.java
@@ -25,10 +25,18 @@ import souther.compiler.values.StringFacts;
  * there is one answer per declaration, it is recomputed when the declaration's clauses change, and
  * it goes when the declaration's source does.
  *
- * <p>Nothing is borrowed while the answer is made. The reading here builds every machine itself
- * — its own declaration's and those of the declarations its fields reach — so no question is put
- * to the store from inside this one, and two declarations that reach each other do not ask for each
- * other's answers in a circle.
+ * <p>Which is about what a store keeps and not about what a walk may be spared. Where a set's
+ * strings stop is settled by the set, under an allowance minted for that set, so it is the same
+ * answer wherever it is met — and what the revision has worked out about sets is held for the
+ * revision and dropped with it ({@link souther.compiler.check.DeclarationReadings#extents}).
+ * Nothing there is an answer of anything, and nothing there outlives the world it was worked out
+ * in.
+ *
+ * <p>No question is put to the store while the answer is made. The reading here works out its own
+ * declaration's machines and those of the declarations its fields reach rather than asking for
+ * their answers, so two declarations that reach each other do not wait on each other in a circle.
+ * What it takes from what the revision knows is asked of nobody: it is a fact about a set, worked
+ * out by whichever reading met it first.
  *
  * <p>The reading made here is the declaration's canonical one, and the store's lender hands it to
  * whoever asks next for the rest of the revision. What the store keeps is still what is written
@@ -54,7 +62,8 @@ public final class Machines {
             if (!source.present() || !policy.present()) {
                 return Answer.absent();
             }
-            StringMachineAnswers recorder = StringMachineAnswers.unborrowed();
+            StringMachineAnswers recorder =
+                    StringMachineAnswers.unborrowed(db.readings().extents());
             FieldDomains domains = FieldDomains.of(TypeSymbols.declared(named), source.value(),
                     policy.value(),
                     db.readings().whileTheAnswerIsMade(named, recorder));

--- a/souther-compiler/src/main/java/souther/compiler/values/KnownExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/KnownExtents.java
@@ -1,0 +1,53 @@
+package souther.compiler.values;
+
+/**
+ * Where the strings of each set stop, as worked out anywhere in one revision.
+ *
+ * <p>Knowledge and not a cache. Where a set's strings stop is settled by the set: the walk that
+ * answers it is handed nothing else, and what it may spend is an allowance of its own, minted for
+ * that set and for no other question ({@link TextExtents}). So the answer is the same whoever
+ * asked, and one worked out under one declaration is the answer under every other — which is what
+ * this is for, since a rule many declarations reach is otherwise walked once for each of them.
+ *
+ * <p><b>Including the ones that were not built.</b> A set whose extent ran past what the walk may
+ * spend comes back saying so, and that too is settled by the set, because the allowance it ran past
+ * is the one this compiler mints for every set alike. Left out, the sets that cost the most would
+ * be the ones walked again by every declaration that reaches them.
+ *
+ * <p>Which is what separates this from what a reading keeps. A reading's own answers are what its
+ * declaration came to and are kept as the declaration's ({@link StringMachineAnswers}), where an
+ * extent nobody could build is not something the declaration came to. Here it is knowledge like any
+ * other: this revision has asked, and the asking is done.
+ *
+ * <p>For a revision and no longer. What the sets of a revision are is settled by what the sources
+ * say, and a revision that has moved is a world whose sets may be other sets — so nothing here is
+ * carried across one. Held by whoever knows which revision is current, and handed to every reading
+ * made under it.
+ */
+public interface KnownExtents {
+
+    /** Where {@code set}'s strings stop as this revision already worked it out, or null. */
+    TextExtent of(ValueSet set);
+
+    /** Says that {@code set}'s extent came to {@code extent}, for the rest of the revision. */
+    void remember(ValueSet set, TextExtent extent);
+
+    /**
+     * Nothing known and nothing remembered, for a reading with no revision behind it.
+     *
+     * <p>A question asked outside a store has no revision to share with, and one in hand for the
+     * length of a single reading would answer only that reading. Both work everything out, which is
+     * what they did before there was anything to share.
+     */
+    KnownExtents NONE = new KnownExtents() {
+
+        @Override
+        public TextExtent of(ValueSet set) {
+            return null;
+        }
+
+        @Override
+        public void remember(ValueSet set, TextExtent extent) {
+        }
+    };
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -40,47 +40,57 @@ public final class StringMachineAnswers {
      * <p><b>Never handed to a reading.</b> A reading's answers are its own and keep what they make,
      * because what a reading came to is what its counterfactual is handed; handed this one, a
      * reading would come to nothing and the counterfactual would build all of it again. A reading
-     * with nothing to borrow is {@link #unborrowed()}, which is a different thing from this and
+     * with nothing to borrow is {@link #unborrowed}, which is a different thing from this and
      * reads like it.
      */
-    public static final StringMachineAnswers NONE = new StringMachineAnswers(StringFacts.NONE, false);
+    public static final StringMachineAnswers NONE =
+            new StringMachineAnswers(StringFacts.NONE, false, KnownExtents.NONE);
 
     private final StringFacts borrowed;
     /** Whether what is made here is kept, which is what a reading's own answers do and what the
      *  shared {@link #NONE} must not. */
     private final boolean keeps;
+    /** Where the sets this meets stopped when anything else in the revision met them, and where
+     *  what this works out is said for the rest of it. */
+    private final KnownExtents known;
     private final Map<AdmittedPlan, ValueSet> realized = new LinkedHashMap<>();
     private final Map<ValueSet, TextExtent> extents = new LinkedHashMap<>();
     private final Map<StringFacts.Stretch, Emptiness> inside = new LinkedHashMap<>();
 
-    private StringMachineAnswers(StringFacts borrowed, boolean keeps) {
+    private StringMachineAnswers(StringFacts borrowed, boolean keeps, KnownExtents known) {
         this.borrowed = borrowed;
         this.keeps = keeps;
+        this.known = known;
     }
 
     /**
-     * A reading's own answers, made from {@code facts} and keeping what it works out beside them.
+     * A reading's own answers, made from {@code facts} and from what {@code known} says the
+     * revision has already worked out, and keeping what it works out beside them.
      *
-     * <p>{@link #unborrowed()} where there is nothing to borrow, which is the same thing over no
+     * <p>{@link #unborrowed} where there is nothing to borrow, which is the same thing over no
      * facts at all.
      */
-    public static StringMachineAnswers borrowing(StringFacts facts) {
+    public static StringMachineAnswers borrowing(StringFacts facts, KnownExtents known) {
         if (facts == null) {
             throw new IllegalArgumentException("a reading borrows from some facts, or from none");
         }
-        return new StringMachineAnswers(facts, true);
+        return new StringMachineAnswers(facts, true, known);
     }
 
     /**
-     * A reading's own answers with nothing to borrow: it builds every machine it meets and holds
-     * every one it built.
+     * A reading's own answers with nothing to borrow: it works out every machine it meets that
+     * {@code known} has no answer for, and holds every one it worked out.
      *
      * <p>Which is what a reading with no lender is, and what a reading of a declaration the lender
      * has nothing for is. Not {@link #NONE}: having nothing to borrow and keeping nothing are two
      * things, and they parted when what a reading came to became what its counterfactual is handed.
+     *
+     * <p>What the revision knows is beside all of that. It is not this reading's and is not lent
+     * to it — an extent is a fact about a set, so a reading that takes one from there came to what
+     * it would have come to on its own.
      */
-    public static StringMachineAnswers unborrowed() {
-        return new StringMachineAnswers(StringFacts.NONE, true);
+    public static StringMachineAnswers unborrowed(KnownExtents known) {
+        return new StringMachineAnswers(StringFacts.NONE, true, known);
     }
 
     /** What {@code plan} admits where somebody has made it, or null; asking makes nothing and
@@ -89,20 +99,49 @@ public final class StringMachineAnswers {
         return borrowed.realized().get(plan);
     }
 
-    /** Where the strings {@code set} holds stop on the order. */
+    /**
+     * Where the strings {@code set} holds stop on the order.
+     *
+     * <p>What the declaration's facts say, then what the revision has worked out, and only then the
+     * walk. The second is not the first: what a declaration came to is its answer and is compared
+     * as one, while what the revision knows is work anybody's reading did — so an extent taken from
+     * there is put where an extent this reading worked out would go, and the declaration comes to
+     * the same facts either way.
+     */
     public TextExtent extentOf(ValueSet set) {
-        TextExtent known = borrowed.extents().get(set);
-        if (known != null) {
-            return known;
+        TextExtent lent = borrowed.extents().get(set);
+        if (lent != null) {
+            return lent;
         }
+        TextExtent had = known.of(set);
+        if (had != null) {
+            keep(set, had);
+            return had;
+        }
+        WALKED.incrementAndGet();
         TextExtent made = TextExtents.of(set);
+        // Whatever it came to, including a walk that ran past what it may spend: an extent is
+        // settled by its set, and the allowance it ran past is the one every set is walked under.
+        known.remember(set, made);
         if (!(made instanceof TextExtent.NotBuilt)) {
             MADE.incrementAndGet();
-            if (keeps) {
-                extents.put(set, made);
-            }
         }
+        keep(set, made);
         return made;
+    }
+
+    /**
+     * Keeps what a set came to, where this reading keeps anything.
+     *
+     * <p>Whether the walk was here or anywhere else in the revision, since what the declaration
+     * came to is the same answer either way. A walk nobody could afford is not among them: it says
+     * what this compiler could do rather than what the declaration's rules leave, and a reading
+     * that kept one would be handing that on as something it came to.
+     */
+    private void keep(ValueSet set, TextExtent extent) {
+        if (keeps && !(extent instanceof TextExtent.NotBuilt)) {
+            extents.put(set, extent);
+        }
     }
 
     /**
@@ -158,8 +197,8 @@ public final class StringMachineAnswers {
     }
 
     /**
-     * How many machines have been made rather than answered from the facts, for a test holding a
-     * reading to what it borrows.
+     * How many machines have been made rather than answered from the facts or from what the
+     * revision knows, for a test holding a reading to what it borrows.
      *
      * <p>All three of the questions this answers, counted where the answer was not there to be had
      * and what was built came out: a plan realized into a set, the extent of a set, and whether a
@@ -174,6 +213,21 @@ public final class StringMachineAnswers {
     }
 
     private static final AtomicLong MADE = new AtomicLong();
+
+    /**
+     * How many times a set's extent has been walked, for a test holding a revision to working one
+     * out once.
+     *
+     * <p>Every walk and only a walk: a set answered from the facts or from what the revision knows
+     * is not one, and a walk that ran past its allowance is, since that is the walk this is about.
+     * Which is what makes it a different count from {@link #machinesMade}, where what is at stake
+     * is what a reading came to hold rather than what any of it cost.
+     */
+    public static long extentsWalked() {
+        return WALKED.get();
+    }
+
+    private static final AtomicLong WALKED = new AtomicLong();
 
     /**
      * Everything this answered from and everything it made: what the reading it belongs to came to.

--- a/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACounterfactualBorrowsTheMachinesTheReadingMadeTest.java
@@ -9,6 +9,7 @@ import souther.compiler.query.ReadAs;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.KnownExtents;
 import souther.compiler.values.StringFacts;
 import souther.compiler.values.StringMachineAnswers;
 
@@ -111,7 +112,7 @@ class ACounterfactualBorrowsTheMachinesTheReadingMadeTest {
         FieldDomains reading = FieldDomains.of(TypeSymbols.declared(held),
                 RuleReadings.of(compilation, compilation.modules().get(0)),
                 ReadAs.THE_COMPILATION_DOES,
-                _ -> StringMachineAnswers.borrowing(part));
+                _ -> StringMachineAnswers.borrowing(part, KnownExtents.NONE));
         assertTrue(StringMachineAnswers.machinesMade() > beforeReading,
                 "the reading builds what the lender had nothing to say about");
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARevisionKnowsAboutSetsGoesWhenTheRevisionMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARevisionKnowsAboutSetsGoesWhenTheRevisionMovesTest.java
@@ -1,0 +1,52 @@
+package souther.compiler.check;
+
+import souther.compiler.values.KnownExtents;
+import souther.compiler.values.TextExtent;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Text;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * What a revision worked out about where sets stop goes when the revision moves.
+ *
+ * <p>The answer itself would survive it. Where a set's strings stop is settled by the set, so one
+ * worked out under one revision is right under the next, and a table that outlived them all would
+ * answer just as well. What it would also do is hold every set an author passed through on the way
+ * to the one they meant, for as long as the process lives — which is what a lifetime is chosen to
+ * stop, and why this is a fact about the lender rather than a fact about extents.
+ *
+ * <p>Beside the readings and dropped by the same move, since the two are shared on the same terms:
+ * within one revision there is one world, and what was worked out in it is worked out of that
+ * world.
+ */
+class WhatARevisionKnowsAboutSetsGoesWhenTheRevisionMovesTest {
+
+    private static final ValueSet A_SET = new ValueSet.Finite(Set.of(new Value.Text("JP")));
+
+    private static final TextExtent WHERE_IT_STOPS =
+            new TextExtent.One(Text.of("JP"), Text.of("JQ"));
+
+    @Test
+    void whatWasWorkedOutUnderOneRevisionIsNotAnsweredUnderTheNext() {
+        AtomicLong revision = new AtomicLong(1);
+        KnownExtents known = new LentReadings(DeclarationReadings.NONE, revision::get,
+                StoreWork.UNWATCHED).extents();
+
+        known.remember(A_SET, WHERE_IT_STOPS);
+        assertEquals(WHERE_IT_STOPS, known.of(A_SET),
+                "worked out under this revision and answered under it");
+
+        revision.incrementAndGet();
+        assertNull(known.of(A_SET),
+                "and not carried into a world it was not worked out in");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -31,6 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * allowance is the one every set is walked under. So the sets that cost the most are the ones this
  * saves most on, and a knowledge that kept only the answers it liked would walk those again for
  * every reading that meets them.
+ *
+ * <p><b>What the revision knows and what a reading comes to are two different sets, and both are
+ * held here.</b> A reading answered from the revision comes to the extent as though it had walked
+ * it, or the declaration's answer would say different things depending on which of its readings got
+ * there first; and a walk nobody could afford is not among what any of them came to, since it says
+ * what this compiler could do rather than what the rules leave. So each case below is asked twice —
+ * once of how much was walked, and once of what the readings hold afterwards.
  */
 class AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest {
 
@@ -45,32 +53,46 @@ class AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest {
     private static final ValueSet COSTS_TOO_MUCH = manyLongWords();
 
     @Test
-    void twoReadingsSharingWhatTheRevisionKnowsWalkARunOnce() {
+    void aReadingAnsweredFromTheRevisionComesToTheRunAsIfItHadWalkedIt() {
         KnownExtents known = aRevisionsKnowledge();
         long walked = StringMachineAnswers.extentsWalked();
 
-        TextExtent first = StringMachineAnswers.unborrowed(known).extentOf(ADMITS_A_RUN);
-        TextExtent second = StringMachineAnswers.unborrowed(known).extentOf(ADMITS_A_RUN);
+        StringMachineAnswers walking = StringMachineAnswers.unborrowed(known);
+        StringMachineAnswers answered = StringMachineAnswers.unborrowed(known);
+        TextExtent first = walking.extentOf(ADMITS_A_RUN);
+        TextExtent second = answered.extentOf(ADMITS_A_RUN);
 
         assertInstanceOf(TextExtent.One.class, first, "the set names a run");
         assertEquals(first, second, "and the second reading is answered with it");
         assertEquals(1, StringMachineAnswers.extentsWalked() - walked,
                 "walked for the first reading and by neither of them again");
+        assertEquals(first, walking.facts().extents().get(ADMITS_A_RUN),
+                "what the reading that walked it came to");
+        assertEquals(first, answered.facts().extents().get(ADMITS_A_RUN),
+                "and what the one that was answered came to, which is the same declaration answer"
+                        + " whichever of them walked");
     }
 
     @Test
-    void twoReadingsSharingWhatTheRevisionKnowsWalkAnUnaffordableSetOnce() {
+    void aReadingAnsweredFromTheRevisionComesToNothingWhereTheWalkRanOut() {
         KnownExtents known = aRevisionsKnowledge();
         long walked = StringMachineAnswers.extentsWalked();
 
-        TextExtent first = StringMachineAnswers.unborrowed(known).extentOf(COSTS_TOO_MUCH);
-        TextExtent second = StringMachineAnswers.unborrowed(known).extentOf(COSTS_TOO_MUCH);
+        StringMachineAnswers walking = StringMachineAnswers.unborrowed(known);
+        StringMachineAnswers answered = StringMachineAnswers.unborrowed(known);
+        TextExtent first = walking.extentOf(COSTS_TOO_MUCH);
+        TextExtent second = answered.extentOf(COSTS_TOO_MUCH);
 
         assertEquals(new TextExtent.NotBuilt(Meter.Stopped.ONE_MACHINE), first,
                 "the words are more than one machine may hold, and that is what stopped it");
         assertEquals(first, second, "and the second reading is told the same");
         assertEquals(1, StringMachineAnswers.extentsWalked() - walked,
                 "a walk that ran out is knowledge like any other");
+        assertFalse(walking.facts().extents().containsKey(COSTS_TOO_MUCH),
+                "and neither reading came to an extent: a walk nobody could afford says what this"
+                        + " compiler could do rather than what the rules leave");
+        assertFalse(answered.facts().extents().containsKey(COSTS_TOO_MUCH),
+                "which is as true of the one told so as of the one that found out");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/values/AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest.java
@@ -1,0 +1,178 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.regex.Language;
+import souther.compiler.regex.Meter;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Where a set's strings stop is walked once in a revision, however many readings meet the set.
+ *
+ * <p>The walk is handed the set and nothing else, and what it may spend is an allowance minted for
+ * that set alone — so the answer is a fact about the set, and a reading that takes one another
+ * reading walked came to what it would have come to on its own. Which is what lets it be shared at
+ * all: a declaration reaching a string rule that ten others also reach is not ten walks.
+ *
+ * <p><b>Including the walks that ran out.</b> A set whose extent costs more than the allowance
+ * comes back saying so, and that is settled by the set like everything else here, because the
+ * allowance is the one every set is walked under. So the sets that cost the most are the ones this
+ * saves most on, and a knowledge that kept only the answers it liked would walk those again for
+ * every reading that meets them.
+ */
+class AnExtentIsWalkedOnceHoweverManyReadingsMeetTheSetTest {
+
+    /** A set with an extent to find, which two readings meet. */
+    private static final ValueSet ADMITS_A_RUN =
+            ValueSet.matching(languageOf("JP[\\s\\S]*"));
+
+    /**
+     * A set whose extent costs more than a walk may spend: the words are more letters between them
+     * than one machine may have states.
+     */
+    private static final ValueSet COSTS_TOO_MUCH = manyLongWords();
+
+    @Test
+    void twoReadingsSharingWhatTheRevisionKnowsWalkARunOnce() {
+        KnownExtents known = aRevisionsKnowledge();
+        long walked = StringMachineAnswers.extentsWalked();
+
+        TextExtent first = StringMachineAnswers.unborrowed(known).extentOf(ADMITS_A_RUN);
+        TextExtent second = StringMachineAnswers.unborrowed(known).extentOf(ADMITS_A_RUN);
+
+        assertInstanceOf(TextExtent.One.class, first, "the set names a run");
+        assertEquals(first, second, "and the second reading is answered with it");
+        assertEquals(1, StringMachineAnswers.extentsWalked() - walked,
+                "walked for the first reading and by neither of them again");
+    }
+
+    @Test
+    void twoReadingsSharingWhatTheRevisionKnowsWalkAnUnaffordableSetOnce() {
+        KnownExtents known = aRevisionsKnowledge();
+        long walked = StringMachineAnswers.extentsWalked();
+
+        TextExtent first = StringMachineAnswers.unborrowed(known).extentOf(COSTS_TOO_MUCH);
+        TextExtent second = StringMachineAnswers.unborrowed(known).extentOf(COSTS_TOO_MUCH);
+
+        assertEquals(new TextExtent.NotBuilt(Meter.Stopped.ONE_MACHINE), first,
+                "the words are more than one machine may hold, and that is what stopped it");
+        assertEquals(first, second, "and the second reading is told the same");
+        assertEquals(1, StringMachineAnswers.extentsWalked() - walked,
+                "a walk that ran out is knowledge like any other");
+    }
+
+    @Test
+    void twoReadingsWithNothingSharedWalkARunEach() {
+        long walked = StringMachineAnswers.extentsWalked();
+
+        StringMachineAnswers.unborrowed(KnownExtents.NONE).extentOf(ADMITS_A_RUN);
+        StringMachineAnswers.unborrowed(KnownExtents.NONE).extentOf(ADMITS_A_RUN);
+
+        assertEquals(2, StringMachineAnswers.extentsWalked() - walked,
+                "nothing to answer from, so each reading walks it");
+    }
+
+    @Test
+    void twoReadingsWithNothingSharedWalkAnUnaffordableSetEach() {
+        long walked = StringMachineAnswers.extentsWalked();
+
+        StringMachineAnswers.unborrowed(KnownExtents.NONE).extentOf(COSTS_TOO_MUCH);
+        StringMachineAnswers.unborrowed(KnownExtents.NONE).extentOf(COSTS_TOO_MUCH);
+
+        assertEquals(2, StringMachineAnswers.extentsWalked() - walked,
+                "the expensive ones are the ones walked again");
+    }
+
+    /**
+     * A string rule two declarations reach, compiled: where its strings stop is walked once for the
+     * whole compile, and a second declaration reaching it walks none of it.
+     *
+     * <p>What this holds is the wiring rather than the mechanism above. Every declaration reaching
+     * a rule is a reading of it, and each of those readings asks where the sets at its own
+     * positions stop — so the rule's set is met once per declaration that reaches it, and the
+     * declaration whose rule it is meets it as well. What makes that one walk is that all of them
+     * are made under the revision and are handed what it knows.
+     */
+    @Test
+    void aSecondDeclarationReachingOneRuleWalksNothingMore() {
+        long alone = walksWhileCompiling("""
+                module demo exposing ( Left )
+
+                data Code = String
+                    invariant String.matches("[A-Z]{2}-[0-9]{4}", value)
+
+                data Left = { code: Code }
+                """);
+        long both = walksWhileCompiling("""
+                module demo exposing ( Left, Right )
+
+                data Code = String
+                    invariant String.matches("[A-Z]{2}-[0-9]{4}", value)
+
+                data Left = { code: Code }
+
+                data Right = { code: Code }
+                """);
+
+        assertEquals(1, alone,
+                "one string rule is one set, and the compile walks where its strings stop once");
+        assertEquals(alone, both,
+                "and the second declaration reaching it walks none of it");
+    }
+
+    /** How many extents were walked while {@code source} was compiled and answered. */
+    private static long walksWhileCompiling(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        long walked = StringMachineAnswers.extentsWalked();
+        compilation.answerEverything();
+        return StringMachineAnswers.extentsWalked() - walked;
+    }
+
+    /** What a revision knows, as the store keeps it: answered by the set and by nothing else. */
+    private static KnownExtents aRevisionsKnowledge() {
+        Map<ValueSet, TextExtent> known = new HashMap<>();
+        return new KnownExtents() {
+
+            @Override
+            public TextExtent of(ValueSet set) {
+                return known.get(set);
+            }
+
+            @Override
+            public void remember(ValueSet set, TextExtent extent) {
+                known.put(set, extent);
+            }
+        };
+    }
+
+    /** The strings {@code pattern} accepts. */
+    private static Language languageOf(String pattern) {
+        PatternRead read = PatternParser.read(pattern);
+        assertInstanceOf(PatternRead.Read.class, read, pattern + " is read");
+        Language made = PatternPlan.of(((PatternRead.Read) read).syntax())
+                .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter());
+        assertNotNull(made, pattern + " compiles");
+        return made;
+    }
+
+    /** More letters written out than one machine may have states. */
+    private static ValueSet manyLongWords() {
+        Set<Value> words = new LinkedHashSet<>();
+        for (int each = 0; each < 700; each++) {
+            words.add(new Value.Text(each + "-".repeat(100)));
+        }
+        return new ValueSet.Finite(words);
+    }
+}


### PR DESCRIPTION
Closes #1439.

A set every declaration of a module reaches was walked once for each of them, because a
declaration's answer works out the machines of the declarations its fields reach rather than asking
for their answers. Where a set's strings stop is settled by the set — the walk is handed nothing
else, and what it may spend is an allowance minted for that set and for no other question — so the
revision now holds what it has worked out about sets, keyed by the set, and hands it to every
reading made under it.

## What is shared, and what is not

Extents only. What a plan admits and whether a language meets a stretch are paid for out of the
allowance of the answer that asked, so sharing one would make which model is refused turn on the
order the store answered in. The rule that draws the line, and the reason those two stay where they
are: memoize only computations whose resource boundary is owned entirely by their key.

The walks that ran out are remembered with the rest, for the same reason the runs are: a walk
stopped by its allowance was stopped by the one every set is walked under. What a reading keeps is
unchanged — an extent nobody could afford is still not part of what the declaration came to.

## What a reader of a model sees

Nothing. A reading that takes an extent from the table puts it where one it walked would have gone,
and the entry is the same value either way, so what each declaration comes to is what it came to
before. No expectation anywhere in the suite moved.

## Where it lives

`LentReadings` already lends what a reading came to for a revision and no longer, and already drops
it when the revision moves. The table is beside it under a key of its own, handed out through
`DeclarationReadings.extents`, and reached by `StringMachineAnswers` after the declaration's own
facts and before the walk.

## What the tests hold

A run and an unaffordable set, each asked by two readings sharing what a revision knows and by two
sharing nothing, and a compile where a second declaration reaching one rule walks none of it.
Checked by mutation both ways: handing the declaration's own recorder nothing to ask makes the
compile walk again, and remembering only the walks that succeeded makes the unaffordable set walk
again.

## Which of the hand-offs carries the work

Every reading made under a revision is handed the table, and each of the places that makes one was
mutated to hand it nothing instead. Only one of them changes anything the corpora reach: the
recorder a declaration's own answer is written into. Taking the table away there makes the compile
walk the same sets again; taking it away at the store's lender, at the readings of the declarations
a field reaches, at a counterfactual's, or at a check that seeds no declaration moves nothing —
those readings meet their sets through the answer's own recorder or answer them from the
declaration's facts.

They are handed it all the same, and the tests pin only the one. A reading made under a revision
has a revision behind it, and four of the five saying otherwise would be four readings claiming to
have none. What the measurement says is that today one of them is where the walking happens, not
that the others are asking for something they should not have.

Also measured and left out: remembering what a reading took from the declaration's own facts, so
that another declaration meeting the same set finds it in the table. It moves neither the compile
nor an edit, so it is a line that would only look symmetric.

## Measured

A warm compile of the corpus with string rules in it is about a third faster, and the walks it makes
are a small fraction of what they were. What an edit costs is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

