### PR TITLE
Let a reading be reached by reading something

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -51,11 +51,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the shape a compiler can never make and a test can, which is how tests came to be written against
  * readings the fold does not build.
  *
- * <p><b>What this does not say.</b> {@code AdmissibleValues} is a record with a public canonical
- * constructor, and this leaves that where it is: what is fixed here is the vocabulary a reading is
- * made by, not the representation. Composing two readings already worked out is not narrowed
- * either — a conjunction of them is what a declaration's clauses come to, and it is on this side of
- * {@code resolve} by design.
+ * <p><b>What this does not say.</b> Composing two readings already worked out is not narrowed here
+ * — a conjunction of them is what a declaration's clauses come to, and it is on this side of
+ * working one out by design. The representation is not this rule's either: that a reading is not
+ * written down from its parts is held by the type, whose parts are its own and whose one
+ * constructor takes them as one thing ({@code AdmissibleValues}). What the two say together is why
+ * neither leaves a gap — a maker handed the parts would be found here whatever it was called, and a
+ * maker handed a position or a set of values is what this refuses.
  *
  * <p>Read off the compiled classes, since a construction reached through a method reference makes a
  * reading as surely as one written out, and neither the enclosing declaration nor a switch over a
@@ -92,8 +94,9 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
      * <p>The four inside {@code AdmissibleValues} are the conjunction, the renaming, what a choice
      * left open and the writing down of the order the rules were read in, each handed the reading
      * it is composing — as {@code this}, which is a reading in hand as much as an argument is.
-     * {@code top} is handed nothing. {@code resolved} is the one place a description becomes
-     * values, and is the only maker outside the type.
+     * {@code top} is handed nothing. {@code realize} is the one place a description becomes values,
+     * and it is the reading's own: it is handed the description and the allowance and does the
+     * building, rather than being handed what the building would have left.
      *
      * <p>{@code metAll} is not here, and that it is not is the reading holding: a conjunction of
      * several is written as one meet after another, so it makes nothing of its own.
@@ -114,14 +117,14 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
             row(READING, "meet",
                     "(" + held(READING) + held(VALUES + "Allowance") + ")" + held(READING),
                     COMPOSED),
+            row(READING, "realize",
+                    "(" + held(DESCRIPTION + "$Settled") + held(VALUES + "Allowance") + ")"
+                            + held(VALUES + "Realized"),
+                    WORKED_OUT),
             row(READING, "renamed", "(Ljava/util/function/Function;)" + held(READING), COMPOSED),
             row(READING, "sayingWhatWasReadInTheOrderOf",
                     "(Ljava/util/List;)" + held(READING), COMPOSED),
