### PR TITLE
A rule of the values enters as a description

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -168,6 +168,10 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
         if (handed.stream().anyMatch(each -> each.startsWith(READING))) {
             return COMPOSED;
         }
+        // Handed nothing is a method with no parameters, and not one whose parameters name no
+        // class of this repository. A maker taking two positions names only the variable they are
+        // written as, and reading that as the empty hand would warrant the very leaf this is
+        // about under the word a reading that starts from nothing is warranted by.
         return handed.isEmpty() ? A_START : "handed " + new TreeSet<>(handed);
     }
 
@@ -180,8 +184,15 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
                         .<Signature>map(Signature::of).toList());
     }
 
-    /** Every class a signature names, its type arguments included. A type variable names none: what
-     *  a position is called is not a type this rule is about. */
+    /**
+     * What one parameter is, as this reading names it: the classes its signature names, its type
+     * arguments included, and the variable itself where it is written as one.
+     *
+     * <p>A variable is named rather than passed over, because what a hand holds is the question.
+     * Passed over, a maker taking two positions would hold nothing this can name and would read as
+     * one handed nothing — which is the warrant of the reading everything starts from, and would
+     * cover the leaf this rule exists to refuse.
+     */
     private static void names(Signature said, Set<String> out) {
         switch (said) {
             case Signature.ClassTypeSig it -> {
@@ -193,6 +204,8 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
                 }
             }
             case Signature.ArrayTypeSig it -> names(it.componentSignature(), out);
+            case Signature.TypeVarSig it -> out.add("a position written as " + it.identifier());
+            case Signature.BaseTypeSig it -> out.add(it.signatureString());
             default -> { }
         }
     }

