### PR TITLE
Work out what a block is called where the block is made

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -258,22 +258,25 @@ public final class Sameness<A> {
      * coordinate: {@code p == q && q == r} and {@code q == r && p == q} name one block, hold one
      * set, and spend from one purse.
      *
-     * <p>Its members are read in the order they are spelled in and not in the order a closure
-     * reached them, so that what is written out of a reading — a proof naming the positions that
-     * must hold one value among them — does not read differently for the order the equalities
-     * behind it were written in. That order is how the positions are spelled, so it carries as far
-     * as a spelling tells two of them apart and no further, and two that render alike are left in
-     * the order they arrived in. Nothing is filed, compared or hashed under it.
+     * <p>Its members are read in the order they are spelled in, so that where their spellings tell
+     * them apart, what is written out of a reading — a proof naming the positions that must hold
+     * one value among them — does not read differently for the order the equalities behind it were
+     * written in. Two that render alike are left in the order they arrived in, which is that order,
+     * so how far this carries is how far a spelling separates positions. Nothing is filed, compared
+     * or hashed under it.
      */
     public static final class Block<A> {
 
-        /** Odd, so that a count multiplied by it keeps every bit of the count, and nowhere near a
-         *  power of two, so that two counts do not agree in the bits the members' sum reaches. */
+        /** What the number of members is multiplied by before it joins their sum, so that two
+         *  blocks whose members sum alike are still told apart where they hold different numbers of
+         *  positions. Odd, so that no bit of the number is lost in the multiplication. */
         private static final int COUNTED = 0x9e3779b9;
 
-        /** The two rounds of the mixing. Each multiplication carries what the shift before it
-         *  folded downwards back up into the high bits, so that what a block's hash comes to
-         *  depends on all of what its members came to rather than on their total alone. */
+        /** The rounds of the mixing. The members reach it as the sum a {@code Set} hashes them to,
+         *  so what is mixed is that sum and the count beside it rather than the members one at a
+         *  time. Each multiplication carries what the shift before it folded downwards back up into
+         *  the high bits, which is what stops a sum of block hashes coming to a function of the sum
+         *  over all their positions. */
         private static final int SCATTER = 0x85ebca6b;
 
         private static final int SPREAD = 0xc2b2ae35;
@@ -299,10 +302,11 @@ public final class Sameness<A> {
          * its hash does not say. One mixing at the block's edge is what stops the sum above it
          * cancelling that grouping out.
          *
-         * <p>What a compile spends on that mixing is nothing it does not spend already, and what it
-         * saves is not why it is here: the blocks a compile makes are nearly all of one position,
-         * and the sets of them are small. It is here because this hash is spelled out rather than
-         * derived, and a sum spelled out is a sum kept.
+         * <p>The mixing is work of its own, a fixed few operations paid where the block is made,
+         * and it is not paid back: the blocks a compile makes are nearly all of one position and
+         * the sets of them are small, so nothing measured here is spending what it saves. It is
+         * here because this hash is spelled out rather than derived, and a sum spelled out is a sum
+         * kept.
          */
         private final int hash;
 
@@ -352,9 +356,15 @@ public final class Sameness<A> {
         /**
          * Equal by its members and by nothing else.
          *
-         * <p>The hash is asked first, which is an answer about the members and settles most pairs
-         * without reading them. Where it agrees the members are read, because two blocks with one
-         * hash are still two blocks unless the same positions are in both.
+         * <p>The hash is asked first, and it is an answer about the members, so two blocks it tells
+         * apart are told apart without reading them. Which comparisons that reaches depends on
+         * where they came from: one made through a map has had the hashes compared already and
+         * arrives only where they agree, and one asked of two blocks in hand — whether both ends of
+         * a pair are one block, whether an answer is filed under a coordinate the reading has —
+         * arrives with nothing compared. It is those this turns away.
+         *
+         * <p>Where the hashes agree the members are read, because two blocks with one hash are
+         * still two blocks unless the same positions are in both.
          */
         @Override
         public boolean equals(Object other) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -261,9 +261,9 @@ public final class Sameness<A> {
      * <p>Its members are read in the order they are spelled in, so that where their spellings tell
      * them apart, what is written out of a reading — a proof naming the positions that must hold
      * one value among them — does not read differently for the order the equalities behind it were
-     * written in. Two that render alike are left in the order they arrived in, which is that order,
-     * so how far this carries is how far a spelling separates positions. Nothing is filed, compared
-     * or hashed under it.
+     * written in. Where two of them are spelled alike it says nothing: those two keep the order
+     * they arrived in, which is the order it was there to keep out. Nothing is filed, compared or
+     * hashed under any of it.
      */
     public static final class Block<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -258,30 +258,77 @@ public final class Sameness<A> {
      * coordinate: {@code p == q && q == r} and {@code q == r && p == q} name one block, hold one
      * set, and spend from one purse.
      *
-     * <p>Its members are read in one order whatever order they were found in. What is written out
-     * of a reading — a proof naming the positions that must hold one value among them — has to come
-     * out the same on two compiles of one model, and the order a closure happened to reach them in
-     * is the order the equalities were written.
+     * <p>Its members are read in the order they are spelled in and not in the order a closure
+     * reached them, so that what is written out of a reading — a proof naming the positions that
+     * must hold one value among them — does not read differently for the order the equalities
+     * behind it were written in. That order is how the positions are spelled, so it carries as far
+     * as a spelling tells two of them apart and no further, and two that render alike are left in
+     * the order they arrived in. Nothing is filed, compared or hashed under it.
      */
-    public record Block<A>(Set<A> members) {
+    public static final class Block<A> {
 
-        public Block {
-            if (members.isEmpty()) {
-                throw new IllegalArgumentException("an answer is about at least one position");
-            }
-            List<A> ordered = new ArrayList<>(members);
-            ordered.sort(Comparator.comparing(String::valueOf));
-            members = Collections.unmodifiableSet(new LinkedHashSet<>(ordered));
+        /** Odd, so that a count multiplied by it keeps every bit of the count, and nowhere near a
+         *  power of two, so that two counts do not agree in the bits the members' sum reaches. */
+        private static final int COUNTED = 0x9e3779b9;
+
+        /** The two rounds of the mixing. Each multiplication carries what the shift before it
+         *  folded downwards back up into the high bits, so that what a block's hash comes to
+         *  depends on all of what its members came to rather than on their total alone. */
+        private static final int SCATTER = 0x85ebca6b;
+
+        private static final int SPREAD = 0xc2b2ae35;
+
+        private final Set<A> members;
+
+        /**
+         * What this block is asked for whenever an answer about it is looked up, worked out where
+         * the block is made.
+         *
+         * <p><b>Held rather than worked out, because a block is asked far more often than one is
+         * made.</b> A relation's answers are filed under blocks — what each is left, what each is
+         * promised, what each spends — so a round of a narrowing reads a map of them for every
+         * block it walks, and a reading asks which block a position is on for every position it
+         * reads. Derived from the members on each of those, the answer is a walk of the set and a
+         * hash of every position in it, over and over, for a value that cannot change.
+         *
+         * <p><b>And mixed, because a set's hash is the sum of its members'.</b> Left as that sum, a
+         * block's hash carries no mark of where the block ends: a set of blocks hashes to the sum
+         * over every position in all of them, so {@code {{p}, {q, r}}} and {@code {{p, q}, {r}}}
+         * come to one hash whatever those positions are. A set of blocks is what a refusal names
+         * and what a lack is about, so the grouping a block exists to state would be the one thing
+         * its hash does not say. One mixing at the block's edge is what stops the sum above it
+         * cancelling that grouping out.
+         *
+         * <p>What a compile spends on that mixing is nothing it does not spend already, and what it
+         * saves is not why it is here: the blocks a compile makes are nearly all of one position,
+         * and the sets of them are small. It is here because this hash is spelled out rather than
+         * derived, and a sum spelled out is a sum kept.
+         */
+        private final int hash;
+
+        private Block(Set<A> members) {
+            this.members = members;
+            this.hash = hashOf(members);
         }
 
-        /** The block one position is on its own. */
+        /**
+         * The block one position is on its own.
+         *
+         * <p>Built without ordering anything. One member is in one order, and the order below is
+         * what several of them are read in.
+         */
         public static <A> Block<A> of(A position) {
             return new Block<>(Set.of(position));
         }
 
         /** The block these positions are held as one in. */
         public static <A> Block<A> of(Set<A> members) {
-            return new Block<>(members);
+            return new Block<>(ordered(members));
+        }
+
+        /** The positions this answer is about. */
+        public Set<A> members() {
+            return members;
         }
 
         /** Whether this is one position on its own. */
@@ -299,12 +346,60 @@ public final class Sameness<A> {
         public <B> Block<B> renamed(Function<A, B> naming) {
             Set<B> out = new LinkedHashSet<>();
             members.forEach(each -> out.add(naming.apply(each)));
-            return new Block<>(out);
+            return of(out);
+        }
+
+        /**
+         * Equal by its members and by nothing else.
+         *
+         * <p>The hash is asked first, which is an answer about the members and settles most pairs
+         * without reading them. Where it agrees the members are read, because two blocks with one
+         * hash are still two blocks unless the same positions are in both.
+         */
+        @Override
+        public boolean equals(Object other) {
+            return this == other
+                    || (other instanceof Block<?> it
+                            && hash == it.hash && members.equals(it.members));
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
         }
 
         @Override
         public String toString() {
             return isOne() ? String.valueOf(members.iterator().next()) : members.toString();
+        }
+
+        /**
+         * The members in the order they are spelled in, which is the order a block reads them in.
+         *
+         * <p>How they are spelled is all a position of any kind can be ordered by here, since what
+         * a position is is the caller's. One of them is in one order already, which is what the
+         * block of a single position is built by.
+         */
+        private static <A> Set<A> ordered(Set<A> members) {
+            if (members.isEmpty()) {
+                throw new IllegalArgumentException("an answer is about at least one position");
+            }
+            if (members.size() == 1) {
+                return Set.of(members.iterator().next());
+            }
+            List<A> sorted = new ArrayList<>(members);
+            sorted.sort(Comparator.comparing(String::valueOf));
+            return Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
+        }
+
+        /** The members' hash, taken so that the block's edge survives being summed with others. */
+        private static int hashOf(Set<?> members) {
+            int gathered = members.hashCode() ^ (members.size() * COUNTED);
+            gathered ^= (gathered >>> 16);
+            gathered *= SCATTER;
+            gathered ^= (gathered >>> 13);
+            gathered *= SPREAD;
+            return gathered ^ (gathered >>> 16);
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest.java
@@ -17,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * Worked out from the members on each of those, the answer is a walk of the set for a value that
  * cannot change — which is what the first of these is about.
  *
+ * <p>Having the answer is also what lets two blocks be told apart without reading either, which is
+ * the second of these. It is worth nothing where a map asked the question, since a map compares the
+ * names before it asks; it is worth a set walk where two blocks in hand are compared.
+ *
  * <p>The rest are about what that answer is. A set's hash is the sum of its members', so a block
  * that answered with that sum and nothing else would be one whose name adds up the same however its
  * positions are grouped: a set of blocks would come to the sum over every position in all of them,
@@ -62,6 +66,28 @@ class WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest {
     }
 
     /**
+     * Two blocks whose names already differ, asked whether they are one.
+     *
+     * <p>Each holds a position the other has one of the same name for, so a comparison that reached
+     * the members would read one: the set is asked whether it holds a position, finds one filed
+     * under that name, and asks the two whether they are the same position. Reaching them is what
+     * the names being different is there to avoid, and a comparison made of two blocks in hand is
+     * where that has anything to avoid — a map has compared the names before it asks.
+     */
+    @Test
+    void andBlocksWhoseNamesDifferAreToldApartWithoutReadingTheirPositions() {
+        Sameness.Block<Counted> one = Sameness.Block.of(members(P, Q));
+        Sameness.Block<Counted> other =
+                Sameness.Block.of(members(new Counted("pp", P.hash), R));
+        assertNotEquals(one.hashCode(), other.hashCode(), "the two blocks were named alike");
+        Counted.compared = 0;
+
+        assertNotEquals(one, other);
+
+        assertEquals(0, Counted.compared, "a block read its positions to answer what its name had");
+    }
+
+    /**
      * The same three positions, grouped two ways.
      *
      * <p>Summed and left, these two are one number whatever the positions are: both come to what
@@ -91,6 +117,7 @@ class WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest {
     private static final class Counted {
 
         private static long asked;
+        private static long compared;
 
         private final String name;
         private final int hash;
@@ -102,6 +129,7 @@ class WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest {
 
         @Override
         public boolean equals(Object other) {
+            compared++;
             return other instanceof Counted it && name.equals(it.name) && hash == it.hash;
         }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A block is asked what it is called far more often than one is made, and what it answers says
+ * which positions are in it rather than only which positions there are.
+ *
+ * <p>A relation's answers are filed under blocks, so a round of a narrowing reads a map of them for
+ * every block it walks and a reading asks which block a position is on for every position it reads.
+ * Worked out from the members on each of those, the answer is a walk of the set for a value that
+ * cannot change — which is what the first of these is about.
+ *
+ * <p>The rest are about what that answer is. A set's hash is the sum of its members', so a block
+ * that answered with that sum and nothing else would be one whose name adds up the same however its
+ * positions are grouped: a set of blocks would come to the sum over every position in all of them,
+ * and the grouping a block exists to state would be the one thing its name leaves out. These do not
+ * ask that two blocks never share a name — nothing can promise that of an {@code int} — but that
+ * regrouping the same positions is not a thing the name is arranged to lose.
+ */
+class WhatABlockIsCalledIsWorkedOutOnceAndKeepsItsGroupingTest {
+
+    private static final Counted P = new Counted("p", 1);
+    private static final Counted Q = new Counted("q", 2);
+    private static final Counted R = new Counted("r", 3);
+
+    /** Asked again and again, a block reads nothing of its members. */
+    @Test
+    void aBlockIsWorkedOutWhereItIsMadeAndNotWhereItIsAsked() {
+        Sameness.Block<Counted> block = Sameness.Block.of(members(P, Q));
+        long made = Counted.asked;
+
+        int name = block.hashCode();
+        for (int again = 0; again < 100; again++) {
+            assertEquals(name, block.hashCode(), "a block gave two answers about one set");
+        }
+
+        assertEquals(made, Counted.asked, "a block asked its name read its members again");
+    }
+
+    /** The same positions found in either order are one block, called one thing. */
+    @Test
+    void andTheOrderItsPositionsArrivedInIsNotPartOfWhatItIsCalled() {
+        Sameness.Block<Counted> one = Sameness.Block.of(members(P, Q));
+        Sameness.Block<Counted> back = Sameness.Block.of(members(Q, P));
+
+        assertEquals(one, back);
+        assertEquals(one.hashCode(), back.hashCode());
+    }
+
+    /** A block of one position, however it was asked for. */
+    @Test
+    void andAPositionOnItsOwnIsOneBlockWhicheverWayItWasAskedFor() {
+        assertEquals(Sameness.Block.of(P), Sameness.Block.of(members(P)));
+        assertEquals(Sameness.Block.of(P).hashCode(), Sameness.Block.of(members(P)).hashCode());
+    }
+
+    /**
+     * The same three positions, grouped two ways.
+     *
+     * <p>Summed and left, these two are one number whatever the positions are: both come to what
+     * the three of them come to. So this is the shape a name that says nothing about grouping
+     * loses, and it is here to keep the name from being arranged that way again.
+     */
+    @Test
+    void andTwoSetsOfBlocksOverThePositionsAreNotOneNumberByArithmetic() {
+        Set<Sameness.Block<Counted>> apart =
+                Set.of(Sameness.Block.of(P), Sameness.Block.of(members(Q, R)));
+        Set<Sameness.Block<Counted>> together =
+                Set.of(Sameness.Block.of(members(P, Q)), Sameness.Block.of(R));
+
+        assertNotEquals(apart.hashCode(), together.hashCode(),
+                "the same positions grouped two ways came to one number");
+    }
+
+    private static Set<Counted> members(Counted... these) {
+        Set<Counted> out = new LinkedHashSet<>();
+        for (Counted each : these) {
+            out.add(each);
+        }
+        return out;
+    }
+
+    /** A position that says how often it was asked what it is called. */
+    private static final class Counted {
+
+        private static long asked;
+
+        private final String name;
+        private final int hash;
+
+        private Counted(String name, int hash) {
+            this.name = name;
+            this.hash = hash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Counted it && name.equals(it.name) && hash == it.hash;
+        }
+
+        @Override
+        public int hashCode() {
+            asked++;
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
Closes #1449.

A block is what a relation's answers are filed under, and it was deriving its name from its members every time it was asked for one. That name is now worked out where the block is made and held beside them, which is why a block is no longer a record.

Measured before any of it was written. On the corpora compiled here, and in the tests that build relations directly, nearly every block holds a single position — so the walk the issue names is a walk of one, and what a compile spends naming blocks is too small to read against the compile it is part of. Across the values tests, about 2.27M blocks were made and `Block.hashCode()` was asked about 69.9M times; only about 1,500 of those walked more than one member. That is why the cache is evidence and the grouping is not. Where it does read is the tests that ask one relation the same questions over and over: they build blocks far less often than they ask what those blocks are called, and that gap is what this closes. The compile of each corpus is unchanged within the spread of repeated runs. Those runs were interleaved both ways round, because which of the two ran first moved the number further than the change did.

The name is not the members' sum left as it stands. A set's hash is the sum of its members', so a set of blocks comes to the sum over every position in all of them, and the same positions grouped two ways come to one number whatever those positions are. A set of blocks is what a refusal names and what a lack is about, so the grouping a block exists to state would be the one thing its name leaves out. Nothing measured says a compilation pays for that today and no performance claim is made for it: it is here because this hash is spelled out by hand rather than generated, and a sum spelled out is a sum kept. A test fixes that shape. It is a test about this design, not a claim that unequal blocks have unequal names — nothing can promise that of an `int`.

Left out on purpose, none of them reached by what is measured here: a wider fingerprint held beside the hash, mixing each member before the sum rather than once at the block's edge, the same treatment for the pair of blocks a denial is between, and any canonicalizing or remembering of the blocks a reading asks for.

One doc claim was corrected rather than kept. A reading's members come out in one order only as far as a spelling tells two positions apart, and the wording now says so. Whether an order that separates positions rendering alike is owed is a question about what a compile writes out, and it is not answered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