-            row(READING, "top", "()" + held(READING), A_START),
-            row(DESCRIPTION, "resolved",
-                    "(" + held(DESCRIPTION + "$Settled") + held(VALUES + "Allowance") + ")"
-                            + held(VALUES + "Realized"),
-                    WORKED_OUT));
+            row(READING, "top", "()" + held(READING), A_START));
 
     @Test
     void everyMakerOfAReadingOfValuesWasHandedOneOrADescriptionOrNothing() {

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -673,8 +672,7 @@ sealed interface Confinement<A> {
         /** A reading whose positions were all worked out, beside the ranges they stop at. */
         static <A> Worked<A> of(AdmissibleValues<A> values, OrderedIntervals<A> ordered,
                                 Map<A, Carrier> carriers) {
-            return new Worked<>(new Realized<>(values, Set.of(), List.of()), ordered, carriers,
-                    null);
+            return new Worked<>(Realized.workedOut(values), ordered, carriers, null);
         }
 
         Realized<A> made() {
@@ -695,8 +693,7 @@ sealed interface Confinement<A> {
          */
         Worked<A> alsoOpenedAt(Set<A> these) {
             return these.isEmpty() ? this
-                    : new Worked<>(new Realized<>(made.values().alsoOpenedAt(these),
-                            made.aboutARule(), made.aboutTheAnswer()), ordered, carriers, shown);
+                    : new Worked<>(made.alsoOpenedAt(these), ordered, carriers, shown);
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -669,12 +669,6 @@ sealed interface Confinement<A> {
             this.shown = shown;
         }
 
-        /** A reading whose positions were all worked out, beside the ranges they stop at. */
-        static <A> Worked<A> of(AdmissibleValues<A> values, OrderedIntervals<A> ordered,
-                                Map<A, Carrier> carriers) {
-            return new Worked<>(Realized.workedOut(values), ordered, carriers, null);
-        }
-
         Realized<A> made() {
             return made;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -9,19 +9,14 @@ import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.ConjoinedAdmissibleValues;
 import souther.compiler.values.StringMachineAnswers;
-import souther.compiler.values.Refusal;
-import souther.compiler.values.RelationalLack;
 
 import java.lang.reflect.RecordComponent;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedMap;
-import java.util.Set;
 
 /**
  * What the rules say, in each of the languages this reading has for saying it.
@@ -278,196 +273,13 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
     public Optional<Emptiness> holdsNothing(SequencedMap<A, Emptiness.AtAField.Where> positions,
                                             StringMachineAnswers machines) {
         Confinement.Admission<A> shown = admitted(machines);
+        // What can be said whatever the readings show, which the nearer sentences are preferred to.
         Emptiness why = shownByAnother() || shown.holdsNothing()
                 ? new Emptiness.ConflictingRules() : null;
-        // A position whose ends cross, which is nearer than the general form: it says not only that
-        // the rules contradict but where they leave nothing.
-        //
-        // Only where there is a position to name. A state can hold nothing without any one position
-        // being what holds nothing — a choice every alternative of which is impossible is one, and
-        // the alternatives may fail at different positions — and the particular proof is particular
-        // by naming a place. Written without one, the sentence read off it would name whatever place
-        // the reader happened to be at, which is the declaration's own value.
-        //
-        // And the set of values and the range sharing none, which is the same kind of proof about
-        // the pair rather than about one of them. Written only where the pair is what holds nothing:
-        // a state the numbers refuse is refused by the numbers, whatever the sets and the ranges
-        // leave beside them.
-        //
-        // And where what showed it is those readings met with what is required of the positions
-        // elsewhere, the proof says that and not which of them the range came from. Which reading
-        // left the pair nothing is a question about the pair, and this is an answer neither of them
-        // reached: the values a position is allowed and the bounds the rules require it to be within
-        // share nothing.
-        Emptiness said = shown.byTheReadings() ? switch (shown.by()) {
-            case ORDER -> new Emptiness.EmptyOrderedInterval();
-            case SET_AND_RANGE -> new Emptiness.NoAllowedValueInRange();
-            case POSITIONS_HELD_AS_ONE -> new Emptiness.NoCommonValueForEqualPositions();
-            // Which of the arguments a relation refuses by is the witness's to say, and the two are
-            // two sentences: one is about how many values there are and the other about nothing of
-            // the kind.
-            case POSITIONS_HELD_APART -> shown.site().together()
-                    .all(lack -> lack instanceof RelationalLack.ABlockApartFromItself)
-                    ? new Emptiness.PositionsHeldAsOneAreHeldApart()
-                    : new Emptiness.NoDistinctValuesForPositionsHeldApart();
-            case NOTHING_SHOWN, VALUES, RULES_TOGETHER -> null;
-        } : new Emptiness.NoAllowedValueWithinRequiredBounds();
-        if (said == null) {
-            return Optional.ofNullable(why);
-        }
-        // Positions stated to differ, which is a lack about all of them at once and at none of
-        // them. Said as its own place rather than through the one below: that one names the block
-        // whose positions are one value, and these positions are not one value — read through it,
-        // a proof would say the rules hold them as one, which is what they state they are not.
-        if (shown.site().nearest() == Refusal.Nearest.OF_THEM_TOGETHER) {
-            List<Emptiness.AtAField.Where> apart =
-                    declaredIn(shown.site().together().blocks(), positions);
-            return Optional.of(apart.size() < 2 ? Emptiness.preferred(why, said)
-                    : Emptiness.preferred(why, new Emptiness.AtPositionsHeldApart(apart, said)));
-        }
-        // One block of the proof is named, and it is named as what it is: a place where it is one
-        // position, and the positions together where it is several.
-        //
-        // One and not all of them. Two blocks left nothing are two lacks, and a sentence over both
-        // would say their positions are one value — a relation no rule of the model states. Which
-        // one is settled by the order the value declares its positions, as which of several empty
-        // positions is named is: read off the state's own set, the block named would be the one
-        // whose clause was met first, and moving a clause would move the refusal.
-        //
-        // And read off the blocks each of which holds nothing, which is what this sentence is
-        // about. A refusal also carries what no assignment to some blocks satisfies, and each of
-        // those blocks is left values of its own — named here, a reader would be sent to a place
-        // whose own rules are fine with what they leave it, and which of the two a proof was about
-        // would turn on which the value declares first.
-        List<Emptiness.AtAField.Where> where = nearestBlock(shown.site().atEachOf(), positions);
-        if (where.size() == 1) {
-            return Optional.of(Emptiness.preferred(why,
-                    new Emptiness.AtAField(where.getFirst(), said)));
-        }
-        if (where.size() > 1) {
-            return Optional.of(Emptiness.preferred(why,
-                    new Emptiness.AtEqualPositions(where, said)));
-        }
-        // No position to name, which is what a choice refused at two of them leaves: each of them
-        // holds values some alternative stands at, so what was shown is about the whole product.
-        //
-        // Only where what was shown is true of the pair rather than of one position. A range with
-        // nothing in it is a position's own answer and is said of that position or not at all —
-        // written without one, the sentence read off it would name whatever place the reader
-        // happened to be at, which is the declaration's own value.
-        return Optional.of(!shown.byTheReadings()
-                || shown.by() == Confinement.EmptyBy.SET_AND_RANGE
-                ? Emptiness.preferred(why, said) : why);
-    }
-
-    /**
-     * The places of the block whose earliest position the value declares first, in that order.
-     *
-     * <p>One block and not the union of them. What each of these says is that the positions in it
-     * are one value and that value has none, which is a lack per block — read together, a
-     * declaration whose {@code p == q} and whose {@code r == s} are each contradictory would be
-     * told that all four are one value, which no rule of it says.
-     *
-     * <p>Empty where no block's positions are all declared here, which is a block about subjects
-     * this value does not name. What can be said then is what the general proof says.
-     */
-    private static <A> List<Emptiness.AtAField.Where> nearestBlock(
-            Set<souther.compiler.values.Sameness.Block<A>> blocks,
-            SequencedMap<A, Emptiness.AtAField.Where> positions) {
-        Map<A, Integer> ordinal = new LinkedHashMap<>();
-        positions.keySet().forEach(each -> ordinal.put(each, ordinal.size()));
-        List<Integer> nearest = null;
-        souther.compiler.values.Sameness.Block<A> chosen = null;
-        for (souther.compiler.values.Sameness.Block<A> block : blocks) {
-            List<Integer> where = declared(block, ordinal);
-            // A block one of whose positions this value does not declare is one no sentence can be
-            // written about, and it says nothing about the blocks beside it.
-            if (where != null && (nearest == null || earlier(where, nearest))) {
-                nearest = where;
-                chosen = block;
-            }
-        }
-        if (chosen == null) {
-            return List.of();
-        }
-        souther.compiler.values.Sameness.Block<A> named = chosen;
-        List<Emptiness.AtAField.Where> out = new ArrayList<>();
-        positions.forEach((position, place) -> {
-            if (named.holds(position)) {
-                out.add(place);
-            }
-        });
-        return out;
-    }
-
-    /**
-     * Where the value declares the positions of every one of {@code blocks}, in that order.
-     *
-     * <p>All of them and not one, which is what parts this from {@link #nearestBlock}. A lack about
-     * blocks together is one lack about all of them, so every place it names is part of the
-     * sentence; there is no choosing between them, and dropping one would say the rules refuse
-     * fewer positions than they do.
-     *
-     * <p>Empty where the value declares none of one of those positions, which is a lack about
-     * subjects it does not name. What can be said then is what the general proof says.
-     */
-    private static <A> List<Emptiness.AtAField.Where> declaredIn(
-            Set<souther.compiler.values.Sameness.Block<A>> blocks,
-            SequencedMap<A, Emptiness.AtAField.Where> positions) {
-        Set<A> named = new java.util.LinkedHashSet<>();
-        for (souther.compiler.values.Sameness.Block<A> block : blocks) {
-            for (A member : block.members()) {
-                if (!positions.containsKey(member)) {
-                    return List.of();
-                }
-                named.add(member);
-            }
-        }
-        List<Emptiness.AtAField.Where> out = new ArrayList<>();
-        positions.forEach((position, place) -> {
-            if (named.contains(position)) {
-                out.add(place);
-            }
-        });
-        return out;
-    }
-
-    /** Where the value declares each of a block's positions, in that order, or null where it
-     *  declares none of one of them. */
-    private static <A> List<Integer> declared(souther.compiler.values.Sameness.Block<A> block,
-                                              Map<A, Integer> ordinal) {
-        List<Integer> out = new ArrayList<>();
-        for (A member : block.members()) {
-            Integer at = ordinal.get(member);
-            if (at == null) {
-                return null;
-            }
-            out.add(at);
-        }
-        out.sort(Comparator.naturalOrder());
-        return out;
-    }
-
-    /**
-     * Whether one block is declared before another, comparing the places they are at.
-     *
-     * <p>Every place and not the first of them. Two blocks may begin at one position — a state left
-     * with no value at {@code p} with {@code q} and at {@code p} with {@code r} has both, since
-     * what is carried is one witness per way the rules were shown empty and not a partition — and
-     * a reader that stopped at the first would pick whichever of them a set happened to iterate to.
-     * Which is an order salted per run of the machine, so one model would be refused two ways.
-     *
-     * <p>A total order over the blocks a value can name, since two of them made of declared
-     * positions are the same block wherever their places are the same. Shorter first where one is
-     * the beginning of the other, which is the only pair the places do not tell apart.
-     */
-    private static boolean earlier(List<Integer> these, List<Integer> those) {
-        for (int at = 0; at < Math.min(these.size(), those.size()); at++) {
-            if (!these.get(at).equals(those.get(at))) {
-                return these.get(at) < those.get(at);
-            }
-        }
-        return these.size() < those.size();
+        // Which proof holds is what this state answers; what it is called in a value declaring
+        // these positions is {@link ProofOfEmptiness}'s, and is about what a proof can say rather
+        // than about the walk that reached this one.
+        return ProofOfEmptiness.named(shown, positions, why);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/ProofOfEmptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ProofOfEmptiness.java
@@ -1,0 +1,240 @@
+package souther.compiler.check;
+
+import souther.compiler.values.RelationalLack;
+import souther.compiler.values.Refusal;
+import souther.compiler.values.Sameness;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SequencedMap;
+import java.util.Set;
+
+/**
+ * The sentence a reader is told, written from what a state was shown empty by.
+ *
+ * <p>Two questions, and this is the second of them. Which proof holds is a question about a state
+ * and is settled by walking it ({@link ConstraintState}); how that proof is named is a question
+ * about the declaration whose positions it is about, and it is settled here. A proof arrives as
+ * what it is — what emptied the pair, and where — and what comes back is what can be said about it
+ * in a value that declares these positions in this order.
+ *
+ * <p><b>Answered for every proof, and not only for the ones a walk reaches today.</b> What arrives
+ * is a {@link Confinement.Admission}, and the rules below are about what one of those can say: a
+ * lack at several blocks, a lack about blocks together, one at a block of subjects the value does
+ * not name. Which of those a walk of a state happens to produce is that walk's business and moves
+ * as the compiler learns to show more — the naming has to be right about each of them the day it
+ * arrives, so it is settled from the proof and never from where the proof came from.
+ */
+final class ProofOfEmptiness {
+
+    private ProofOfEmptiness() {
+    }
+
+    /**
+     * What is said about a state shown to hold nothing, or nothing where it was not shown.
+     *
+     * @param shown what emptied the pair of readings, and where
+     * @param positions where the value declares each of its positions, in the order it declares
+     *                  them — which is what settles the naming wherever a proof names several
+     *                  blocks
+     * @param general what can be said whatever the readings show, or null where nothing showed the
+     *                state empty. The nearer sentences below are preferred to it where there is
+     *                one to write
+     */
+    static <A> Optional<Emptiness> named(Confinement.Admission<A> shown,
+                                         SequencedMap<A, Emptiness.AtAField.Where> positions,
+                                         Emptiness general) {
+        // A position whose ends cross, which is nearer than the general form: it says not only that
+        // the rules contradict but where they leave nothing.
+        //
+        // Only where there is a position to name. A state can hold nothing without any one position
+        // being what holds nothing — a choice every alternative of which is impossible is one, and
+        // the alternatives may fail at different positions — and the particular proof is particular
+        // by naming a place. Written without one, the sentence read off it would name whatever place
+        // the reader happened to be at, which is the declaration's own value.
+        //
+        // And the set of values and the range sharing none, which is the same kind of proof about
+        // the pair rather than about one of them. Written only where the pair is what holds nothing:
+        // a state the numbers refuse is refused by the numbers, whatever the sets and the ranges
+        // leave beside them.
+        //
+        // And where what showed it is those readings met with what is required of the positions
+        // elsewhere, the proof says that and not which of them the range came from. Which reading
+        // left the pair nothing is a question about the pair, and this is an answer neither of them
+        // reached: the values a position is allowed and the bounds the rules require it to be within
+        // share nothing.
+        Emptiness said = shown.byTheReadings() ? switch (shown.by()) {
+            case ORDER -> new Emptiness.EmptyOrderedInterval();
+            case SET_AND_RANGE -> new Emptiness.NoAllowedValueInRange();
+            case POSITIONS_HELD_AS_ONE -> new Emptiness.NoCommonValueForEqualPositions();
+            // Which of the arguments a relation refuses by is the witness's to say, and the two are
+            // two sentences: one is about how many values there are and the other about nothing of
+            // the kind.
+            case POSITIONS_HELD_APART -> shown.site().together()
+                    .all(lack -> lack instanceof RelationalLack.ABlockApartFromItself)
+                    ? new Emptiness.PositionsHeldAsOneAreHeldApart()
+                    : new Emptiness.NoDistinctValuesForPositionsHeldApart();
+            case NOTHING_SHOWN, VALUES, RULES_TOGETHER -> null;
+        } : new Emptiness.NoAllowedValueWithinRequiredBounds();
+        if (said == null) {
+            return Optional.ofNullable(general);
+        }
+        // Positions stated to differ, which is a lack about all of them at once and at none of
+        // them. Said as its own place rather than through the one below: that one names the block
+        // whose positions are one value, and these positions are not one value — read through it,
+        // a proof would say the rules hold them as one, which is what they state they are not.
+        if (shown.site().nearest() == Refusal.Nearest.OF_THEM_TOGETHER) {
+            List<Emptiness.AtAField.Where> apart =
+                    declaredIn(shown.site().together().blocks(), positions);
+            return Optional.of(apart.size() < 2 ? Emptiness.preferred(general, said)
+                    : Emptiness.preferred(general, new Emptiness.AtPositionsHeldApart(apart, said)));
+        }
+        // One block of the proof is named, and it is named as what it is: a place where it is one
+        // position, and the positions together where it is several.
+        //
+        // One and not all of them. Two blocks left nothing are two lacks, and a sentence over both
+        // would say their positions are one value — a relation no rule of the model states. Which
+        // one is settled by the order the value declares its positions, as which of several empty
+        // positions is named is: read off the state's own set, the block named would be the one
+        // whose clause was met first, and moving a clause would move the refusal.
+        //
+        // And read off the blocks each of which holds nothing, which is what this sentence is
+        // about. A refusal also carries what no assignment to some blocks satisfies, and each of
+        // those blocks is left values of its own — named here, a reader would be sent to a place
+        // whose own rules are fine with what they leave it, and which of the two a proof was about
+        // would turn on which the value declares first.
+        List<Emptiness.AtAField.Where> where = nearestBlock(shown.site().atEachOf(), positions);
+        if (where.size() == 1) {
+            return Optional.of(Emptiness.preferred(general,
+                    new Emptiness.AtAField(where.getFirst(), said)));
+        }
+        if (where.size() > 1) {
+            return Optional.of(Emptiness.preferred(general,
+                    new Emptiness.AtEqualPositions(where, said)));
+        }
+        // No position to name, which is what a choice refused at two of them leaves: each of them
+        // holds values some alternative stands at, so what was shown is about the whole product.
+        //
+        // Only where what was shown is true of the pair rather than of one position. A range with
+        // nothing in it is a position's own answer and is said of that position or not at all —
+        // written without one, the sentence read off it would name whatever place the reader
+        // happened to be at, which is the declaration's own value.
+        return Optional.of(!shown.byTheReadings()
+                || shown.by() == Confinement.EmptyBy.SET_AND_RANGE
+                ? Emptiness.preferred(general, said) : general);
+    }
+
+    /**
+     * The places of the block whose earliest position the value declares first, in that order.
+     *
+     * <p>One block and not the union of them. What each of these says is that the positions in it
+     * are one value and that value has none, which is a lack per block — read together, a
+     * declaration whose {@code p == q} and whose {@code r == s} are each contradictory would be
+     * told that all four are one value, which no rule of it says.
+     *
+     * <p>Empty where no block's positions are all declared here, which is a block about subjects
+     * this value does not name. What can be said then is what the general proof says.
+     */
+    private static <A> List<Emptiness.AtAField.Where> nearestBlock(
+            Set<Sameness.Block<A>> blocks,
+            SequencedMap<A, Emptiness.AtAField.Where> positions) {
+        Map<A, Integer> ordinal = new LinkedHashMap<>();
+        positions.keySet().forEach(each -> ordinal.put(each, ordinal.size()));
+        List<Integer> nearest = null;
+        Sameness.Block<A> chosen = null;
+        for (Sameness.Block<A> block : blocks) {
+            List<Integer> where = declared(block, ordinal);
+            // A block one of whose positions this value does not declare is one no sentence can be
+            // written about, and it says nothing about the blocks beside it.
+            if (where != null && (nearest == null || earlier(where, nearest))) {
+                nearest = where;
+                chosen = block;
+            }
+        }
+        if (chosen == null) {
+            return List.of();
+        }
+        Sameness.Block<A> named = chosen;
+        List<Emptiness.AtAField.Where> out = new ArrayList<>();
+        positions.forEach((position, place) -> {
+            if (named.holds(position)) {
+                out.add(place);
+            }
+        });
+        return out;
+    }
+
+    /**
+     * Where the value declares the positions of every one of {@code blocks}, in that order.
+     *
+     * <p>All of them and not one, which is what parts this from {@link #nearestBlock}. A lack about
+     * blocks together is one lack about all of them, so every place it names is part of the
+     * sentence; there is no choosing between them, and dropping one would say the rules refuse
+     * fewer positions than they do.
+     *
+     * <p>Empty where the value declares none of one of those positions, which is a lack about
+     * subjects it does not name. What can be said then is what the general proof says.
+     */
+    private static <A> List<Emptiness.AtAField.Where> declaredIn(
+            Set<Sameness.Block<A>> blocks,
+            SequencedMap<A, Emptiness.AtAField.Where> positions) {
+        Set<A> named = new LinkedHashSet<>();
+        for (Sameness.Block<A> block : blocks) {
+            for (A member : block.members()) {
+                if (!positions.containsKey(member)) {
+                    return List.of();
+                }
+                named.add(member);
+            }
+        }
+        List<Emptiness.AtAField.Where> out = new ArrayList<>();
+        positions.forEach((position, place) -> {
+            if (named.contains(position)) {
+                out.add(place);
+            }
+        });
+        return out;
+    }
+
+    /** Where the value declares each of a block's positions, in that order, or null where it
+     *  declares none of one of them. */
+    private static <A> List<Integer> declared(Sameness.Block<A> block, Map<A, Integer> ordinal) {
+        List<Integer> out = new ArrayList<>();
+        for (A member : block.members()) {
+            Integer at = ordinal.get(member);
+            if (at == null) {
+                return null;
+            }
+            out.add(at);
+        }
+        out.sort(Comparator.naturalOrder());
+        return out;
+    }
+
+    /**
+     * Whether one block is declared before another, comparing the places they are at.
+     *
+     * <p>Every place and not the first of them. Two blocks may begin at one position — a state left
+     * with no value at {@code p} with {@code q} and at {@code p} with {@code r} has both, since
+     * what is carried is one witness per way the rules were shown empty and not a partition — and
+     * a reader that stopped at the first would pick whichever of them a set happened to iterate to.
+     * Which is an order salted per run of the machine, so one model would be refused two ways.
+     *
+     * <p>A total order over the blocks a value can name, since two of them made of declared
+     * positions are the same block wherever their places are the same. Shorter first where one is
+     * the beginning of the other, which is the only pair the places do not tell apart.
+     */
+    private static boolean earlier(List<Integer> these, List<Integer> those) {
+        for (int at = 0; at < Math.min(these.size(), those.size()); at++) {
+            if (!these.get(at).equals(those.get(at))) {
+                return these.get(at) < those.get(at);
+            }
+        }
+        return these.size() < those.size();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -494,12 +494,13 @@ sealed interface StatedByClauses {
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
+            Set<FactSubject> bounded = range.boundedAt();
             return new Said(new Confinement.Planned<>(said, range, ordered.carriers()), new Part(
                     // Each language says whether it gave up on the leaf. The reading of values
                     // carries it; the reading of order has nothing to hand back but its ranges, and
                     // a leaf it read leaves at least one.
                     Adoption.at(mentions, said.adoptedAt(), values.gaveUpAt(e)),
-                    Adoption.at(mentions, range.boundedAt(), range.boundedAt().isEmpty()),
+                    Adoption.at(mentions, bounded, bounded.isEmpty()),
                     // And what the leaf states about the strings at a position, where it is a rule
                     // about them. Asked of the reading that recognises one, so this is where the
                     // answer enters and the connectives below are what compose it.

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -499,7 +499,7 @@ sealed interface StatedByClauses {
                     // carries it; the reading of order has nothing to hand back but its ranges, and
                     // a leaf it read leaves at least one.
                     Adoption.at(mentions, said.adoptedAt(), values.gaveUpAt(e)),
-                    Adoption.at(mentions, range.ranges().keySet(), range.ranges().isEmpty()),
+                    Adoption.at(mentions, range.boundedAt(), range.boundedAt().isEmpty()),
                     // And what the leaf states about the strings at a position, where it is a rule
                     // about them. Asked of the reading that recognises one, so this is where the
                     // answer enters and the connectives below are what compose it.

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -35,14 +35,36 @@ import java.util.Set;
  * is — so a rule comparing a date against a written one lands here, and one comparing two fields of
  * a record lands there. Both may hold the same rule about an {@code Int}, and neither is the other's
  * copy: what each of them can show is its own, and a contradiction shown anywhere is a contradiction.
+ *
+ * <p><b>The states are the ones these operations reach.</b> The two parts depend on each other —
+ * {@code nothing} says the whole is empty where no position is, and a position left an empty range
+ * says it where the whole need not carry it — so a pair of them written down side by side is a
+ * combination nothing read. What the parts are is this one's own; a caller reaches a state by doing
+ * to a reading what the state says was done to it.
  */
-public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothing) {
+public final class OrderedIntervals<A> {
 
-    public OrderedIntervals {
-        // Kept in the order the positions were read. What is written out of these has to come out
-        // the same on two runs of the compiler, and the iteration order of an immutable copy does
-        // not.
-        ranges = Collections.unmodifiableMap(new LinkedHashMap<>(ranges));
+    /**
+     * The parts, together, so that everything answered from all of them is answered from one place.
+     *
+     * <p>Equality and the parts a reader may be shown are the whole of what this is, and both of
+     * them are the record's. A part added here arrives in each of them the day it is declared, which
+     * is what keeps a state that differs from telling a caller it does not.
+     */
+    private record Parts<A>(Map<A, OrderedInterval> ranges, boolean nothing) {
+
+        private Parts {
+            // Kept in the order the positions were read. What is written out of these has to come
+            // out the same on two runs of the compiler, and the iteration order of an immutable
+            // copy does not.
+            ranges = Collections.unmodifiableMap(new LinkedHashMap<>(ranges));
+        }
+    }
+
+    private final Parts<A> parts;
+
+    private OrderedIntervals(Map<A, OrderedInterval> ranges, boolean nothing) {
+        this.parts = new Parts<>(ranges, nothing);
     }
 
     /** Nothing read, so every position holds every value its order has. */
@@ -55,14 +77,48 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
         return new OrderedIntervals<>(Map.of(position, range), false);
     }
 
+    private Map<A, OrderedInterval> ranges() {
+        return parts.ranges();
+    }
+
+    private boolean nothing() {
+        return parts.nothing();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof OrderedIntervals<?> it && parts.equals(it.parts);
+    }
+
+    @Override
+    public int hashCode() {
+        return parts.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return parts.toString();
+    }
+
+    /**
+     * The positions these rules bounded, which is what a caller asking what this took in is asking.
+     *
+     * <p>A rule read about a position leaves it a range, so a reading that bounded nothing is one
+     * that read nothing — which is the same question asked of the whole and is answered from the
+     * same set.
+     */
+    public Set<A> boundedAt() {
+        return ranges().keySet();
+    }
+
     /** What {@code position} is left, every value of its order where nothing was said. */
     public OrderedInterval at(A position) {
-        return ranges.getOrDefault(position, OrderedInterval.OPEN);
+        return ranges().getOrDefault(position, OrderedInterval.OPEN);
     }
 
     /** Whether nothing satisfies these rules, at a position or otherwise. */
     public boolean isBottom() {
-        return nothing || ranges.values().stream().anyMatch(OrderedInterval::holdsNothing);
+        return nothing() || ranges().values().stream().anyMatch(OrderedInterval::holdsNothing);
     }
 
     /**
@@ -75,7 +131,7 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
      */
     public Set<A> holdingNothing() {
         Set<A> out = new LinkedHashSet<>();
-        ranges.forEach((position, range) -> {
+        ranges().forEach((position, range) -> {
             if (range.holdsNothing()) {
                 out.add(position);
             }
@@ -85,9 +141,10 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
 
     /** Both readings holding at once. */
     public OrderedIntervals<A> meet(OrderedIntervals<A> other) {
-        Map<A, OrderedInterval> out = new LinkedHashMap<>(ranges);
-        other.ranges.forEach((position, range) -> out.merge(position, range, OrderedInterval::meet));
-        return new OrderedIntervals<>(out, nothing || other.nothing);
+        Map<A, OrderedInterval> out = new LinkedHashMap<>(ranges());
+        other.ranges().forEach((position, range) ->
+                out.merge(position, range, OrderedInterval::meet));
+        return new OrderedIntervals<>(out, nothing() || other.nothing());
     }
 
     /**
@@ -108,8 +165,8 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
      */
     public <B> OrderedIntervals<B> renamed(java.util.function.Function<A, B> naming) {
         Map<B, OrderedInterval> out = new LinkedHashMap<>();
-        ranges.forEach((position, range) -> out.put(naming.apply(position), range));
-        return new OrderedIntervals<>(out, nothing);
+        ranges().forEach((position, range) -> out.put(naming.apply(position), range));
+        return new OrderedIntervals<>(out, nothing());
     }
 
     /**
@@ -171,8 +228,8 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
         assert !isBottom() && !other.isBottom()
                 : "a choice of two live alternatives was asked of " + this + " and " + other;
         Map<A, OrderedInterval> out = new LinkedHashMap<>();
-        ranges.forEach((position, range) -> {
-            OrderedInterval there = other.ranges.get(position);
+        ranges().forEach((position, range) -> {
+            OrderedInterval there = other.ranges().get(position);
             if (there != null) {
                 out.put(position, range.join(there));
             }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -63,18 +63,20 @@ public final class OrderedIntervals<A> {
 
     private final Parts<A> parts;
 
-    private OrderedIntervals(Map<A, OrderedInterval> ranges, boolean nothing) {
-        this.parts = new Parts<>(ranges, nothing);
+    /** The one constructor there is, and it takes the parts as one — see {@code AdmissibleValues},
+     *  where a maker handed the parts is what a reading may not be come by. */
+    private OrderedIntervals(Parts<A> parts) {
+        this.parts = parts;
     }
 
     /** Nothing read, so every position holds every value its order has. */
     public static <A> OrderedIntervals<A> top() {
-        return new OrderedIntervals<>(Map.of(), false);
+        return new OrderedIntervals<>(new Parts<>(Map.of(), false));
     }
 
     /** One position said to lie inside {@code range}. */
     public static <A> OrderedIntervals<A> at(A position, OrderedInterval range) {
-        return new OrderedIntervals<>(Map.of(position, range), false);
+        return new OrderedIntervals<>(new Parts<>(Map.of(position, range), false));
     }
 
     private Map<A, OrderedInterval> ranges() {
@@ -144,7 +146,7 @@ public final class OrderedIntervals<A> {
         Map<A, OrderedInterval> out = new LinkedHashMap<>(ranges());
         other.ranges().forEach((position, range) ->
                 out.merge(position, range, OrderedInterval::meet));
-        return new OrderedIntervals<>(out, nothing() || other.nothing());
+        return new OrderedIntervals<>(new Parts<>(out, nothing() || other.nothing()));
     }
 
     /**
@@ -166,7 +168,7 @@ public final class OrderedIntervals<A> {
     public <B> OrderedIntervals<B> renamed(java.util.function.Function<A, B> naming) {
         Map<B, OrderedInterval> out = new LinkedHashMap<>();
         ranges().forEach((position, range) -> out.put(naming.apply(position), range));
-        return new OrderedIntervals<>(out, nothing());
+        return new OrderedIntervals<>(new Parts<>(out, nothing()));
     }
 
     /**
@@ -202,7 +204,7 @@ public final class OrderedIntervals<A> {
                 both.put(position, at(position).meet(other.at(position)));
             }
         }
-        return new OrderedIntervals<>(both, true);
+        return new OrderedIntervals<>(new Parts<>(both, true));
     }
 
     /**
@@ -234,6 +236,6 @@ public final class OrderedIntervals<A> {
                 out.put(position, range.join(there));
             }
         });
-        return new OrderedIntervals<>(out, false);
+        return new OrderedIntervals<>(new Parts<>(out, false));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -103,9 +103,9 @@ public final class OrderedIntervals<A> {
     /**
      * The positions these rules bounded, which is what a caller asking what this took in is asking.
      *
-     * <p>A rule read about a position leaves it a range, so a reading that bounded nothing is one
-     * that read nothing — which is the same question asked of the whole and is answered from the
-     * same set.
+     * <p>The positions and not the ranges, which are this one's own: what a rule left a position is
+     * read through {@link #at}, and a caller holding the map would be holding a state to work its
+     * own answers out of.
      */
     public Set<A> boundedAt() {
         return ranges().keySet();

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -42,6 +42,7 @@ import java.util.Set;
  * combination nothing read. What the parts are is this one's own; a caller reaches a state by doing
  * to a reading what the state says was done to it.
  */
+@souther.compiler.reading.StateOfAReading
 public final class OrderedIntervals<A> {
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/reading/StateOfAReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/StateOfAReading.java
@@ -1,0 +1,31 @@
+package souther.compiler.reading;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A state of a reading of the rules: what the operations that compose one reach, and nothing else.
+ *
+ * <p>What a type says by carrying this is that its parts state relations to each other that no part
+ * states on its own — a whole that holds nothing is not a position that holds nothing, alternatives
+ * are never an empty union, a refusal is one the work that built the reading noted. None of those
+ * is a property a constructor call can be asked to keep, so the parts are the type's own: it holds
+ * them as one record of its own, it publishes no constructor, and a caller reaches one by doing to
+ * a reading what the reading says was done to it.
+ *
+ * <p><b>Declared and not read off the shape.</b> A type that is one of these says so here, and what
+ * it says is then held to ({@code AReadingIsWhatItsOperationsReach}). Worked out instead from
+ * whether a type already keeps its parts the way these do, the reading would find the states that
+ * are already right and pass over the one written as a record of its parts — which is the state
+ * this whole arrangement exists to refuse, and the one such a reading would never see.
+ *
+ * <p>Its own package because the languages a reading is written in are their own, and one of them
+ * ({@code souther.compiler.numeric}) depends on nothing else here. A word both of them can say has
+ * to be somewhere neither of them owns.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface StateOfAReading {
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.reading.StateOfAReading;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -126,6 +128,7 @@ import java.util.Set;
  * say so; what holds the relations up is that a reading is come by doing to one what the reading
  * says was done to it.
  */
+@StateOfAReading
 public final class AdmissibleValues<A> {
 
     /**
@@ -991,6 +994,35 @@ public final class AdmissibleValues<A> {
     }
 
     /**
+     * What one working-out came to: the reading, and the record of the work that made it.
+     *
+     * <p>The two of them travel as one thing because they are settled by one piece of work, and
+     * this is what makes that true of what comes out rather than of whoever wrote the call. Handed
+     * over as two, a caller pairs a reading with a record of work that did not make it — a reading
+     * whose positions an allowance ran out on, beside a record that noted nothing — and what it
+     * says about itself is false. Nothing outside this type can make one, so a reading beside what
+     * could not be built while making it is what a working-out came to and is nothing else.
+     */
+    static final class Outcome<A> {
+
+        private final AdmissibleValues<A> values;
+        private final Unbuilt<A> work;
+
+        private Outcome(AdmissibleValues<A> values, Unbuilt<A> work) {
+            this.values = values;
+            this.work = work;
+        }
+
+        AdmissibleValues<A> values() {
+            return values;
+        }
+
+        Unbuilt<A> work() {
+            return work;
+        }
+    }
+
+    /**
      * The reading a description comes to, with everything it describes built.
      *
      * <p>The one way from a description to a reading, and it is here because this is what it makes.
@@ -1020,12 +1052,12 @@ public final class AdmissibleValues<A> {
         of.guaranteed().forEach((block, plan) -> promising.merge(
                 heldAsOne.blockOf(block.members().iterator().next()), plan,
                 (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
-        return Realized.of(new AdmissibleValues<>(new Parts<>(held, perPosition,
+        return Realized.of(new Outcome<>(new AdmissibleValues<>(new Parts<>(held, perPosition,
                 gaveUp.beside(of.standing()),
                 promised(promising, by), promised(of.defaultGuaranteed(), by.elsewhere()),
                 of.guaranteedTogether(),
                 mapped(of.tangled(), heldAsOne),
-                mapped(both(of.widened(), gaveUp.names()), heldAsOne))), gaveUp);
+                mapped(both(of.widened(), gaveUp.names()), heldAsOne))), gaveUp));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -116,17 +116,15 @@ import java.util.Set;
  *
  * <h2>What a reading may be</h2>
  *
- * <p>The states are the ones these operations reach: nothing read, a rule read at a position, two
- * positions held as one value or held apart, a rule nothing could read, a conjunction, the
- * positions a choice left open, the same reading under other names, and a description worked out
- * ({@link #realize}). A choice is not among them and is not missing from them — one is taken while
- * a reading is still a description, which is the paragraph above. Every one of the paragraphs
- * above states a relation between the parts — a whole that holds nothing is not a position that
- * holds nothing, {@link Held.Nothing} is not an empty union, what a promise is about is the blocks
- * the alternatives agree on — and none of those relations is a property of any part on its own. So
- * the parts are this one's own and are not a way in. A caller reaches a reading by doing to one
- * what the reading says was done to it, and a combination nothing read is one nobody can write
- * down.
+ * <p>The states are the ones the operations above reach, together with {@link #realize}, which is
+ * where a description crosses. The parts are not among the ways in.
+ *
+ * <p>Every paragraph here states a relation between them — a whole that holds nothing is not a
+ * position that holds nothing, {@link Held.Nothing} is not an empty union, what a promise is about
+ * is the blocks the alternatives agree on — and none of those is a property of one part. So a
+ * caller handed the parts side by side could write down a combination nothing read, with nothing to
+ * say so; what holds the relations up is that a reading is come by doing to one what the reading
+ * says was done to it.
  */
 public final class AdmissibleValues<A> {
 
@@ -662,11 +660,10 @@ public final class AdmissibleValues<A> {
      * declared — written out by hand, a part left off one of them is a reading that differs from
      * another and says it does not, and nothing fails while it is wrong.
      *
-     * <p>Nameable inside this package and nowhere else, and it is no way in either way: a reading is
-     * made by {@link AdmissibleValues}'s own constructor, which nothing outside the type may call.
-     * What the package may do with it is read the parts off it — which is what the propositions
-     * about every part of a reading are asked of, and asking them of a list written out beside this
-     * one would be asking about a copy with the same holes.
+     * <p>The reading's own, and named nowhere else. A proposition about every part of a reading
+     * finds it where the reading keeps it — the one thing a reading is made of — rather than being
+     * handed it, which would put the boundary of what is published a step wider than the sentence
+     * above it.
      *
      * @param held what the rules leave: the alternatives, or nothing
      * @param perPosition what each position's own rules leave it, every alternative merged. Not
@@ -736,13 +733,13 @@ public final class AdmissibleValues<A> {
      *                about one of them is handed that sentence about each — which is the other
      *                quantifier and is false wherever a clause of its own answers for a position
      */
-    record Parts<A>(Held<A> held, Map<A, ValueSet> perPosition,
-                    Standing<A> standing,
-                    Map<Sameness.Block<A>, ValueSet> guaranteed,
-                    ValueSet defaultGuaranteed,
-                    boolean guaranteedTogether,
-                    Set<Sameness.Block<A>> tangled,
-                    Set<Sameness.Block<A>> widened) {
+    private record Parts<A>(Held<A> held, Map<A, ValueSet> perPosition,
+                            Standing<A> standing,
+                            Map<Sameness.Block<A>, ValueSet> guaranteed,
+                            ValueSet defaultGuaranteed,
+                            boolean guaranteedTogether,
+                            Set<Sameness.Block<A>> tangled,
+                            Set<Sameness.Block<A>> widened) {
 
         Parts {
             // Every part is copied, and a reader wanting to know that they all are asks the record
@@ -776,16 +773,16 @@ public final class AdmissibleValues<A> {
 
     private final Parts<A> parts;
 
+    /**
+     * The one constructor there is, and it takes the parts as one.
+     *
+     * <p>One and not two, though a second taking the parts side by side would read more easily
+     * where they are worked out. A constructor is a maker of a reading, and a maker handed the
+     * parts is the thing a reading of the values may not be come by — so the walk of the compiled
+     * classes that reads what every maker was handed would find it, and would be right.
+     */
     private AdmissibleValues(Parts<A> parts) {
         this.parts = parts;
-    }
-
-    private AdmissibleValues(Held<A> held, Map<A, ValueSet> perPosition, Standing<A> standing,
-                             Map<Sameness.Block<A>, ValueSet> guaranteed,
-                             ValueSet defaultGuaranteed, boolean guaranteedTogether,
-                             Set<Sameness.Block<A>> tangled, Set<Sameness.Block<A>> widened) {
-        this(new Parts<>(held, perPosition, standing, guaranteed, defaultGuaranteed,
-                guaranteedTogether, tangled, widened));
     }
 
     /** What the rules leave: the alternatives, or nothing. */
@@ -973,8 +970,8 @@ public final class AdmissibleValues<A> {
 
     /** Nothing read and nothing missed, which is what a reading starts from. */
     public static <A> AdmissibleValues<A> top() {
-        return new AdmissibleValues<>(one(Alternative.at(Map.of())), Map.of(), Standing.nothing(),
-                Map.of(), ValueSet.ANY, true, Set.of(), Set.of());
+        return new AdmissibleValues<>(new Parts<>(one(Alternative.at(Map.of())), Map.of(),
+                Standing.nothing(), Map.of(), ValueSet.ANY, true, Set.of(), Set.of()));
     }
 
     /**
@@ -1023,12 +1020,12 @@ public final class AdmissibleValues<A> {
         of.guaranteed().forEach((block, plan) -> promising.merge(
                 heldAsOne.blockOf(block.members().iterator().next()), plan,
                 (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
-        return Realized.of(new AdmissibleValues<>(held, perPosition,
+        return Realized.of(new AdmissibleValues<>(new Parts<>(held, perPosition,
                 gaveUp.beside(of.standing()),
                 promised(promising, by), promised(of.defaultGuaranteed(), by.elsewhere()),
                 of.guaranteedTogether(),
                 mapped(of.tangled(), heldAsOne),
-                mapped(both(of.widened(), gaveUp.names()), heldAsOne)), gaveUp);
+                mapped(both(of.widened(), gaveUp.names()), heldAsOne))), gaveUp);
     }
 
     /**
@@ -1408,10 +1405,10 @@ public final class AdmissibleValues<A> {
             case Held.Nothing<A> it -> new Held.Nothing<B>(it.shown().renamed(naming));
             case Held.Alternatives<A> alternatives -> alternatives.renamed(naming);
         };
-        return new AdmissibleValues<>(renamedHeld, renamedKeys(perPosition(), naming),
+        return new AdmissibleValues<>(new Parts<>(renamedHeld, renamedKeys(perPosition(), naming),
                 standing().renamed(naming),
                 renamedBlocks(guaranteed(), naming), defaultGuaranteed(), guaranteedTogether(),
-                renamedNames(tangled(), naming), renamedNames(widened(), naming));
+                renamedNames(tangled(), naming), renamedNames(widened(), naming)));
     }
 
     /** The same map, filed under what {@code naming} calls the positions of each of its blocks. */
@@ -1485,8 +1482,8 @@ public final class AdmissibleValues<A> {
         Set<Sameness.Block<A>> widened = new LinkedHashSet<>();
         read.forEach(each -> widened.addAll(mapped(each.widened(), sameness())));
         widened.addAll(widened());
-        return new AdmissibleValues<>(held(), perPosition(), out, guaranteed(),
-                defaultGuaranteed(), guaranteedTogether(), tangled(), widened);
+        return new AdmissibleValues<>(new Parts<>(held(), perPosition(), out, guaranteed(),
+                defaultGuaranteed(), guaranteedTogether(), tangled(), widened));
     }
 
     /** Both readings holding at once. */
@@ -1505,7 +1502,7 @@ public final class AdmissibleValues<A> {
         // {@code r} would stay two promises where the conjunction has one value.
         Sameness<A> heldAsOne = both instanceof Held.Alternatives<A> it
                 ? it.commonSameness() : Sameness.discrete();
-        return new AdmissibleValues<>(both,
+        return new AdmissibleValues<>(new Parts<>(both,
                 narrowed(perPosition(), other.perPosition(), sets, heldAsOne, gaveUp),
                 alsoStanding(standing().and(other.standing()), gaveUp),
                 // Either way what comes out is a promise about whole values, which is why a
@@ -1530,7 +1527,7 @@ public final class AdmissibleValues<A> {
                 // meet of a product is exact at each of its places, so those blocks keep what
                 // they had.
                 both(mapped(both(both(widened(), other.widened()), both(tangled(), other.tangled())),
-                        heldAsOne), gaveUp));
+                        heldAsOne), gaveUp)));
     }
 
     /**
@@ -1630,9 +1627,9 @@ public final class AdmissibleValues<A> {
      */
     public AdmissibleValues<A> alsoOpenedAt(Set<A> these) {
         return these.isEmpty() ? this
-                : new AdmissibleValues<>(held(), perPosition(), standing().alsoOpenedAt(these),
-                        guaranteed(), defaultGuaranteed(), guaranteedTogether(), tangled(),
-                        widened());
+                : new AdmissibleValues<>(new Parts<>(held(), perPosition(),
+                        standing().alsoOpenedAt(these), guaranteed(), defaultGuaranteed(),
+                        guaranteedTogether(), tangled(), widened()));
     }
 
     /** The alternatives this holds, which a reading that admits nothing has none of. */

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -113,14 +113,20 @@ import java.util.Set;
  * alternatives admits every value at a position admits every value at it. That is what
  * {@link #guaranteedAt} is carried for, and holding "something went unread" alone would answer the
  * same clause two ways depending on where its brackets fell.
+ *
+ * <h2>What a reading may be</h2>
+ *
+ * <p>The states are the ones these operations reach: a leaf, a rule read at a position, two
+ * positions held as one value or held apart, a rule nothing could read, a conjunction, what a
+ * settled choice left, and a description worked out ({@link #realize}). Every one of the paragraphs
+ * above states a relation between the parts — a whole that holds nothing is not a position that
+ * holds nothing, {@link Held.Nothing} is not an empty union, what a promise is about is the blocks
+ * the alternatives agree on — and none of those relations is a property of any part on its own. So
+ * the parts are this one's own and are not a way in. A caller reaches a reading by doing to one
+ * what the reading says was done to it, and a combination nothing read is one nobody can write
+ * down.
  */
-public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
-                                  Standing<A> standing,
-                                  Map<Sameness.Block<A>, ValueSet> guaranteed,
-                                  ValueSet defaultGuaranteed,
-                                  boolean guaranteedTogether,
-                                  Set<Sameness.Block<A>> tangled,
-                                  Set<Sameness.Block<A>> widened) {
+public final class AdmissibleValues<A> {
 
     /**
      * The whole of what this reading is, written out for putting several of them in a work order.
@@ -141,13 +147,13 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     void schedulingForm(StringBuilder out) {
         for (String each : COMPONENTS) {
             switch (each) {
-                case "held" -> PlanOrder.written(held, out);
-                case "perPosition" -> PlanOrder.written(perPosition, out);
-                case "guaranteed" -> PlanOrder.written(guaranteed, out);
-                case "defaultGuaranteed" -> PlanOrder.write(defaultGuaranteed, out);
-                case "guaranteedTogether" -> out.append(guaranteedTogether).append(';');
-                case "tangled" -> named(tangled, out);
-                case "widened" -> named(widened, out);
+                case "held" -> PlanOrder.written(held(), out);
+                case "perPosition" -> PlanOrder.written(perPosition(), out);
+                case "guaranteed" -> PlanOrder.written(guaranteed(), out);
+                case "defaultGuaranteed" -> PlanOrder.write(defaultGuaranteed(), out);
+                case "guaranteedTogether" -> out.append(guaranteedTogether()).append(';');
+                case "tangled" -> named(tangled(), out);
+                case "widened" -> named(widened(), out);
                 // The author's, and not this. See above.
                 case "standing" -> { }
                 default -> throw new IllegalStateException(
@@ -163,9 +169,9 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         these.stream().map(String::valueOf).sorted().forEach(each -> out.append(each).append(';'));
     }
 
-    /** Every part of a reading, in the order this record declares them. */
+    /** Every part of a reading, in the order {@link Parts} declares them. */
     private static final List<String> COMPONENTS =
-            java.util.Arrays.stream(AdmissibleValues.class.getRecordComponents())
+            java.util.Arrays.stream(Parts.class.getRecordComponents())
                     .map(java.lang.reflect.RecordComponent::getName).toList();
 
     /**
@@ -647,6 +653,19 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /**
+     * The parts, together, so that everything answered from all of them is answered from one place.
+     *
+     * <p>Which reading two of these are is settled here, and so is the list a reader is shown, and
+     * both of them are the record's. A part added to this arrives in each of them the day it is
+     * declared — written out by hand, a part left off one of them is a reading that differs from
+     * another and says it does not, and nothing fails while it is wrong.
+     *
+     * <p>Nameable inside this package and nowhere else, and it is no way in either way: a reading is
+     * made by {@link AdmissibleValues}'s own constructor, which nothing outside the type may call.
+     * What the package may do with it is read the parts off it — which is what the propositions
+     * about every part of a reading are asked of, and asking them of a list written out beside this
+     * one would be asking about a copy with the same holes.
+     *
      * @param held what the rules leave: the alternatives, or nothing
      * @param perPosition what each position's own rules leave it, every alternative merged. Not
      *                what a position may hold — {@link #at} is narrower wherever the alternatives
@@ -715,32 +734,112 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      *                about one of them is handed that sentence about each — which is the other
      *                quantifier and is false wherever a clause of its own answers for a position
      */
-    public AdmissibleValues {
-        // Every part is copied, and a reader wanting to know that they all are asks the record
-        // rather than this list — `EveryPartOfAReadingIsAValue` counts the parts off the
-        // declaration, because a list written here is one a part added later is missing from and
-        // a list written there would be a copy of it with the same hole.
-        perPosition = said(perPosition);
-        // A guarantee empty at one position is empty at all of them. What is promised is one set
-        // per position standing for the product of them, and a product with an empty side is
-        // empty — so there is no value at any position that this can promise. This is also where a
-        // reading that admits nothing arrives, by whichever way it got there: a leaf left no value,
-        // two rules that cannot both hold, a caller that showed it from outside.
-        if (held instanceof Held.Nothing || defaultGuaranteed.isEmpty()
-                || guaranteed.values().stream().anyMatch(ValueSet::isEmpty)) {
-            guaranteed = Map.of();
-            defaultGuaranteed = ValueSet.NONE;
-            guaranteedTogether = true;
+    record Parts<A>(Held<A> held, Map<A, ValueSet> perPosition,
+                    Standing<A> standing,
+                    Map<Sameness.Block<A>, ValueSet> guaranteed,
+                    ValueSet defaultGuaranteed,
+                    boolean guaranteedTogether,
+                    Set<Sameness.Block<A>> tangled,
+                    Set<Sameness.Block<A>> widened) {
+
+        Parts {
+            // Every part is copied, and a reader wanting to know that they all are asks the record
+            // rather than this list — `EveryPartOfAReadingIsAValue` counts the parts off the
+            // declaration, because a list written here is one a part added later is missing from
+            // and a list written there would be a copy of it with the same hole.
+            perPosition = said(perPosition);
+            // A guarantee empty at one position is empty at all of them. What is promised is one
+            // set per position standing for the product of them, and a product with an empty side
+            // is empty — so there is no value at any position that this can promise. This is also
+            // where a reading that admits nothing arrives, by whichever way it got there: a leaf
+            // left no value, two rules that cannot both hold, a choice every branch of which was
+            // shown impossible.
+            if (held instanceof Held.Nothing || defaultGuaranteed.isEmpty()
+                    || guaranteed.values().stream().anyMatch(ValueSet::isEmpty)) {
+                guaranteed = Map.of();
+                defaultGuaranteed = ValueSet.NONE;
+                guaranteedTogether = true;
+            }
+            guaranteed = Collections.unmodifiableMap(new LinkedHashMap<>(guaranteed));
+            // Kept in the order they were recorded rather than as an immutable copy, whose
+            // iteration order is salted per run of the JVM: what is written out of a reading has to
+            // come out the same on two compiles of one model.
+            tangled = Collections.unmodifiableSet(new LinkedHashSet<>(tangled));
+            widened = Collections.unmodifiableSet(new LinkedHashSet<>(widened));
+            Sameness<A> mine = held instanceof Held.Alternatives<A> it
+                    ? it.commonSameness() : Sameness.discrete();
+            mine.filing(guaranteed.keySet(), tangled, widened);
         }
-        guaranteed = Collections.unmodifiableMap(new LinkedHashMap<>(guaranteed));
-        // Kept in the order they were recorded rather than as an immutable copy, whose iteration
-        // order is salted per run of the JVM: what is written out of a reading has to come out the
-        // same on two compiles of one model.
-        tangled = Collections.unmodifiableSet(new LinkedHashSet<>(tangled));
-        widened = Collections.unmodifiableSet(new LinkedHashSet<>(widened));
-        Sameness<A> mine = held instanceof Held.Alternatives<A> it
-                ? it.commonSameness() : Sameness.discrete();
-        mine.filing(guaranteed.keySet(), tangled, widened);
+    }
+
+    private final Parts<A> parts;
+
+    private AdmissibleValues(Parts<A> parts) {
+        this.parts = parts;
+    }
+
+    private AdmissibleValues(Held<A> held, Map<A, ValueSet> perPosition, Standing<A> standing,
+                             Map<Sameness.Block<A>, ValueSet> guaranteed,
+                             ValueSet defaultGuaranteed, boolean guaranteedTogether,
+                             Set<Sameness.Block<A>> tangled, Set<Sameness.Block<A>> widened) {
+        this(new Parts<>(held, perPosition, standing, guaranteed, defaultGuaranteed,
+                guaranteedTogether, tangled, widened));
+    }
+
+    /** What the rules leave: the alternatives, or nothing. */
+    public Held<A> held() {
+        return parts.held();
+    }
+
+    /** What each position's own rules leave it, every alternative merged. */
+    public Map<A, ValueSet> perPosition() {
+        return parts.perPosition();
+    }
+
+    /** What the rules of the model could not say, and what stopped this reading saying it. */
+    public Standing<A> standing() {
+        return parts.standing();
+    }
+
+    /** Which values each block is guaranteed to admit, read through {@link #guaranteedAt}. */
+    public Map<Sameness.Block<A>, ValueSet> guaranteed() {
+        return parts.guaranteed();
+    }
+
+    /** What a position this holds no guarantee for is guaranteed to admit. */
+    public ValueSet defaultGuaranteed() {
+        return parts.defaultGuaranteed();
+    }
+
+    /** Whether one value may be taken from each position's guarantee and the whole of them stand
+     *  together in this reading. */
+    public boolean guaranteedTogether() {
+        return parts.guaranteedTogether();
+    }
+
+    /** The blocks whose correlations this reading has lost. */
+    public Set<Sameness.Block<A>> tangled() {
+        return parts.tangled();
+    }
+
+    /** The blocks whose {@link #at} cannot be guaranteed to be what the read rules leave them. */
+    public Set<Sameness.Block<A>> widened() {
+        return parts.widened();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof AdmissibleValues<?> it && parts.equals(it.parts);
+    }
+
+    @Override
+    public int hashCode() {
+        return parts.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return parts.toString();
     }
 
     /**
@@ -814,7 +913,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * than a promise and less than this holds.
      */
     public ValueSet guaranteedAt(A atom) {
-        return guaranteed.getOrDefault(blockOf(atom), defaultGuaranteed);
+        return guaranteed().getOrDefault(blockOf(atom), defaultGuaranteed());
     }
 
     /**
@@ -831,7 +930,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * intersection.
      */
     public Sameness<A> sameness() {
-        return held instanceof Held.Alternatives<A> it ? it.commonSameness() : Sameness.discrete();
+        return held() instanceof Held.Alternatives<A> it
+                ? it.commonSameness() : Sameness.discrete();
     }
 
     /** The block {@code position} is on, which is the position on its own wherever no equality
@@ -858,7 +958,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         // is: read per position, a block whose machine was given up on would report the position
         // the widening was recorded against as wide and the position beside it as exact, while
         // {@link #at} hands both of them the same set.
-        return held instanceof Held.Nothing || !widened.contains(blockOf(atom));
+        return held() instanceof Held.Nothing || !widened().contains(blockOf(atom));
     }
 
     /** Whether what this holds can be guaranteed to be the whole of what the read rules admit,
@@ -866,7 +966,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      *  proof state as above and about the same readings: one that admits nothing holds no
      *  relation. */
     public boolean relationExact() {
-        return tangled.isEmpty();
+        return tangled().isEmpty();
     }
 
     /** Nothing read and nothing missed, which is what a reading starts from. */
@@ -892,6 +992,144 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /**
+     * The reading a description comes to, with everything it describes built.
+     *
+     * <p>The one way from a description to a reading, and it is here because this is what it makes.
+     * Handed the description and the allowance, it builds the sets, decides which of them nobody
+     * could work out, and settles the rest against what came out — so a caller has a reading
+     * because the work a reading claims was done was done, and not because it wrote down what that
+     * work would have left. What could not be built comes back beside it ({@link Realized}).
+     *
+     * <p>Read through the description's own questions and not through what it is made of. What each
+     * of the parts means is {@link PlannedValues.Settled}'s, and what they come to together is this
+     * one's — which is the same division either side of the line.
+     */
+    static <A> Realized<A> realize(PlannedValues.Settled<A> of, Allowance<A> by) {
+        Unbuilt<A> gaveUp = new Unbuilt<>();
+        Map<A, ValueSet> perPosition = built(of.perPosition(), of.sameness(), by, gaveUp);
+        Held<A> held = switch (of.held()) {
+            case PlannedHeld.Nothing<A> _ -> new Held.Nothing<A>();
+            case PlannedHeld.Alternatives<A> boxes -> standingIn(boxes, by, gaveUp);
+        };
+        // The blocks the answer is in, which are not the ones it was described in. An alternative
+        // dropped for admitting nothing is one whose equalities the rest need not state, so what
+        // the survivors hold as one may be coarser than what every description did — and everything
+        // filed under a block is said in the answer's own before it is built.
+        Sameness<A> heldAsOne = held instanceof Held.Alternatives<A> it
+                ? it.commonSameness() : Sameness.discrete();
+        Map<Sameness.Block<A>, AdmittedPlan> promising = new LinkedHashMap<>();
+        of.guaranteed().forEach((block, plan) -> promising.merge(
+                heldAsOne.blockOf(block.members().iterator().next()), plan,
+                (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
+        return Realized.of(new AdmissibleValues<>(held, perPosition,
+                gaveUp.beside(of.standing()),
+                promised(promising, by), promised(of.defaultGuaranteed(), by.elsewhere()),
+                of.guaranteedTogether(),
+                mapped(of.tangled(), heldAsOne),
+                mapped(both(of.widened(), gaveUp.names()), heldAsOne)), gaveUp);
+    }
+
+    /**
+     * The alternatives, with the ones nothing stands in dropped.
+     *
+     * <p>Where the invariant a reading has is kept: a box with a side admitting nothing stands for
+     * nothing, and now that the sides are values it can be seen and taken out. Where every box
+     * goes, nothing satisfies the rules.
+     */
+    private static <A> Held<A> standingIn(PlannedHeld.Alternatives<A> boxes,
+                                          Allowance<A> by, Unbuilt<A> gaveUp) {
+        Set<Alternative<A>> live = new LinkedHashSet<>();
+        Set<PlannedHeld.Alternative<A>> stands = new LinkedHashSet<>();
+        Refusal<A> dropped = null;
+        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
+            // The relation crosses unchanged. What a denial says is about the blocks and not about
+            // what they were described as holding, so building the descriptions is not where it
+            // could be lost or gained — and whether anything stands in the alternative is asked the
+            // one way it is asked wherever two of them are put together.
+            Held<A> said = new Alternative.Met<>(builtIn(box, by, gaveUp), box.apart()).stands();
+            switch (said) {
+                case Held.Alternatives<A> it -> {
+                    live.addAll(it.boxes());
+                    stands.add(box);
+                }
+                case Held.Nothing<A> it -> dropped = dropped == null ? it.shown()
+                        : Refusal.shownByBoth(dropped, it.shown());
+            }
+        }
+        if (live.isEmpty()) {
+            return new Held.Nothing<>(dropped == null ? Refusal.nowhere() : dropped);
+        }
+        // What each block the alternatives agree on holds across the ones that stand, described
+        // first and built once. Read off the sets instead, a join of two languages would be a
+        // machine nobody counted.
+        Sameness<A> common = new PlannedHeld.Alternatives<>(stands).commonSameness();
+        Set<Sameness.Block<A>> named = new LinkedHashSet<>();
+        stands.forEach(box ->
+                box.positions().forEach(position -> named.add(common.blockOf(position))));
+        Map<Sameness.Block<A>, ValueSet> across = new LinkedHashMap<>();
+        for (Sameness.Block<A> block : named) {
+            A member = block.members().iterator().next();
+            AdmittedPlan plan = AdmittedPlan.joining(
+                    stands.stream().map(box -> box.get(member)).toList());
+            Realization made = by.realizer(block).of(plan);
+            gaveUp.note(block, made);
+            if (!made.upperBound().isAny()) {
+                across.put(block, made.upperBound());
+            }
+        }
+        return Held.Alternatives.of(live, common, across);
+    }
+
+    /** One alternative's descriptions as the sets they come to, each built under its own block's
+     *  allowance. */
+    private static <A> Map<Sameness.Block<A>, ValueSet> builtIn(PlannedHeld.Alternative<A> box,
+                                                                Allowance<A> by,
+                                                                Unbuilt<A> gaveUp) {
+        Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
+        box.at().forEach((block, plan) -> {
+            Realization made = by.realizer(block).of(plan);
+            gaveUp.note(block, made);
+            out.put(block, made.upperBound());
+        });
+        return out;
+    }
+
+    /** Each position's own description as the set it comes to, built under the allowance of the
+     *  block that position is on, the ones nobody could build widened to every value and written
+     *  down as such. */
+    private static <A> Map<A, ValueSet> built(Map<A, AdmittedPlan> of, Sameness<A> heldAsOne,
+                                              Allowance<A> by, Unbuilt<A> gaveUp) {
+        Map<A, ValueSet> out = new LinkedHashMap<>();
+        of.forEach((atom, plan) -> {
+            Sameness.Block<A> block = heldAsOne.blockOf(atom);
+            Realization made = by.realizer(block).of(plan);
+            gaveUp.note(block, made);
+            out.put(atom, made.upperBound());
+        });
+        return out;
+    }
+
+    /**
+     * The same for a promise, which widens the other way.
+     *
+     * <p>A promise nobody could work out promises nothing, and that is the strongest thing that
+     * stays true — where an answer this could not build widens to every value, a guarantee it could
+     * not build shrinks to none. Nothing is recorded: a reader short of a guarantee has been told
+     * no more than the truth, and the reasons below are about the upper bound.
+     */
+    private static <A> Map<Sameness.Block<A>, ValueSet> promised(
+            Map<Sameness.Block<A>, AdmittedPlan> of, Allowance<A> by) {
+        Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
+        of.forEach((block, plan) -> out.put(block, promised(plan, by.realizer(block))));
+        return out;
+    }
+
+    private static ValueSet promised(AdmittedPlan plan, Realizer by) {
+        Realization made = by.of(plan);
+        return made.isExact() ? made.upperBound() : ValueSet.NONE;
+    }
+
+    /**
      * What {@code atom} may hold, everything being admitted where nothing was said.
      *
      * <p>Over the alternatives, since a value standing in any of them stands in the reading. Which
@@ -900,8 +1138,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * this asks.
      */
     public ValueSet at(A atom) {
-        return switch (held) {
-            case Held.Nothing<A> _ -> perPosition.getOrDefault(atom, ValueSet.ANY);
+        return switch (held()) {
+            case Held.Nothing<A> _ -> perPosition().getOrDefault(atom, ValueSet.ANY);
             // Read and not worked out. What a position holds across the alternatives was settled
             // where they were put together, which is where there was an allowance for the machine
             // it may take. See {@link Held.Alternatives#of}.
@@ -973,12 +1211,12 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         if (guaranteedAt(atom).equals(at(atom))) {
             return List.of();
         }
-        return standing.across(blockOf(atom).members());
+        return standing().across(blockOf(atom).members());
     }
 
     /** Whether nothing satisfies these rules, at a position or otherwise. */
     public boolean isBottom() {
-        return held instanceof Held.Nothing;
+        return held() instanceof Held.Nothing;
     }
 
     /**
@@ -990,7 +1228,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * is knowable only while it is being refused.
      */
     public Refusal<A> refusedBy() {
-        return held instanceof Held.Nothing<A> it ? it.shown() : Refusal.nowhere();
+        return held() instanceof Held.Nothing<A> it ? it.shown() : Refusal.nowhere();
     }
 
     /**
@@ -1018,7 +1256,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * hold something.
      */
     public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked, AskedOfARelation<A> relating) {
-        if (held instanceof Held.Alternatives<A> it) {
+        if (held() instanceof Held.Alternatives<A> it) {
             Emptiness any = Emptiness.EMPTY;
             for (Alternative<A> box : it.boxes()) {
                 Emptiness stands = Emptiness.NONEMPTY;
@@ -1063,7 +1301,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     public Refusal<A> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked,
                                                   AskedOfARelation<A> relating) {
-        if (!(held instanceof Held.Alternatives<A> it)) {
+        if (!(held() instanceof Held.Alternatives<A> it)) {
             return Refusal.nowhere();
         }
         Refusal<A> everywhere = null;
@@ -1128,14 +1366,14 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     public Set<A> subjects() {
         Set<A> out = new LinkedHashSet<>();
-        if (held instanceof Held.Alternatives<A> alternatives) {
+        if (held() instanceof Held.Alternatives<A> alternatives) {
             alternatives.boxes().forEach(box -> out.addAll(box.positions()));
         }
-        out.addAll(perPosition.keySet());
-        out.addAll(standing.positions());
-        members(guaranteed.keySet(), out);
-        members(tangled, out);
-        members(widened, out);
+        out.addAll(perPosition().keySet());
+        out.addAll(standing().positions());
+        members(guaranteed().keySet(), out);
+        members(tangled(), out);
+        members(widened(), out);
         return Collections.unmodifiableSet(out);
     }
 
@@ -1164,14 +1402,14 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * said anything about.
      */
     public <B> AdmissibleValues<B> renamed(java.util.function.Function<A, B> naming) {
-        Held<B> renamedHeld = switch (held) {
+        Held<B> renamedHeld = switch (held()) {
             case Held.Nothing<A> it -> new Held.Nothing<B>(it.shown().renamed(naming));
             case Held.Alternatives<A> alternatives -> alternatives.renamed(naming);
         };
-        return new AdmissibleValues<>(renamedHeld, renamedKeys(perPosition, naming),
-                standing.renamed(naming),
-                renamedBlocks(guaranteed, naming), defaultGuaranteed, guaranteedTogether,
-                renamedNames(tangled, naming), renamedNames(widened, naming));
+        return new AdmissibleValues<>(renamedHeld, renamedKeys(perPosition(), naming),
+                standing().renamed(naming),
+                renamedBlocks(guaranteed(), naming), defaultGuaranteed(), guaranteedTogether(),
+                renamedNames(tangled(), naming), renamedNames(widened(), naming));
     }
 
     /** The same map, filed under what {@code naming} calls the positions of each of its blocks. */
@@ -1240,12 +1478,13 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     private AdmissibleValues<A> sayingWhatWasReadInTheOrderOf(List<AdmissibleValues<A>> read) {
         // Theirs in the order they were read, and then the ones the meet itself added, which no
         // reading arrived with.
-        Standing<A> out = standing.inTheOrderOf(read.stream().map(each -> each.standing).toList());
-        Set<Sameness.Block<A>> widened = new LinkedHashSet<>();
-        read.forEach(each -> widened.addAll(mapped(each.widened, sameness())));
-        widened.addAll(this.widened);
-        return new AdmissibleValues<>(held, perPosition, out, guaranteed,
-                defaultGuaranteed, guaranteedTogether, tangled, widened);
+        Standing<A> out =
+                standing().inTheOrderOf(read.stream().map(AdmissibleValues::standing).toList());
+        Set<Sameness.Block<A>> opened = new LinkedHashSet<>();
+        read.forEach(each -> opened.addAll(mapped(each.widened(), sameness())));
+        opened.addAll(widened());
+        return new AdmissibleValues<>(held(), perPosition(), out, guaranteed(),
+                defaultGuaranteed(), guaranteedTogether(), tangled(), opened);
     }
 
     /** Both readings holding at once. */
@@ -1254,7 +1493,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         // one of them does not, the sets it holds are each true of some value and of no one value
         // at once, and met they would promise a combination neither reading has — so the
         // conjunction promises nothing. See {@link #guaranteedAt}.
-        boolean apart = !guaranteedTogether || !other.guaranteedTogether;
+        boolean apart = !guaranteedTogether() || !other.guaranteedTogether();
         Set<Sameness.Block<A>> gaveUp = new LinkedHashSet<>();
         Held<A> both = met(other, sets, gaveUp);
         // The coordinates the conjunction answers in, which are the two readings' equalities
@@ -1265,8 +1504,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         Sameness<A> heldAsOne = both instanceof Held.Alternatives<A> it
                 ? it.commonSameness() : Sameness.discrete();
         return new AdmissibleValues<>(both,
-                narrowed(perPosition, other.perPosition, sets, heldAsOne, gaveUp),
-                alsoStanding(standing.and(other.standing), gaveUp),
+                narrowed(perPosition(), other.perPosition(), sets, heldAsOne, gaveUp),
+                alsoStanding(standing().and(other.standing()), gaveUp),
                 // Either way what comes out is a promise about whole values, which is why a
                 // conjunction never has to say it is not one. Two of them met is one — a value
                 // taken from each position of both stands in both readings — and nothing promised
@@ -1277,17 +1516,18 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
                 // more than the truth. The reasons below are about {@link #at}, which is an upper
                 // bound and would be saying something false if it widened quietly.
                 apart ? ValueSet.NONE
-                        : sets.meetPromised(null, defaultGuaranteed, other.defaultGuaranteed).set(),
+                        : sets.meetPromised(null, defaultGuaranteed(),
+                                other.defaultGuaranteed()).set(),
                 true,
                 // The intersection of two products is a product, and of anything else it need not
                 // be. What each side could not state, the conjunction cannot state either.
-                mapped(both(tangled, other.tangled), heldAsOne),
+                mapped(both(tangled(), other.tangled()), heldAsOne),
                 // And a block the two of them are tangled at is where the intersection can come
                 // back wider than the rules are: a pair they refuse between them is one neither
                 // per-block meet excludes. Everywhere else the relation is a product and the
                 // meet of a product is exact at each of its places, so those blocks keep what
                 // they had.
-                both(mapped(both(both(widened, other.widened), both(tangled, other.tangled)),
+                both(mapped(both(both(widened(), other.widened()), both(tangled(), other.tangled())),
                         heldAsOne), gaveUp));
     }
 
@@ -1388,13 +1628,14 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     public AdmissibleValues<A> alsoOpenedAt(Set<A> these) {
         return these.isEmpty() ? this
-                : new AdmissibleValues<>(held, perPosition, standing.alsoOpenedAt(these),
-                        guaranteed, defaultGuaranteed, guaranteedTogether, tangled, widened);
+                : new AdmissibleValues<>(held(), perPosition(), standing().alsoOpenedAt(these),
+                        guaranteed(), defaultGuaranteed(), guaranteedTogether(), tangled(),
+                        widened());
     }
 
     /** The alternatives this holds, which a reading that admits nothing has none of. */
     private Set<Alternative<A>> alternatives() {
-        return held instanceof Held.Alternatives<A> it ? it.boxes() : Set.of();
+        return held() instanceof Held.Alternatives<A> it ? it.boxes() : Set.of();
     }
 
     /** One alternative, which is what most readings hold. Nothing is put together, so what each
@@ -1433,8 +1674,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     private static <A> Map<Sameness.Block<A>, ValueSet> guaranteedBy(
             AdmissibleValues<A> these, AdmissibleValues<A> those, Sameness<A> heldAsOne,
             Allowance.Composing<A> both) {
-        Set<Sameness.Block<A>> named = mapped(these.guaranteed.keySet(), heldAsOne);
-        named.addAll(mapped(those.guaranteed.keySet(), heldAsOne));
+        Set<Sameness.Block<A>> named = mapped(these.guaranteed().keySet(), heldAsOne);
+        named.addAll(mapped(those.guaranteed().keySet(), heldAsOne));
         Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
         // What could not be built exactly comes back as nothing promised, which is what a promise
         // widens to. Nothing is recorded: see {@link #meet}.
@@ -1446,8 +1687,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     /** What this reading promises the value {@code block} stands for, whichever blocks of its own
      *  it holds those positions in. */
     private ValueSet promisedFor(Sameness.Block<A> block) {
-        return guaranteed.getOrDefault(blockOf(block.members().iterator().next()),
-                defaultGuaranteed);
+        return guaranteed().getOrDefault(blockOf(block.members().iterator().next()),
+                defaultGuaranteed());
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -116,9 +116,11 @@ import java.util.Set;
  *
  * <h2>What a reading may be</h2>
  *
- * <p>The states are the ones these operations reach: a leaf, a rule read at a position, two
- * positions held as one value or held apart, a rule nothing could read, a conjunction, what a
- * settled choice left, and a description worked out ({@link #realize}). Every one of the paragraphs
+ * <p>The states are the ones these operations reach: nothing read, a rule read at a position, two
+ * positions held as one value or held apart, a rule nothing could read, a conjunction, the
+ * positions a choice left open, the same reading under other names, and a description worked out
+ * ({@link #realize}). A choice is not among them and is not missing from them — one is taken while
+ * a reading is still a description, which is the paragraph above. Every one of the paragraphs
  * above states a relation between the parts — a whole that holds nothing is not a position that
  * holds nothing, {@link Held.Nothing} is not an empty union, what a promise is about is the blocks
  * the alternatives agree on — and none of those relations is a property of any part on its own. So
@@ -1006,10 +1008,10 @@ public final class AdmissibleValues<A> {
      */
     static <A> Realized<A> realize(PlannedValues.Settled<A> of, Allowance<A> by) {
         Unbuilt<A> gaveUp = new Unbuilt<>();
-        Map<A, ValueSet> perPosition = built(of.perPosition(), of.sameness(), by, gaveUp);
+        Map<A, ValueSet> perPosition = realized(of.perPosition(), of.sameness(), by, gaveUp);
         Held<A> held = switch (of.held()) {
             case PlannedHeld.Nothing<A> _ -> new Held.Nothing<A>();
-            case PlannedHeld.Alternatives<A> boxes -> standingIn(boxes, by, gaveUp);
+            case PlannedHeld.Alternatives<A> boxes -> alternatives(boxes, by, gaveUp);
         };
         // The blocks the answer is in, which are not the ones it was described in. An alternative
         // dropped for admitting nothing is one whose equalities the rest need not state, so what
@@ -1036,10 +1038,10 @@ public final class AdmissibleValues<A> {
      * nothing, and now that the sides are values it can be seen and taken out. Where every box
      * goes, nothing satisfies the rules.
      */
-    private static <A> Held<A> standingIn(PlannedHeld.Alternatives<A> boxes,
-                                          Allowance<A> by, Unbuilt<A> gaveUp) {
+    private static <A> Held<A> alternatives(PlannedHeld.Alternatives<A> boxes,
+                                            Allowance<A> by, Unbuilt<A> gaveUp) {
         Set<Alternative<A>> live = new LinkedHashSet<>();
-        Set<PlannedHeld.Alternative<A>> stands = new LinkedHashSet<>();
+        Set<PlannedHeld.Alternative<A>> standing = new LinkedHashSet<>();
         Refusal<A> dropped = null;
         for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             // The relation crosses unchanged. What a denial says is about the blocks and not about
@@ -1050,7 +1052,7 @@ public final class AdmissibleValues<A> {
             switch (said) {
                 case Held.Alternatives<A> it -> {
                     live.addAll(it.boxes());
-                    stands.add(box);
+                    standing.add(box);
                 }
                 case Held.Nothing<A> it -> dropped = dropped == null ? it.shown()
                         : Refusal.shownByBoth(dropped, it.shown());
@@ -1062,15 +1064,15 @@ public final class AdmissibleValues<A> {
         // What each block the alternatives agree on holds across the ones that stand, described
         // first and built once. Read off the sets instead, a join of two languages would be a
         // machine nobody counted.
-        Sameness<A> common = new PlannedHeld.Alternatives<>(stands).commonSameness();
+        Sameness<A> common = new PlannedHeld.Alternatives<>(standing).commonSameness();
         Set<Sameness.Block<A>> named = new LinkedHashSet<>();
-        stands.forEach(box ->
+        standing.forEach(box ->
                 box.positions().forEach(position -> named.add(common.blockOf(position))));
         Map<Sameness.Block<A>, ValueSet> across = new LinkedHashMap<>();
         for (Sameness.Block<A> block : named) {
             A member = block.members().iterator().next();
             AdmittedPlan plan = AdmittedPlan.joining(
-                    stands.stream().map(box -> box.get(member)).toList());
+                    standing.stream().map(box -> box.get(member)).toList());
             Realization made = by.realizer(block).of(plan);
             gaveUp.note(block, made);
             if (!made.upperBound().isAny()) {
@@ -1097,8 +1099,8 @@ public final class AdmissibleValues<A> {
     /** Each position's own description as the set it comes to, built under the allowance of the
      *  block that position is on, the ones nobody could build widened to every value and written
      *  down as such. */
-    private static <A> Map<A, ValueSet> built(Map<A, AdmittedPlan> of, Sameness<A> heldAsOne,
-                                              Allowance<A> by, Unbuilt<A> gaveUp) {
+    private static <A> Map<A, ValueSet> realized(Map<A, AdmittedPlan> of, Sameness<A> heldAsOne,
+                                                 Allowance<A> by, Unbuilt<A> gaveUp) {
         Map<A, ValueSet> out = new LinkedHashMap<>();
         of.forEach((atom, plan) -> {
             Sameness.Block<A> block = heldAsOne.blockOf(atom);
@@ -1480,11 +1482,11 @@ public final class AdmissibleValues<A> {
         // reading arrived with.
         Standing<A> out =
                 standing().inTheOrderOf(read.stream().map(AdmissibleValues::standing).toList());
-        Set<Sameness.Block<A>> opened = new LinkedHashSet<>();
-        read.forEach(each -> opened.addAll(mapped(each.widened(), sameness())));
-        opened.addAll(widened());
+        Set<Sameness.Block<A>> widened = new LinkedHashSet<>();
+        read.forEach(each -> widened.addAll(mapped(each.widened(), sameness())));
+        widened.addAll(widened());
         return new AdmissibleValues<>(held(), perPosition(), out, guaranteed(),
-                defaultGuaranteed(), guaranteedTogether(), tangled(), opened);
+                defaultGuaranteed(), guaranteedTogether(), tangled(), widened);
     }
 
     /** Both readings holding at once. */

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -361,6 +361,32 @@ public final class ConjoinedAdmissibleValues<A> {
         return out;
     }
 
+    /**
+     * Two of these say the same thing where they hold the same readings in the same order.
+     *
+     * <p>Written out, because what a query graph stops work on is whether an answer equals the one
+     * before it, and a conjunction ends up inside such an answer ({@code Confinement.Conjoined}).
+     * Left to the default, every conjunction differs from the one the last compile made and nothing
+     * that read one is kept past an edit that changed nothing.
+     *
+     * <p>The readings and not the index beside them: {@link #naming} is worked out from the factors
+     * and holds no fact they do not.
+     *
+     * <p><b>In the order they arrived, though what is answered does not turn on it.</b> The order is
+     * what a compilation writes out, so two of these holding the same readings in two orders write
+     * two things — and equal, one of them would be handed back where the other was made and a model
+     * would come out two ways on two days.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ConjoinedAdmissibleValues<?> it && factors.equals(it.factors);
+    }
+
+    @Override
+    public int hashCode() {
+        return factors.hashCode();
+    }
+
     @Override
     public String toString() {
         return factors.isEmpty() ? "everything" : String.join(" and ", factors.stream()

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -42,6 +42,22 @@ sealed interface PlannedHeld<A> {
             }
             boxes = Collections.unmodifiableSet(new LinkedHashSet<>(boxes));
         }
+
+        /**
+         * Which positions every alternative holds as one value.
+         *
+         * <p>What each of them holds as one is its own, so what the choice can say of a position is
+         * what every one of them says — read the other way round, a branch would lend its equality
+         * to the branch beside it. {@link AdmissibleValues.Held.Alternatives#commonSameness} over
+         * descriptions, and answered the same way.
+         */
+        Sameness<A> commonSameness() {
+            Sameness<A> out = null;
+            for (Alternative<A> box : boxes) {
+                out = out == null ? box.sameness() : out.common(box.sameness());
+            }
+            return out == null ? Sameness.discrete() : out;
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -38,6 +38,7 @@ public sealed interface PlannedValues<A> {
      * relations to each other that no part states on its own, so they are this one's own and a
      * caller arrives at a description by writing one.
      */
+    @souther.compiler.reading.StateOfAReading
     final class Settled<A> implements PlannedValues<A> {
 
         /** The parts, together — see {@link AdmissibleValues}, whose reasoning this is. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -92,6 +92,7 @@ public sealed interface PlannedValues<A> {
         }
 
         /** What the rules of the model could not say, and what stopped this reading saying it. */
+        @Override
         public Standing<A> standing() {
             return parts.standing();
         }

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -75,12 +75,10 @@ public sealed interface PlannedValues<A> {
 
         private final Parts<A> parts;
 
-        private Settled(PlannedHeld<A> held, Map<A, AdmittedPlan> perPosition,
-                        Standing<A> standing, Map<Sameness.Block<A>, AdmittedPlan> guaranteed,
-                        AdmittedPlan defaultGuaranteed, boolean guaranteedTogether,
-                        Set<Sameness.Block<A>> tangled, Set<Sameness.Block<A>> widened) {
-            this.parts = new Parts<>(held, perPosition, standing, guaranteed, defaultGuaranteed,
-                    guaranteedTogether, tangled, widened);
+        /** The one constructor there is, and it takes the parts as one — see
+         *  {@link AdmissibleValues}, where a maker handed the parts is what may not be written. */
+        private Settled(Parts<A> parts) {
+            this.parts = parts;
         }
 
         /** What the rules leave: the alternatives, or nothing. */
@@ -141,18 +139,19 @@ public sealed interface PlannedValues<A> {
 
     /** Nothing read and nothing missed, which is what a reading starts from. */
     static <A> PlannedValues<A> top() {
-        return new Settled<>(PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
-                Standing.nothing(), Map.of(), AdmittedPlan.ANY, true, Set.of(), Set.of());
+        return new Settled<>(new Settled.Parts<>(
+                PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
+                Standing.nothing(), Map.of(), AdmittedPlan.ANY, true, Set.of(), Set.of()));
     }
 
     /** One position said to admit what {@code plan} describes, and nothing missed. */
     static <A> PlannedValues<A> at(A atom, AdmittedPlan plan) {
         Map<A, AdmittedPlan> said = Map.of(atom, plan);
-        return new Settled<>(
+        return new Settled<>(new Settled.Parts<>(
                 plan instanceof AdmittedPlan.Nothing ? new PlannedHeld.Nothing<>()
                         : PlannedHeld.one(PlannedHeld.Alternative.at(said)),
                 said, Standing.nothing(), Map.of(Sameness.Block.of(atom), plan),
-                AdmittedPlan.ANY, true, Set.of(), Set.of());
+                AdmittedPlan.ANY, true, Set.of(), Set.of()));
     }
 
     /**
@@ -171,11 +170,11 @@ public sealed interface PlannedValues<A> {
         // one: it shapes the relation without touching what any position admits. Left out, a
         // choice between two equalities would be a union of two relations that no product holds
         // and would say it lost nothing, since what it reads to decide that is this key set.
-        return new Settled<>(
+        return new Settled<>(new Settled.Parts<>(
                 PlannedHeld.one(PlannedHeld.Alternative.of(
                         new PlannedHeld.Box<>(Map.of(block, AdmittedPlan.ANY)))),
                 Map.of(), Standing.nothing(), Map.of(block, AdmittedPlan.ANY),
-                AdmittedPlan.ANY, true, Set.of(), Set.of());
+                AdmittedPlan.ANY, true, Set.of(), Set.of()));
     }
 
     /**
@@ -199,11 +198,11 @@ public sealed interface PlannedValues<A> {
         Map<Sameness.Block<A>, AdmittedPlan> promised = new LinkedHashMap<>();
         promised.put(Sameness.Block.of(here), AdmittedPlan.NONE);
         promised.put(Sameness.Block.of(there), AdmittedPlan.NONE);
-        return new Settled<>(
+        return new Settled<>(new Settled.Parts<>(
                 PlannedHeld.one(new PlannedHeld.Alternative<>(
                         new PlannedHeld.Box<>(Map.of()), Apartness.of(here, there))),
                 Map.of(), Standing.nothing(), promised, AdmittedPlan.ANY, true,
-                Set.of(), Set.of());
+                Set.of(), Set.of()));
     }
 
     /**
@@ -222,9 +221,10 @@ public sealed interface PlannedValues<A> {
         // Nothing is guaranteed anywhere, and at the positions it does not name as much as at the
         // ones it does: what a rule this has no word for admits is not known, so a choice offering
         // it as an alternative is offering nothing that can be counted on.
-        return new Settled<>(PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
+        return new Settled<>(new Settled.Parts<>(
+                PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
                 Standing.of(named, why), Map.of(), AdmittedPlan.NONE, true, Set.of(),
-                Set.of());
+                Set.of()));
     }
 
     /**
@@ -520,7 +520,7 @@ public sealed interface PlannedValues<A> {
         // conjoined and closed — see {@link AdmissibleValues#meet}.
         Sameness<A> heldAsOne = both instanceof PlannedHeld.Alternatives<A> it
                 ? it.commonSameness() : Sameness.discrete();
-        return new Settled<>(both,
+        return new Settled<>(new Settled.Parts<>(both,
                 narrowed(here.perPosition(), there.perPosition()),
                 here.standing().and(there.standing()),
                 apart ? Map.of() : guaranteedBy(here, there, heldAsOne, true),
@@ -530,7 +530,7 @@ public sealed interface PlannedValues<A> {
                 true,
                 mapped(both(here.tangled(), there.tangled()), heldAsOne),
                 mapped(both(both(here.widened(), there.widened()),
-                        both(here.tangled(), there.tangled())), heldAsOne));
+                        both(here.tangled(), there.tangled())), heldAsOne)));
     }
 
     /**
@@ -685,11 +685,11 @@ public sealed interface PlannedValues<A> {
                 empty.put(atom, AdmittedPlan.NONE);
             }
         });
-        return new Settled<>(new PlannedHeld.Nothing<>(), empty,
+        return new Settled<>(new Settled.Parts<>(new PlannedHeld.Nothing<>(), empty,
                 here.standing().and(there.standing()),
                 Map.of(), AdmittedPlan.NONE, true,
                 eachApart(both(here.tangled(), there.tangled())),
-                eachApart(both(here.widened(), there.widened())));
+                eachApart(both(here.widened(), there.widened()))));
     }
 
     /**
@@ -726,7 +726,7 @@ public sealed interface PlannedValues<A> {
         // and what it costs is a promise this could have kept rather than one it could not.
         Set<Sameness.Block<A>> shapedBy = mapped(promisedAt(here), heldAsOne);
         shapedBy.addAll(mapped(promisedAt(there), heldAsOne));
-        return new Settled<>(held,
+        return new Settled<>(new Settled.Parts<>(held,
                 widenedBy(here.perPosition(), there.perPosition()), spoiled,
                 covered, coveredElsewhere,
                 here.guaranteedTogether() && there.guaranteedTogether() && shapedBy.size() <= 1,
@@ -737,7 +737,7 @@ public sealed interface PlannedValues<A> {
                 apart || shapedBy.size() <= 1
                         ? mapped(both(here.tangled(), there.tangled()), heldAsOne)
                         : both(mapped(both(here.tangled(), there.tangled()), heldAsOne), shapedBy),
-                mapped(both(here.widened(), there.widened()), heldAsOne));
+                mapped(both(here.widened(), there.widened()), heldAsOne)));
     }
 
     /** The alternatives of both, which is what the choice leaves where they are held apart. */
@@ -923,9 +923,9 @@ public sealed interface PlannedValues<A> {
         Sameness<A> heldAsOne = it.sameness();
         Set<Sameness.Block<A>> widened = new LinkedHashSet<>(it.widened());
         why.positions().forEach(atom -> widened.add(heldAsOne.blockOf(atom)));
-        return new Settled<>(it.held(), it.perPosition(), it.standing().and(why),
-                it.guaranteed(), it.defaultGuaranteed(), it.guaranteedTogether(), it.tangled(),
-                widened);
+        return new Settled<>(new Settled.Parts<>(it.held(), it.perPosition(),
+                it.standing().and(why), it.guaranteed(), it.defaultGuaranteed(),
+                it.guaranteedTogether(), it.tangled(), widened));
     }
 
     /** Every subject this reading is filed under — see {@link AdmissibleValues#subjects}. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -33,35 +33,109 @@ public sealed interface PlannedValues<A> {
      * What each of them is for is written there and is not written twice; what is different is that
      * a box may describe a set that turns out to be empty, since telling that is the work this
      * whole arrangement puts off.
+     *
+     * <p>And reached the way a reading is reached, for the reason written there: the parts state
+     * relations to each other that no part states on its own, so they are this one's own and a
+     * caller arrives at a description by writing one.
      */
-    record Settled<A>(PlannedHeld<A> held, Map<A, AdmittedPlan> perPosition,
-                      Standing<A> standing,
-                      Map<Sameness.Block<A>, AdmittedPlan> guaranteed,
-                      AdmittedPlan defaultGuaranteed,
-                      boolean guaranteedTogether, Set<Sameness.Block<A>> tangled,
-                      Set<Sameness.Block<A>> widened) implements PlannedValues<A> {
+    final class Settled<A> implements PlannedValues<A> {
 
-        public Settled {
-            perPosition = said(perPosition);
-            // A guarantee empty at one position is empty at all of them — see
-            // {@link AdmissibleValues}. Only what is settled empty counts: a description nobody has
-            // worked out is not a reason to throw a promise away, and where it does turn out empty
-            // the resolved reading drops it then.
-            if (held instanceof PlannedHeld.Nothing
-                    || defaultGuaranteed instanceof AdmittedPlan.Nothing
-                    || guaranteed.values().stream().anyMatch(AdmittedPlan.Nothing.class::isInstance)) {
-                guaranteed = Map.of();
-                defaultGuaranteed = AdmittedPlan.NONE;
-                guaranteedTogether = true;
+        /** The parts, together — see {@link AdmissibleValues}, whose reasoning this is. */
+        private record Parts<A>(PlannedHeld<A> held, Map<A, AdmittedPlan> perPosition,
+                                Standing<A> standing,
+                                Map<Sameness.Block<A>, AdmittedPlan> guaranteed,
+                                AdmittedPlan defaultGuaranteed,
+                                boolean guaranteedTogether, Set<Sameness.Block<A>> tangled,
+                                Set<Sameness.Block<A>> widened) {
+
+            private Parts {
+                perPosition = said(perPosition);
+                // A guarantee empty at one position is empty at all of them — see
+                // {@link AdmissibleValues}. Only what is settled empty counts: a description
+                // nobody has worked out is not a reason to throw a promise away, and where it does
+                // turn out empty the resolved reading drops it then.
+                if (held instanceof PlannedHeld.Nothing
+                        || defaultGuaranteed instanceof AdmittedPlan.Nothing
+                        || guaranteed.values().stream()
+                                .anyMatch(AdmittedPlan.Nothing.class::isInstance)) {
+                    guaranteed = Map.of();
+                    defaultGuaranteed = AdmittedPlan.NONE;
+                    guaranteedTogether = true;
+                }
+                guaranteed = Collections.unmodifiableMap(new LinkedHashMap<>(guaranteed));
+                tangled = Collections.unmodifiableSet(new LinkedHashSet<>(tangled));
+                widened = Collections.unmodifiableSet(new LinkedHashSet<>(widened));
+                // Everything filed under a block, said in this reading's own terms — see
+                // {@link AdmissibleValues}, whose reasoning this is.
+                Sameness<A> mine = held instanceof PlannedHeld.Alternatives<A> it
+                        ? it.commonSameness() : Sameness.discrete();
+                mine.filing(guaranteed.keySet(), tangled, widened);
             }
-            guaranteed = Collections.unmodifiableMap(new LinkedHashMap<>(guaranteed));
-            tangled = Collections.unmodifiableSet(new LinkedHashSet<>(tangled));
-            widened = Collections.unmodifiableSet(new LinkedHashSet<>(widened));
-            // Everything filed under a block, said in this reading's own coordinates — see
-            // {@link AdmissibleValues}, whose reasoning this is.
-            Sameness<A> mine = held instanceof PlannedHeld.Alternatives<A> it
-                    ? commonTo(it) : Sameness.discrete();
-            mine.filing(guaranteed.keySet(), tangled, widened);
+        }
+
+        private final Parts<A> parts;
+
+        private Settled(PlannedHeld<A> held, Map<A, AdmittedPlan> perPosition,
+                        Standing<A> standing, Map<Sameness.Block<A>, AdmittedPlan> guaranteed,
+                        AdmittedPlan defaultGuaranteed, boolean guaranteedTogether,
+                        Set<Sameness.Block<A>> tangled, Set<Sameness.Block<A>> widened) {
+            this.parts = new Parts<>(held, perPosition, standing, guaranteed, defaultGuaranteed,
+                    guaranteedTogether, tangled, widened);
+        }
+
+        /** What the rules leave: the alternatives, or nothing. */
+        public PlannedHeld<A> held() {
+            return parts.held();
+        }
+
+        /** What each position's own rules leave it, every alternative merged. */
+        public Map<A, AdmittedPlan> perPosition() {
+            return parts.perPosition();
+        }
+
+        /** What the rules of the model could not say, and what stopped this reading saying it. */
+        public Standing<A> standing() {
+            return parts.standing();
+        }
+
+        /** What each block is guaranteed to admit. */
+        public Map<Sameness.Block<A>, AdmittedPlan> guaranteed() {
+            return parts.guaranteed();
+        }
+
+        /** What a position this holds no guarantee for is guaranteed to admit. */
+        public AdmittedPlan defaultGuaranteed() {
+            return parts.defaultGuaranteed();
+        }
+
+        /** Whether the guarantees are about whole values. */
+        public boolean guaranteedTogether() {
+            return parts.guaranteedTogether();
+        }
+
+        /** The blocks whose correlations this reading has lost. */
+        public Set<Sameness.Block<A>> tangled() {
+            return parts.tangled();
+        }
+
+        /** The blocks whose answer cannot be guaranteed to be what the read rules leave them. */
+        public Set<Sameness.Block<A>> widened() {
+            return parts.widened();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Settled<?> it && parts.equals(it.parts);
+        }
+
+        @Override
+        public int hashCode() {
+            return parts.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return parts.toString();
         }
     }
 
@@ -341,7 +415,7 @@ public sealed interface PlannedValues<A> {
     default Sameness<A> sameness() {
         return switch (this) {
             case Settled<A> it -> it.held() instanceof PlannedHeld.Alternatives<A> boxes
-                    ? commonTo(boxes) : Sameness.discrete();
+                    ? boxes.commonSameness() : Sameness.discrete();
         };
     }
 
@@ -379,14 +453,6 @@ public sealed interface PlannedValues<A> {
         return everywhere == null ? Refusal.nowhere() : everywhere;
     }
 
-    /** What every alternative holds as one value. */
-    private static <A> Sameness<A> commonTo(PlannedHeld.Alternatives<A> boxes) {
-        Sameness<A> out = null;
-        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
-            out = out == null ? box.sameness() : out.common(box.sameness());
-        }
-        return out == null ? Sameness.discrete() : out;
-    }
 
     /**
      * The positions this reading narrowed, which is what a reader asking what it took in is asking.
@@ -453,7 +519,7 @@ public sealed interface PlannedValues<A> {
         // The coordinates the conjunction answers in, which are the two readings' equalities
         // conjoined and closed — see {@link AdmissibleValues#meet}.
         Sameness<A> heldAsOne = both instanceof PlannedHeld.Alternatives<A> it
-                ? commonTo(it) : Sameness.discrete();
+                ? it.commonSameness() : Sameness.discrete();
         return new Settled<>(both,
                 narrowed(here.perPosition(), there.perPosition()),
                 here.standing().and(there.standing()),
@@ -638,7 +704,7 @@ public sealed interface PlannedValues<A> {
         Settled<A> there = other.settled();
         PlannedHeld<A> held = apart ? apart(here, there) : merged(here, there);
         Sameness<A> heldAsOne = held instanceof PlannedHeld.Alternatives<A> it
-                ? commonTo(it) : Sameness.discrete();
+                ? it.commonSameness() : Sameness.discrete();
         Map<Sameness.Block<A>, AdmittedPlan> covered = guaranteedBy(here, there, heldAsOne, false);
         AdmittedPlan coveredElsewhere = AdmittedPlan.joining(
                 List.of(here.defaultGuaranteed(), there.defaultGuaranteed()));
@@ -781,7 +847,7 @@ public sealed interface PlannedValues<A> {
      */
     default Realized<A> resolve(Allowance<A> by) {
         return switch (this) {
-            case Settled<A> it -> resolved(it, by);
+            case Settled<A> it -> AdmissibleValues.realize(it, by);
         };
     }
 
@@ -841,32 +907,6 @@ public sealed interface PlannedValues<A> {
         }
     }
 
-    private static <A> Realized<A> resolved(Settled<A> of, Allowance<A> by) {
-        Unbuilt<A> gaveUp = new Unbuilt<>();
-        Map<A, ValueSet> perPosition = realized(of.perPosition(), of.sameness(), by, gaveUp);
-        AdmissibleValues.Held<A> held = switch (of.held()) {
-            case PlannedHeld.Nothing<A> _ -> new AdmissibleValues.Held.Nothing<A>();
-            case PlannedHeld.Alternatives<A> boxes -> alternatives(boxes, by, gaveUp);
-        };
-        // The coordinates the answer is in, which are not the ones it was described in. An
-        // alternative dropped for admitting nothing is one whose equalities the rest need not
-        // state, so what the survivors hold as one may be coarser than what every description did
-        // — and everything filed under a block is said in the answer's own before it is built.
-        Sameness<A> heldAsOne = held instanceof AdmissibleValues.Held.Alternatives<A> it
-                ? it.commonSameness() : Sameness.discrete();
-        Map<Sameness.Block<A>, AdmittedPlan> promising = new LinkedHashMap<>();
-        of.guaranteed().forEach((block, plan) -> promising.merge(
-                heldAsOne.blockOf(block.members().iterator().next()), plan,
-                (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
-        return new Realized<>(new AdmissibleValues<>(held, perPosition,
-                gaveUp.beside(of.standing()),
-                promised(promising, by), promised(of.defaultGuaranteed(), by.elsewhere()),
-                of.guaranteedTogether(),
-                mapped(of.tangled(), heldAsOne),
-                mapped(both(of.widened(), gaveUp.names()), heldAsOne)),
-                gaveUp.aboutARule(), gaveUp.aboutTheAnswer());
-    }
-
     /**
      * The same reading with more said about what stopped it.
      *
@@ -886,108 +926,6 @@ public sealed interface PlannedValues<A> {
         return new Settled<>(it.held(), it.perPosition(), it.standing().and(why),
                 it.guaranteed(), it.defaultGuaranteed(), it.guaranteedTogether(), it.tangled(),
                 widened);
-    }
-
-    /**
-     * The alternatives, with the ones nothing stands in dropped.
-     *
-     * <p>Where the invariant a settled reading has is kept: a box with a side admitting nothing
-     * stands for nothing, and now that the sides are values it can be seen and taken out. Where
-     * every box goes, nothing satisfies the rules.
-     */
-    private static <A> AdmissibleValues.Held<A> alternatives(PlannedHeld.Alternatives<A> boxes,
-                                                             Allowance<A> by, Unbuilt<A> gaveUp) {
-        Set<AdmissibleValues.Alternative<A>> live = new LinkedHashSet<>();
-        Set<PlannedHeld.Alternative<A>> standing = new LinkedHashSet<>();
-        Refusal<A> dropped = null;
-        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
-            // The relation crosses unchanged. What a denial says is about the blocks and not about
-            // what they were described as holding, so building the descriptions is not where it
-            // could be lost or gained — and whether anything stands in the alternative is asked the
-            // one way it is asked wherever two of them are put together.
-            AdmissibleValues.Held<A> said = new AdmissibleValues.Alternative.Met<>(
-                    builtIn(box, by, gaveUp), box.apart()).stands();
-            switch (said) {
-                case AdmissibleValues.Held.Alternatives<A> it -> {
-                    live.addAll(it.boxes());
-                    standing.add(box);
-                }
-                case AdmissibleValues.Held.Nothing<A> it -> dropped = dropped == null ? it.shown()
-                        : Refusal.shownByBoth(dropped, it.shown());
-            }
-        }
-        if (live.isEmpty()) {
-            return new AdmissibleValues.Held.Nothing<>(
-                    dropped == null ? Refusal.nowhere() : dropped);
-        }
-        // What each block the alternatives agree on holds across the ones that stand, described
-        // first and built once. Read off the sets instead, a join of two languages would be a
-        // machine nobody counted.
-        Sameness<A> common = commonTo(new PlannedHeld.Alternatives<>(standing));
-        Set<Sameness.Block<A>> named = new LinkedHashSet<>();
-        standing.forEach(box ->
-                box.positions().forEach(position -> named.add(common.blockOf(position))));
-        Map<Sameness.Block<A>, ValueSet> across = new LinkedHashMap<>();
-        for (Sameness.Block<A> block : named) {
-            A member = block.members().iterator().next();
-            AdmittedPlan plan = AdmittedPlan.joining(
-                    standing.stream().map(box -> box.get(member)).toList());
-            Realization made = by.realizer(block).of(plan);
-            gaveUp.note(block, made);
-            if (!made.upperBound().isAny()) {
-                across.put(block, made.upperBound());
-            }
-        }
-        return AdmissibleValues.Held.Alternatives.of(live, common, across);
-    }
-
-    /** One alternative's descriptions as the sets they come to, each built under its own block's
-     *  allowance. */
-    private static <A> Map<Sameness.Block<A>, ValueSet> builtIn(PlannedHeld.Alternative<A> box,
-                                                                Allowance<A> by,
-                                                                Unbuilt<A> gaveUp) {
-        Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
-        box.at().forEach((block, plan) -> {
-            Realization made = by.realizer(block).of(plan);
-            gaveUp.note(block, made);
-            out.put(block, made.upperBound());
-        });
-        return out;
-    }
-
-    /** Each position's own description as the set it comes to, built under the allowance of the
-     *  block that position is on, the ones nobody could build widened to every value and written
-     *  down as such. */
-    private static <A> Map<A, ValueSet> realized(Map<A, AdmittedPlan> of, Sameness<A> heldAsOne,
-                                                 Allowance<A> by, Unbuilt<A> gaveUp) {
-        Map<A, ValueSet> out = new LinkedHashMap<>();
-        of.forEach((atom, plan) -> {
-            Sameness.Block<A> block = heldAsOne.blockOf(atom);
-            Realization made = by.realizer(block).of(plan);
-            gaveUp.note(block, made);
-            out.put(atom, made.upperBound());
-        });
-        return out;
-    }
-
-    /**
-     * The same for a promise, which widens the other way.
-     *
-     * <p>A promise nobody could work out promises nothing, and that is the strongest thing that
-     * stays true — where an answer this could not build widens to every value, a guarantee it could
-     * not build shrinks to none. Nothing is recorded: a reader short of a guarantee has been told
-     * no more than the truth, and the reasons below are about the upper bound.
-     */
-    private static <A> Map<Sameness.Block<A>, ValueSet> promised(
-            Map<Sameness.Block<A>, AdmittedPlan> of, Allowance<A> by) {
-        Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
-        of.forEach((block, plan) -> out.put(block, promised(plan, by.realizer(block))));
-        return out;
-    }
-
-    private static ValueSet promised(AdmittedPlan plan, Realizer by) {
-        Realization made = by.of(plan);
-        return made.isExact() ? made.upperBound() : ValueSet.NONE;
     }
 
     /** Every subject this reading is filed under — see {@link AdmissibleValues#subjects}. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -21,23 +21,103 @@ import java.util.Set;
  * answer may not: the same rules in another order would have been built, so there is no rule to
  * name. A store that took either would be a store whose type says less than the model does.
  *
- * @param values what the reading leaves, every position it could not work out widened to every value
- * @param aboutARule what a rule of the model is answerable for, each saying which written thing
- *                   asked for what was refused. Not per position: an allowance is held per position
- *                   and every rule reaching one pays into it, so the place is what the spending was
- *                   arranged by and is not what any of it is about
- * @param aboutTheAnswer what the answer is answerable for, naming no rule and nothing written
+ * <p>Which is why the three of them are not a way in. Handed side by side, a caller writes a reading
+ * beside shortfalls no work refused, and the sentence above — that they were settled by one piece of
+ * work — is true of nothing. So one is reached by doing the work ({@link AdmissibleValues#realize}),
+ * or by saying that there was none to do ({@link #workedOut}).
+ *
+ * <p>{@code aboutARule} is not per position: an allowance is held per position and every rule
+ * reaching one pays into it, so the place is what the spending was arranged by and is not what any
+ * of it is about.
  */
-public record Realized<A>(AdmissibleValues<A> values,
-                          Set<Unbuilt.RuleShortfall<A>> aboutARule,
-                          List<Unbuilt.AnswerShortfall<A>> aboutTheAnswer) {
+public final class Realized<A> {
 
-    public Realized {
-        // Held in the order they were recorded, which nothing may read and every run has to give
-        // the same: an immutable copy iterates in an order salted per run of the machine, and a
-        // reader that seeded anything from one would report a model two ways on two days.
-        aboutARule = Collections.unmodifiableSet(new LinkedHashSet<>(aboutARule));
-        aboutTheAnswer = List.copyOf(aboutTheAnswer);
+    /** The parts, together — see {@link AdmissibleValues.Parts}, whose reasoning this is. */
+    private record Parts<A>(AdmissibleValues<A> values,
+                            Set<Unbuilt.RuleShortfall<A>> aboutARule,
+                            List<Unbuilt.AnswerShortfall<A>> aboutTheAnswer) {
+
+        private Parts {
+            // Held in the order they were recorded, which nothing may read and every run has to
+            // give the same: an immutable copy iterates in an order salted per run of the machine,
+            // and a reader that seeded anything from one would report a model two ways on two days.
+            aboutARule = Collections.unmodifiableSet(new LinkedHashSet<>(aboutARule));
+            aboutTheAnswer = List.copyOf(aboutTheAnswer);
+        }
+    }
+
+    private final Parts<A> parts;
+
+    private Realized(AdmissibleValues<A> values, Set<Unbuilt.RuleShortfall<A>> aboutARule,
+                     List<Unbuilt.AnswerShortfall<A>> aboutTheAnswer) {
+        this.parts = new Parts<>(values, aboutARule, aboutTheAnswer);
+    }
+
+    /**
+     * A reading beside the work that made it.
+     *
+     * <p>Handed the record of the work rather than the two lists it kept, which is what makes the
+     * sentence above true of what comes out: the shortfalls are the ones that piece of work noted,
+     * and a caller cannot pair a reading with refusals nothing refused. Read off it here, since
+     * which of the two a refusal is owed to is settled where it was noted.
+     */
+    static <A> Realized<A> of(AdmissibleValues<A> values, Unbuilt<A> gaveUp) {
+        return new Realized<>(values, gaveUp.aboutARule(), gaveUp.aboutTheAnswer());
+    }
+
+    /**
+     * A reading every position of which was worked out, so nothing was left unbuilt.
+     *
+     * <p>For a caller holding a reading that never was a description — one read straight into sets,
+     * where there was nothing to build and no allowance to run out. What is said here is that
+     * nothing was refused, and it is said by there being nothing to say it about.
+     */
+    public static <A> Realized<A> workedOut(AdmissibleValues<A> values) {
+        return new Realized<>(values, Set.of(), List.of());
+    }
+
+    /** What the reading leaves, every position it could not work out widened to every value. */
+    public AdmissibleValues<A> values() {
+        return parts.values();
+    }
+
+    /** What a rule of the model is answerable for, each saying which written thing asked for what
+     *  was refused. */
+    public Set<Unbuilt.RuleShortfall<A>> aboutARule() {
+        return parts.aboutARule();
+    }
+
+    /** What the answer is answerable for, naming no rule and nothing written. */
+    public List<Unbuilt.AnswerShortfall<A>> aboutTheAnswer() {
+        return parts.aboutTheAnswer();
+    }
+
+    /**
+     * The same answer, unable to speak for {@code these} because a choice offered an alternative
+     * nothing could read.
+     *
+     * <p>What was refused while working the reading out is what it was, and this adds nothing to
+     * it: the positions a choice left open are a fact about the branches anybody can be in, and
+     * they are carried by the reading — see {@link AdmissibleValues#alsoOpenedAt}.
+     */
+    public Realized<A> alsoOpenedAt(Set<A> these) {
+        return these.isEmpty() ? this
+                : new Realized<>(values().alsoOpenedAt(these), aboutARule(), aboutTheAnswer());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Realized<?> it && parts.equals(it.parts);
+    }
+
+    @Override
+    public int hashCode() {
+        return parts.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return parts.toString();
     }
 
     /**
@@ -53,7 +133,7 @@ public record Realized<A>(AdmissibleValues<A> values,
      * be in, and has kept no record of why nobody knows.
      */
     public Emptiness emptiness() {
-        if (values.isBottom()) {
+        if (values().isBottom()) {
             return Emptiness.EMPTY;
         }
         return unbuilt().isEmpty() ? Emptiness.NONEMPTY : Emptiness.UNDECIDED;
@@ -62,8 +142,8 @@ public record Realized<A>(AdmissibleValues<A> values,
     /** Every position whose answer was not built, whichever of the two it is owed to. */
     public Set<A> unbuilt() {
         Set<A> out = new LinkedHashSet<>();
-        aboutARule.forEach(each -> out.add(each.at()));
-        aboutTheAnswer.forEach(each -> out.add(each.at()));
+        aboutARule().forEach(each -> out.add(each.at()));
+        aboutTheAnswer().forEach(each -> out.add(each.at()));
         return Collections.unmodifiableSet(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -32,6 +32,7 @@ import java.util.Set;
  * reaching one pays into it, so the place is what the spending was arranged by and is not what any
  * of it is about.
  */
+@souther.compiler.reading.StateOfAReading
 public final class Realized<A> {
 
     /** The parts, together — see {@link AdmissibleValues.Parts}, whose reasoning this is. */
@@ -57,16 +58,20 @@ public final class Realized<A> {
     }
 
     /**
-     * A reading beside the work that made it.
+     * What a working-out came to, as the two things it settled.
      *
-     * <p>Handed the record of the work rather than the two lists it kept, which is what makes the
-     * sentence above true of what comes out: the shortfalls are the ones that piece of work noted,
-     * and a caller cannot pair a reading with refusals nothing refused. Read off it here, since
-     * which of the two a refusal is owed to is settled where it was noted.
+     * <p>Handed one thing and not two. The reading and the record of the work are settled together
+     * and only realization can put them together ({@link AdmissibleValues.Outcome}), so what comes
+     * back holds shortfalls that piece of work noted — handed them separately, a caller pairs a
+     * reading whose positions an allowance ran out on with a record that noted nothing, and the
+     * sentence this type says about itself is false of it.
+     *
+     * <p>Which of the two a refusal is owed to is read off the record here, since that is settled
+     * where it was noted.
      */
-    static <A> Realized<A> of(AdmissibleValues<A> values, Unbuilt<A> gaveUp) {
-        return new Realized<>(
-                new Parts<>(values, gaveUp.aboutARule(), gaveUp.aboutTheAnswer()));
+    static <A> Realized<A> of(AdmissibleValues.Outcome<A> outcome) {
+        return new Realized<>(new Parts<>(outcome.values(), outcome.work().aboutARule(),
+                outcome.work().aboutTheAnswer()));
     }
 
     /** What the reading leaves, every position it could not work out widened to every value. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -21,10 +21,12 @@ import java.util.Set;
  * answer may not: the same rules in another order would have been built, so there is no rule to
  * name. A store that took either would be a store whose type says less than the model does.
  *
- * <p>Which is why the three of them are not a way in. Handed side by side, a caller writes a reading
- * beside shortfalls no work refused, and the sentence above — that they were settled by one piece of
- * work — is true of nothing. So one is reached by doing the work ({@link AdmissibleValues#realize}),
- * or by saying that there was none to do ({@link #workedOut}).
+ * <p>Which is why the three of them are not a way in, and why there is no way in that takes the
+ * reading alone either. Handed the parts side by side, a caller writes a reading beside shortfalls
+ * no work refused; handed the reading, a caller says of a reading that came from somewhere that
+ * nothing was refused while it was made, which is a claim about work it did not do and can be false
+ * of the very reading it is handed. So one is reached by doing the work
+ * ({@link AdmissibleValues#realize}), and there is no second way.
  *
  * <p>{@code aboutARule} is not per position: an allowance is held per position and every rule
  * reaching one pays into it, so the place is what the spending was arranged by and is not what any
@@ -48,9 +50,10 @@ public final class Realized<A> {
 
     private final Parts<A> parts;
 
-    private Realized(AdmissibleValues<A> values, Set<Unbuilt.RuleShortfall<A>> aboutARule,
-                     List<Unbuilt.AnswerShortfall<A>> aboutTheAnswer) {
-        this.parts = new Parts<>(values, aboutARule, aboutTheAnswer);
+    /** The one constructor there is, and it takes the parts as one — see
+     *  {@link AdmissibleValues}, where a maker handed the parts is what may not be written. */
+    private Realized(Parts<A> parts) {
+        this.parts = parts;
     }
 
     /**
@@ -62,18 +65,8 @@ public final class Realized<A> {
      * which of the two a refusal is owed to is settled where it was noted.
      */
     static <A> Realized<A> of(AdmissibleValues<A> values, Unbuilt<A> gaveUp) {
-        return new Realized<>(values, gaveUp.aboutARule(), gaveUp.aboutTheAnswer());
-    }
-
-    /**
-     * A reading every position of which was worked out, so nothing was left unbuilt.
-     *
-     * <p>For a caller holding a reading that never was a description — one read straight into sets,
-     * where there was nothing to build and no allowance to run out. What is said here is that
-     * nothing was refused, and it is said by there being nothing to say it about.
-     */
-    public static <A> Realized<A> workedOut(AdmissibleValues<A> values) {
-        return new Realized<>(values, Set.of(), List.of());
+        return new Realized<>(
+                new Parts<>(values, gaveUp.aboutARule(), gaveUp.aboutTheAnswer()));
     }
 
     /** What the reading leaves, every position it could not work out widened to every value. */
@@ -102,7 +95,8 @@ public final class Realized<A> {
      */
     public Realized<A> alsoOpenedAt(Set<A> these) {
         return these.isEmpty() ? this
-                : new Realized<>(values().alsoOpenedAt(these), aboutARule(), aboutTheAnswer());
+                : new Realized<>(new Parts<>(values().alsoOpenedAt(these), aboutARule(),
+                        aboutTheAnswer()));
     }
 
     @Override

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -3,11 +3,14 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.numeric.OrderedIntervals;
-import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.Lacks;
 import souther.compiler.values.PlannedValues;
+import souther.compiler.values.Refusal;
+import souther.compiler.values.RelationalLack;
+import souther.compiler.values.Sameness;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -30,10 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * of the model states. So one is named, and which one is settled by the order the value declares
  * its positions rather than by the order the reading met them.
  *
- * <p>Made here rather than from a declaration. A branch is settled by the first thing that shows it
- * empty and the proof is fixed there, so a clause never reaches the second block — the state that
- * holds both is one a caller builds by conjoining two readings that are each already empty, which
- * is what {@link ConstraintState} has to answer about however it arrives.
+ * <p><b>Asked of the proof and not of a state built to carry it.</b> Which proof a walk of a state
+ * reaches is that walk's business and moves as this compiler learns to show more; how a proof is
+ * named is about what a proof can say, and a {@link Refusal} carrying two blocks is a value the
+ * refusals of two clauses conjoined come to. Asked through a state, these would need one built out
+ * of parts nothing read — which is the shape a reading of values is no longer come by, and a test
+ * that wrote one would be fixing the naming to whatever a walk happens to reach today.
+ *
+ * <p>What a walk does reach is asked once, at the end, through the reading a declaration's clauses
+ * are worked out into.
  */
 class AProofNamesOneBlockAndNotAllOfThemTest {
 
@@ -47,23 +55,52 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
     private static final Value B = Value.text("B");
 
     /** Two positions held as one and stated to admit values that share none. */
-    private static AdmissibleValues<FactSubject> emptiedAt(FactSubject one, FactSubject other,
-                                                           Allowance<FactSubject> sets) {
-        return built(PlannedValues.holdingAsOne(one, other), sets)
-                .meet(says(one, A, sets), sets)
-                .meet(says(other, B, sets), sets);
+    private static PlannedValues<FactSubject> emptiedAt(FactSubject one, FactSubject other) {
+        return PlannedValues.<FactSubject>holdingAsOne(one, other)
+                .meet(says(one, A))
+                .meet(says(other, B));
     }
 
-    /** A description worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> built(PlannedValues<FactSubject> planned,
-                                                       Allowance<FactSubject> sets) {
-        return planned.resolve(sets).values();
+    /** One rule about one position. */
+    private static PlannedValues<FactSubject> says(FactSubject atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
     }
 
-    /** One rule about one position, worked out. */
-    private static AdmissibleValues<FactSubject> says(FactSubject atom, Value value,
-                                                      Allowance<FactSubject> sets) {
-        return built(PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value))), sets);
+    /**
+     * A description worked out, which is how a confinement whose values are in hand is come by.
+     *
+     * <p>The clauses are conjoined while they are still descriptions and worked out once, which is
+     * what a declaration's reading does. Worked out one at a time and met afterwards, the fixture
+     * would be paying for a machine per clause and asking a question this compiler never asks.
+     */
+    private static Confinement.Worked<FactSubject> worked(PlannedValues<FactSubject> planned,
+                                                          Allowance<FactSubject> sets) {
+        return new Confinement.Planned<>(planned, OrderedIntervals.top(), Map.of()).resolve(sets);
+    }
+
+    /**
+     * A block left with no value, said the way a reading of a clause says it.
+     *
+     * <p>What a proof of this kind is: the rules hold these positions as one value, and that value
+     * has none.
+     */
+    private static Confinement.Admission<FactSubject> emptyAt(
+            Set<Sameness.Block<FactSubject>> blocks) {
+        return Confinement.Admission.eachOf(souther.compiler.values.Emptiness.EMPTY,
+                Confinement.EmptyBy.POSITIONS_HELD_AS_ONE, blocks,
+                Confinement.Shown.BY_THE_READINGS);
+    }
+
+    /** The block those positions are one value in. */
+    private static Sameness.Block<FactSubject> block(FactSubject one, FactSubject other) {
+        return Sameness.of(one, other).blockOf(one);
+    }
+
+    /** What a proof comes to in a value declaring these positions, which is the question. */
+    private static Emptiness named(Confinement.Admission<FactSubject> shown,
+                                   SequencedMap<FactSubject, Emptiness.AtAField.Where> positions) {
+        return ProofOfEmptiness.named(shown, positions, new Emptiness.ConflictingRules())
+                .orElseThrow();
     }
 
     /** Where the value declares each of its positions, in the order it declares them. */
@@ -81,8 +118,7 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
     void oneBlockLeftWithNoValueIsNamedAsThePlacesTogether() {
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(emptiedAt(P, Q, sets), OrderedIntervals.top(),
-                        Map.of()), sets);
+                .takingRead(worked(emptiedAt(P, Q), sets), sets);
 
         Optional<Emptiness> why = state.holdsNothing(declared());
 
@@ -100,20 +136,12 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
      */
     @Test
     void twoBlocksLeftWithNoValueAreNamedOneAtATime() {
-        Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<FactSubject> both =
-                emptiedAt(R, S, sets).meet(emptiedAt(P, Q, sets), sets);
-        assertEquals(2, both.refusedBy().blocks().size(), "or this measures one block twice");
-
-        ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(both, OrderedIntervals.top(), Map.of()), sets);
-
         Emptiness.AtEqualPositions at = assertInstanceOf(Emptiness.AtEqualPositions.class,
-                state.holdsNothing(declared()).orElseThrow());
+                named(emptyAt(Set.of(block(R, S), block(P, Q))), declared()));
 
         assertEquals(2, at.where().size(), "one block, not the four positions of both");
         assertEquals(new Emptiness.AtAField.Where.In("p"), at.where().getFirst(),
-                "and the one whose places the value declares first, whichever was met first");
+                "and the one whose places the value declares first, whichever was shown first");
     }
 
     /**
@@ -131,14 +159,19 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
      */
     @Test
     void aStateRefusedBothWaysIsReportedAtTheBlockThatHoldsNothing() {
-        Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<FactSubject> both = emptiedAt(P, Q, sets)
-                .meet(built(PlannedValues.<FactSubject>holdingAsOne(R, S)
-                        .meet(PlannedValues.heldApart(R, S)), sets), sets);
+        // A conjunction keeps what either side showed, which is how one proof comes to carry both.
+        Refusal<FactSubject> shown = Refusal.eitherShown(
+                Refusal.atEachOf(Set.of(block(P, Q))),
+                Refusal.ofThemTogether(Lacks.of(
+                        new RelationalLack.ABlockApartFromItself<>(block(R, S)))));
+        Confinement.Admission<FactSubject> both = new Confinement.Admission<>(
+                souther.compiler.values.Emptiness.EMPTY,
+                Confinement.EmptyBy.POSITIONS_HELD_AS_ONE, shown,
+                Confinement.Shown.BY_THE_READINGS);
 
-        assertEquals(Set.of(souther.compiler.values.Sameness.of(P, Q).blockOf(P)),
-                both.refusedBy().atEachOf(), "one side leaves this block nothing");
-        assertTrue(!both.refusedBy().together().isEmpty(), "and the other refuses two together");
+        assertEquals(Set.of(block(P, Q)), shown.atEachOf(),
+                "one side leaves this block nothing");
+        assertTrue(!shown.together().isEmpty(), "and the other refuses two together");
 
         SequencedMap<FactSubject, Emptiness.AtAField.Where> declared = new LinkedHashMap<>();
         declared.put(R, new Emptiness.AtAField.Where.In("r"));
@@ -146,11 +179,8 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
         declared.put(P, new Emptiness.AtAField.Where.In("p"));
         declared.put(Q, new Emptiness.AtAField.Where.In("q"));
 
-        ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(both, OrderedIntervals.top(), Map.of()), sets);
-
         Emptiness.AtEqualPositions at = assertInstanceOf(Emptiness.AtEqualPositions.class,
-                state.holdsNothing(declared).orElseThrow());
+                named(both, declared));
         assertEquals(List.of(new Emptiness.AtAField.Where.In("p"),
                         new Emptiness.AtAField.Where.In("q")), at.where(),
                 "the places whose one value has none, and not the ones declared first");
@@ -168,22 +198,21 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
     @Test
     void twoBlocksBeginningAtOnePositionAreToldApartByThePlacesAfterIt() {
         for (boolean reversed : new boolean[] {false, true}) {
-            Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-            AdmissibleValues<FactSubject> one = emptiedAt(P, R, sets);
-            AdmissibleValues<FactSubject> other = emptiedAt(P, Q, sets);
-            AdmissibleValues<FactSubject> both = reversed
-                    ? other.meet(one, sets) : one.meet(other, sets);
-            assertEquals(2, both.refusedBy().blocks().size(), "or the two witnesses are not both here");
-
-            ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                    .takingRead(Confinement.Worked.of(both, OrderedIntervals.top(), Map.of()),
-                            sets);
+            Refusal<FactSubject> one = Refusal.atEachOf(Set.of(block(P, R)));
+            Refusal<FactSubject> other = Refusal.atEachOf(Set.of(block(P, Q)));
+            Confinement.Admission<FactSubject> both = new Confinement.Admission<>(
+                    souther.compiler.values.Emptiness.EMPTY,
+                    Confinement.EmptyBy.POSITIONS_HELD_AS_ONE,
+                    reversed ? Refusal.eitherShown(other, one) : Refusal.eitherShown(one, other),
+                    Confinement.Shown.BY_THE_READINGS);
+            assertEquals(2, both.site().blocks().size(),
+                    "or the two witnesses are not both here");
 
             Emptiness.AtEqualPositions at = assertInstanceOf(Emptiness.AtEqualPositions.class,
-                    state.holdsNothing(declared()).orElseThrow());
+                    named(both, declared()));
             assertEquals(List.of(new Emptiness.AtAField.Where.In("p"),
                             new Emptiness.AtAField.Where.In("q")), at.where(),
-                    "p with q is declared before p with r, met either way round");
+                    "p with q is declared before p with r, shown either way round");
         }
     }
 
@@ -220,8 +249,7 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
     void aBlockOfPositionsThisValueDoesNotDeclareIsNotNamed() {
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(emptiedAt(P, Q, sets), OrderedIntervals.top(),
-                        Map.of()), sets);
+                .takingRead(worked(emptiedAt(P, Q), sets), sets);
 
         SequencedMap<FactSubject, Emptiness.AtAField.Where> elsewhere = new LinkedHashMap<>();
         elsewhere.put(R, new Emptiness.AtAField.Where.In("r"));

--- a/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARenamingNamesTwoSubjectsTwoSubjectsTest.java
@@ -9,7 +9,6 @@ import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
-import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.AsACompilationAllows;
 import souther.compiler.values.PlannedValues;
@@ -118,9 +117,9 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
     void aSubjectHeldByTwoDomainsIsRenamedOnce() {
         ConstraintState<FactSubject> both = ConstraintState.<FactSubject>top()
                 .taking(ONLY_IN_FACTS, true)
-                .takingRead(Confinement.Worked.of(
-                                says(ONLY_IN_FACTS, "A"),
-                                OrderedIntervals.top(), Map.of()),
+                .takingRead(new Confinement.Planned<>(says(ONLY_IN_FACTS, "A"),
+                                OrderedIntervals.top(), Map.<FactSubject, Carrier>of())
+                                .resolve(AsACompilationAllows.forAdmittedValues()),
                         AsACompilationAllows.forAdmittedValues());
         java.util.concurrent.atomic.AtomicInteger asked = new java.util.concurrent.atomic.AtomicInteger();
 
@@ -131,23 +130,21 @@ class ARenamingNamesTwoSubjectsTwoSubjectsTest {
         assertEquals(ValueSet.just(Value.text("A")), said.values().at("p#0"));
     }
 
-    /** One rule about one position, worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> says(FactSubject atom, String text) {
-        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(Value.text(text))))
-                .resolve(AsACompilationAllows.forAdmittedValues())
-                .values();
+    /** One rule about one position. */
+    private static PlannedValues<FactSubject> says(FactSubject atom, String text) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(Value.text(text))));
     }
 
     /** One subject in each domain, and no subject in two of them. */
     private static ConstraintState<FactSubject> spread() {
         return ConstraintState.<FactSubject>top()
                 .taking(ONLY_IN_FACTS, true)
-                .takingRead(Confinement.Worked.of(
-                                says(ONLY_IN_VALUES, "A"),
+                .takingRead(new Confinement.Planned<>(says(ONLY_IN_VALUES, "A"),
                                 OrderedIntervals.at(ONLY_IN_ORDERED, new OrderedInterval(
                                         Endpoint.inclusive(Count.of(6)),
                                         Endpoint.inclusive(Count.of(2)))),
-                                Map.of()),
+                                Map.<FactSubject, Carrier>of())
+                                .resolve(AsACompilationAllows.forAdmittedValues()),
                         AsACompilationAllows.forAdmittedValues())
                 .taking(LinearForm.<FactSubject>atom(ONLY_IN_NUMBERS)
                                 .minus(LinearForm.<FactSubject>constant(BigDecimal.valueOf(3))),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest.java
@@ -241,9 +241,8 @@ class WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest {
                 .meet(OrderedIntervals.at(Y, new OrderedInterval(
                         Endpoint.inclusive(Text.of("D")), null)));
         ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(
-                        here.joinLiveApart(there).resolve(sets).values(), ends,
-                        Map.of(X, Carrier.TEXT, Y, Carrier.TEXT)), sets);
+                .takingRead(new Confinement.Planned<>(here.joinLiveApart(there), ends,
+                        Map.of(X, Carrier.TEXT, Y, Carrier.TEXT)).resolve(sets), sets);
 
         assertEquals(ValueSet.oneOf(new LinkedHashSet<>(List.of(
                         Value.text("A"), Value.text("C")))), state.values().at(X),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -9,7 +9,6 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
-import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
@@ -181,15 +180,14 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
         // Met as one reading and handed over as one. Two readings are combined where the
         // clauses of a declaration are read, and never at the state's boundary.
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                says("A", sets).meet(says("B", sets), sets),
-                OrderedIntervals.top(), Map.of()), sets);
+        return ConstraintState.<FactSubject>top().takingRead(
+                new Confinement.Planned<>(says("A").meet(says("B")), OrderedIntervals.top(),
+                        Map.<FactSubject, Carrier>of()).resolve(sets), sets);
     }
 
-    /** One rule about the position, worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> says(String text, Allowance<FactSubject> sets) {
-        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
-                .resolve(sets).values();
+    /** One rule about the position. */
+    private static PlannedValues<FactSubject> says(String text) {
+        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))));
     }
 
     private static ConstraintState<FactSubject> orderedAtBottom() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -9,7 +9,6 @@ import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
-import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
@@ -138,15 +137,14 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
         // Met as one reading and handed over as one. Two readings are combined where the
         // clauses of a declaration are read, and never at the state's boundary.
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                says("A", sets).meet(says("B", sets), sets),
-                OrderedIntervals.top(), Map.of()), sets);
+        return ConstraintState.<FactSubject>top().takingRead(
+                new Confinement.Planned<>(says("A").meet(says("B")), OrderedIntervals.top(),
+                        Map.<FactSubject, Carrier>of()).resolve(sets), sets);
     }
 
-    /** One rule about the position, worked out, which is how a reading is come by. */
-    private static AdmissibleValues<FactSubject> says(String text, Allowance<FactSubject> sets) {
-        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))))
-                .resolve(sets).values();
+    /** One rule about the position. */
+    private static PlannedValues<FactSubject> says(String text) {
+        return PlannedValues.at(A_POSITION, AdmittedPlan.of(ValueSet.just(Value.text(text))));
     }
 
     private static ConstraintState<FactSubject> orderedAtBottom() {
@@ -160,11 +158,11 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
     /** The values pinned at one string, and the order left the strings above another. */
     private static ConstraintState<FactSubject> setBesideARangeItIsOutside() {
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        return ConstraintState.<FactSubject>top().takingRead(Confinement.Worked.of(
-                says("A", sets),
-                OrderedIntervals.at(A_POSITION, new OrderedInterval(
-                        Endpoint.inclusive(souther.compiler.numeric.Text.of("B")), null)),
-                Map.of(A_POSITION, Carrier.TEXT)), sets);
+        return ConstraintState.<FactSubject>top().takingRead(
+                new Confinement.Planned<>(says("A"),
+                        OrderedIntervals.at(A_POSITION, new OrderedInterval(
+                                Endpoint.inclusive(souther.compiler.numeric.Text.of("B")), null)),
+                        Map.of(A_POSITION, Carrier.TEXT)).resolve(sets), sets);
     }
 
     private static ConstraintState<FactSubject> shownAtBottom() {

--- a/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
@@ -84,15 +84,22 @@ class AReadingIsWhatItsOperationsReachTest {
      * <p>Found from a class of the compiler rather than from a path written here, so this reads the
      * classes it is running with. Its own tests are not among them: a test writes a reading to look
      * at it and ships nothing.
+     *
+     * <p>Loaded without being initialised. What is asked of them is what they declare, which is
+     * there as soon as the class is; running their static initialisers would make this walk carry
+     * whatever any of them does on the way in, and a proposition about what a type says of itself
+     * would fail for a reason that is nothing to do with it.
      */
     private static List<Class<?>> compiled() {
         Path where = classesUnder(AdmissibleValues.class);
+        ClassLoader by = AdmissibleValues.class.getClassLoader();
         try (Stream<Path> found = Files.walk(where)) {
             List<Class<?>> out = new ArrayList<>();
             for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
                 String named = where.relativize(each).toString()
                         .replace(java.io.File.separatorChar, '.');
-                out.add(Class.forName(named.substring(0, named.length() - ".class".length())));
+                out.add(Class.forName(named.substring(0, named.length() - ".class".length()),
+                        false, by));
             }
             return List.copyOf(out);
         } catch (IOException e) {

--- a/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
@@ -50,11 +50,12 @@ class AReadingIsWhatItsOperationsReachTest {
         declaring.add(state);
         declaring.addAll(Set.of(alsoDeclaring));
         for (Class<?> each : declaring) {
-            // A constructor is a way in where what it makes is one of these, which is what takes in
-            // the class a sealed reading permits and leaves out a type that only answers with one.
-            for (Constructor<?> made : state.isAssignableFrom(each)
-                    ? each.getDeclaredConstructors() : new Constructor<?>[0]) {
-                ways.add(access(made) + signature(made, each.getSimpleName()));
+            // A constructor is a way in where what it makes is one of these, which takes in the
+            // class a sealed reading permits and leaves out a type that only answers with one.
+            if (state.isAssignableFrom(each)) {
+                for (Constructor<?> made : each.getDeclaredConstructors()) {
+                    ways.add(access(made) + signature(made, each.getSimpleName()));
+                }
             }
             for (Method m : each.getDeclaredMethods()) {
                 if (!Modifier.isPrivate(m.getModifiers()) && m.getReturnType() == state) {

--- a/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
@@ -3,21 +3,33 @@ package souther.compiler.values;
 import org.junit.jupiter.api.Test;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.reading.StateOfAReading;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.RecordComponent;
-import java.util.ArrayDeque;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -37,102 +49,119 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * operation rather than in the value: remove the operation and the way to say the fact is gone with
  * it.
  *
- * <p><b>Nothing outside the type can mint one</b>, since every constructor is its own, so the ways
- * in are what the type declares and the lists below are the whole of them. A way added tomorrow
- * arrives here as a difference and is a question somebody answers, rather than a hole nobody sees.
+ * <p><b>Which types these are is read off what they say of themselves</b>
+ * ({@link StateOfAReading}), and never off whether they already hold their parts the way a state
+ * does. Worked out from the shape, this would find the states that are already right and pass over
+ * one written as a record of its parts — which is the state these propositions exist to refuse, and
+ * the only one such a reading could never report. So membership is declared and the shape is what
+ * is held to.
  *
- * <p><b>Which types those are is found and not listed.</b> A state added tomorrow and left off a
- * list here would be one nothing says anything about, which is the shape of the very thing these
- * propositions are for. So the family is walked to from the two languages a reading of a
- * declaration joins, through what each state is made of and what its operations take and answer
- * with, and what makes a type one of them is that it holds its parts the way these do.
+ * <p>And read off the compiled classes, so a state declaring itself in a package nothing here names
+ * is found as surely as one beside these.
  */
 class AReadingIsWhatItsOperationsReachTest {
 
-    /**
-     * The two languages a declaration's reading joins, which is where the walk starts.
-     *
-     * <p>Roots and not the family: what a rule of a value leaves is said in these two and in
-     * nothing else ({@code Confinement}), and everything the two of them are made of, take, or
-     * answer with is reached from here.
-     */
-    private static final List<Class<?>> ROOTS =
-            List.of(AdmissibleValues.class, OrderedIntervals.class);
+    /** Every class the compiler is made of, which is what both of the walks below read. */
+    private static final List<Class<?>> COMPILED = compiled();
 
-    /**
-     * Every state the readings reach, in the order their names sort.
-     *
-     * <p>A state is one that keeps its parts as this design says a state keeps them: one thing, and
-     * that thing a record of the parts. Which is what makes the family findable at all — a type
-     * that publishes its parts as a constructor is exactly what these propositions refuse, and one
-     * that is reached from here and does not hold them this way is a difference in
-     * {@link #theFamilyIsTheOneTheReadingsReach}.
-     */
+    /** Every state of a reading the compiler declares, in the order their names sort. */
     private static final List<Class<?>> FAMILY = family();
 
     private static List<Class<?>> family() {
-        List<Class<?>> found = new java.util.ArrayList<>();
-        Set<Class<?>> walked = new LinkedHashSet<>();
-        Deque<Class<?>> pending = new ArrayDeque<>(ROOTS);
-        while (!pending.isEmpty()) {
-            Class<?> one = pending.poll();
-            if (!ofTheReadings(one) || !walked.add(one)) {
-                continue;
-            }
-            if (!keepsItsPartsAsAState(one)) {
-                continue;
-            }
-            found.add(one);
-            for (RecordComponent part : WhatAReadingIsMadeOf.of(one)) {
-                pending.add(part.getType());
-            }
-            for (Method each : one.getDeclaredMethods()) {
-                pending.add(each.getReturnType());
-                pending.addAll(List.of(each.getParameterTypes()));
-            }
-            for (Class<?> nested : one.getDeclaredClasses()) {
-                pending.add(nested);
+        List<Class<?>> found = new ArrayList<>();
+        for (Class<?> each : COMPILED) {
+            if (each.isAnnotationPresent(StateOfAReading.class)) {
+                found.add(each);
             }
         }
         found.sort(Comparator.comparing(Class::getName));
         return List.copyOf(found);
     }
 
-    /** Whether the type is one of the two packages a reading of a value is written in. */
-    private static boolean ofTheReadings(Class<?> type) {
-        return "souther.compiler.values".equals(type.getPackageName())
-                || "souther.compiler.numeric".equals(type.getPackageName());
+    /**
+     * The compiler's own classes, read from where the ones this test runs against were built.
+     *
+     * <p>Found from a class of the compiler rather than from a path written here, so this reads the
+     * classes it is running with. Its own tests are not among them: a test writes a reading to look
+     * at it and ships nothing.
+     */
+    private static List<Class<?>> compiled() {
+        Path where = classesUnder(AdmissibleValues.class);
+        try (Stream<Path> found = Files.walk(where)) {
+            List<Class<?>> out = new ArrayList<>();
+            for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
+                String named = where.relativize(each).toString()
+                        .replace(java.io.File.separatorChar, '.');
+                out.add(Class.forName(named.substring(0, named.length() - ".class".length())));
+            }
+            return List.copyOf(out);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Path classesUnder(Class<?> one) {
+        try {
+            return Path.of(one.getProtectionDomain().getCodeSource().getLocation().toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * The states of a reading are these, and a type saying so is one of them.
+     *
+     * <p>Written down so that a state added to the family is somebody saying so. What each of them
+     * is for is its own type's business; that these are the ones is read off what they declare, and
+     * one added or dropped arrives here as a difference.
+     */
+    @Test
+    void theStatesOfAReadingAreTheOnesThatSaySo() {
+        assertEquals(List.of(AdmissibleValues.class, PlannedValues.Settled.class, Realized.class,
+                        OrderedIntervals.class).stream()
+                        .sorted(Comparator.comparing(Class::getName)).toList(),
+                FAMILY,
+                "the states of a reading are not the ones this says they are. One added here is"
+                        + " held to the propositions below, which is what declaring it means");
+        assertTrue(COMPILED.size() > FAMILY.size(),
+                "the walk read the compiler's classes, or every proposition below is about nothing");
+    }
+
+    /** And each of them keeps its parts as one record of its own, which is what it declared. */
+    @Test
+    void eachOfThemKeepsItsPartsAsOneRecordOfItsOwn() {
+        for (Class<?> state : FAMILY) {
+            assertTrue(keepsItsPartsAsOne(state),
+                    () -> state.getSimpleName() + " says it is a state of a reading and holds "
+                            + List.of(state.getDeclaredFields()) + ", where a state holds one"
+                            + " record of the parts it is made of");
+        }
+    }
+
+    /**
+     * And the reading that asks it can say no, which is what makes the answer above worth having.
+     *
+     * <p>{@link OrderedInterval} is a pair of ends: a product with nothing to hold up between its
+     * parts, which writes them out as what it is. Asked the same question, it comes back with no —
+     * so a state reported as keeping its parts as its own is a fact about the state.
+     */
+    @Test
+    void andATypeThatIsARecordOfItsPartsIsSeenNotToKeepThem() {
+        assertFalse(keepsItsPartsAsOne(OrderedInterval.class),
+                "the question cannot answer no, so its yes above says nothing");
     }
 
     /** Whether it holds one thing and that thing is a record of its parts. */
-    private static boolean keepsItsPartsAsAState(Class<?> type) {
-        List<Field> mine = new java.util.ArrayList<>();
+    private static boolean keepsItsPartsAsOne(Class<?> type) {
+        List<Field> mine = new ArrayList<>();
         for (Field each : type.getDeclaredFields()) {
             if (!Modifier.isStatic(each.getModifiers())) {
                 mine.add(each);
             }
         }
-        return mine.size() == 1 && mine.getFirst().getType().isRecord()
-                && "Parts".equals(mine.getFirst().getType().getSimpleName());
-    }
-
-    /**
-     * The family is the one the readings reach, and it is these.
-     *
-     * <p>Written down so that a state added to it is somebody saying so. What each of the four is
-     * for is its own type's business; that they are four is this walk's answer and not a list kept
-     * here — a fifth reached from the readings arrives as a difference, and one that stops being
-     * reachable does too.
-     */
-    @Test
-    void theFamilyIsTheOneTheReadingsReach() {
-        assertEquals(List.of(AdmissibleValues.class, PlannedValues.Settled.class, Realized.class,
-                        OrderedIntervals.class).stream()
-                        .sorted(Comparator.comparing(Class::getName)).toList(),
-                FAMILY,
-                "the states the readings reach are not the ones this says they are. A state added"
-                        + " here holds its parts the way these do, and the propositions below are"
-                        + " asked of it too");
+        return mine.size() == 1 && mine.getFirst().getType().isRecord();
     }
 
     /** And none of them may be made from outside, whichever of them it is. */
@@ -146,50 +175,92 @@ class AReadingIsWhatItsOperationsReachTest {
     }
 
     /**
-     * Every way to get one, read off what declares them.
+     * Every way one of these is made, read off the code of every class the compiler is made of.
      *
-     * <p>Constructors whatever their access, because a maker handed the parts is the thing being
-     * asked about and being private is not what settles it; methods unless they are private, since
-     * a private one is this type composing itself. Read off the declaring types and not off the
-     * compiler: a reading's constructor is its own, so nothing else can answer with one it did not
-     * get from here.
+     * <p>Read off what a method does and not off what it answers with. A method whose type says it
+     * answers with a reading may be handing back one it was given — a projection of a state that
+     * holds it, an answer that carries it along — and that is not a way in. What makes a way in is
+     * making one, which is the constructor and whatever invokes it, and that is in the code.
+     *
+     * <p>Every class, whatever it is called and wherever it is written: a maker somewhere this
+     * happened to be told to look at is a maker, and a walk told where to look answers about the
+     * places it was told about.
+     *
+     * <p>Whatever its access, because a maker handed the parts is the thing being asked about and
+     * being private is not what settles it. A construction reached through a method reference makes
+     * one as surely as one written out, so the bootstrap arguments of an {@code invokedynamic} are
+     * read too.
      */
-    private static Set<String> waysInto(Class<?> state, Class<?>... alsoDeclaring) {
+    private static Set<String> waysInto(Class<?> state) {
+        String internal = state.getName().replace('.', '/');
         Set<String> ways = new LinkedHashSet<>();
-        Set<Class<?>> declaring = new LinkedHashSet<>();
-        declaring.add(state);
-        declaring.addAll(Set.of(alsoDeclaring));
-        for (Class<?> each : declaring) {
-            // A constructor is a way in where what it makes is one of these, which takes in the
-            // class a sealed reading permits and leaves out a type that only answers with one.
-            if (state.isAssignableFrom(each)) {
-                for (Constructor<?> made : each.getDeclaredConstructors()) {
-                    ways.add(access(made) + signature(made, each.getSimpleName()));
-                }
-            }
-            for (Method m : each.getDeclaredMethods()) {
-                if (!Modifier.isPrivate(m.getModifiers()) && m.getReturnType() == state) {
-                    ways.add(access(m) + signature(m, m.getName()));
+        for (Path each : classFiles()) {
+            ClassModel owner = parse(each);
+            boolean itself = owner.thisClass().asInternalName().equals(internal);
+            for (MethodModel method : owner.methods()) {
+                boolean made = "<init>".equals(method.methodName().stringValue())
+                        ? itself : makes(method, internal);
+                if (made) {
+                    ways.add(named(owner, method));
                 }
             }
         }
         return ways;
     }
 
-    private static String access(Executable of) {
-        int modifiers = of.getModifiers();
-        if (Modifier.isPublic(modifiers)) {
-            return "public ";
+    /** One way in, as the method it is: what it is called, and what it was handed. */
+    private static String named(ClassModel owner, MethodModel method) {
+        boolean constructor = "<init>".equals(method.methodName().stringValue());
+        StringBuilder out = new StringBuilder();
+        if (method.flags().has(AccessFlag.PUBLIC)) {
+            out.append("public ");
+        } else if (method.flags().has(AccessFlag.PRIVATE)) {
+            out.append("private ");
         }
-        return Modifier.isPrivate(modifiers) ? "private " : "";
-    }
-
-    private static String signature(Executable of, String named) {
-        StringBuilder out = new StringBuilder(named).append('(');
-        for (int i = 0; i < of.getParameterTypes().length; i++) {
-            out.append(i == 0 ? "" : ", ").append(of.getParameterTypes()[i].getSimpleName());
+        out.append(constructor ? simpleNameOf(owner.thisClass().asInternalName())
+                : method.methodName().stringValue()).append('(');
+        List<ClassDesc> takes = method.methodTypeSymbol().parameterList();
+        for (int at = 0; at < takes.size(); at++) {
+            String takesOne = takes.get(at).displayName();
+            out.append(at == 0 ? "" : ", ").append(takesOne.substring(takesOne.lastIndexOf('$') + 1));
         }
         return out.append(')').toString();
+    }
+
+    private static String simpleNameOf(String internal) {
+        String named = internal.substring(internal.lastIndexOf('/') + 1);
+        return named.substring(named.lastIndexOf('$') + 1);
+    }
+
+    /** Whether the method's own code makes one: written out, or handed to something that will. */
+    private static boolean makes(MethodModel method, String internal) {
+        return method.code().map(code -> code.elementStream().anyMatch(element -> switch (element) {
+            case InvokeInstruction it -> internal.equals(it.owner().asInternalName())
+                    && "<init>".equals(it.name().stringValue());
+            case InvokeDynamicInstruction it -> it.invokedynamic().bootstrap().arguments().stream()
+                    .anyMatch(argument -> argument instanceof MethodHandleEntry handle
+                            && handle.asSymbol() instanceof DirectMethodHandleDesc said
+                            && internal.equals(said.owner().descriptorString()
+                                    .substring(1, said.owner().descriptorString().length() - 1))
+                            && "<init>".equals(said.methodName()));
+            default -> false;
+        })).orElse(false);
+    }
+
+    private static ClassModel parse(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static List<Path> classFiles() {
+        try (Stream<Path> found = Files.walk(classesUnder(AdmissibleValues.class))) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**
@@ -206,9 +277,12 @@ class AReadingIsWhatItsOperationsReachTest {
                         "private AdmissibleValues(Parts)",
                         "public top()",
                         "public meet(AdmissibleValues, Allowance)",
-                        "public metAll(List, Allowance)",
                         "public renamed(Function)",
-                        "public alsoOpenedAt(Set)"),
+                        "public alsoOpenedAt(Set)",
+                        // A conjunction of several, which writes down the order the rules were
+                        // read in over what meeting them one after another left.
+                        "private sayingWhatWasReadInTheOrderOf(List)",
+                        "realize(Settled, Allowance)"),
                 waysInto(AdmissibleValues.class),
                 "a way into a reading of the values that is not one of the operations it is"
                         + " composed by. If it takes the parts and hands a reading back, the"
@@ -218,30 +292,38 @@ class AReadingIsWhatItsOperationsReachTest {
     /**
      * And realization answers with the reading beside what could not be built while making it.
      *
-     * <p>The two are settled by one piece of work and are handed over together, so writing them
-     * side by side is writing down a refusal no work made — and handing over the reading alone is
-     * saying of a reading that came from somewhere that nothing was refused while it was made,
-     * which is a claim about work that was not done. So the work is what it is made from: the one
-     * way in takes what noted the shortfalls, and there is no way in that takes the reading.
+     * <p>The two are settled by one piece of work, so what makes one is handed what that work came
+     * to and cannot be handed the two halves — a reading whose positions an allowance ran out on,
+     * beside a record of work that noted nothing, is a pair no working-out produced.
      */
     @Test
     void andADescriptionIsWorkedOutByTheReadingItComesTo() {
         assertEquals(Set.of(
                         "private Realized(Parts)",
-                        "of(AdmissibleValues, Unbuilt)",
-                        "public alsoOpenedAt(Set)",
-                        "realize(Settled, Allowance)"),
-                waysInto(Realized.class, AdmissibleValues.class),
+                        "of(Outcome)",
+                        "public alsoOpenedAt(Set)"),
+                waysInto(Realized.class),
                 "realization is the one way across, and it is the reading's own: handed the"
                         + " description and the allowance it builds the sets, decides which of"
                         + " them nobody could work out, and settles the rest against what came out");
     }
 
+    /** And what realization came to is minted by realization and by nothing else. */
+    @Test
+    void andWhatAWorkingOutCameToIsMintedWhereTheWorkIsDone() {
+        assertEquals(Set.of(
+                        "private Outcome(AdmissibleValues, Unbuilt)",
+                        "realize(Settled, Allowance)"),
+                waysInto(AdmissibleValues.Outcome.class),
+                "a second way to put a reading beside a record of work is a second way to say that"
+                        + " this work made this reading, which is what handing them over as two"
+                        + " came to");
+    }
+
     /**
      * A description is reached the same way, over plans rather than sets.
      *
-     * <p>Asked of the interface and the one reading it permits together, since what a caller holds
-     * is the interface and every way to one of those answers with it.
+     * <p>Asked of the interface a caller holds, since every way to one of these answers with it.
      */
     @Test
     void everyWayToADescriptionIsSomethingReadingIt() {
@@ -255,9 +337,10 @@ class AReadingIsWhatItsOperationsReachTest {
                         "public meet(PlannedValues)",
                         "public alsoStanding(Standing)",
                         "public bothDead(PlannedValues)",
-                        "public joinLive(PlannedValues)",
-                        "public joinLiveApart(PlannedValues)"),
-                waysInto(PlannedValues.class, PlannedValues.Settled.class),
+                        // A choice, whose two ways of leaving the alternatives — merged into one
+                        // product, or held apart — are one maker told which.
+                        "private joinedLive(PlannedValues, boolean)"),
+                waysInto(PlannedValues.Settled.class),
                 "a way into a description that is not one of the operations it is composed by");
     }
 
@@ -278,12 +361,11 @@ class AReadingIsWhatItsOperationsReachTest {
     }
 
     /**
-     * And a reading is closed because it is closed, not because nothing here can see a way in.
+     * And the walk that reads the ways in can see one that is published.
      *
-     * <p>{@link OrderedInterval} is a pair of ends, which is a product with nothing to hold up
-     * between its parts: any pair of them is an interval somebody can read, and it publishes the
-     * way to write one down. Read by the same walk, it comes back with that way — so a reading
-     * reported as having none is a fact about the reading.
+     * <p>{@link OrderedInterval} publishes the way to write a pair of ends down. Read by the same
+     * walk, it comes back with that way — so a state reported as having none is a fact about the
+     * state and not about a walk that finds nothing wherever it looks.
      */
     @Test
     void aTypeThatDoesPublishItsPartsIsSeenToPublishThem() {

--- a/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
@@ -6,9 +6,15 @@ import souther.compiler.numeric.OrderedIntervals;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,9 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>What each of these holds is several parts that state relations to each other — a whole that
  * holds nothing is not a position that holds nothing, the alternatives are never an empty union, a
- * promise is about the blocks every alternative agrees on. None of those is a property of one part,
- * so a caller handed the parts side by side can write down a combination nothing read, and nothing
- * says so. What holds the relations up is that the operations are the only things that make one.
+ * promise is about the blocks every alternative agrees on, a refusal is one the work that built the
+ * reading noted. None of those is a property of one part, so a caller handed the parts side by side
+ * can write down a combination nothing read, and nothing says so. What holds the relations up is
+ * that the operations are the only things that make one.
  *
  * <p>So the propositions are about the ways in. A reading answers with a reading — that is what an
  * algebra is — and what is asked of each of those is that it composes or narrows one, rather than
@@ -31,18 +38,121 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * it.
  *
  * <p><b>Nothing outside the type can mint one</b>, since every constructor is its own, so the ways
- * in are what the type declares and the list below is the whole of it. A way added tomorrow arrives
- * here as a difference and is a question somebody answers, rather than a hole nobody sees.
+ * in are what the type declares and the lists below are the whole of them. A way added tomorrow
+ * arrives here as a difference and is a question somebody answers, rather than a hole nobody sees.
+ *
+ * <p><b>Which types those are is found and not listed.</b> A state added tomorrow and left off a
+ * list here would be one nothing says anything about, which is the shape of the very thing these
+ * propositions are for. So the family is walked to from the two languages a reading of a
+ * declaration joins, through what each state is made of and what its operations take and answer
+ * with, and what makes a type one of them is that it holds its parts the way these do.
  */
 class AReadingIsWhatItsOperationsReachTest {
 
     /**
+     * The two languages a declaration's reading joins, which is where the walk starts.
+     *
+     * <p>Roots and not the family: what a rule of a value leaves is said in these two and in
+     * nothing else ({@code Confinement}), and everything the two of them are made of, take, or
+     * answer with is reached from here.
+     */
+    private static final List<Class<?>> ROOTS =
+            List.of(AdmissibleValues.class, OrderedIntervals.class);
+
+    /**
+     * Every state the readings reach, in the order their names sort.
+     *
+     * <p>A state is one that keeps its parts as this design says a state keeps them: one thing, and
+     * that thing a record of the parts. Which is what makes the family findable at all — a type
+     * that publishes its parts as a constructor is exactly what these propositions refuse, and one
+     * that is reached from here and does not hold them this way is a difference in
+     * {@link #theFamilyIsTheOneTheReadingsReach}.
+     */
+    private static final List<Class<?>> FAMILY = family();
+
+    private static List<Class<?>> family() {
+        List<Class<?>> found = new java.util.ArrayList<>();
+        Set<Class<?>> walked = new LinkedHashSet<>();
+        Deque<Class<?>> pending = new ArrayDeque<>(ROOTS);
+        while (!pending.isEmpty()) {
+            Class<?> one = pending.poll();
+            if (!ofTheReadings(one) || !walked.add(one)) {
+                continue;
+            }
+            if (!keepsItsPartsAsAState(one)) {
+                continue;
+            }
+            found.add(one);
+            for (RecordComponent part : WhatAReadingIsMadeOf.of(one)) {
+                pending.add(part.getType());
+            }
+            for (Method each : one.getDeclaredMethods()) {
+                pending.add(each.getReturnType());
+                pending.addAll(List.of(each.getParameterTypes()));
+            }
+            for (Class<?> nested : one.getDeclaredClasses()) {
+                pending.add(nested);
+            }
+        }
+        found.sort(Comparator.comparing(Class::getName));
+        return List.copyOf(found);
+    }
+
+    /** Whether the type is one of the two packages a reading of a value is written in. */
+    private static boolean ofTheReadings(Class<?> type) {
+        return "souther.compiler.values".equals(type.getPackageName())
+                || "souther.compiler.numeric".equals(type.getPackageName());
+    }
+
+    /** Whether it holds one thing and that thing is a record of its parts. */
+    private static boolean keepsItsPartsAsAState(Class<?> type) {
+        List<Field> mine = new java.util.ArrayList<>();
+        for (Field each : type.getDeclaredFields()) {
+            if (!Modifier.isStatic(each.getModifiers())) {
+                mine.add(each);
+            }
+        }
+        return mine.size() == 1 && mine.getFirst().getType().isRecord()
+                && "Parts".equals(mine.getFirst().getType().getSimpleName());
+    }
+
+    /**
+     * The family is the one the readings reach, and it is these.
+     *
+     * <p>Written down so that a state added to it is somebody saying so. What each of the four is
+     * for is its own type's business; that they are four is this walk's answer and not a list kept
+     * here — a fifth reached from the readings arrives as a difference, and one that stops being
+     * reachable does too.
+     */
+    @Test
+    void theFamilyIsTheOneTheReadingsReach() {
+        assertEquals(List.of(AdmissibleValues.class, PlannedValues.Settled.class, Realized.class,
+                        OrderedIntervals.class).stream()
+                        .sorted(Comparator.comparing(Class::getName)).toList(),
+                FAMILY,
+                "the states the readings reach are not the ones this says they are. A state added"
+                        + " here holds its parts the way these do, and the propositions below are"
+                        + " asked of it too");
+    }
+
+    /** And none of them may be made from outside, whichever of them it is. */
+    @Test
+    void noneOfThemMayBeMadeFromOutside() {
+        for (Class<?> state : FAMILY) {
+            assertEquals(0, state.getConstructors().length,
+                    () -> state.getSimpleName() + " publishes a way to write its parts down, and"
+                            + " the relations they state to each other are held up by nothing");
+        }
+    }
+
+    /**
      * Every way to get one, read off what declares them.
      *
-     * <p>Constructors whatever their access, because a way in that is published is the thing being
-     * asked about; methods unless they are private, because a private one is this type composing
-     * itself. Read off the declaring types and not off the compiler: a reading's constructor is its
-     * own, so nothing else can answer with one it did not get from here.
+     * <p>Constructors whatever their access, because a maker handed the parts is the thing being
+     * asked about and being private is not what settles it; methods unless they are private, since
+     * a private one is this type composing itself. Read off the declaring types and not off the
+     * compiler: a reading's constructor is its own, so nothing else can answer with one it did not
+     * get from here.
      */
     private static Set<String> waysInto(Class<?> state, Class<?>... alsoDeclaring) {
         Set<String> ways = new LinkedHashSet<>();
@@ -85,23 +195,16 @@ class AReadingIsWhatItsOperationsReachTest {
     /**
      * A reading of the values is reached by reading something.
      *
-     * <p>A leaf, a rule read at a position, two positions held as one value or held apart, a rule
-     * nothing could read, a conjunction, the same reading with more said about what a choice left
-     * open, the same blocks under other names — and a description worked out, which is the one way
-     * across from {@link PlannedValues} and does the work rather than being handed what the work
-     * would have left.
+     * <p>Where a reading starts, a conjunction of two or of several, the same reading with more
+     * said about what a choice left open, and the same blocks under other names. A rule of the
+     * values is not among them: it enters as a description and is worked out, which is the one way
+     * across and does the work rather than being handed what the work would have left.
      */
     @Test
     void everyWayToAReadingOfTheValuesIsSomethingReadingIt() {
         assertEquals(Set.of(
                         "private AdmissibleValues(Parts)",
-                        "private AdmissibleValues(Held, Map, Standing, Map, ValueSet, boolean,"
-                                + " Set, Set)",
                         "public top()",
-                        "public at(Object, ValueSet)",
-                        "public holdingAsOne(Object, Object)",
-                        "public heldApart(Object, Object)",
-                        "public unreadable(Set, UnreadReason)",
                         "public meet(AdmissibleValues, Allowance)",
                         "public metAll(List, Allowance)",
                         "public renamed(Function)",
@@ -113,19 +216,19 @@ class AReadingIsWhatItsOperationsReachTest {
     }
 
     /**
-     * And realization answers with the reading beside what could not be built while making it,
-     * which is why it is not in the list above.
+     * And realization answers with the reading beside what could not be built while making it.
      *
      * <p>The two are settled by one piece of work and are handed over together, so writing them
-     * side by side is writing down a refusal no work made. One way in does the work; the other says
-     * there was none to do, and says it by having nothing to say it about.
+     * side by side is writing down a refusal no work made — and handing over the reading alone is
+     * saying of a reading that came from somewhere that nothing was refused while it was made,
+     * which is a claim about work that was not done. So the work is what it is made from: the one
+     * way in takes what noted the shortfalls, and there is no way in that takes the reading.
      */
     @Test
     void andADescriptionIsWorkedOutByTheReadingItComesTo() {
         assertEquals(Set.of(
-                        "private Realized(AdmissibleValues, Set, List)",
+                        "private Realized(Parts)",
                         "of(AdmissibleValues, Unbuilt)",
-                        "public workedOut(AdmissibleValues)",
                         "public alsoOpenedAt(Set)",
                         "realize(Settled, Allowance)"),
                 waysInto(Realized.class, AdmissibleValues.class),
@@ -143,8 +246,7 @@ class AReadingIsWhatItsOperationsReachTest {
     @Test
     void everyWayToADescriptionIsSomethingReadingIt() {
         assertEquals(Set.of(
-                        "private Settled(PlannedHeld, Map, Standing, Map, AdmittedPlan, boolean,"
-                                + " Set, Set)",
+                        "private Settled(Parts)",
                         "public top()",
                         "public at(Object, AdmittedPlan)",
                         "public holdingAsOne(Object, Object)",
@@ -163,7 +265,7 @@ class AReadingIsWhatItsOperationsReachTest {
     @Test
     void everyWayToAReadingOfTheOrderIsSomethingReadingIt() {
         assertEquals(Set.of(
-                        "private OrderedIntervals(Map, boolean)",
+                        "private OrderedIntervals(Parts)",
                         "public top()",
                         "public at(Object, OrderedInterval)",
                         "public meet(OrderedIntervals)",
@@ -176,7 +278,7 @@ class AReadingIsWhatItsOperationsReachTest {
     }
 
     /**
-     * And the reading is closed because it is closed, not because nothing here can see a way in.
+     * And a reading is closed because it is closed, not because nothing here can see a way in.
      *
      * <p>{@link OrderedInterval} is a pair of ends, which is a product with nothing to hold up
      * between its parts: any pair of them is an interval somebody can read, and it publishes the

--- a/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AReadingIsWhatItsOperationsReachTest.java
@@ -1,0 +1,193 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A reading is in one of the states its operations reach, and the parts are not a way in.
+ *
+ * <p>What each of these holds is several parts that state relations to each other — a whole that
+ * holds nothing is not a position that holds nothing, the alternatives are never an empty union, a
+ * promise is about the blocks every alternative agrees on. None of those is a property of one part,
+ * so a caller handed the parts side by side can write down a combination nothing read, and nothing
+ * says so. What holds the relations up is that the operations are the only things that make one.
+ *
+ * <p>So the propositions are about the ways in. A reading answers with a reading — that is what an
+ * algebra is — and what is asked of each of those is that it composes or narrows one, rather than
+ * taking the parts and handing the reading back. The second shape is the one that lets a state be
+ * asserted of parts nothing put together, and it is also the one that lets a fact live in an
+ * operation rather than in the value: remove the operation and the way to say the fact is gone with
+ * it.
+ *
+ * <p><b>Nothing outside the type can mint one</b>, since every constructor is its own, so the ways
+ * in are what the type declares and the list below is the whole of it. A way added tomorrow arrives
+ * here as a difference and is a question somebody answers, rather than a hole nobody sees.
+ */
+class AReadingIsWhatItsOperationsReachTest {
+
+    /**
+     * Every way to get one, read off what declares them.
+     *
+     * <p>Constructors whatever their access, because a way in that is published is the thing being
+     * asked about; methods unless they are private, because a private one is this type composing
+     * itself. Read off the declaring types and not off the compiler: a reading's constructor is its
+     * own, so nothing else can answer with one it did not get from here.
+     */
+    private static Set<String> waysInto(Class<?> state, Class<?>... alsoDeclaring) {
+        Set<String> ways = new LinkedHashSet<>();
+        Set<Class<?>> declaring = new LinkedHashSet<>();
+        declaring.add(state);
+        declaring.addAll(Set.of(alsoDeclaring));
+        for (Class<?> each : declaring) {
+            // A constructor is a way in where what it makes is one of these, which is what takes in
+            // the class a sealed reading permits and leaves out a type that only answers with one.
+            for (Constructor<?> made : state.isAssignableFrom(each)
+                    ? each.getDeclaredConstructors() : new Constructor<?>[0]) {
+                ways.add(access(made) + signature(made, each.getSimpleName()));
+            }
+            for (Method m : each.getDeclaredMethods()) {
+                if (!Modifier.isPrivate(m.getModifiers()) && m.getReturnType() == state) {
+                    ways.add(access(m) + signature(m, m.getName()));
+                }
+            }
+        }
+        return ways;
+    }
+
+    private static String access(Executable of) {
+        int modifiers = of.getModifiers();
+        if (Modifier.isPublic(modifiers)) {
+            return "public ";
+        }
+        return Modifier.isPrivate(modifiers) ? "private " : "";
+    }
+
+    private static String signature(Executable of, String named) {
+        StringBuilder out = new StringBuilder(named).append('(');
+        for (int i = 0; i < of.getParameterTypes().length; i++) {
+            out.append(i == 0 ? "" : ", ").append(of.getParameterTypes()[i].getSimpleName());
+        }
+        return out.append(')').toString();
+    }
+
+    /**
+     * A reading of the values is reached by reading something.
+     *
+     * <p>A leaf, a rule read at a position, two positions held as one value or held apart, a rule
+     * nothing could read, a conjunction, the same reading with more said about what a choice left
+     * open, the same blocks under other names — and a description worked out, which is the one way
+     * across from {@link PlannedValues} and does the work rather than being handed what the work
+     * would have left.
+     */
+    @Test
+    void everyWayToAReadingOfTheValuesIsSomethingReadingIt() {
+        assertEquals(Set.of(
+                        "private AdmissibleValues(Parts)",
+                        "private AdmissibleValues(Held, Map, Standing, Map, ValueSet, boolean,"
+                                + " Set, Set)",
+                        "public top()",
+                        "public at(Object, ValueSet)",
+                        "public holdingAsOne(Object, Object)",
+                        "public heldApart(Object, Object)",
+                        "public unreadable(Set, UnreadReason)",
+                        "public meet(AdmissibleValues, Allowance)",
+                        "public metAll(List, Allowance)",
+                        "public renamed(Function)",
+                        "public alsoOpenedAt(Set)"),
+                waysInto(AdmissibleValues.class),
+                "a way into a reading of the values that is not one of the operations it is"
+                        + " composed by. If it takes the parts and hands a reading back, the"
+                        + " relations they state to each other are held up by nothing");
+    }
+
+    /**
+     * And realization answers with the reading beside what could not be built while making it,
+     * which is why it is not in the list above.
+     *
+     * <p>The two are settled by one piece of work and are handed over together, so writing them
+     * side by side is writing down a refusal no work made. One way in does the work; the other says
+     * there was none to do, and says it by having nothing to say it about.
+     */
+    @Test
+    void andADescriptionIsWorkedOutByTheReadingItComesTo() {
+        assertEquals(Set.of(
+                        "private Realized(AdmissibleValues, Set, List)",
+                        "of(AdmissibleValues, Unbuilt)",
+                        "public workedOut(AdmissibleValues)",
+                        "public alsoOpenedAt(Set)",
+                        "realize(Settled, Allowance)"),
+                waysInto(Realized.class, AdmissibleValues.class),
+                "realization is the one way across, and it is the reading's own: handed the"
+                        + " description and the allowance it builds the sets, decides which of"
+                        + " them nobody could work out, and settles the rest against what came out");
+    }
+
+    /**
+     * A description is reached the same way, over plans rather than sets.
+     *
+     * <p>Asked of the interface and the one reading it permits together, since what a caller holds
+     * is the interface and every way to one of those answers with it.
+     */
+    @Test
+    void everyWayToADescriptionIsSomethingReadingIt() {
+        assertEquals(Set.of(
+                        "private Settled(PlannedHeld, Map, Standing, Map, AdmittedPlan, boolean,"
+                                + " Set, Set)",
+                        "public top()",
+                        "public at(Object, AdmittedPlan)",
+                        "public holdingAsOne(Object, Object)",
+                        "public heldApart(Object, Object)",
+                        "public unreadable(Set, UnreadReason)",
+                        "public meet(PlannedValues)",
+                        "public alsoStanding(Standing)",
+                        "public bothDead(PlannedValues)",
+                        "public joinLive(PlannedValues)",
+                        "public joinLiveApart(PlannedValues)"),
+                waysInto(PlannedValues.class, PlannedValues.Settled.class),
+                "a way into a description that is not one of the operations it is composed by");
+    }
+
+    /** And so is a reading of the ordered rules. */
+    @Test
+    void everyWayToAReadingOfTheOrderIsSomethingReadingIt() {
+        assertEquals(Set.of(
+                        "private OrderedIntervals(Map, boolean)",
+                        "public top()",
+                        "public at(Object, OrderedInterval)",
+                        "public meet(OrderedIntervals)",
+                        "public renamed(Function)",
+                        "public bothDead(OrderedIntervals)",
+                        "public joinLive(OrderedIntervals)"),
+                waysInto(OrderedIntervals.class),
+                "a way into a reading of the ordered rules that is not one of the operations it is"
+                        + " composed by");
+    }
+
+    /**
+     * And the reading is closed because it is closed, not because nothing here can see a way in.
+     *
+     * <p>{@link OrderedInterval} is a pair of ends, which is a product with nothing to hold up
+     * between its parts: any pair of them is an interval somebody can read, and it publishes the
+     * way to write one down. Read by the same walk, it comes back with that way — so a reading
+     * reported as having none is a fact about the reading.
+     */
+    @Test
+    void aTypeThatDoesPublishItsPartsIsSeenToPublishThem() {
+        Set<String> ways = waysInto(OrderedInterval.class);
+
+        assertTrue(ways.contains("public OrderedInterval(Endpoint, Endpoint)"),
+                () -> "the walk did not find the way in a product publishes, and would report a"
+                        + " reading closed whatever the reading did: " + ways);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
@@ -158,7 +158,13 @@ class EveryPartOfAReadingIsAValueTest {
      */
     private static AdmissibleValues<?> made(List<Sample> handed) throws Exception {
         Object[] args = handed.stream().map(Sample::value).toArray();
-        Constructor<?> ofParts = AdmissibleValues.Parts.class.getDeclaredConstructors()[0];
+        Constructor<?>[] every = AdmissibleValues.Parts.class.getDeclaredConstructors();
+        Constructor<?> ofParts = every[0];
+        for (Constructor<?> each : every) {
+            if (each.getParameterCount() == handed.size()) {
+                ofParts = each;
+            }
+        }
         ofParts.setAccessible(true);
         Constructor<?> canonical =
                 AdmissibleValues.class.getDeclaredConstructor(AdmissibleValues.Parts.class);

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
@@ -3,6 +3,7 @@ package souther.compiler.values;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -147,18 +148,22 @@ class EveryPartOfAReadingIsAValueTest {
         return out;
     }
 
-    @SuppressWarnings("unchecked")
-    private static Object made(Class<?> of, List<Sample> handed) throws Exception {
-        Constructor<?>[] every = of.getDeclaredConstructors();
-        Constructor<?> canonical = every[0];
-        for (Constructor<?> each : every) {
-            if (each.getParameterCount() == handed.size()) {
-                canonical = each;
-            }
-        }
+    /**
+     * A reading made of exactly what was handed over, by the one constructor there is.
+     *
+     * <p>Through the parts and not through an operation, because what is being asked about is what
+     * a reading does with what it is made of. Every way in composes or narrows what it is given, so
+     * a reading reached through one holds sets it made itself and a maker holding the map it passed
+     * in has nothing here to write into.
+     */
+    private static AdmissibleValues<?> made(List<Sample> handed) throws Exception {
         Object[] args = handed.stream().map(Sample::value).toArray();
+        Constructor<?> ofParts = AdmissibleValues.Parts.class.getDeclaredConstructors()[0];
+        ofParts.setAccessible(true);
+        Constructor<?> canonical =
+                AdmissibleValues.class.getDeclaredConstructor(AdmissibleValues.Parts.class);
         canonical.setAccessible(true);
-        return canonical.newInstance(args);
+        return (AdmissibleValues<?>) canonical.newInstance(ofParts.newInstance(args));
     }
 
     /**
@@ -175,7 +180,7 @@ class EveryPartOfAReadingIsAValueTest {
      */
     @Test
     void nothingAReadingHoldsMayBeChangedAfterItIsMade() throws Exception {
-        RecordComponent[] parts = AdmissibleValues.class.getRecordComponents();
+        RecordComponent[] parts = AdmissibleValues.Parts.class.getRecordComponents();
         assertTrue(parts.length > 0);
 
         for (int i = 0; i < parts.length; i++) {
@@ -185,8 +190,12 @@ class EveryPartOfAReadingIsAValueTest {
                 continue;
             }
             List<Sample> handed = handedOver(parts);
-            Object reading = made(AdmissibleValues.class, handed);
-            Object held = part.getAccessor().invoke(reading);
+            AdmissibleValues<?> reading = made(handed);
+            // Asked of what the reading hands out and not of what the parts hold. The reading is
+            // what a caller has, and a part it copied and then handed over by reference is one
+            // whose maker can still write into what somebody else is holding.
+            Method accessor = AdmissibleValues.class.getDeclaredMethod(part.getName());
+            Object held = accessor.invoke(reading);
 
             assertThrows(UnsupportedOperationException.class, () -> add(held),
                     part.getName() + " may be written to after the reading was made");
@@ -199,7 +208,7 @@ class EveryPartOfAReadingIsAValueTest {
             assertTrue(!writes.isEmpty(), part.getName() + " is a part with nothing to write into");
             for (Runnable write : writes) {
                 write.run();
-                assertEquals(said, String.valueOf(part.getAccessor().invoke(reading)),
+                assertEquals(said, String.valueOf(accessor.invoke(reading)),
                         part.getName() + " moved when the maker wrote into what it was made of");
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
@@ -158,7 +158,8 @@ class EveryPartOfAReadingIsAValueTest {
      */
     private static AdmissibleValues<?> made(List<Sample> handed) throws Exception {
         Object[] args = handed.stream().map(Sample::value).toArray();
-        Constructor<?>[] every = AdmissibleValues.Parts.class.getDeclaredConstructors();
+        Class<?> parts = WhatAReadingIsMadeOf.held(AdmissibleValues.class);
+        Constructor<?>[] every = parts.getDeclaredConstructors();
         Constructor<?> ofParts = every[0];
         for (Constructor<?> each : every) {
             if (each.getParameterCount() == handed.size()) {
@@ -166,8 +167,7 @@ class EveryPartOfAReadingIsAValueTest {
             }
         }
         ofParts.setAccessible(true);
-        Constructor<?> canonical =
-                AdmissibleValues.class.getDeclaredConstructor(AdmissibleValues.Parts.class);
+        Constructor<?> canonical = AdmissibleValues.class.getDeclaredConstructor(parts);
         canonical.setAccessible(true);
         return (AdmissibleValues<?>) canonical.newInstance(ofParts.newInstance(args));
     }
@@ -186,7 +186,7 @@ class EveryPartOfAReadingIsAValueTest {
      */
     @Test
     void nothingAReadingHoldsMayBeChangedAfterItIsMade() throws Exception {
-        RecordComponent[] parts = AdmissibleValues.Parts.class.getRecordComponents();
+        RecordComponent[] parts = WhatAReadingIsMadeOf.of(AdmissibleValues.class);
         assertTrue(parts.length > 0);
 
         for (int i = 0; i < parts.length; i++) {

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -227,9 +227,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
      */
     @Test
     void everyPlaceASubjectIsFiledUnderIsOneSubjectsKnowsAbout() {
-        List<String> named =
-                java.util.Arrays.stream(AdmissibleValues.Parts.class.getRecordComponents())
-                        .map(RecordComponent::getName).toList();
+        List<String> named = java.util.Arrays.stream(WhatAReadingIsMadeOf.of(AdmissibleValues.class))
+                .map(RecordComponent::getName).toList();
 
         assertEquals(List.of("held", "perPosition", "standing", "guaranteed", "defaultGuaranteed",
                         "guaranteedTogether", "tangled", "widened"),

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -227,8 +227,9 @@ class ReadingsConjoinedAreNotMultipliedTest {
      */
     @Test
     void everyPlaceASubjectIsFiledUnderIsOneSubjectsKnowsAbout() {
-        List<String> named = java.util.Arrays.stream(AdmissibleValues.class.getRecordComponents())
-                .map(RecordComponent::getName).toList();
+        List<String> named =
+                java.util.Arrays.stream(AdmissibleValues.Parts.class.getRecordComponents())
+                        .map(RecordComponent::getName).toList();
 
         assertEquals(List.of("held", "perPosition", "standing", "guaranteed", "defaultGuaranteed",
                         "guaranteedTogether", "tangled", "widened"),

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingIsMadeOf.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingIsMadeOf.java
@@ -1,0 +1,49 @@
+package souther.compiler.values;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The parts a reading is made of, found where the reading keeps them.
+ *
+ * <p>A reading holds one thing, and that thing is a record of its parts — which is what makes the
+ * list of parts, the equality of two readings and the order several of them are put in one
+ * declaration rather than three. So a proposition about every part finds them by asking what the
+ * reading is made of, and not by being handed a list beside it: a list written here is one a part
+ * added later is missing from, which is the failure these propositions are about.
+ *
+ * <p>Read off the field and not off a name. The parts are the reading's own and are named nowhere
+ * else, so what is asked here is what a reading holds — a class that came to hold two things, or to
+ * hold something that is not a record of parts, is one nothing here can answer about, and it says
+ * so rather than answering about the first thing it finds.
+ */
+final class WhatAReadingIsMadeOf {
+
+    private WhatAReadingIsMadeOf() {
+    }
+
+    /** The parts of {@code reading}, in the order they are declared. */
+    static RecordComponent[] of(Class<?> reading) {
+        return held(reading).getRecordComponents();
+    }
+
+    /** The record a reading keeps its parts in, which is the type of the one thing it holds. */
+    static Class<?> held(Class<?> reading) {
+        List<Field> mine = new ArrayList<>();
+        for (Field each : reading.getDeclaredFields()) {
+            if (!Modifier.isStatic(each.getModifiers())) {
+                mine.add(each);
+            }
+        }
+        if (mine.size() != 1 || !mine.getFirst().getType().isRecord()) {
+            throw new IllegalStateException(reading.getSimpleName() + " holds " + mine
+                    + ", and a reading holds one record of the parts it is made of. Whatever it"
+                    + " holds now, that is where its parts, its equality and the order several of"
+                    + " them are put came from, and they have to come from one place");
+        }
+        return mine.getFirst().getType();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest.java
@@ -106,13 +106,11 @@ class WhatIsUnreadAtOnePositionIsUnreadAtTheOnesItIsOneValueWithTest {
      */
     @Test
     void whetherWhatStandsIsExactIsTheBlocksAnswer() {
-        AdmissibleValues<String> reading = heldAsOne("p", "r");
-        Sameness.Block<String> block = reading.blockOf("p");
-
-        AdmissibleValues<String> wide = new AdmissibleValues<>(reading.held(),
-                reading.perPosition(), reading.standing(),
-                reading.guaranteed(), reading.defaultGuaranteed(), reading.guaranteedTogether(),
-                reading.tangled(), Set.of(block));
+        // A machine somebody gave up on at one of the pair, which is what leaves a block wide: the
+        // description says so of the position it was written at, and the reading it comes to says
+        // it of the block that position is on.
+        AdmissibleValues<String> wide = built(PlannedValues.<String>holdingAsOne("p", "r")
+                .alsoStanding(Standing.of(Set.of("p"), UnreadReason.EXACT_VALUES_TOO_COSTLY)));
 
         assertFalse(wide.projectionExactAt("p"));
         assertFalse(wide.projectionExactAt("r"), "one machine, one answer about it");


### PR DESCRIPTION
Closes #1425.

A reading of the values, a description of one, the ranges the ordered rules
leave, and a reading beside what could not be built while making it were
records. Their parts state relations to each other that no part states on its
own — a whole that holds nothing is not a position that holds nothing, the
alternatives are never an empty union, a promise is about the blocks every
alternative agrees on, a refusal is one the work that built the reading noted —
so a caller handed the parts side by side could write down a combination nothing
read, and nothing said so. What held the relations up was that the operations
happened to be the only things that made one, which is not something a type can
say.

That is also what #1384 ran into from the other end. The way to say "this branch
is impossible because another language proved it" was an operation, so removing
the operation removed the way to say it. Had it been a constructor call there
would have been nothing to remove, and the fact would have had nowhere to live.

## What the parts are now

Each of them is a final class over its own record of its parts, with one
constructor, and that constructor takes the parts as one. The record is what
settles which two readings are the same and what list a reader is shown, so a
part added later arrives in both of those the day it is declared. A constructor
handed the parts side by side would be a maker handed the parts whatever its
access, which the walk of the compiled classes finds and is right to.

## Realization does the work rather than being handed what it would have left

`PlannedValues.resolve` was assembling a reading from outside: it worked the
parts out and wrote them into the constructor. So realization moves to the
reading it makes — handed the description and the allowance, it builds the sets,
decides which of them nobody could work out, and settles the rest against what
came out — and it reads the description through the questions the description
answers rather than through what it is made of.

What it answers with is reached by doing that work and by nothing else. There
was a second way in: hand over a reading and say of it that there had been no
work to do. That is a claim about work that was not done and can be false of the
very reading it is handed. It is gone, and with it the maker of a confinement
that used it — a maker the compiler never called, which was there for fixtures.

The reading and the record of the work now travel as one thing that only
realization can put together, so what makes the answer is handed that and cannot
be handed the two halves: a reading whose positions an allowance ran out on,
beside a record of work that noted nothing, is a pair no working-out produced.

## Naming a proof is a question about the proof

Which proof holds is what a state answers; what that proof is called in a value
declaring these positions is its own question, and it now has its own place. It
is asked of the refusal rather than of the walk that reached one, so it is
answered for every proof the type can carry rather than for the ones a walk
happens to build today — including a proof carrying two witnesses, which the
fixtures used to reach by conjoining two readings already worked out and
stamping the result.

## What keeps it closed

A state of a reading says that it is one, and what it says is what it is held
to: its parts are one record of its own, and it publishes no constructor. Read
the other way round — a type is one of these because it already keeps its parts
that way — the reading would find the states that are already right and pass
over one written as a record of its parts, which is the state these propositions
exist to refuse and the only one such a reading could never report.

The ways in are read off what a method does rather than off what its type says
it answers with, since a method answering with a reading may be handing back one
it was given. Every class the compiler is made of is walked, and the
constructions in them are what count, so a maker behind a name no caller writes
is found too.

Mutated both ways. A fifth state declaring itself and written as a record of its
parts is found and fails, where a reading that discovered the family by its shape
would never have seen it. A caller pairing a reading with a record of work that
did not make it does not compile.

## Found on the way

`ConjoinedAdmissibleValues` was already a final class nobody outside can build,
and it had lost `equals` when it was closed by hand. It ends up inside an answer
a compilation remembers, so every conjunction differed from the one the last
compile made and nothing that read one was kept past an edit that changed
nothing. Its identity is the readings it holds, in the order they arrived, since
that order is what a compilation writes out.

An alternative refused two ways reports only the first of them, which the old
fixtures were reaching around. Filed as #1456 rather than changed here.

## Cost

The parts record is an object per reading, and what a working-out came to is
another. Measured against the base of this branch, JDK 25.0.3, `-Xms2g -Xmx2g`,
three runs each of `souther-bench warm` and `souther-bench edit`, base
`40c2ad577` and head `f806688bf`:

| | base | head |
|---|---|---|
| crm warm, median | 334.3 / 335.6 / 336.4 ms | 341.1 / 340.4 / 338.2 ms |
| crm warm, min | 313.3 / 315.9 / 306.8 ms | 316.5 / 305.8 / 311.8 ms |
| young collections | 28 / 28 / 28 | 28 / 28 / 28 |
| reclaimed | 28336 / 28548 / 28591 M | 28368 / 28346 / 28327 M |
| edit in a leaf | 53.64 / 47.17 / 54.18 ms | 55.62 / 47.11 / 49.25 ms |

The collection count is the sharp part: at a fixed heap a real allocation shift
moves a boundary, and none moved. Reclaimed bytes are no higher on the head, and
the minima and the edit figures interleave. The medians this time all land above
the base's, which an earlier run of the same comparison did not show; with the
allocation evidence flat, that reads as drift between two separately built jars
rather than as a cost of the object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)