--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -1,0 +1,255 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.reflect.AccessFlag;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every way a reading of worked-out values is made, and what each of them was handed to make it.
+ *
+ * <p>A rule of the model enters as a description ({@code PlannedValues}), and a description is
+ * turned into values once, under an allowance, by {@code resolve}. That is where the rules of one
+ * value's positions become sets — so a reading of values is either the empty one a reading starts
+ * from, or one composed of readings already worked out, or one worked out from a description. What
+ * there is no way to make is a leaf: a reading of values standing for a rule, made straight out of
+ * a position, a set of values, or a reason a rule went unread, without a description having been
+ * worked out.
+ *
+ * <p>A second vocabulary for that would be a second answer to what a rule of the values comes to,
+ * and the two would not be the same answer. What {@code resolve} settles is what the allowance let
+ * it build and what it went short of, and a reading minted beside it is one where those questions
+ * were never asked — so a caller reads it as a reading whose every position was worked out. That is
+ * the shape a compiler can never make and a test can, which is how tests came to be written against
+ * readings the fold does not build.
+ *
+ * <p><b>What this does not say.</b> {@code AdmissibleValues} is a record with a public canonical
+ * constructor, and this leaves that where it is: what is fixed here is the vocabulary a reading is
+ * made by, not the representation. Composing two readings already worked out is not narrowed
+ * either — a conjunction of them is what a declaration's clauses come to, and it is on this side of
+ * {@code resolve} by design.
+ *
+ * <p>Read off the compiled classes, since a construction reached through a method reference makes a
+ * reading as surely as one written out, and neither the enclosing declaration nor a switch over a
+ * sealed type is visible to a scan of source text. Every module's, because a maker anywhere in the
+ * repository is one of these.
+ */
+class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
+
+    private static final String READING = "souther/compiler/values/AdmissibleValues";
+
+    private static final String DESCRIPTION = "souther/compiler/values/PlannedValues";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** Handed nothing at all, which is what a reading starts from. */
+    private static final String A_START = "handed nothing";
+
+    /** Handed readings already worked out, which is what the connectives compose. */
+    private static final String COMPOSED = "handed a reading";
+
+    /** Handed a description, which is where the rules of a value become sets. */
+    private static final String WORKED_OUT = "handed a description";
+
+    /**
+     * Every method that makes one, and what it was handed to make it with.
+     *
+     * <p>The four inside {@code AdmissibleValues} are the conjunction, the renaming, what a choice
+     * left open and the writing down of the order the rules were read in, each handed the reading
+     * it is composing — as {@code this}, which is a reading in hand as much as an argument is.
+     * {@code top} is handed nothing. {@code resolved} is the one place a description becomes
+     * values, and is the only maker outside the type.
+     *
+     * <p>{@code metAll} is not here, and that it is not is the reading holding: a conjunction of
+     * several is written as one meet after another, so it makes nothing of its own.
+     *
+     * <p>A row whose warrant reads {@code handed nothing} and which takes an argument is the defect
+     * this is about, and cannot be written: the warrant is read off the signature rather than
+     * declared beside the row.
+     */
+    private static final List<String> MAKING_ONE = List.of(
+            READING + "#alsoOpenedAt -> " + COMPOSED,
+            READING + "#meet -> " + COMPOSED,
+            READING + "#renamed -> " + COMPOSED,
+            READING + "#sayingWhatWasReadInTheOrderOf -> " + COMPOSED,
+            READING + "#top -> " + A_START,
+            DESCRIPTION + "#resolved -> " + WORKED_OUT);
+
+    @Test
+    void everyMakerOfAReadingOfValuesWasHandedOneOrADescriptionOrNothing() {
+        assertEquals(MAKING_ONE, new ArrayList<>(makers()),
+                "a maker handed a position, a set of values or a reason a rule went unread is a"
+                        + " second way of saying what a rule of the values comes to, and it says it"
+                        + " without the allowance and the shortfall resolving one settles");
+    }
+
+    /**
+     * And the walk found the maker outside the type, which is what it is for.
+     *
+     * <p>A reading of the class files that found only what {@code AdmissibleValues} does to itself
+     * would be a reading that never reached the boundary the rule is about, and it would pass.
+     */
+    @Test
+    void andTheOneMakerOutsideTheTypeWasReached() {
+        assertTrue(makers().contains(DESCRIPTION + "#resolved -> " + WORKED_OUT),
+                "the walk reaches the place a description becomes values");
+        assertTrue(modulesRead() > 1,
+                "the classes this reads are in more than the module that declares the reading");
+    }
+
+    /** Every method whose code makes a reading, as the method and the warrant its signature gives
+     *  it. Sorted, so the rows do not turn on the order a walk of the file system took. */
+    private static Set<String> makers() {
+        Set<String> found = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                ClassModel owner = parse(each);
+                for (MethodModel method : owner.methods()) {
+                    if (makesAReading(method)) {
+                        found.add(owner.thisClass().asInternalName() + "#"
+                                + method.methodName().stringValue() + " -> "
+                                + warrantOf(owner, method));
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * What the method was handed, read off what its signature names.
+     *
+     * <p>An instance method of the reading is handed one as {@code this}, which is what makes the
+     * connectives compositions rather than makers out of nothing. Everything else is read from the
+     * parameters, through the generic signature where there is one: a list of readings is a reading
+     * in hand, and the erasure that calls it a list would not say so.
+     *
+     * <p>A lambda is compiled to a method of its own, and this reads that method's own parameters —
+     * what it captured and what it is applied to — rather than the ones the method around it took.
+     * Which is the reading that holds: a lambda making a reading out of a set it captured has made
+     * one out of a set, whatever was in scope where it was written.
+     */
+    private static String warrantOf(ClassModel owner, MethodModel method) {
+        Set<String> handed = new LinkedHashSet<>();
+        if (!method.flags().has(AccessFlag.STATIC)) {
+            handed.add(owner.thisClass().asInternalName());
+        }
+        for (Signature each : parametersOf(method)) {
+            names(each, handed);
+        }
+        if (handed.stream().anyMatch(each -> each.startsWith(DESCRIPTION))) {
+            return WORKED_OUT;
+        }
+        if (handed.stream().anyMatch(each -> each.startsWith(READING))) {
+            return COMPOSED;
+        }
+        return handed.isEmpty() ? A_START : "handed " + new TreeSet<>(handed);
+    }
+
+    /** The parameter types, generic where the method declares a signature of its own. */
+    private static List<Signature> parametersOf(MethodModel method) {
+        return method.findAttribute(Attributes.signature())
+                .map(SignatureAttribute::asMethodSignature)
+                .map(it -> List.<Signature>copyOf(it.arguments()))
+                .orElseGet(() -> method.methodTypeSymbol().parameterList().stream()
+                        .<Signature>map(Signature::of).toList());
+    }
+
+    /** Every class a signature names, its type arguments included. A type variable names none: what
+     *  a position is called is not a type this rule is about. */
+    private static void names(Signature said, Set<String> out) {
+        switch (said) {
+            case Signature.ClassTypeSig it -> {
+                out.add(internalNameOf(it.classDesc()));
+                for (Signature.TypeArg argument : it.typeArgs()) {
+                    if (argument instanceof Signature.TypeArg.Bounded bounded) {
+                        names(bounded.boundType(), out);
+                    }
+                }
+            }
+            case Signature.ArrayTypeSig it -> names(it.componentSignature(), out);
+            default -> { }
+        }
+    }
+
+    private static String internalNameOf(ClassDesc said) {
+        String descriptor = said.descriptorString();
+        return descriptor.substring(1, descriptor.length() - 1);
+    }
+
+    /** Whether the method's own code makes a reading: written out, or handed to something that will
+     *  make one, which a constructor reference is. */
+    private static boolean makesAReading(MethodModel method) {
+        return method.code().map(code -> code.elementStream().anyMatch(element -> switch (element) {
+            case InvokeInstruction it -> READING.equals(it.owner().asInternalName())
+                    && "<init>".equals(it.name().stringValue());
+            case InvokeDynamicInstruction it -> it.invokedynamic().bootstrap().arguments().stream()
+                    .anyMatch(AReadingOfValuesIsStartedComposedOrWorkedOutTest::makesAReading);
+            default -> false;
+        })).orElse(false);
+    }
+
+    private static boolean makesAReading(Object argument) {
+        return argument instanceof MethodHandleEntry handle
+                && handle.asSymbol() instanceof DirectMethodHandleDesc said
+                && READING.equals(internalNameOf(said.owner()))
+                && "<init>".equals(said.methodName());
+    }
+
+    private static int modulesRead() {
+        int read = 0;
+        for (Path module : REPOSITORY.modules()) {
+            if (!classesUnder(module).isEmpty()) {
+                read++;
+            }
+        }
+        return read;
+    }
+
+    private static ClassModel parse(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
+     *  them: a test makes a reading to look at it and ships nothing. */
+    private static List<Path> classesUnder(Path module) {
+        Path where = module.resolve("target").resolve("classes");
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -109,17 +109,31 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
     }
 
     /**
-     * And the walk found the maker outside the type, which is what it is for.
+     * And every module the repository holds was read.
      *
-     * <p>A reading of the class files that found only what {@code AdmissibleValues} does to itself
-     * would be a reading that never reached the boundary the rule is about, and it would pass.
+     * <p>Asked of the modules the repository has rather than of what a build happened to leave. A
+     * module whose classes are missing is one whose makers this cannot see, and the rows from the
+     * rest would match — so this would pass while answering about fewer modules than it names.
      */
     @Test
-    void andTheOneMakerOutsideTheTypeWasReached() {
-        assertTrue(makers().contains(DESCRIPTION + "#resolved -> " + WORKED_OUT),
-                "the walk reaches the place a description becomes values");
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        List<String> unbuilt = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            if (classesUnder(module).isEmpty() && hasMainSources(module)) {
+                unbuilt.add(module.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), unbuilt,
+                "a module whose classes are not built is one this walk passes over");
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the module that declares the reading");
+    }
+
+    /** Whether the module has main sources to have been built from. A module holding only tests or
+     *  only a pom leaves no classes and is not one this walk is missing. */
+    private static boolean hasMainSources(Path module) {
+        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
     }
 
     /** Every method whose code makes a reading, as the method and the warrant its signature gives

--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -12,7 +12,9 @@ import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.constant.ClassDesc;
@@ -143,6 +145,9 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
         for (Path module : REPOSITORY.modules()) {
             for (Path each : classesUnder(module)) {
                 ClassModel owner = parse(each);
+                if (!namesTheConstructor(owner)) {
+                    continue;
+                }
                 for (MethodModel method : owner.methods()) {
                     if (makesAReading(method)) {
                         found.add(owner.thisClass().asInternalName() + "#"
@@ -227,6 +232,26 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
     private static String internalNameOf(ClassDesc said) {
         String descriptor = said.descriptorString();
         return descriptor.substring(1, descriptor.length() - 1);
+    }
+
+    /**
+     * Whether the class names the constructor at all, which is read off its constant pool.
+     *
+     * <p>Ahead of the methods because it answers for the whole file at once: a class that makes a
+     * reading names the constructor there whichever way it was written, since both an
+     * {@code invokespecial} and the handle a constructor reference carries are entries in that
+     * pool. Almost every class in the repository names it nowhere, and this is what keeps their
+     * code from being taken apart to find that out.
+     */
+    private static boolean namesTheConstructor(ClassModel owner) {
+        for (PoolEntry entry : owner.constantPool()) {
+            if (entry instanceof MemberRefEntry member
+                    && READING.equals(member.owner().name().stringValue())
+                    && "<init>".equals(member.name().stringValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Whether the method's own code makes a reading: written out, or handed to something that will

--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -23,6 +23,7 @@ import java.lang.reflect.AccessFlag;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -63,9 +64,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
 
-    private static final String READING = "souther/compiler/values/AdmissibleValues";
+    private static final String VALUES = "souther/compiler/values/";
 
-    private static final String DESCRIPTION = "souther/compiler/values/PlannedValues";
+    private static final String READING = VALUES + "AdmissibleValues";
+
+    private static final String DESCRIPTION = VALUES + "PlannedValues";
+
+    /** What a parameter or a return of one of these is written as in a descriptor. */
+    private static String held(String type) {
+        return "L" + type + ";";
+    }
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
@@ -90,21 +98,34 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
      * <p>{@code metAll} is not here, and that it is not is the reading holding: a conjunction of
      * several is written as one meet after another, so it makes nothing of its own.
      *
-     * <p>A row whose warrant reads {@code handed nothing} and which takes an argument is the defect
-     * this is about, and cannot be written: the warrant is read off the signature rather than
-     * declared beside the row.
+     * <p>Each row carries the descriptor, so a second maker written as an overload of a name
+     * already here is a row of its own rather than the one that was allowed.
+     *
+     * <p><b>What the warrant does and does not settle.</b> It is read off the signature and not
+     * declared beside the row, so a maker cannot be written down as something it is not — a static
+     * one handed a set of values says so, whatever it is called. It does not settle that a row
+     * belongs here: a method of the reading is handed one as {@code this} and its warrant says so
+     * however much else it takes, and {@code alsoOpenedAt} is such a method and is right. So what
+     * this list is, is every place a reading is made, each with what it had in hand; adding to it
+     * is somebody saying that a new one of those is a composition and not a leaf.
      */
     private static final List<String> MAKING_ONE = List.of(
-            READING + "#alsoOpenedAt -> " + COMPOSED,
-            READING + "#meet -> " + COMPOSED,
-            READING + "#renamed -> " + COMPOSED,
-            READING + "#sayingWhatWasReadInTheOrderOf -> " + COMPOSED,
-            READING + "#top -> " + A_START,
-            DESCRIPTION + "#resolved -> " + WORKED_OUT);
+            row(READING, "alsoOpenedAt", "(Ljava/util/Set;)" + held(READING), COMPOSED),
+            row(READING, "meet",
+                    "(" + held(READING) + held(VALUES + "Allowance") + ")" + held(READING),
+                    COMPOSED),
+            row(READING, "renamed", "(Ljava/util/function/Function;)" + held(READING), COMPOSED),
+            row(READING, "sayingWhatWasReadInTheOrderOf",
+                    "(Ljava/util/List;)" + held(READING), COMPOSED),
+            row(READING, "top", "()" + held(READING), A_START),
+            row(DESCRIPTION, "resolved",
+                    "(" + held(DESCRIPTION + "$Settled") + held(VALUES + "Allowance") + ")"
+                            + held(VALUES + "Realized"),
+                    WORKED_OUT));
 
     @Test
     void everyMakerOfAReadingOfValuesWasHandedOneOrADescriptionOrNothing() {
-        assertEquals(MAKING_ONE, new ArrayList<>(makers()),
+        assertEquals(MAKING_ONE, makers(),
                 "a maker handed a position, a set of values or a reason a rule went unread is a"
                         + " second way of saying what a rule of the values comes to, and it says it"
                         + " without the allowance and the shortfall resolving one settles");
@@ -138,10 +159,23 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
         return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
     }
 
-    /** Every method whose code makes a reading, as the method and the warrant its signature gives
-     *  it. Sorted, so the rows do not turn on the order a walk of the file system took. */
-    private static Set<String> makers() {
-        Set<String> found = new TreeSet<>();
+    /**
+     * Every method whose code makes a reading, as the method and the warrant its signature gives
+     * it.
+     *
+     * <p>A method and not a name: the descriptor is part of what is written down, because two
+     * methods of one name are two makers. A row is what a reader sees and is not what a maker is,
+     * and identifying one by the sentence printed about it would let a leaf come back as an
+     * overload of something already allowed — same name, same warrant where the receiver is a
+     * reading, and nothing left to tell them apart.
+     *
+     * <p>Held in a list for the same reason. A set keeps one of whatever it is given twice, and
+     * what a rule like this is asking is how many there are as much as which.
+     *
+     * <p>Sorted, so the rows do not turn on the order a walk of the file system took.
+     */
+    private static List<String> makers() {
+        List<String> found = new ArrayList<>();
         for (Path module : REPOSITORY.modules()) {
             for (Path each : classesUnder(module)) {
                 ClassModel owner = parse(each);
@@ -150,14 +184,21 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
                 }
                 for (MethodModel method : owner.methods()) {
                     if (makesAReading(method)) {
-                        found.add(owner.thisClass().asInternalName() + "#"
-                                + method.methodName().stringValue() + " -> "
-                                + warrantOf(owner, method));
+                        found.add(row(owner.thisClass().asInternalName(),
+                                method.methodName().stringValue(),
+                                method.methodTypeSymbol().descriptorString(),
+                                warrantOf(owner, method)));
                     }
                 }
             }
         }
+        found.sort(Comparator.naturalOrder());
         return found;
+    }
+
+    /** One maker, as it is written down and as it is read off the classes. */
+    private static String row(String owner, String name, String descriptor, String warrant) {
+        return owner + "#" + name + descriptor + " -> " + warrant;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * through the obligations would turn "some reading took this in" into "a construction may be held
  * to it", and a row would be offered at an edge promised by nothing.
  *
- * <p>Everything this cannot read is {@link AdmissibleValues#unreadable}, which widens and never
+ * <p>Everything this cannot read is {@code PlannedValues.unreadable}, which widens and never
  * narrows. That is the whole discipline: a reading that answered "no value" from a clause it did
  * not read would refuse a model somebody can write. A denial is turned into what it leaves where
  * the values can be written out ({@link ValueUniverse}) and is kept as a denial where they cannot,
@@ -165,7 +165,7 @@ final class AdmissibleReading {
      * is reaching the position and the written text and turning the answer into a plan — so a
      * predicate this reading learns is a row in that table and not an arm added here.
      *
-     * <p>Null and not {@link AdmissibleValues#unreadable} wherever the leaf's own account is the
+     * <p>Null and not {@code PlannedValues.unreadable} wherever the leaf's own account is the
      * right one, so that the one place a reading gives up stays where it is: what a rule this could
      * not read costs is worked out there, and a second answer to it here would be a second account
      * of the same thing. That is every leaf that is not one of these, and every one of these whose

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * through the obligations would turn "some reading took this in" into "a construction may be held
  * to it", and a row would be offered at an edge promised by nothing.
  *
- * <p>Everything this cannot read is {@code PlannedValues.unreadable}, which widens and never
+ * <p>Everything this cannot read is {@link PlannedValues#unreadable}, which widens and never
  * narrows. That is the whole discipline: a reading that answered "no value" from a clause it did
  * not read would refuse a model somebody can write. A denial is turned into what it leaves where
  * the values can be written out ({@link ValueUniverse}) and is kept as a denial where they cannot,
@@ -165,7 +165,7 @@ final class AdmissibleReading {
      * is reaching the position and the written text and turning the answer into a plan — so a
      * predicate this reading learns is a row in that table and not an arm added here.
      *
-     * <p>Null and not {@code PlannedValues.unreadable} wherever the leaf's own account is the
+     * <p>Null and not {@link PlannedValues#unreadable} wherever the leaf's own account is the
      * right one, so that the one place a reading gives up stays where it is: what a rule this could
      * not read costs is worked out there, and a second answer to it here would be a second account
      * of the same thing. That is every leaf that is not one of these, and every one of these whose

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -31,10 +31,10 @@ import java.util.Set;
  * could read: those are written as {@link PlannedValues} and worked out. What a leaf minted here
  * would leave out is what working one out settles — what the allowance let it build, and what it
  * went short of — so a caller would be handed a reading whose every position looks worked out and
- * whose shortfall was never asked about. What this side does have is what it does to readings
- * already in hand: {@link #meet} and {@link #metAll}, {@link #renamed}, {@link #alsoOpenedAt}, and
- * {@link #top}, which is handed nothing. That list is what
- * {@code AReadingOfValuesIsStartedComposedOrWorkedOutTest} holds it to.
+ * whose shortfall was never asked about. What this side has instead is what a reading already in
+ * hand can be put through: {@link #meet} and {@link #metAll}, {@link #renamed} and
+ * {@link #alsoOpenedAt}. Beside them is {@link #top}, which is handed nothing and is where a
+ * reading starts.
  *
  * <h2>What is held</h2>
  *

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -26,6 +26,16 @@ import java.util.Set;
  * another choice, and a reader looking for one is looking on the wrong side of {@link
  * PlannedValues#resolve}.
  *
+ * <p><b>And a rule of the values enters as a description.</b> There is no word here for a reading
+ * of one position, of two positions held as one value, of two held apart, or of a rule nothing
+ * could read: those are written as {@link PlannedValues} and worked out. What a leaf minted here
+ * would leave out is what working one out settles — what the allowance let it build, and what it
+ * went short of — so a caller would be handed a reading whose every position looks worked out and
+ * whose shortfall was never asked about. What this side does have is what it does to readings
+ * already in hand: {@link #meet} and {@link #metAll}, {@link #renamed}, {@link #alsoOpenedAt}, and
+ * {@link #top}, which is handed nothing. That list is what
+ * {@code AReadingOfValuesIsStartedComposedOrWorkedOutTest} holds it to.
+ *
  * <h2>What is held</h2>
  *
  * <p>A union of products, or nothing. A product — a {@link Box} — is one set per position, standing
@@ -884,86 +894,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         return out;
     }
 
-    /** One position said to admit {@code set}, and nothing missed. */
-    public static <A> AdmissibleValues<A> at(A atom, ValueSet set) {
-        Map<A, ValueSet> said = Map.of(atom, set);
-        return new AdmissibleValues<>(
-                set.isEmpty() ? new Held.Nothing<>() : one(Alternative.at(said)),
-                said, Standing.nothing(), Map.of(Sameness.Block.of(atom), set),
-                ValueSet.ANY, true, Set.of(), Set.of());
-    }
-
-    /**
-     * Two positions said to hold one value, which is what an equality between them states.
-     *
-     * <p>Nothing is narrowed anywhere: what this says is that the two are one side of the product,
-     * so whatever either of them is stated to admit is what both admit. Which is why it is a
-     * reading of the values at all — a rule relating two positions was one nothing here could take
-     * in, and what it left was two positions with two answers and a rule between them that reached
-     * nothing.
-     */
-    public static <A> AdmissibleValues<A> holdingAsOne(A here, A there) {
-        Sameness.Block<A> block = Sameness.of(here, there).blockOf(here);
-        // Promised at the block, though it narrows nothing there. The keys of the promise are the
-        // footprint as well — the blocks a rule of this reading reached — and this rule reached
-        // one: it shapes the relation without touching what any position admits. Left out, a
-        // choice between two equalities would be a union of two relations that no product holds
-        // and would say it lost nothing, since what it reads to decide that is this key set.
-        return new AdmissibleValues<>(
-                one(Alternative.of(new Box<>(Map.of(block, ValueSet.ANY)))), Map.of(),
-                Standing.nothing(), Map.of(block, ValueSet.ANY), ValueSet.ANY, true,
-                Set.of(), Set.of());
-    }
-
-    /**
-     * Two positions said to hold different values, which is what a denial between them states.
-     *
-     * <p>Narrowing neither, the way an equality narrows neither: what a denial says is that no one
-     * value stands at both, which is a relation between two sides of the product rather than a
-     * statement about either. So it is held beside the product ({@link Apartness}) and what it
-     * comes to is worked out where the values each side is left are in hand.
-     *
-     * <p><b>And guaranteeing nothing at either of them.</b> What is guaranteed is a lower bound —
-     * these values are admitted whatever else is read — and no value can be shown admitted at one
-     * of two positions held apart without an assignment for the other. Over a carrier of one value
-     * a denial admits nothing at all, so a guarantee of every value would be false of a model
-     * somebody can write. Said here rather than wherever a denial is met with something, because
-     * meeting a guarantee with nothing leaves nothing: every conjunction this rule reaches has it
-     * without a second rule saying so, and a choice beside it keeps what its other branch
-     * guarantees, which is right — a value satisfying that branch is under no denial.
-     */
-    public static <A> AdmissibleValues<A> heldApart(A here, A there) {
-        Sameness.Block<A> one = Sameness.Block.of(here);
-        Sameness.Block<A> other = Sameness.Block.of(there);
-        Map<Sameness.Block<A>, ValueSet> promised = new LinkedHashMap<>();
-        promised.put(one, ValueSet.NONE);
-        promised.put(other, ValueSet.NONE);
-        return new AdmissibleValues<>(
-                one(new Alternative<>(new Box<>(Map.of()), Apartness.of(here, there))),
-                Map.of(), Standing.nothing(), promised, ValueSet.ANY, true, Set.of(), Set.of());
-    }
-
-    /**
-     * A rule this could not read, which says nothing about any position and spoils the ones it
-     * names.
-     *
-     * <p>{@code named} may be empty — a rule reaching no position this can name is still a rule that
-     * was not read, and that it was is a fact about the clause somebody wrote rather than about any
-     * position of this reading ({@code Adoption}).
-     *
-     * <p>Nothing here was opened by an alternative. What this leaves at the positions it names is
-     * its own account of them, said directly; that a choice above holds this clause in one of its
-     * branches is that choice's fact, and reaches the positions from where the choice is.
-     */
-    public static <A> AdmissibleValues<A> unreadable(Set<A> named, UnreadReason why) {
-        // Nothing is guaranteed anywhere, and at the positions it does not name as much as at the
-        // ones it does: what a rule this has no word for admits is not known, so a choice offering
-        // it as an alternative is offering nothing that can be counted on.
-        return new AdmissibleValues<>(one(Alternative.at(Map.of())), Map.of(),
-                Standing.of(named, why), Map.of(),
-                ValueSet.NONE, true, Set.of(), Set.of());
-    }
-
     /**
      * What {@code atom} may hold, everything being admitted where nothing was said.
      *
@@ -980,23 +910,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             // it may take. See {@link Held.Alternatives#of}.
             case Held.Alternatives<A> it -> it.at(atom);
         };
-    }
-
-    /**
-     * The positions this reading narrowed, which is what a reader asking what it took in is asking.
-     *
-     * <p>Narrowed by the reading and not by an alternative of it: a position one alternative names
-     * and another says nothing about is left at every value by the choice, and a rule that narrowed
-     * nothing is not one a question can be answered from.
-     */
-    public Set<A> adoptedAt() {
-        Set<A> out = new LinkedHashSet<>();
-        adopted().forEach(atom -> {
-            if (!at(atom).isAny()) {
-                out.add(atom);
-            }
-        });
-        return out;
     }
 
     /**
@@ -1485,16 +1398,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     /** The alternatives this holds, which a reading that admits nothing has none of. */
     private Set<Alternative<A>> alternatives() {
         return held instanceof Held.Alternatives<A> it ? it.boxes() : Set.of();
-    }
-
-    /** The positions this holds an answer about, in the order they were read. */
-    private Set<A> adopted() {
-        Set<A> out = new LinkedHashSet<>();
-        switch (held) {
-            case Held.Nothing<A> _ -> out.addAll(perPosition.keySet());
-            case Held.Alternatives<A> it -> it.boxes().forEach(box -> out.addAll(box.positions()));
-        }
-        return out;
     }
 
     /** One alternative, which is what most readings hold. Nothing is put together, so what each

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -82,12 +82,21 @@ public sealed interface PlannedValues<A> {
     }
 
     /**
-     * Two positions said to hold one value — see {@link AdmissibleValues#holdingAsOne}.
+     * Two positions said to hold one value, which is what an equality between them states.
+     *
+     * <p>Nothing is narrowed anywhere: what this says is that the two are one side of the product,
+     * so whatever either of them is stated to admit is what both admit. Which is why it is a
+     * reading of the values at all — a rule relating two positions was one nothing here could take
+     * in, and what it left was two positions with two answers and a rule between them that reached
+     * nothing.
      */
     static <A> PlannedValues<A> holdingAsOne(A here, A there) {
         Sameness.Block<A> block = Sameness.of(here, there).blockOf(here);
-        // Promised at the block, though it narrows nothing there — see
-        // {@link AdmissibleValues#holdingAsOne}.
+        // Promised at the block, though it narrows nothing there. The keys of the promise are the
+        // footprint as well — the blocks a rule of this reading reached — and this rule reached
+        // one: it shapes the relation without touching what any position admits. Left out, a
+        // choice between two equalities would be a union of two relations that no product holds
+        // and would say it lost nothing, since what it reads to decide that is this key set.
         return new Settled<>(
                 PlannedHeld.one(PlannedHeld.Alternative.of(
                         new PlannedHeld.Box<>(Map.of(block, AdmittedPlan.ANY)))),
@@ -96,7 +105,21 @@ public sealed interface PlannedValues<A> {
     }
 
     /**
-     * Two positions said to hold different values — see {@link AdmissibleValues#heldApart}.
+     * Two positions said to hold different values, which is what a denial between them states.
+     *
+     * <p>Narrowing neither, the way an equality narrows neither: what a denial says is that no one
+     * value stands at both, which is a relation between two sides of the product rather than a
+     * statement about either. So it is held beside the product ({@link Apartness}) and what it
+     * comes to is worked out where the values each side is left are in hand.
+     *
+     * <p><b>And guaranteeing nothing at either of them.</b> What is guaranteed is a lower bound —
+     * these values are admitted whatever else is read — and no value can be shown admitted at one
+     * of two positions held apart without an assignment for the other. Over a carrier of one value
+     * a denial admits nothing at all, so a guarantee of every value would be false of a model
+     * somebody can write. Said here rather than wherever a denial is met with something, because
+     * meeting a guarantee with nothing leaves nothing: every conjunction this rule reaches has it
+     * without a second rule saying so, and a choice beside it keeps what its other branch
+     * guarantees, which is right — a value satisfying that branch is under no denial.
      */
     static <A> PlannedValues<A> heldApart(A here, A there) {
         Map<Sameness.Block<A>, AdmittedPlan> promised = new LinkedHashMap<>();
@@ -111,9 +134,20 @@ public sealed interface PlannedValues<A> {
 
     /**
      * A rule this could not read, which says nothing about any position and spoils the ones it
-     * names — see {@link AdmissibleValues#unreadable}.
+     * names.
+     *
+     * <p>{@code named} may be empty — a rule reaching no position this can name is still a rule
+     * that was not read, and that it was is a fact about the clause somebody wrote rather than
+     * about any position of this reading ({@code Adoption}).
+     *
+     * <p>Nothing here was opened by an alternative. What this leaves at the positions it names is
+     * its own account of them, said directly; that a choice above holds this clause in one of its
+     * branches is that choice's fact, and reaches the positions from where the choice is.
      */
     static <A> PlannedValues<A> unreadable(Set<A> named, UnreadReason why) {
+        // Nothing is guaranteed anywhere, and at the positions it does not name as much as at the
+        // ones it does: what a rule this has no word for admits is not known, so a choice offering
+        // it as an alternative is offering nothing that can be counted on.
         return new Settled<>(PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
                 Standing.of(named, why), Map.of(), AdmittedPlan.NONE, true, Set.of(),
                 Set.of());

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -6,8 +6,8 @@ import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
-import souther.compiler.values.PlannedValues;
 import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.AsACompilationAllows;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
@@ -47,9 +49,21 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
     /** Two positions held as one and stated to admit values that share none. */
     private static AdmissibleValues<FactSubject> emptiedAt(FactSubject one, FactSubject other,
                                                            Allowance<FactSubject> sets) {
-        return AdmissibleValues.<FactSubject>holdingAsOne(one, other)
-                .meet(AdmissibleValues.at(one, ValueSet.just(A)), sets)
-                .meet(AdmissibleValues.at(other, ValueSet.just(B)), sets);
+        return built(PlannedValues.holdingAsOne(one, other), sets)
+                .meet(says(one, A, sets), sets)
+                .meet(says(other, B, sets), sets);
+    }
+
+    /** A description worked out, which is how a reading is come by. */
+    private static AdmissibleValues<FactSubject> built(PlannedValues<FactSubject> planned,
+                                                       Allowance<FactSubject> sets) {
+        return planned.resolve(sets).values();
+    }
+
+    /** One rule about one position, worked out. */
+    private static AdmissibleValues<FactSubject> says(FactSubject atom, Value value,
+                                                      Allowance<FactSubject> sets) {
+        return built(PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value))), sets);
     }
 
     /** Where the value declares each of its positions, in the order it declares them. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
@@ -10,6 +10,8 @@ import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -116,7 +118,7 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
         ConstraintState<FactSubject> both = ConstraintState.<FactSubject>top()
                 .taking(ONLY_IN_FACTS, true)
                 .takingRead(Confinement.Worked.of(
-                                AdmissibleValues.at(ONLY_IN_FACTS, ValueSet.just(Value.text("A"))),
+                                says(ONLY_IN_FACTS, "A"),
                                 OrderedIntervals.top(), Map.of()),
                         souther.compiler.values.AsACompilationAllows.forAdmittedValues());
         java.util.concurrent.atomic.AtomicInteger asked = new java.util.concurrent.atomic.AtomicInteger();
@@ -128,12 +130,19 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
         assertEquals(ValueSet.just(Value.text("A")), said.values().at("p#0"));
     }
 
+    /** One rule about one position, worked out, which is how a reading is come by. */
+    private static AdmissibleValues<FactSubject> says(FactSubject atom, String text) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(Value.text(text))))
+                .resolve(souther.compiler.values.AsACompilationAllows.forAdmittedValues())
+                .values();
+    }
+
     /** One subject in each domain, and no subject in two of them. */
     private static ConstraintState<FactSubject> spread() {
         return ConstraintState.<FactSubject>top()
                 .taking(ONLY_IN_FACTS, true)
                 .takingRead(Confinement.Worked.of(
-                                AdmissibleValues.at(ONLY_IN_VALUES, ValueSet.just(Value.text("A"))),
+                                says(ONLY_IN_VALUES, "A"),
                                 OrderedIntervals.at(ONLY_IN_ORDERED, new OrderedInterval(
                                         Endpoint.inclusive(Count.of(6)),
                                         Endpoint.inclusive(Count.of(2)))),

--- a/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
@@ -11,6 +11,7 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.AsACompilationAllows;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
@@ -120,7 +121,7 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
                 .takingRead(Confinement.Worked.of(
                                 says(ONLY_IN_FACTS, "A"),
                                 OrderedIntervals.top(), Map.of()),
-                        souther.compiler.values.AsACompilationAllows.forAdmittedValues());
+                        AsACompilationAllows.forAdmittedValues());
         java.util.concurrent.atomic.AtomicInteger asked = new java.util.concurrent.atomic.AtomicInteger();
 
         ConstraintState<String> said = both.renamed(
@@ -133,7 +134,7 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
     /** One rule about one position, worked out, which is how a reading is come by. */
     private static AdmissibleValues<FactSubject> says(FactSubject atom, String text) {
         return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(Value.text(text))))
-                .resolve(souther.compiler.values.AsACompilationAllows.forAdmittedValues())
+                .resolve(AsACompilationAllows.forAdmittedValues())
                 .values();
     }
 
@@ -147,7 +148,7 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
                                         Endpoint.inclusive(Count.of(6)),
                                         Endpoint.inclusive(Count.of(2)))),
                                 Map.of()),
-                        souther.compiler.values.AsACompilationAllows.forAdmittedValues())
+                        AsACompilationAllows.forAdmittedValues())
                 .taking(LinearForm.<FactSubject>atom(ONLY_IN_NUMBERS)
                                 .minus(LinearForm.<FactSubject>constant(BigDecimal.valueOf(3))),
                         Rel.LE, Map.of(ONLY_IN_NUMBERS, souther.compiler.numeric.Granularity.DISCRETE));

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -10,6 +10,8 @@ import souther.compiler.numeric.Rel;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -179,9 +181,15 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
         souther.compiler.values.Allowance<FactSubject> sets =
                 souther.compiler.values.AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("A")))
-                        .meet(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("B"))),
-                                sets), OrderedIntervals.top(), Map.of()), sets);
+                says("A", sets).meet(says("B", sets), sets),
+                OrderedIntervals.top(), Map.of()), sets);
+    }
+
+    /** One rule about the position, worked out, which is how a reading is come by. */
+    private static AdmissibleValues<FactSubject> says(String text,
+            souther.compiler.values.Allowance<FactSubject> sets) {
+        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
+                .resolve(sets).values();
     }
 
     private static ConstraintState<FactSubject> orderedAtBottom() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -11,6 +11,8 @@ import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Allowance;
+import souther.compiler.values.AsACompilationAllows;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
@@ -178,16 +180,14 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
     private static ConstraintState<FactSubject> valuesAtBottom() {
         // Met as one reading and handed over as one. Two readings are combined where the
         // clauses of a declaration are read, and never at the state's boundary.
-        souther.compiler.values.Allowance<FactSubject> sets =
-                souther.compiler.values.AsACompilationAllows.forAdmittedValues();
+        Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
                 says("A", sets).meet(says("B", sets), sets),
                 OrderedIntervals.top(), Map.of()), sets);
     }
 
     /** One rule about the position, worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> says(String text,
-            souther.compiler.values.Allowance<FactSubject> sets) {
+    private static AdmissibleValues<FactSubject> says(String text, Allowance<FactSubject> sets) {
         return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
                 .resolve(sets).values();
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -11,6 +11,8 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Allowance;
+import souther.compiler.values.AsACompilationAllows;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
@@ -135,16 +137,14 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
     private static ConstraintState<FactSubject> valuesAtBottom() {
         // Met as one reading and handed over as one. Two readings are combined where the
         // clauses of a declaration are read, and never at the state's boundary.
-        souther.compiler.values.Allowance<FactSubject> sets =
-                souther.compiler.values.AsACompilationAllows.forAdmittedValues();
+        Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
                 says("A", sets).meet(says("B", sets), sets),
                 OrderedIntervals.top(), Map.of()), sets);
     }
 
     /** One rule about the position, worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> says(String text,
-            souther.compiler.values.Allowance<FactSubject> sets) {
+    private static AdmissibleValues<FactSubject> says(String text, Allowance<FactSubject> sets) {
         return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
                 .resolve(sets).values();
     }
@@ -159,8 +159,7 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
 
     /** The values pinned at one string, and the order left the strings above another. */
     private static ConstraintState<FactSubject> setBesideARangeItIsOutside() {
-        souther.compiler.values.Allowance<FactSubject> sets =
-                souther.compiler.values.AsACompilationAllows.forAdmittedValues();
+        Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
                 says("A", sets),
                 OrderedIntervals.at(A_POSITION, new OrderedInterval(

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -10,6 +10,8 @@ import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -136,9 +138,15 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
         souther.compiler.values.Allowance<FactSubject> sets =
                 souther.compiler.values.AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("A")))
-                        .meet(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("B"))),
-                                sets), OrderedIntervals.top(), Map.of()), sets);
+                says("A", sets).meet(says("B", sets), sets),
+                OrderedIntervals.top(), Map.of()), sets);
+    }
+
+    /** One rule about the position, worked out, which is how a reading is come by. */
+    private static AdmissibleValues<FactSubject> says(String text,
+            souther.compiler.values.Allowance<FactSubject> sets) {
+        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
+                .resolve(sets).values();
     }
 
     private static ConstraintState<FactSubject> orderedAtBottom() {
@@ -154,7 +162,7 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
         souther.compiler.values.Allowance<FactSubject> sets =
                 souther.compiler.values.AsACompilationAllows.forAdmittedValues();
         return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("A"))),
