### PR TITLE
Do only the construction a machine's shape asks for

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -417,9 +417,16 @@ final class Automaton {
      * does not stop. The steps do not move and neither does what each is numbered, so nothing is
      * built and nothing is charged.
      *
-     * <p>Which is why a caller holding the one machine for its strings ({@link #canonical}) gets
-     * the one machine for the rest: what makes a machine that one is read off the steps and the
-     * walk that numbers them, and neither asks where a walk may stop.
+     * <p><b>And a caller holding the one machine for its strings ({@link #canonical}) gets the one
+     * machine for the rest.</b> A string tells two states apart when a walk from one of them stops
+     * on it and a walk from the other does not. Turning the states over turns both of those answers
+     * over together, so a string that told two states apart tells them apart still and a string
+     * that told them nothing tells them nothing still — the strings a walk from a state stops on
+     * become the strings it does not, and which states no string separates is not a question those
+     * answers changed. A machine no two of whose states a string could tell apart still has none.
+     * The steps do not move, so the walk that numbers them meets the same states in the same order,
+     * and being smallest and being numbered that way are the whole of what makes a machine the one
+     * machine.
      *
      * <p><b>And why anything else has to be made deterministic first.</b> What a walk ends in has
      * to be one answer before the answer can be turned over, and a machine that steps for nothing
@@ -907,7 +914,6 @@ final class Automaton {
          * <p>Asked once, of the machine. Where nothing does, the states reachable without spending
          * a symbol are the states themselves, and the closure of a subset is that subset — so what
          * it comes to is a copy of what it was handed, made for every symbol out of every state.
-         * A machine that came from anything but a pattern has no such step at all.
          */
         private final boolean anyFree;
 

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -416,8 +416,19 @@ final class Automaton {
      * and neither do the two questions about holding nothing and holding everything: a language is
      * kept as {@link #canonical}, where being deterministic has already been paid for, and both are
      * read off the one state such a machine has.
+     *
+     * <p><b>Where it is already deterministic and complete, the states it stops at are turned over
+     * and nothing else happens.</b> A walk over such a machine ends in one state whatever it reads,
+     * and every string ends somewhere — so the strings it does not accept are the ones ending where
+     * it does not stop, and that is the same table with the other states stopped at. The steps do
+     * not move, which is why a caller holding the one machine for its strings ({@link #canonical})
+     * gets the one machine for the rest: what makes it the one machine is read off the steps and
+     * the walk that numbers them, and neither asks where a walk may stop.
      */
     Automaton not(Meter meter) {
+        if (everySymbolLeadsOneWay()) {
+            return turnedOver(meter.making());
+        }
         try {
             Subsets subsets = new Subsets(meter.making());
             Meter.Making making = meter.making();
@@ -441,6 +452,54 @@ final class Automaton {
         } catch (TooMany _) {
             return null;
         }
+    }
+
+    /**
+     * Whether a walk over this is only ever in one state, and every symbol takes it somewhere.
+     *
+     * <p>Asked of the machine and not of where it came from. A machine carries no account of what
+     * was done to it, and a reader that took one operation's word for the shape of its answer would
+     * be reading the caller rather than the thing in front of it.
+     *
+     * <p>The labels out of a state say both. Together they are every symbol there is, so nothing
+     * leads nowhere; and they are as wide apart as they are wide, so no symbol is on two of them.
+     * A step costing no symbol is a second state to be in and there are none of those either.
+     *
+     * <p>Those steps are looked for first, over the whole machine. A machine that has one is one
+     * this is going to say no about, and finding that out costs a length where the labels cost
+     * every symbol they hold — so what a pattern's machine pays to be turned down is a walk over
+     * the states and nothing more.
+     */
+    private boolean everySymbolLeadsOneWay() {
+        for (int[] each : free) {
+            if (each.length > 0) {
+                return false;
+            }
+        }
+        for (int at = 0; at < steps.size(); at++) {
+            CodePoints together = CodePoints.NONE;
+            long apart = 0;
+            for (Step each : steps.get(at)) {
+                together = together.or(each.over());
+                apart += each.over().size();
+            }
+            if (!together.isEverything() || apart != together.size()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** The same machine with the states it stops at turned over — see {@link #not}. */
+    private Automaton turnedOver(Meter.Making making) {
+        // A state apiece and the count is known, the states being the ones already here.
+        if (!making.states(size())) {
+            return null;
+        }
+        BitSet stops = new BitSet();
+        stops.set(0, size());
+        stops.andNot(accepting);
+        return new Automaton(steps, free, stops);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -2,7 +2,9 @@ package souther.compiler.regex;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The strings a pattern accepts, as states to walk between.
@@ -300,59 +302,110 @@ final class Automaton {
      * moves for nothing is the same pair with that side further on, which is exactly what a step
      * costing no symbol means.
      *
-     * <p>The states are the product, and nothing here says whether that is a price worth paying:
-     * both sizes are known before this is called, so a caller that has to answer for its work asks
-     * them rather than being told afterwards.
+     * <p><b>The pairs a walk reaches, and not every pair there is.</b> Grown from the pair a walk
+     * begins at, so a pair nothing leads to is never made. One that is made costs a state, the
+     * steps out of it worked out over both machines' labels, and an allowance charged for both —
+     * and a pair no string is ever in is all of that spent on a state the minimisation afterwards
+     * would throw away.
+     *
+     * <p>Which is why nothing is asked of the meter before the first state is made. The two sizes
+     * multiplied is what a product could come to and hardly ever what it comes to, so a caller
+     * refused on that number is refused an answer it could have afforded.
      */
     Automaton and(Automaton other, Meter meter) {
-        int wide = other.size();
-        // The pairs, asked for before the first of them is made. This is the operation the whole
-        // allowance is about: two machines that cost nothing on their own have a product that is
-        // the two multiplied, and allocating it to find that out is paying the price to learn it.
-        if (!meter.making().states((long) size() * wide)) {
-            return null;
-        }
-        int count = size() * wide;
-        List<List<Step>> steps = new ArrayList<>(count);
-        List<int[]> free = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            steps.add(new ArrayList<>());
-            free.add(null);
-        }
-        for (int mine = 0; mine < size(); mine++) {
-            for (int theirs = 0; theirs < wide; theirs++) {
-                int pair = mine * wide + theirs;
+        try {
+            Pairs pairs = new Pairs(other.size(), meter.making());
+            List<List<Step>> steps = new ArrayList<>();
+            List<int[]> free = new ArrayList<>();
+            BitSet accepting = new BitSet();
+            pairs.at(START, START);
+            // Grows while it is walked: a pair first reached here is one more to take the steps
+            // out of, and the walk is over when nothing new has been reached.
+            for (int at = 0; at < pairs.count(); at++) {
+                int mine = pairs.mine(at);
+                int theirs = pairs.theirs(at);
+                List<Step> out = new ArrayList<>();
                 for (Step one : this.steps.get(mine)) {
                     for (Step two : other.steps.get(theirs)) {
                         CodePoints over = one.over().and(two.over());
                         if (!over.isEmpty()) {
-                            steps.get(pair).add(new Step(over, one.to() * wide + two.to()));
+                            out.add(new Step(over, pairs.at(one.to(), two.to())));
                         }
                     }
                 }
                 List<Integer> freely = new ArrayList<>();
                 for (int to : this.free.get(mine)) {
-                    freely.add(to * wide + theirs);
+                    freely.add(pairs.at(to, theirs));
                 }
                 for (int to : other.free.get(theirs)) {
-                    freely.add(mine * wide + to);
+                    freely.add(pairs.at(mine, to));
                 }
-                int[] out = new int[freely.size()];
-                for (int i = 0; i < out.length; i++) {
-                    out[i] = freely.get(i);
+                int[] freeOut = new int[freely.size()];
+                for (int i = 0; i < freeOut.length; i++) {
+                    freeOut[i] = freely.get(i);
                 }
-                free.set(pair, out);
+                steps.add(out);
+                free.add(freeOut);
+                if (this.accepting.get(mine) && other.accepting.get(theirs)) {
+                    accepting.set(at);
+                }
             }
+            return new Automaton(steps, free, accepting);
+        } catch (TooMany _) {
+            return null;
         }
-        BitSet accepting = new BitSet();
-        for (int mine = this.accepting.nextSetBit(0); mine >= 0;
-                mine = this.accepting.nextSetBit(mine + 1)) {
-            for (int theirs = other.accepting.nextSetBit(0); theirs >= 0;
-                    theirs = other.accepting.nextSetBit(theirs + 1)) {
-                accepting.set(mine * wide + theirs);
+    }
+
+    /**
+     * The pairs of states a walk over two machines is in at once, numbered as they are reached.
+     *
+     * <p>Where a meet's states come from and where they are counted. A pair asked for twice is the
+     * same state both times, which is what makes the walk finish; a pair asked for the first time
+     * is a state, and it is charged for there — so what a meet spends is the pairs it reached.
+     */
+    private static final class Pairs {
+
+        private final int wide;
+        private final Meter.Making making;
+        private final Map<Long, Integer> known = new HashMap<>();
+        private final List<Integer> mine = new ArrayList<>();
+        private final List<Integer> theirs = new ArrayList<>();
+
+        Pairs(int wide, Meter.Making making) {
+            this.wide = wide;
+            this.making = making;
+        }
+
+        /** Which state the pair is, making it where it has not been reached before. */
+        int at(int mine, int theirs) {
+            // A long, because the two sizes multiplied is what this could run to and nothing has
+            // been asked about that: a key that overflowed would put two pairs in one state.
+            Long key = (long) mine * wide + theirs;
+            Integer had = known.get(key);
+            if (had != null) {
+                return had;
             }
+            if (!making.state()) {
+                throw new TooMany();
+            }
+            int made = this.mine.size();
+            this.mine.add(mine);
+            this.theirs.add(theirs);
+            known.put(key, made);
+            return made;
         }
-        return new Automaton(steps, free, accepting);
+
+        int count() {
+            return mine.size();
+        }
+
+        int mine(int state) {
+            return mine.get(state);
+        }
+
+        int theirs(int state) {
+            return theirs.get(state);
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -835,10 +835,31 @@ final class Automaton {
          *  a machine — one this throws away, and one whose states were made all the same. */
         private final Meter.Making making;
 
+        /**
+         * Whether anything here steps for nothing, which is whether the closure has anything to
+         * add.
+         *
+         * <p>Asked once, of the machine. Where nothing does, the states reachable without spending
+         * a symbol are the states themselves, and the closure of a subset is that subset — so what
+         * it comes to is a copy of what it was handed, made for every symbol out of every state.
+         * A machine that came from anything but a pattern has no such step at all.
+         */
+        private final boolean anyFree;
+
         Subsets(Meter.Making making) {
             this.making = making;
+            boolean found = false;
+            for (int[] each : free) {
+                found = found || each.length > 0;
+            }
+            this.anyFree = found;
             cutTheAlphabet();
-            at(closure(only(START)));
+            at(reached(only(START)));
+        }
+
+        /** The subset a walk is in, having got to {@code these}. */
+        private BitSet reached(BitSet these) {
+            return anyFree ? closure(these) : these;
         }
 
         int count() {
@@ -873,7 +894,7 @@ final class Automaton {
                         }
                     }
                 }
-                out.add(new Move(run, at(closure(next))));
+                out.add(new Move(run, at(reached(next))));
             }
             moves.set(state, out);
             return out;

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -411,23 +411,26 @@ final class Automaton {
     /**
      * Everything it does not accept.
      *
-     * <p>The one operation that has to make the machine deterministic first, because what a walk
-     * ends in has to be one answer before the answer can be turned over. Acceptance never needs it,
-     * and neither do the two questions about holding nothing and holding everything: a language is
-     * kept as {@link #canonical}, where being deterministic has already been paid for, and both are
-     * read off the one state such a machine has.
+     * <p><b>The states a walk may stop at, turned over.</b> Which is the whole of it where a walk
+     * is only ever in one state and every symbol takes it somewhere: a string ends in one state and
+     * every string ends somewhere, so the ones this does not accept are the ones ending where it
+     * does not stop. The steps do not move and neither does what each is numbered, so nothing is
+     * built and nothing is charged.
      *
-     * <p><b>Where it is already deterministic and complete, the states it stops at are turned over
-     * and nothing else happens.</b> A walk over such a machine ends in one state whatever it reads,
-     * and every string ends somewhere — so the strings it does not accept are the ones ending where
-     * it does not stop, and that is the same table with the other states stopped at. The steps do
-     * not move, which is why a caller holding the one machine for its strings ({@link #canonical})
-     * gets the one machine for the rest: what makes it the one machine is read off the steps and
-     * the walk that numbers them, and neither asks where a walk may stop.
+     * <p>Which is why a caller holding the one machine for its strings ({@link #canonical}) gets
+     * the one machine for the rest: what makes a machine that one is read off the steps and the
+     * walk that numbers them, and neither asks where a walk may stop.
+     *
+     * <p><b>And why anything else has to be made deterministic first.</b> What a walk ends in has
+     * to be one answer before the answer can be turned over, and a machine that steps for nothing
+     * or twice over a symbol has not said what a string ends in. That is the one place this
+     * construction is needed — acceptance never needs it, and neither do the two questions about
+     * holding nothing and holding everything, both of which are read off the one state a canonical
+     * machine has.
      */
     Automaton not(Meter meter) {
         if (everySymbolLeadsOneWay()) {
-            return turnedOver(meter.making());
+            return turnedOver();
         }
         try {
             Subsets subsets = new Subsets(meter.making());
@@ -490,12 +493,15 @@ final class Automaton {
         return true;
     }
 
-    /** The same machine with the states it stops at turned over — see {@link #not}. */
-    private Automaton turnedOver(Meter.Making making) {
-        // A state apiece and the count is known, the states being the ones already here.
-        if (!making.states(size())) {
-            return null;
-        }
+    /**
+     * The same machine with the states it stops at turned over — see {@link #not}.
+     *
+     * <p>Nothing is asked of an allowance, because no state is made. The steps are the steps that
+     * were already there and so is what each one is numbered, and what is built is the answer to
+     * one question about each of them. A meter counts the states a construction makes, and a
+     * construction that shares the ones it was handed made none.
+     */
+    private Automaton turnedOver() {
         BitSet stops = new BitSet();
         stops.set(0, size());
         stops.andNot(accepting);
@@ -866,10 +872,10 @@ final class Automaton {
     /**
      * The machine read as one where a walk is only ever in one state, made as it is asked for.
      *
-     * <p>Every question that needs a walk's end to be one answer comes through here: what a language
-     * leaves out, and whether it leaves anything out. Grown a subset at a time, because both of them
-     * usually have their answer within a step or two and the whole of a deterministic machine is
-     * what the worst case costs.
+     * <p>Where a machine has not already said what a string ends in, this is what says it: a
+     * complement of one that steps for nothing or twice over a symbol, and the one machine any
+     * language is kept as. Grown a subset at a time, because the whole of a deterministic machine
+     * is what the worst case costs and a walk usually meets far fewer.
      *
      * <p><b>Complete, the subset of no states among them.</b> A symbol with nowhere to go is a walk
      * that ends outside the language, and a machine that simply had no step there would leave every

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -51,7 +51,8 @@ public final class Language {
      * compiler can afford to answer exactly, and a half-made answer handed out is one whose next
      * question does the rest of the work somewhere nobody is counting.
      *
-     * <p><b>The sequences no string is read as are taken out here, and nowhere else.</b> A machine
+     * <p><b>The sequences no string is read as are taken out by {@link #holdingOnlyStrings}, and
+     * nowhere else.</b> Every way to one of these ends there, this one and {@link #not}. A machine
      * steps over what a matcher reads, and a high surrogate followed by a low one is one symbol
      * rather than two — so there are sequences of symbols no string is written as, and a complement
      * holds them like anything else. Left in, two machines telling each other apart only over those
@@ -84,8 +85,9 @@ public final class Language {
      * sequences it stops on.
      *
      * <p>Beside {@link #canonical} rather than inside it, because there is a way to a canonical
-     * machine that is not a construction: see {@link #not}. What the two share is this, and the
-     * account of why it is done and where it is skipped is on {@link #canonical}.
+     * machine that is not a construction: see {@link #not}. Both end here, which is what makes this
+     * the one place the sequences come out; why they have to and where the walk is skipped is
+     * written on {@link #canonical}, which is where a reader arrives from.
      */
     private static Language holdingOnlyStrings(Automaton one, Meter meter) {
         if (!one.mayStopHavingReadALoneSurrogatePair()) {
@@ -170,7 +172,7 @@ public final class Language {
      * canonical again, the construction would arrive where it started, having paid for the walk.
      *
      * <p>The sequences no string is read as still have to come out. A complement holds them like
-     * anything else, and that is where this spends what it spends.
+     * anything else, which is why this ends where every other way to one of these ends.
      */
     public Language not(Meter meter) {
         Automaton turned = machine.not(meter);

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -76,9 +76,18 @@ public final class Language {
             return null;
         }
         Automaton one = made.canonical(meter);
-        if (one == null) {
-            return null;
-        }
+        return one == null ? null : holdingOnlyStrings(one, meter);
+    }
+
+    /**
+     * The strings {@code one} stops on, where {@code one} is already the one machine for the
+     * sequences it stops on.
+     *
+     * <p>Beside {@link #canonical} rather than inside it, because there is a way to a canonical
+     * machine that is not a construction: see {@link #not}. What the two share is this, and the
+     * account of why it is done and where it is skipped is on {@link #canonical}.
+     */
+    private static Language holdingOnlyStrings(Automaton one, Meter meter) {
         if (!one.mayStopHavingReadALoneSurrogatePair()) {
             return new Language(one);
         }
@@ -151,9 +160,21 @@ public final class Language {
         return canonical(machine.or(other.machine, meter), meter);
     }
 
-    /** The strings this does not hold, on the same terms. */
+    /**
+     * The strings this does not hold, on the same terms.
+     *
+     * <p><b>Not made canonical afterwards, because it arrives that way.</b> What is held here is
+     * the one machine for these strings, and the complement of such a machine is that machine with
+     * the states it stops at turned over ({@link Automaton#not}) — the steps are the same steps, so
+     * a machine already smallest and already numbered by a walk over its steps stays both. Made
+     * canonical again, the construction would arrive where it started, having paid for the walk.
+     *
+     * <p>The sequences no string is read as still have to come out. A complement holds them like
+     * anything else, and that is where this spends what it spends.
+     */
     public Language not(Meter meter) {
-        return canonical(machine.not(meter), meter);
+        Automaton turned = machine.not(meter);
+        return turned == null ? null : holdingOnlyStrings(turned, meter);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -167,9 +167,11 @@ public final class Language {
      *
      * <p><b>Not made canonical afterwards, because it arrives that way.</b> What is held here is
      * the one machine for these strings, and the complement of such a machine is that machine with
-     * the states it stops at turned over ({@link Automaton#not}) — the steps are the same steps, so
-     * a machine already smallest and already numbered by a walk over its steps stays both. Made
-     * canonical again, the construction would arrive where it started, having paid for the walk.
+     * the states it stops at turned over ({@link Automaton#not}). A string that told two of its
+     * states apart tells them apart still, both of the answers it read having turned over together,
+     * so a machine no string could tell two states of stays one — and the steps not moving leaves
+     * the walk that numbers them where it was. Made canonical again, the construction would arrive
+     * where it started, having paid for the walk.
      *
      * <p>The sequences no string is read as still have to come out. A complement holds them like
      * anything else, which is why this ends where every other way to one of these ends.

--- a/souther-compiler/src/main/java/souther/compiler/regex/Meter.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Meter.java
@@ -139,9 +139,10 @@ public final class Meter {
         /**
          * The same for {@code many} at once, for a builder that knows its size before it starts.
          *
-         * <p>Asked before the first of them is made. A product of two machines knows how many
-         * states it will have, and allocating them to find out that they were too many is the
-         * thing this exists to stop.
+         * <p>Asked before the first of them is made. A machine put beside another is the two of
+         * them and a state to step into either, which is a count and not a guess about what will
+         * be reached — and allocating that many to find out they were too many is the thing this
+         * exists to stop.
          */
         boolean states(long many) {
             if (many < 0) {

--- a/souther-compiler/src/test/java/souther/compiler/check/ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest.java
@@ -38,15 +38,17 @@ class ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest {
     /**
      * A choice whose left branch is empty and expensive to show empty.
      *
-     * <p>Each pattern is small; their meet is about ninety thousand states, which is past what one
-     * machine may be. So the left branch neither survives being worked out nor comes back empty.
+     * <p>Each pattern is small; their meet is past what one machine may be. The two repeat over
+     * runs of one length and of another that share no factor, so a walk over both at once is in a
+     * different pair at every step until the lengths come round together. So the left branch
+     * neither survives being worked out nor comes back empty.
      */
     private static final String MODEL = """
             module demo
 
             data Pair = { x: String, y: String, p: String }
                 invariant r =
-                    (String.matches("a{300}", y) && String.matches("b{300}", y))
+                    (String.matches("(a{251})*b", y) && String.matches("(a{223})*c", y))
                     || x == "A"
                 invariant wide =
                     (p == "1" || p == "2")

--- a/souther-compiler/src/test/java/souther/compiler/check/ALimitIsAnsweredForByWhatAskedForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALimitIsAnsweredForByWhatAskedForItTest.java
@@ -45,7 +45,7 @@ class ALimitIsAnsweredForByWhatAskedForItTest {
 
             data N = { x: String, y: String }
                 invariant r =
-                    (String.matches("a{300}", y) && String.matches("b{300}", y))
+                    (String.matches("(a{251})*b", y) && String.matches("(a{223})*c", y))
                     || x == "A"
                 invariant huge = String.matches("a{60000}", y)
             """;

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -273,25 +273,6 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         return out;
     }
 
-    /** The rules of one declaration of {@code over}, read as the compilation reads them. */
-    private static FieldDomains read(String clause, String named, String over) {
-        String source = """
-                module example.rooms
-
-                data %s = %s
-                    %s
-                """.formatted(named, over, clause);
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
-        String module = compilation.modules().get(0);
-        Symbols symbols = Scopes.derived(compilation.db(), module).value();
-        assertNotNull(symbols);
-        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
-        assertNotNull(symbols.declaredNode(at.key()), "no `" + named + "` declared");
-        return FieldDomains.of(at, RuleReadings.of(compilation, module),
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-    }
-
     /** What the one clause of {@code named} raises, over every place it writes. */
     private static Set<CoverageObligation> raisedIn(String source, String named) {
         Set<CoverageObligation> out = new LinkedHashSet<>();

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -273,27 +273,6 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         return out;
     }
 
-    /**
-     * A reading that ran out of what it may build says so in its own words.
-     *
-     * <p>The pattern is one this reads and the machine for what it admits is one it makes; what runs
-     * out is the further machine that says where those strings begin and end. Written down as a
-     * pattern too large, an author would be sent to a pattern this read perfectly — so it is its
-     * own reason, and which limit refused it is kept.
-     */
-    @Test
-    void whereTheRunRanOutTheReasonIsTheRunsOwn() {
-        FieldDomains domains = read("invariant top = String.matches(\"[0-9]{300}\", value)",
-                "Code", "String");
-        List<BlockReason.RuleWithoutLineReason> why = domains.noLineAt(RuleKey.THE_VALUE).stream()
-                .map(FieldDomains.NoLine::why).toList();
-        assertEquals(1, why.size(), () -> "one rule, one reason: " + why);
-        BlockReason.OrderedExtentTooCostly stopped = assertInstanceOf(
-                BlockReason.OrderedExtentTooCostly.class, why.get(0));
-        assertEquals(souther.compiler.regex.Meter.Stopped.ONE_MACHINE, stopped.stopped(),
-                "the machine the run wanted is larger than a machine may be");
-    }
-
     /** The rules of one declaration of {@code over}, read as the compilation reads them. */
     private static FieldDomains read(String clause, String named, String over) {
         String source = """

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
@@ -40,13 +40,15 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
     /**
      * Two patterns that share one string and nothing else short, and the string itself.
      *
-     * <p>{@code a{300}} and {@code b{300}} make the meet large; {@code x} is what both of them
-     * accept. A reading that meets the two patterns builds three hundred states against three
-     * hundred, and one that reaches the written value first has a question about one string.
+     * <p>The two arms beside {@code x} repeat over runs of one length and of another that share no
+     * factor, so a walk over both at once is in a different pair at every step until the lengths
+     * come round together — which is past what one machine may be. {@code x} is what both of them
+     * accept. A reading that meets the two patterns is refused, and one that reaches the written
+     * value first has a question about one string.
      */
     private static final List<String> RULES = List.of(
-            "    invariant one = String.matches(\"x|a{300}\", value)",
-            "    invariant two = String.matches(\"x|b{300}\", value)",
+            "    invariant one = String.matches(\"x|(a{251})*b\", value)",
+            "    invariant two = String.matches(\"x|(a{223})*c\", value)",
             "    invariant three = value == \"x\"");
 
     /**
@@ -58,8 +60,8 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
      * test above while every pair of patterns still met in the order somebody wrote them.
      */
     private static final List<String> ALL_PATTERNS = List.of(
-            "    invariant one = String.matches(\"x|a{300}\", value)",
-            "    invariant two = String.matches(\"x|b{300}\", value)",
+            "    invariant one = String.matches(\"x|(a{251})*b\", value)",
+            "    invariant two = String.matches(\"x|(a{223})*c\", value)",
             "    invariant three = String.matches(\"x\", value)");
 
     private static String model(List<String> rules, List<Integer> order) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
@@ -69,10 +69,12 @@ class WhatAStandingQuestionIsAccountedForByTest {
     /**
      * Rules read in full whose answer is more than the allowance will build.
      *
-     * <p>Each pattern is small and both are taken in; showing the branch they share empty takes a
-     * machine of about ninety thousand states. So nothing is short of a rule here, and what is short
-     * is the answer they come to between them — which is why the question stands with no reading
-     * naming a rule. The same model is read for what it leaves the position in
+     * <p>Each pattern is small and both are taken in; showing the branch they share empty is past
+     * what one machine may be. The two repeat over runs of one length and of another that share no
+     * factor, so a walk over both at once is in a different pair at every step until the lengths
+     * come round together. So nothing is short of a rule here, and what is short is the answer they
+     * come to between them — which is why the question stands with no reading naming a rule. The
+     * same model is read for what it leaves the position in
      * {@code ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest}.
      */
     private static final String AN_ANSWER_BEYOND_THE_ALLOWANCE = """
@@ -80,7 +82,7 @@ class WhatAStandingQuestionIsAccountedForByTest {
 
             data N = { x: String, y: String }
                 invariant r =
-                    (String.matches("a{300}", y) && String.matches("b{300}", y))
+                    (String.matches("(a{251})*b", y) && String.matches("(a{223})*c", y))
                     || x == "A"
             """;
 
@@ -216,7 +218,7 @@ class WhatAStandingQuestionIsAccountedForByTest {
 
             data N = { x: String, y: String }
                 invariant r =
-                    String.matches("a{300}", y) && String.matches("b{300}", y) && UNREAD_Y
+                    String.matches("(a{251})*b", y) && String.matches("(a{223})*c", y) && UNREAD_Y
             """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
@@ -206,16 +206,19 @@ class ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest {
      * told their rule holds the position to what it admits and stops it nowhere, of a rule whose
      * geometry nobody read.
      *
-     * <p>The pattern is one this compiler reads and the machine for what it admits is one it makes;
-     * what runs out is the further machine the run needs, which is the product of that one with the
-     * strings above where it begins.
+     * <p>Both patterns are ones this compiler reads; what runs out is the machine for the strings
+     * they admit between them. They repeat over runs of one length and of another that share no
+     * factor, so a walk over both at once is in a different pair at every step until the lengths
+     * come round together, and that is past what one machine may be.
      */
     @Test
     void areadingThatRanOutSaysSoRatherThanThatTheRuleDrawsNoLine() {
         String report = report("""
                 module costly
 
-                data Long = String invariant String.matches("[0-9]{300}", value)
+                data Long = String
+                    invariant String.matches("(0{251})*8", value)
+                    invariant String.matches("(0{223})*9", value)
 
                 data Ok = { size: Int }
 

--- a/souther-compiler/src/test/java/souther/compiler/regex/AMeetIsMadeOfThePairsAWalkReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/AMeetIsMadeOfThePairsAWalkReachesTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.regex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A meet holds the pairs of states a walk gets to, and is charged for those.
+ *
+ * <p>Two things are being said and they fail apart. The pairs the two sizes multiply to are what a
+ * meet could hold, and a pair nothing leads to is a state made, stepped out of and paid for that no
+ * string is ever in — so what is built is the walk's own. And the walk is over both kinds of step:
+ * a pair one side leaves for nothing is reached by no symbol at all, and a growth that followed
+ * only the labelled steps would come to a smaller machine accepting less.
+ */
+class AMeetIsMadeOfThePairsAWalkReachesTest {
+
+    private static Automaton of(String regex, Meter meter) {
+        PatternSyntax syntax =
+                assertInstanceOf(PatternRead.Read.class, PatternParser.read(regex), regex).syntax();
+        Automaton made = Automaton.of(syntax, meter);
+        assertNotNull(made, regex);
+        return made;
+    }
+
+    private static Meter roomy() {
+        return new Meter(100_000, 10_000_000);
+    }
+
+    /**
+     * Two machines whose labels never agree.
+     *
+     * <p>Every pair past the one a walk begins at is reached by a symbol both sides step over, and
+     * there is none — so the meet is the beginning and nothing else, where the pairs of four states
+     * against four are sixteen.
+     */
+    @Test
+    void aPairNothingLeadsToIsNotMade() {
+        Meter meter = roomy();
+        Automaton left = of("[ab]{2}", meter);
+        Automaton right = of("[cd]{2}", meter);
+        assertEquals(16, left.size() * right.size(), "the pairs there are");
+
+        Automaton met = left.and(right, meter);
+
+        assertNotNull(met);
+        assertEquals(1, met.size(), "and the pairs a walk gets to is the one it begins at");
+        assertFalse(met.accepts("ab"), "nothing is accepted, which is what the meet holds");
+    }
+
+    /** And what a meet spends is the pairs it made, not the pairs it could have made. */
+    @Test
+    void aMeetIsChargedThePairsItReached() {
+        Meter meter = roomy();
+        Automaton left = of("[ab]{2}", meter);
+        Automaton right = of("[cd]{2}", meter);
+        int before = meter.left();
+
+        assertNotNull(left.and(right, meter));
+
+        assertEquals(1, before - meter.left(), "one pair reached is one state charged");
+    }
+
+    /**
+     * A meet whose sides do agree, where the pairs reached are still fewer than the pairs there
+     * are: the two walk in step, so all but the ones around the end are the same state on both
+     * sides.
+     */
+    @Test
+    void thePairsReachedAreTheWalksOwn() {
+        Meter meter = roomy();
+        Automaton left = of("[ab]{2}", meter);
+        Automaton right = of("[bc]{2}", meter);
+
+        Automaton met = left.and(right, meter);
+
+        assertNotNull(met);
+        assertEquals(6, met.size(), "six of the sixteen pairs are reached");
+        assertTrue(met.accepts("bb"), "the one string both sides accept");
+        assertFalse(met.accepts("ab"), "which the right side does not");
+        assertFalse(met.accepts("bc"), "nor the left");
+    }
+
+    /**
+     * The walk follows the steps that cost nothing as well.
+     *
+     * <p>Where the sides repeat different numbers of times, a pair is left by one side moving for
+     * nothing while the other stays — so the pairs are not the ones both sides reach at the same
+     * point in a string. A growth over the labelled steps alone stops early and the meet accepts
+     * less than it holds.
+     */
+    @Test
+    void aPairReachedByASideMovingForNothingIsMadeToo() {
+        Meter meter = roomy();
+        Automaton left = of("(aa)*", meter);
+        Automaton right = of("(aaa)*", meter);
+
+        Automaton met = left.and(right, meter);
+
+        assertNotNull(met);
+        assertTrue(met.accepts(""), "no letters at all is a run of both");
+        assertTrue(met.accepts("aaaaaa"), "six is two threes and three twos");
+        assertFalse(met.accepts("aa"), "which the right side does not accept");
+        assertFalse(met.accepts("aaa"), "nor the left");
+        assertFalse(met.accepts("aaaa"), "and four is neither");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/regex/AMeetIsMadeOfThePairsAWalkReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/AMeetIsMadeOfThePairsAWalkReachesTest.java
@@ -52,6 +52,27 @@ class AMeetIsMadeOfThePairsAWalkReachesTest {
         assertFalse(met.accepts("ab"), "nothing is accepted, which is what the meet holds");
     }
 
+    /**
+     * And a meet whose pairs would not have fit is built where the ones it reaches do.
+     *
+     * <p>The observable half of the same rule. What the two sizes multiply to is over what a
+     * machine may hold and the walk reaches a handful, so a caller told this was not built would be
+     * told it about an answer this compiler can afford — and the caller is a model somebody wrote.
+     */
+    @Test
+    void aMeetIsRefusedOnWhatItReachesAndNotOnWhatItCouldReach() {
+        // Room for either side and for what the walk reaches, and not for the pairs there are.
+        Meter meter = new Meter(600, 2000);
+        Automaton left = of("[ab]{30}", meter);
+        Automaton right = of("[bc]{30}", meter);
+        assertTrue(left.size() * right.size() > 600, "the pairs there are do not fit in a machine");
+
+        Automaton met = left.and(right, meter);
+
+        assertNotNull(met, "and the meet is built, being the pairs a walk reaches");
+        assertTrue(met.accepts("b".repeat(30)), "and it holds what both sides hold");
+    }
+
     /** And what a meet spends is the pairs it made, not the pairs it could have made. */
     @Test
     void aMeetIsChargedThePairsItReached() {

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheComplementOfTheOneMachineIsTheOneMachineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheComplementOfTheOneMachineIsTheOneMachineTest.java
@@ -31,6 +31,16 @@ class TheComplementOfTheOneMachineIsTheOneMachineTest {
         return new Meter(100_000, 10_000_000);
     }
 
+    private static Automaton canonicalMachineOf(String regex, Meter meter) {
+        PatternSyntax syntax =
+                assertInstanceOf(PatternRead.Read.class, PatternParser.read(regex), regex).syntax();
+        Automaton made = Automaton.of(syntax, meter);
+        assertNotNull(made, regex);
+        Automaton one = made.canonical(meter);
+        assertNotNull(one, regex);
+        return one;
+    }
+
     private static Language language(String regex, Meter meter) {
         PatternSyntax syntax =
                 assertInstanceOf(PatternRead.Read.class, PatternParser.read(regex), regex).syntax();
@@ -40,26 +50,47 @@ class TheComplementOfTheOneMachineIsTheOneMachineTest {
     }
 
     /**
-     * What a complement of the one machine costs is the states it turned over.
+     * What a complement of the one machine costs is nothing.
      *
-     * <p>Made deterministic first, it would be the subsets as well — a machine of the same states
-     * discovered a second time, and charged for. The meter is what says which happened: it counts
-     * where the states are made, so a construction that made them twice spent twice.
+     * <p>A meter counts the states a construction makes, and this one makes none: the steps are the
+     * steps that were there and so is what each is numbered, and the answer to where a walk may
+     * stop is what is built. Made deterministic first, it would be the subsets and then a machine
+     * written out of them — the same states discovered a second time and charged for both.
      */
     @Test
-    void turningTheStatesOverCostsTheStatesAndNothingElse() {
+    void turningTheStatesOverCostsNothing() {
         Meter meter = roomy();
-        PatternSyntax syntax = assertInstanceOf(PatternRead.Read.class,
-                PatternParser.read("[ab]+"), "[ab]+").syntax();
-        Automaton one = Automaton.of(syntax, meter).canonical(meter);
-        assertNotNull(one);
+        Automaton one = canonicalMachineOf("[ab]+", meter);
         int before = meter.left();
 
         Automaton turned = one.not(meter);
 
         assertNotNull(turned);
         assertEquals(one.size(), turned.size(), "the same states");
-        assertEquals(one.size(), before - meter.left(), "and the states are what it spent");
+        assertEquals(before, meter.left(), "and none of them was made, so none was charged");
+    }
+
+    /**
+     * And it is made where there is nothing left to make a state with.
+     *
+     * <p>Which is the half a reader has to be able to see. A construction that shares what it was
+     * handed is not one an allowance has anything to say about, and a complement asked for with
+     * nothing left is answered — where charging it for the states it did not make would refuse an
+     * answer that costs this compiler nothing.
+     */
+    @Test
+    void aComplementIsMadeWithNothingLeftToMakeAStateWith() {
+        // As much in all as one machine may hold, so that what is left can be taken in one ask.
+        Meter meter = new Meter(100_000, 100_000);
+        Automaton one = canonicalMachineOf("[ab]+", meter);
+        // Everything the meter had, so that a state asked for now is refused.
+        assertTrue(meter.making().states(meter.left()), "the allowance is spent down to nothing");
+        assertEquals(0, meter.left());
+
+        Automaton turned = one.not(meter);
+
+        assertNotNull(turned, "the complement is still answered");
+        assertEquals(one.size(), turned.size());
     }
 
     /**
@@ -72,10 +103,7 @@ class TheComplementOfTheOneMachineIsTheOneMachineTest {
     @Test
     void aComplementOfTheOneMachineNeedsNoMaking() {
         Meter meter = roomy();
-        PatternSyntax syntax = assertInstanceOf(PatternRead.Read.class,
-                PatternParser.read("[ab]+"), "[ab]+").syntax();
-        Automaton one = Automaton.of(syntax, meter).canonical(meter);
-        assertNotNull(one);
+        Automaton one = canonicalMachineOf("[ab]+", meter);
 
         Automaton turned = one.not(meter);
         Automaton again = turned == null ? null : turned.canonical(meter);

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheComplementOfTheOneMachineIsTheOneMachineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheComplementOfTheOneMachineIsTheOneMachineTest.java
@@ -1,0 +1,134 @@
+package souther.compiler.regex;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A complement turns over the states a walk stops at, and what it leaves is still the one machine.
+ *
+ * <p>Two things and they fail apart. A machine a walk is only ever in one state of, where every
+ * symbol leads somewhere, has a complement that is the same table with the other states stopped at
+ * — so nothing is made deterministic and nothing is walked, and what a caller spends is the states
+ * it already had. And the table being the same table is what makes the answer canonical without
+ * being made so: what settles the one machine is read off the steps and the walk that numbers them,
+ * and neither of those asks where a walk may stop.
+ *
+ * <p>Which is why the second is asked of the machine and not of a language made out of it. A
+ * complement that came back short of canonical still holds the right strings, so every question
+ * answered by walking agrees; and where a complement holds sequences no string is read as, taking
+ * those out makes the answer canonical on the way and nothing downstream can tell either. The
+ * question is about the machine the complement hands back, and it is asked there.
+ */
+class TheComplementOfTheOneMachineIsTheOneMachineTest {
+
+    private static Meter roomy() {
+        return new Meter(100_000, 10_000_000);
+    }
+
+    private static Language language(String regex, Meter meter) {
+        PatternSyntax syntax =
+                assertInstanceOf(PatternRead.Read.class, PatternParser.read(regex), regex).syntax();
+        Language made = PatternPlan.of(syntax).compile(meter);
+        assertNotNull(made, regex);
+        return made;
+    }
+
+    /**
+     * What a complement of the one machine costs is the states it turned over.
+     *
+     * <p>Made deterministic first, it would be the subsets as well — a machine of the same states
+     * discovered a second time, and charged for. The meter is what says which happened: it counts
+     * where the states are made, so a construction that made them twice spent twice.
+     */
+    @Test
+    void turningTheStatesOverCostsTheStatesAndNothingElse() {
+        Meter meter = roomy();
+        PatternSyntax syntax = assertInstanceOf(PatternRead.Read.class,
+                PatternParser.read("[ab]+"), "[ab]+").syntax();
+        Automaton one = Automaton.of(syntax, meter).canonical(meter);
+        assertNotNull(one);
+        int before = meter.left();
+
+        Automaton turned = one.not(meter);
+
+        assertNotNull(turned);
+        assertEquals(one.size(), turned.size(), "the same states");
+        assertEquals(one.size(), before - meter.left(), "and the states are what it spent");
+    }
+
+    /**
+     * And what it hands back is the one machine for those strings already.
+     *
+     * <p>Asked of the complement itself and not of anything built out of it. Made canonical, it
+     * comes to itself — same states, same steps, same numbering — which is what lets the caller
+     * that knows its machine is canonical keep the answer without paying for that walk.
+     */
+    @Test
+    void aComplementOfTheOneMachineNeedsNoMaking() {
+        Meter meter = roomy();
+        PatternSyntax syntax = assertInstanceOf(PatternRead.Read.class,
+                PatternParser.read("[ab]+"), "[ab]+").syntax();
+        Automaton one = Automaton.of(syntax, meter).canonical(meter);
+        assertNotNull(one);
+
+        Automaton turned = one.not(meter);
+        Automaton again = turned == null ? null : turned.canonical(meter);
+
+        assertNotNull(turned);
+        assertNotNull(again);
+        assertTrue(turned.sameAs(again), "the complement is the one machine for what it accepts");
+    }
+
+    /**
+     * And the complement of a language is the language the same strings come to by another road.
+     *
+     * <p>The two are built without a step in common past the pattern: one turns a canonical machine
+     * over, the other meets every string with the complement of a machine written out of the words
+     * themselves, which is not deterministic to begin with. Equal means the tables are equal, state
+     * for state, which is what a language being the one machine for its strings says.
+     */
+    @Test
+    void aComplementIsTheSameMachineAsTheOneTheStringsComeToOtherwise() {
+        Meter meter = roomy();
+
+        Language turned = Language.ofWords(List.of("a"), meter).not(meter);
+        Language met = Language.EVERY_STRING.without(List.of("a"), meter);
+
+        assertNotNull(turned);
+        assertNotNull(met);
+        assertEquals(met, turned, "one set of strings is one machine, however it was reached");
+        assertEquals(met.hashCode(), turned.hashCode(), "which is what a map looking one up asks");
+    }
+
+    /** And the strings themselves are the ones the complement should hold. */
+    @Test
+    void aComplementHoldsTheStringsTheLanguageDoesNot() {
+        Meter meter = roomy();
+
+        Language left = language("[ab]+", meter).not(meter);
+
+        assertNotNull(left);
+        assertTrue(left.has(""), "no letters at all is not one or more of them");
+        assertTrue(left.has("c"), "nor is a letter the pattern leaves out");
+        assertTrue(left.has("abc"), "nor is a word holding one");
+        assertEquals(false, left.has("ab"), "and a word the language holds is not left over");
+    }
+
+    /** Turned over twice, a language is itself — table for table, not merely string for string. */
+    @Test
+    void aLanguageTurnedOverTwiceIsTheOneItWas() {
+        Meter meter = roomy();
+        Language held = language("[ab]+", meter);
+
+        Language back = held.not(meter).not(meter);
+
+        assertNotNull(back);
+        assertEquals(held, back, "the same machine and not only the same strings");
+    }
+}


### PR DESCRIPTION
Three ways to a language established from nothing what the machine in front of
them already held. Closes #1440.

**A meet is built out of the pairs a walk reaches.** A product was every pair of
states of the two machines, with the steps out of all of them worked out. A pair
nothing leads to is a state made, stepped out of and charged for that no string
is ever in, and the minimisation afterwards throws it away. It is grown from the
pair a walk begins at now, over both kinds of step. Nothing is asked of the meter
before the first state is made: the two sizes multiplied is what a product could
come to and hardly ever what it comes to, and refusing on that number refuses
answers the caller could have afforded. Which is what the meter's own account of
why it counts where the states are made already said.

**The closure is skipped where the machine has no free steps.** Where nothing
steps for nothing, the states reachable without spending a symbol are the states
themselves and the closure is a copy of what it was handed, made for every symbol
out of every state. Asked once, of the machine.

**A complement turns the states over where a walk is only ever in one of them.**
The strings such a machine does not accept are the ones ending where it does not
stop, which is the same table with the other states stopped at. The shape is
asked of the machine and not of where it came from. It shares the steps it was
handed and shares what each one is numbered, so no state is made and nothing is
charged — the same rule as the meet above, read the other way. A language holds
the one machine for its strings, so its complement arrives canonical: what
settles the one machine is read off the steps and the walk that numbers them,
neither of which asks where a walk may stop. So a language turning itself over
keeps what comes back rather than making it again, and taking out the sequences
no string is read as is now beside the making rather than inside it.

Both rules are the one contract the meter states: it counts state construction
and not state cardinality. What is charged falls with what is built, and a model
refused for want of an allowance may now be answered.

Several readings reached a limit by naming two machines whose sizes multiplied
past what one machine may hold. Those models are answered now — one of them
exactly enough for the compiler to see that its rule admits nothing — so each is
rewritten to run out by building: patterns repeating over runs whose lengths
share no factor put a walk in a different pair at every step until the lengths
come round together. One reading held that shape without failing, having been
given rules no ordering could make expensive; it has the same patterns now.

Left out, and written up on the issue as what to look at next: canonicalising a
deterministic machine by a road that is not the subset construction. The subsets
a walk forms over such a machine are the states it reaches, not the states it was
given rediscovered — the construction is the reachability and completion walk,
and measuring it after the above left nothing in it worth a second way in.

One reading is gone rather than rewritten. It asked, through a whole compile, for
the limit that stops a single machine at the position where a run of the strings
is worked out. Everything that run builds grows with a language already bounded
by that same limit, so what stops a compile there is now the allowance for the
whole answer, at a size no reading can afford to reach. The contract it was about
— that a run refused for one machine says which limit refused it — is asked of
`TextExtents`, where the allowance is an argument, and a reading beside that
operation already asks it. What has no reading of its own any more is the step
from there to the reason a rule carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)