+                says("A", sets),
                 OrderedIntervals.at(A_POSITION, new OrderedInterval(
                         Endpoint.inclusive(souther.compiler.numeric.Text.of("B")), null)),
                 Map.of(A_POSITION, Carrier.TEXT)), sets);

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -142,7 +142,8 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
                         .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
                 "the choice states it, so an equality read beside it refuses");
         assertTrue(planned.resolve(sets).values()
-                        .meet(AdmissibleValues.holdingAsOne("p", "r"), sets).isBottom(),
+                        .meet(PlannedValues.<String>holdingAsOne("p", "r")
+                                .resolve(sets).values(), sets).isBottom(),
                 "and it is still stated once the values are worked out");
     }
 
@@ -268,8 +269,9 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     @Test
     void aConjunctionEmptiedByItsRelationHoldsNothingAndSaysWhat() {
         Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<String> both = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.heldApart("p", "r"), sets);
+        AdmissibleValues<String> both = PlannedValues.<String>holdingAsOne("p", "r")
+                .resolve(sets).values()
+                .meet(PlannedValues.<String>heldApart("p", "r").resolve(sets).values(), sets);
 
         assertTrue(both.isBottom(), "no value of these rules can be written");
 

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -141,9 +141,8 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertTrue(planned.meet(PlannedValues.holdingAsOne("p", "r"))
                         .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
                 "the choice states it, so an equality read beside it refuses");
-        assertTrue(planned.resolve(sets).values()
-                        .meet(PlannedValues.<String>holdingAsOne("p", "r")
-                                .resolve(sets).values(), sets).isBottom(),
+        assertTrue(built(planned, sets)
+                        .meet(built(PlannedValues.holdingAsOne("p", "r"), sets), sets).isBottom(),
                 "and it is still stated once the values are worked out");
     }
 
@@ -269,9 +268,8 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     @Test
     void aConjunctionEmptiedByItsRelationHoldsNothingAndSaysWhat() {
         Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<String> both = PlannedValues.<String>holdingAsOne("p", "r")
-                .resolve(sets).values()
-                .meet(PlannedValues.<String>heldApart("p", "r").resolve(sets).values(), sets);
+        AdmissibleValues<String> both = built(PlannedValues.holdingAsOne("p", "r"), sets)
+                .meet(built(PlannedValues.heldApart("p", "r"), sets), sets);
 
         assertTrue(both.isBottom(), "no value of these rules can be written");
 
@@ -746,6 +744,12 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertInstanceOf(Apartness.Reduction.NotKnown.class,
                 even.reduce((block, _) -> new Admits.These(block.equals(P0) ? three : two)),
                 "and one value more at one block is one assignment too many");
+    }
+
+    /** A description worked out, which is how a reading is come by. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned,
+                                                  Allowance<String> sets) {
+        return planned.resolve(sets).values();
     }
 
     /** A relation nothing stated is one nothing refuses. */

--- a/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
@@ -123,7 +123,7 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
     void aPositionBesideThemKeepsItsOwnAnswer() {
         AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ONE)));
         AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ZERO)));
-        AdmissibleValues<String> apart = AdmissibleValues.at(C, ValueSet.just(ZERO));
+        AdmissibleValues<String> apart = built(plans(C, ZERO));
 
         AdmissibleValues<String> all = one.meet(two, sets).meet(apart, sets);
 

--- a/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
@@ -33,8 +33,8 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      *  nothing is built and no allowance is spent. */
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
-    private static AdmissibleValues<String> says(String atom, Value value) {
-        return AdmissibleValues.at(atom, ValueSet.just(value));
+    private AdmissibleValues<String> says(String atom, Value value) {
+        return built(plans(atom, value));
     }
 
     /** The same rule while it is still a description, which is where a choice between two of them
@@ -45,6 +45,11 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
 
     private static PlannedValues<String> unread(Set<String> named) {
         return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
+    }
+
+    /** A description worked out, which is how a reading is come by. */
+    private AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(sets).values();
     }
 
     /** A description worked out and told what its unread alternatives left open, which is what a
@@ -88,7 +93,7 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
     @Test
     void anUnreadRuleStatedBesideAnotherNarrowsNothing() {
         AdmissibleValues<String> both = says(VALUE, A)
-                .meet(AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), sets);
+                .meet(built(unread(Set.of())), sets);
         assertEquals(ValueSet.just(A), both.at(VALUE));
         assertFalse(both.isBottom());
         assertTrue(both.speaksFor(VALUE));
@@ -98,9 +103,7 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
     @Test
     void anUnreadRuleNamingAPositionLeavesItSpokenForByNothing() {
         AdmissibleValues<String> both =
-                says(VALUE, A).meet(
-                        AdmissibleValues.unreadable(Set.of(OTHER), UnreadReason.FORM_NOT_READ),
-                        sets);
+                says(VALUE, A).meet(built(unread(Set.of(OTHER))), sets);
         assertTrue(both.speaksFor(VALUE));
         assertFalse(both.speaksFor(OTHER));
         assertEquals(ValueSet.ANY, both.at(OTHER));
@@ -177,8 +180,8 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      */
     @Test
     void whatStoppedARuleIsHeldWithThePositionItNamed() {
-        AdmissibleValues<String> read =
-                AdmissibleValues.unreadable(Set.of(VALUE), UnreadReason.RELATES_TWO_POSITIONS);
+        AdmissibleValues<String> read = built(
+                PlannedValues.unreadable(Set.of(VALUE), UnreadReason.RELATES_TWO_POSITIONS));
 
         assertEquals(List.of(UnreadReason.RELATES_TWO_POSITIONS), read.whyUnread(VALUE));
         assertEquals(List.of(), read.whyUnread(OTHER),

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
@@ -49,6 +49,16 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
         return planned.resolve(by).values();
     }
 
+    /** One rule about one position, worked out. */
+    private static AdmissibleValues<String> says(String atom, Value value) {
+        return built(plans(atom, value), allowing());
+    }
+
+    /** An equality between two positions, worked out. */
+    private static AdmissibleValues<String> heldAsOne(String here, String there) {
+        return built(PlannedValues.holdingAsOne(here, there), allowing());
+    }
+
     /** Every coordinate this reading files an answer under. */
     private static Set<Sameness.Block<String>> filedUnder(AdmissibleValues<String> reading) {
         Set<Sameness.Block<String>> out = new LinkedHashSet<>(reading.guaranteed().keySet());
@@ -69,7 +79,7 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     /** A reading of one position is a product over that position, and files its answers there. */
     @Test
     void aReadingOfOnePositionIsAProductOverIt() {
-        AdmissibleValues<String> reading = AdmissibleValues.at("p", ValueSet.just(A));
+        AdmissibleValues<String> reading = says("p", A);
 
         assertTrue(reading.sameness().isDiscrete());
         assertEquals(Sameness.Block.of("p"), reading.blockOf("p"));
@@ -79,8 +89,8 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     /** An equality makes one block of two positions, and both of them answer in it. */
     @Test
     void anEqualityMakesTheCoordinateBothPositionsAnswerIn() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.at("p", ValueSet.just(A)), allowing());
+        AdmissibleValues<String> reading = heldAsOne("p", "r")
+                .meet(says("p", A), allowing());
 
         assertEquals(reading.blockOf("p"), reading.blockOf("r"));
         assertEquals(Set.of("p", "r"), reading.blockOf("p").members());
@@ -93,8 +103,8 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
      */
     @Test
     void whatIsStatedAtOneOfThemIsWhatTheOtherAdmits() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.at("p", ValueSet.just(A)), allowing());
+        AdmissibleValues<String> reading = heldAsOne("p", "r")
+                .meet(says("p", A), allowing());
 
         assertEquals(ValueSet.just(A), reading.at("r"));
         assertEquals(reading.at("p"), reading.at("r"));
@@ -103,9 +113,9 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     /** Two rules the equality cannot both hold leave the reading nothing, and say which places. */
     @Test
     void twoRulesOneValueCannotBothSatisfyLeaveNothing() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.at("p", ValueSet.just(A)), allowing())
-                .meet(AdmissibleValues.at("r", ValueSet.just(B)), allowing());
+        AdmissibleValues<String> reading = heldAsOne("p", "r")
+                .meet(says("p", A), allowing())
+                .meet(says("r", B), allowing());
 
         assertTrue(reading.isBottom());
         assertEquals(Set.of(Set.of("p", "r")),
@@ -117,9 +127,9 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
      *  them said into it. */
     @Test
     void aConjunctionCarriesEachSidesAnswersIntoTheCoarserRelation() {
-        AdmissibleValues<String> reading = AdmissibleValues.at("p", ValueSet.just(A))
-                .meet(AdmissibleValues.at("r", ValueSet.just(A)), allowing())
-                .meet(AdmissibleValues.holdingAsOne("p", "r"), allowing());
+        AdmissibleValues<String> reading = says("p", A)
+                .meet(says("r", A), allowing())
+                .meet(heldAsOne("p", "r"), allowing());
 
         assertEquals(Set.of("p", "r"), reading.blockOf("p").members());
         filedUnderItsOwn(reading);

--- a/souther-compiler/src/test/java/souther/compiler/values/HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest.java
@@ -83,7 +83,8 @@ class HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest {
                 List.of(1, 2, 0), List.of(2, 0, 1), List.of(2, 1, 0))) {
             Allowance<String> by = AsACompilationAllows.forAdmittedValues();
             List<AdmissibleValues<String>> read = List.of(related(false, by), related(true, by),
-                    AdmissibleValues.at("left", ValueSet.just(Value.text("x"))));
+                    PlannedValues.at("left", AdmittedPlan.of(ValueSet.just(Value.text("x"))))
+                            .resolve(by).values());
             AdmissibleValues<String> made =
                     AdmissibleValues.metAll(order.stream().map(read::get).toList(), by);
 

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -73,12 +73,12 @@ class ReadingsConjoinedAreNotMultipliedTest {
         ConjoinedAdmissibleValues<String> apart =
                 ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
                         .meet(ConjoinedAdmissibleValues.of(
-                                AdmissibleValues.at("c", just("x"))), SETS);
+                                says("c", just("x"))), SETS);
         assertEquals(2, apart.factors().size());
 
         ConjoinedAdmissibleValues<String> joined = apart.meet(ConjoinedAdmissibleValues.of(
-                AdmissibleValues.at("b", just("y"))
-                        .meet(AdmissibleValues.at("c", just("x")), SETS)), SETS);
+                says("b", just("y"))
+                        .meet(says("c", just("x")), SETS)), SETS);
 
         assertEquals(1, joined.factors().size(), "all three reach each other");
         assertEquals(Set.of("a", "b", "c"), joined.subjects());
@@ -92,8 +92,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
         ConjoinedAdmissibleValues<String> both =
                 ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
                         .meet(ConjoinedAdmissibleValues.of(
-                                AdmissibleValues.at("c", just("x"))
-                                        .meet(AdmissibleValues.at("c", just("y")), SETS)), SETS);
+                                says("c", just("x"))
+                                        .meet(says("c", just("y")), SETS)), SETS);
 
         assertEquals(Emptiness.EMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY,
                 (_, _) -> new Apartness.Reduction.Standing<>()));
@@ -117,12 +117,11 @@ class ReadingsConjoinedAreNotMultipliedTest {
      */
     @Test
     void aComponentIsMetInTheOrderItsReadingsArrived() {
-        AdmissibleValues<String> named = AdmissibleValues.at("a", just("x"))
-                .meet(AdmissibleValues.at("b", just("y")), SETS);
-        AdmissibleValues<String> arrivedSecond =
-                AdmissibleValues.unreadable(Set.of("x"), UnreadReason.FORM_NOT_READ);
+        AdmissibleValues<String> named = says("a", just("x"))
+                .meet(says("b", just("y")), SETS);
+        AdmissibleValues<String> arrivedSecond = unread(Set.of("x"), UnreadReason.FORM_NOT_READ);
         AdmissibleValues<String> bridge =
-                AdmissibleValues.unreadable(Set.of("b", "x"), UnreadReason.RELATES_TWO_POSITIONS);
+                unread(Set.of("b", "x"), UnreadReason.RELATES_TWO_POSITIONS);
 
         ConjoinedAdmissibleValues<String> apart = ConjoinedAdmissibleValues.of(named)
                 .meet(ConjoinedAdmissibleValues.of(arrivedSecond), SETS);
@@ -174,9 +173,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
         assertFalse(nothing.hasReadings());
 
         ConjoinedAdmissibleValues<String> overOneVocabulary =
-                ConjoinedAdmissibleValues.of(AdmissibleValues.at("x", just("A")))
-                        .meet(ConjoinedAdmissibleValues.of(
-                                AdmissibleValues.at("x", just("B"))), SETS);
+                ConjoinedAdmissibleValues.of(says("x", just("A")))
+                        .meet(ConjoinedAdmissibleValues.of(says("x", just("B"))), SETS);
 
         assertEquals(1, overOneVocabulary.factors().size(),
                 "two readings of one position are one factor");
@@ -263,6 +261,16 @@ class ReadingsConjoinedAreNotMultipliedTest {
 
     private static ValueSet just(String text) {
         return ValueSet.just(Value.text(text));
+    }
+
+    /** One rule about one position, worked out. */
+    private static AdmissibleValues<String> says(String atom, ValueSet set) {
+        return PlannedValues.at(atom, AdmittedPlan.of(set)).resolve(SETS).values();
+    }
+
+    /** A rule nothing could read, worked out. */
+    private static AdmissibleValues<String> unread(Set<String> named, UnreadReason why) {
+        return PlannedValues.unreadable(named, why).resolve(SETS).values();
     }
 
     private static int alternativesOf(AdmissibleValues<String> read) {

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
@@ -48,8 +48,11 @@ class WhatAConjunctionCostsIsTheComposersToSayTest {
      * and there would be no purse to tell apart.
      */
     private static ConjoinedAdmissibleValues<String> everyMultipleOf(int every) {
-        return ConjoinedAdmissibleValues.of(AdmissibleValues.at("here",
-                ValueSet.matching(language("(?:[0-9]{" + every + "})+"))));
+        return ConjoinedAdmissibleValues.of(
+                PlannedValues.at("here",
+                                AdmittedPlan.of(ValueSet.matching(
+                                        language("(?:[0-9]{" + every + "})+"))))
+                        .resolve(AsACompilationAllows.forAdmittedValues()).values());
     }
 
     private static Language language(String regex) {

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingCanPromiseAboutItsProjectionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingCanPromiseAboutItsProjectionsTest.java
@@ -39,8 +39,9 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
     private static final Value ZERO = Value.text("0");
     private static final Value ONE = Value.text("1");
 
+    /** One rule worked out, which is how a reading of one position is come by. */
     private static AdmissibleValues<String> says(String atom, Value value) {
-        return AdmissibleValues.at(atom, ValueSet.just(value));
+        return built(plans(atom, value));
     }
 
     /** What puts the sets of these readings together. Every set here is values written out, so
@@ -145,7 +146,7 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
     void aPositionNoLostCorrelationReachesKeepsItsPromise() {
         AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE)));
         AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLive(pair(SIX, ZERO)));
-        AdmissibleValues<String> apart = AdmissibleValues.at(C, ValueSet.just(ZERO));
+        AdmissibleValues<String> apart = says(C, ZERO);
 
         AdmissibleValues<String> all = one.meet(two, SETS).meet(apart, SETS);
 

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
@@ -43,11 +43,11 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
     private static final Allowance<String> SETS = AsACompilationAllows.forAdmittedValues();
 
     private static AdmissibleValues<String> says(String atom, Value value) {
-        return AdmissibleValues.at(atom, ValueSet.just(value));
+        return built(plans(atom, value));
     }
 
     private static AdmissibleValues<String> unreadable(Set<String> named) {
-        return AdmissibleValues.unreadable(named, UnreadReason.FORM_NOT_READ);
+        return built(plansUnreadable(named));
     }
 
     private static Arguments made(String how, AdmissibleValues<String> state) {
@@ -101,9 +101,9 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
                         built(plans(VALUE, A).meet(plans(OTHER, A))
                                 .joinLive(plans(VALUE, B).meet(plans(OTHER, B))))
                                 .meet(says(VALUE, A), SETS)),
-                made("heldApart", AdmissibleValues.heldApart(VALUE, OTHER)),
+                made("heldApart", built(PlannedValues.heldApart(VALUE, OTHER))),
                 made("meet with heldApart",
-                        says(VALUE, A).meet(AdmissibleValues.heldApart(VALUE, OTHER), SETS)),
+                        says(VALUE, A).meet(built(PlannedValues.heldApart(VALUE, OTHER)), SETS)),
                 made("join with heldApart",
                         built(plans(VALUE, A).joinLive(PlannedValues.heldApart(VALUE, OTHER)))),
                 made("join nested under a join",
@@ -146,7 +146,7 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
      */
     @Test
     void aPositionHeldApartFromAnotherIsGuaranteedNothing() {
-        AdmissibleValues<String> apart = AdmissibleValues.heldApart(VALUE, OTHER);
+        AdmissibleValues<String> apart = built(PlannedValues.heldApart(VALUE, OTHER));
 
         assertEquals(ValueSet.NONE, apart.guaranteedAt(VALUE));
         assertEquals(ValueSet.NONE, apart.guaranteedAt(OTHER));
@@ -163,7 +163,8 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
 
     static Stream<Arguments> admittingNothing() {
         return Stream.of(
-                made("a position left no value", AdmissibleValues.at(VALUE, ValueSet.NONE)),
+                made("a position left no value",
+                        built(PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.NONE)))),
                 made("two rules leaving nothing", says(VALUE, A).meet(says(VALUE, B), SETS)),
                 made("a meet under a wider one",
                         says(OTHER, A).meet(says(VALUE, A), SETS).meet(says(VALUE, B), SETS)),
@@ -217,8 +218,7 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
         assertTrue(state.meet(says(OTHER, B), SETS).guaranteedTogether(),
                 "met with a rule about one position");
         assertTrue(state.meet(state, SETS).guaranteedTogether(), "and met with itself");
-        assertTrue(state.meet(AdmissibleValues.<String>unreadable(Set.of(VALUE),
-                UnreadReason.FORM_NOT_READ), SETS).guaranteedTogether(),
+        assertTrue(state.meet(unreadable(Set.of(VALUE)), SETS).guaranteedTogether(),
                 "and met with a rule nothing could read");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest.java
@@ -28,11 +28,25 @@ class WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest {
         return AsACompilationAllows.forAdmittedValues();
     }
 
+    /** A description worked out, which is how a reading is come by. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(allowing()).values();
+    }
+
+    /** An equality between two positions, worked out. */
+    private static AdmissibleValues<String> heldAsOne(String here, String there) {
+        return built(PlannedValues.holdingAsOne(here, there));
+    }
+
+    /** A rule nothing could read, worked out. */
+    private static AdmissibleValues<String> unread(Set<String> named, UnreadReason why) {
+        return built(PlannedValues.unreadable(named, why));
+    }
+
     /** A rule nothing could read at one position, beside an equality holding it with another. */
     private static AdmissibleValues<String> unreadAtOneOfAPair() {
-        return AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.unreadable(Set.of("p"), UnreadReason.FORM_NOT_READ),
-                        allowing());
+        return heldAsOne("p", "r")
+                .meet(unread(Set.of("p"), UnreadReason.FORM_NOT_READ), allowing());
     }
 
     /** The position the rule was written at is one the reading does not speak for. */
@@ -92,7 +106,7 @@ class WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest {
      */
     @Test
     void whetherWhatStandsIsExactIsTheBlocksAnswer() {
-        AdmissibleValues<String> reading = AdmissibleValues.holdingAsOne("p", "r");
+        AdmissibleValues<String> reading = heldAsOne("p", "r");
         Sameness.Block<String> block = reading.blockOf("p");
 
         AdmissibleValues<String> wide = new AdmissibleValues<>(reading.held(),
@@ -115,11 +129,9 @@ class WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest {
      */
     @Test
     void reasonsAtSeveralPositionsAreReadInTheOrderTheRulesWereWritten() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.unreadable(Set.of("r"),
-                        UnreadReason.RELATES_TWO_POSITIONS), allowing())
-                .meet(AdmissibleValues.unreadable(Set.of("p"),
-                        UnreadReason.FORM_NOT_READ), allowing());
+        AdmissibleValues<String> reading = heldAsOne("p", "r")
+                .meet(unread(Set.of("r"), UnreadReason.RELATES_TWO_POSITIONS), allowing())
+                .meet(unread(Set.of("p"), UnreadReason.FORM_NOT_READ), allowing());
 
         assertEquals(List.of(UnreadReason.RELATES_TWO_POSITIONS, UnreadReason.FORM_NOT_READ),
                 reading.whyUnread("p"), "the rule about r was written first");
@@ -130,11 +142,9 @@ class WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest {
     /** And the other way round, so the order is the rules' and not the positions'. */
     @Test
     void andTheOtherWayRoundWhenTheRulesAreWrittenTheOtherWayRound() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.unreadable(Set.of("p"),
-                        UnreadReason.FORM_NOT_READ), allowing())
-                .meet(AdmissibleValues.unreadable(Set.of("r"),
-                        UnreadReason.RELATES_TWO_POSITIONS), allowing());
+        AdmissibleValues<String> reading = heldAsOne("p", "r")
+                .meet(unread(Set.of("p"), UnreadReason.FORM_NOT_READ), allowing())
+                .meet(unread(Set.of("r"), UnreadReason.RELATES_TWO_POSITIONS), allowing());
 
         assertEquals(List.of(UnreadReason.FORM_NOT_READ, UnreadReason.RELATES_TWO_POSITIONS),
                 reading.whyUnread("p"));

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatSeveralReadingsCostDoesNotTurnOnWhichArrivedFirstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatSeveralReadingsCostDoesNotTurnOnWhichArrivedFirstTest.java
@@ -37,9 +37,15 @@ class WhatSeveralReadingsCostDoesNotTurnOnWhichArrivedFirstTest {
      */
     private static AdmissibleValues<String> matching(String regex) {
         PatternRead said = PatternParser.read(regex);
-        return AdmissibleValues.at("value", ValueSet.matching(
+        return built(PlannedValues.at("value", AdmittedPlan.of(ValueSet.matching(
                 PatternPlan.of(assertInstanceOf(PatternRead.Read.class, said).syntax())
-                        .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter())));
+                        .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter())))));
+    }
+
+    /** A description worked out, which is how a reading is come by. The machine is compiled
+     *  above, so working this out builds nothing and spends nothing. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(AsACompilationAllows.forAdmittedValues()).values();
     }
 
     private static List<AdmissibleValues<String>> readings() {
@@ -100,7 +106,7 @@ class WhatSeveralReadingsCostDoesNotTurnOnWhichArrivedFirstTest {
     /** The same reading, with a rule about another position that it could not read. */
     private static AdmissibleValues<String> alsoUnread(AdmissibleValues<String> read,
                                                        UnreadReason why) {
-        return read.meet(AdmissibleValues.unreadable(java.util.Set.of("elsewhere"), why),
+        return read.meet(built(PlannedValues.unreadable(java.util.Set.of("elsewhere"), why)),
                 AsACompilationAllows.forAdmittedValues());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest.java
@@ -39,13 +39,15 @@ class WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest {
     private static final Value ZERO = Value.number(0);
     private static final Value ONE = Value.number(1);
 
-    private static AdmissibleValues<String> at(String atom, Value value) {
-        return AdmissibleValues.at(atom, ValueSet.just(value));
-    }
-
     /** What puts the sets of one reading together. Every set here is written out, so nothing is
      *  built and no allowance is spent. */
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+
+    /** One rule about one position, worked out. */
+    private AdmissibleValues<String> at(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)))
+                .resolve(sets).values();
+    }
 
     private AdmissibleValues<String> pair(Value a, Value b) {
         return at(A, a).meet(at(B, b), sets);


### PR DESCRIPTION
Closes #1423.

A rule of the model is written down as a description and becomes values by being worked out, which
is what `PlannedValues.resolve` is. `AdmissibleValues` published the other way as well: a reading of
one position, of two positions held as one value, of two held apart, and of a rule nothing could
read, each made straight out of what the rule said. Read off the class files, no compile reached any
of them, and neither did the question about which positions a reading narrowed — every consumer of
that asks the description instead.

A leaf minted beside `resolve` leaves out what working one out settles: what the allowance let it
build, and what it went short of. A caller is then handed a reading whose every position looks
worked out and whose shortfall was never asked about. That is a reading no compile produces, and it
is what the tests moved by #1417 came to be written against — one of them met a resolved reading
with a minted one, so the two sides of the same conjunction had different provenance and only one
of them had been through resolution.

The tests that wanted a reading now build one the way a compile does, through
`AdmittedPlan.of(...)` and `resolve`, which is the boundary an already-built set is meant to cross.

## What is fixed, and what is not

The closed sentence is not that a reading of values can only be made by `resolve`. `top` and `meet`
are reached from the compiler and make readings on this side of it, by design: a conjunction of
readings already worked out is what a declaration's clauses come to. What is closed is narrower and
is the thing #1423 is about — there is no second vocabulary for introducing a rule of the values as
a leaf.

So the guard states the whole of what may make a reading rather than the names now gone: handed
nothing, handed a reading already worked out, or handed a description. The warrant on each row is
computed from the signature rather than declared beside it, so a maker cannot be written down as
something it is not. Two mutations were run against it — a leaf taking a set of values, and one
taking only positions — and the second is why the empty hand is read off the parameter list rather
than off the classes the parameters name.

`AdmissibleValues` stays a record with a public canonical constructor, and this does not close that.
A test still writes one out directly where it wants a reading with one component changed. Fixing the
vocabulary and confining the representation are two changes, and only the first is #1423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)