### PR TITLE
Measure what a caller assumes, and what an edit to it costs the callers

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Incremental.java
+++ b/souther-bench/src/main/java/souther/bench/Incremental.java
@@ -29,10 +29,11 @@ import java.util.Set;
  * <p>Restating a relation is a fifth, and it is the one the other four cannot stand in for. Adding a
  * definition gives the module something it did not declare, so what is re-asked is everything that
  * reads the declaration list. Rewriting a rule of an {@code ensures} leaves the declaration where it
- * was and changes one thing: what a caller of that behavior may assume. The bodies that call it have
- * to be checked again and nothing else has learnt anything, so this is where an answer held per
- * behavior rather than per module would show, and where losing one would show as well. The two edits
- * are the same keystroke to an author, and what separates them is only visible if both are timed.
+ * was and changes what a caller of that behavior may assume, while what the compiler says about the
+ * corpus and how well its rows cover it come back as they were. So the bodies that call it are what
+ * has anything to learn, and this is where an answer held per behavior rather than per module would
+ * show, and where losing one would show as well. The two edits are the same keystroke to an author,
+ * and what separates them is only visible if both are timed.
  */
 final class Incremental {
 
@@ -51,6 +52,9 @@ final class Incremental {
      */
     static final String STATED_RULE =
             "    ensures onTheDomainAsked = Account -> accountHasDomain(domain, value)";
+
+    /** What the rule already says, said again — see {@link #restated}. */
+    private static final String RESTATED_CONJUNCT = " && accountHasDomain(domain, value)";
 
     private Incremental() {}
 
@@ -102,17 +106,22 @@ final class Incremental {
     }
 
     /**
-     * {@code source} with the rule restated, differently in each round.
+     * {@code source} with the rule restated, alternating between rounds so that no round writes what
+     * the round before it wrote — two rounds writing one text is no edit, and the second would find
+     * every answer holding and time the floor.
      *
-     * <p>A conjunct is added rather than the rule replaced, so what the behavior states is what it
-     * stated and one thing more: the rows the corpus writes go on satisfying the clause, and a
-     * corpus that stopped compiling would be timed as it stopped early. The bound moves with the
-     * round because two rounds writing one text is no edit at all — the second would find every
-     * answer holding and time the floor.
+     * <p>The conjunct the rule already states is written a second time and taken away again. It says
+     * what the rule said, which is the point: what a caller may assume is a different value and every
+     * other reading of the corpus is the one it was. An edit that added a relation instead — a
+     * comparison of the parameter against a bound, which is what an author tightening a rule writes —
+     * draws a line on what it compares (spec §a-clause-draws-a-line-on-what-it-compares-an-input-against)
+     * and moves the adequacy reading with it, so the round would be timing two things and the number
+     * would be attributable to neither. Both halves of that are held by
+     * {@code TheRelationAnEditRestatesIsOneACallerReadsTest}.
      */
     static String restated(String source, int round) {
-        return source.replace(STATED_RULE,
-                STATED_RULE + " && String.length(domain.value) < " + (100 + round));
+        return round % 2 != 0 ? source
+                : source.replace(STATED_RULE, STATED_RULE + RESTATED_CONJUNCT);
     }
 
     private static String added(String source, int round) {

--- a/souther-bench/src/main/java/souther/bench/Incremental.java
+++ b/souther-bench/src/main/java/souther/bench/Incremental.java
@@ -25,8 +25,32 @@ import java.util.Set;
  * first source, which the others import, and to the last, which nothing imports. The two numbers
  * bound what an author pays while typing — the first is the cost of editing the type everything is
  * built on, the second the cost of editing a leaf, and a workspace is mostly leaves.
+ *
+ * <p>Restating a relation is a fifth, and it is the one the other four cannot stand in for. Adding a
+ * definition gives the module something it did not declare, so what is re-asked is everything that
+ * reads the declaration list. Rewriting a rule of an {@code ensures} leaves the declaration where it
+ * was and changes one thing: what a caller of that behavior may assume. The bodies that call it have
+ * to be checked again and nothing else has learnt anything, so this is where an answer held per
+ * behavior rather than per module would show, and where losing one would show as well. The two edits
+ * are the same keystroke to an author, and what separates them is only visible if both are timed.
  */
 final class Incremental {
+
+    /**
+     * The rule a relation edit rewrites, written out as the corpus writes it.
+     *
+     * <p>Matched as text rather than found by walking the parse, because what is being edited here is
+     * text: an author types into a file, and the measurement is of what the store does with the file
+     * that comes out. A rule located any other way would still have to be turned back into the line
+     * it replaces.
+     *
+     * <p>That the corpus still writes this line is held by
+     * {@code TheRelationAnEditRestatesIsOneACallerReadsTest} rather than found here at run time. A
+     * corpus that stopped writing it would leave this measurement silently unreported, and a line
+     * that is sometimes absent is one nobody notices the absence of.
+     */
+    static final String STATED_RULE =
+            "    ensures onTheDomainAsked = Account -> accountHasDomain(domain, value)";
 
     private Incremental() {}
 
@@ -57,6 +81,38 @@ final class Incremental {
                         + "definition in an imported module %6.2f ms   in a leaf %6.2f ms",
                 corpus.name(), reask.medianMillis(), comment.medianMillis(),
                 atImported.medianMillis(), atLeaf.medianMillis());
+
+        String stating = statingSource(byId);
+        if (stating != null) {
+            Timing atRelation = Timing.ofRounds(40, 40, round ->
+                    apply(compilation, byId, stating, restated(byId.get(stating), round)));
+            report.line("EDIT  %-14s a rule of a relation its callers read %6.2f ms",
+                    corpus.name(), atRelation.medianMillis());
+        }
+    }
+
+    /** Which source states the rule, or null where this corpus states none. */
+    private static String statingSource(Map<String, String> byId) {
+        for (Map.Entry<String, String> source : byId.entrySet()) {
+            if (source.getValue().contains(STATED_RULE)) {
+                return source.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * {@code source} with the rule restated, differently in each round.
+     *
+     * <p>A conjunct is added rather than the rule replaced, so what the behavior states is what it
+     * stated and one thing more: the rows the corpus writes go on satisfying the clause, and a
+     * corpus that stopped compiling would be timed as it stopped early. The bound moves with the
+     * round because two rounds writing one text is no edit at all — the second would find every
+     * answer holding and time the floor.
+     */
+    static String restated(String source, int round) {
+        return source.replace(STATED_RULE,
+                STATED_RULE + " && String.length(domain.value) < " + (100 + round));
     }
 
     private static String added(String source, int round) {

--- a/souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou
+++ b/souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou
@@ -715,7 +715,15 @@ let screenForDuplicates (lead, accounts, contacts) = {
 // holds, so the implementation builds it through the generated decoder rather than through a constructor
 // this declaration would have to grant — which is also why an injected behavior's non-unit `constructs`
 // has to be exposed (E1305) and this one has nothing to expose.
+//
+// The clause is what the implementation is for. A lookup by domain that answered some other account
+// would be a matching bug of the worst kind — the lead would be linked to a company nobody asked
+// about — and the type says nothing about it, since one Account is the same shape as another. So the
+// relation is declared: where an account comes back, it is an account on the domain that was asked
+// for. The predicate is accountHasDomain, the one the duplicate screen already matches the account
+// book with, because the two are asking the same question of an account and there is one answer to it.
 behavior findAccountByDomain : (domain: DomainName) -> Account | AccountNotFound
+    ensures onTheDomainAsked = Account -> accountHasDomain(domain, value)
 
 data MatchedAccount = { leadId: LeadId, accountId: AccountId }
 

--- a/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
@@ -92,12 +92,12 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
     @Test
     void restatingItChangesWhatThatCallerMayAssume() {
         Corpus crm = Corpus.load("crm");
-        List<String> restated = new ArrayList<>();
-        for (String source : crm.sources()) {
-            restated.add(Incremental.restated(source, 0));
-        }
+        List<String> restated = restated(crm, 0);
         assertNotEquals(crm.sources(), restated,
                 "the relation edit left the corpus as it found it");
+        assertEquals(crm.sources(), restated(crm, 1),
+                "two rounds of the relation edit write one text, so the second is no edit and the"
+                        + " round after it times the floor");
 
         Compilation before = compiled(crm.sources());
         Compilation after = compiled(restated);
@@ -109,6 +109,42 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
         assertNotNull(was, () -> STATING + " states nothing before the edit");
         assertNotEquals(was, now, "restating the rule left what a caller may assume unchanged, so"
                 + " the store has nothing to re-establish and the round times the floor");
+    }
+
+    /**
+     * And changes nothing else this corpus is read for.
+     *
+     * <p>A rule is read by more than the caller. What it compares draws a line on the values it
+     * compares (spec §a-clause-draws-a-line-on-what-it-compares-an-input-against), so a rule stating
+     * a relation the clause did not state moves the adequacy reading as well, and the round would be
+     * timing an edit to two readings under a name that says one. Which is what the first writing of
+     * this edit did: it added a bound on the parameter, the way an author tightening a rule would,
+     * and the adequacy answer for the module came back different.
+     *
+     * <p>Two readings, and neither is every reading there is. What they are is the two a rule is
+     * known to be read by beside the caller — what the compiler says about the module, and how well
+     * the module's rows cover it — so an edit that moved a third would go on being timed here. The
+     * claim is that these two do not move, not that nothing else can.
+     */
+    @Test
+    void restatingItLeavesTheOtherReadingsOfTheCorpusWhereTheyWere() {
+        Corpus crm = Corpus.load("crm");
+        Compilation before = compiled(crm.sources());
+        Compilation after = compiled(restated(crm, 0));
+
+        assertEquals(diagnosticsOf(before), diagnosticsOf(after),
+                "restating the rule moved what the compiler says about the corpus");
+        assertEquals(before.adequacy(MODULE), after.adequacy(MODULE),
+                "restating the rule moved how well the module's rows are said to cover it, so the"
+                        + " round times an edit to that reading as well as to the caller's");
+    }
+
+    private static List<String> restated(Corpus corpus, int round) {
+        List<String> out = new ArrayList<>();
+        for (String source : corpus.sources()) {
+            out.add(Incremental.restated(source, round));
+        }
+        return out;
     }
 
     private static Compilation compiled(List<String> sources) {
@@ -127,5 +163,18 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
             }
         }
         return errors;
+    }
+
+    /** Every diagnostic, by what it says and where — the primary is read so that a diagnostic
+     *  moving to another line is a difference and not a coincidence of counts. */
+    private static List<String> diagnosticsOf(Compilation compilation) {
+        List<String> said = new ArrayList<>();
+        for (List<Diagnostic> found : Located.diagnosticsOf(compilation.diagnostics()).values()) {
+            for (Diagnostic diagnostic : found) {
+                said.add(diagnostic.severity() + " " + diagnostic.code() + " at "
+                        + diagnostic.primary());
+            }
+        }
+        return said;
     }
 }

--- a/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
@@ -13,6 +13,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -29,10 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * relation compiles, is timed, and reports a number for a walk that stopped at the declaration.
  * Which is what this corpus did until the relation was written.
  *
- * <p>Three things, because the edit measures nothing if any of them stops holding. The rule is in
- * the corpus, so there is something to rewrite. A caller reads it, so rewriting it reaches a body.
- * And the rewrite changes what that caller may assume, so the store has an answer to re-establish
- * rather than one it finds unchanged and stops at.
+ * <p>What the measurement rests on, asked one claim at a time. The rule is in the corpus, so there
+ * is something to rewrite. Compiling it takes a rule of that contract into a caller's arguments, so
+ * the walk this is about is one the corpus reaches rather than one a fixture reaches. The body that
+ * takes it in is checked against it. The rewrite changes what that body may assume, so the store has
+ * an answer to re-establish rather than one it finds unchanged. And it leaves the other readings the
+ * corpus is held to where they were, so the round times one edit and not two.
  */
 @Tag("population")
 class TheRelationAnEditRestatesIsOneACallerReadsTest {
@@ -64,9 +67,40 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
                 + "` " + found + " time(s), and the relation edit rewrites every one of them");
     }
 
-    /** A body of the corpus reads what that behavior states. */
+    /**
+     * Compiling the corpus takes a rule of that contract into a caller's arguments.
+     *
+     * <p>The claim the measurement rests on, and the one nothing else here makes. What a body is
+     * checked against is a question about the graph: the contract is in the map handed to the
+     * analysis. Whether the analysis reached it is a question about the walk — the call has to be
+     * followed to what produced the answer, the arm has to name a case the rule is about, and the
+     * declaration's parameters have to be paired with what this call handed over. A body that went
+     * on calling the behavior and stopped matching its cases would leave the map as it is and take
+     * nothing in, and so would a hand-over that stopped between the two.
+     *
+     * <p>Read where the substitution is made ({@link AssumedContract#TAKEN_IN}), because taking a
+     * rule in is silent: it narrows what the caller may hold of the answer, and a body that is
+     * correct either way is checked either way. There is no diagnostic to read it off.
+     */
     @Test
-    void aCallerOfItReadsWhatItStates() {
+    void compilingTheCorpusTakesInWhatItStates() {
+        List<ValueName.Behavior> takenIn = Collections.synchronizedList(new ArrayList<>());
+        AssumedContract.TAKEN_IN = takenIn;
+        try {
+            compiled(Corpus.load("crm").sources());
+        } finally {
+            AssumedContract.TAKEN_IN = null;
+        }
+        assertTrue(takenIn.contains(STATING),
+                () -> "compiling the corpus substituted no rule of " + STATING + " into a call, so"
+                        + " the reading a caller depends on is built and not reached. Taken in: "
+                        + takenIn);
+    }
+
+    /** And the body that takes it in is checked against it, which is what says the two are one
+     *  arrangement rather than the contract being reached from somewhere else. */
+    @Test
+    void whatThatCallerIsCheckedAgainstIncludesWhatItStates() {
         Compilation compilation = compiled(Corpus.load("crm").sources());
         Map<ValueName.Behavior, AssumedContract> read =
                 compilation.db().ask(new Bodies.ContractsForBody(MODULE, CALLER)).value();

--- a/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
@@ -1,5 +1,6 @@
 package souther.bench;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,58 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
     private static final String CALLER = "linkLeadToAccount";
 
     /**
+     * The corpus as it is written and the corpus with the rule restated, each compiled once for the
+     * class.
+     *
+     * <p>Two texts and five questions. A corpus is the size somebody writes, so compiling one is
+     * most of what this class costs, and asking each question of its own compile is the same answer
+     * worked out again — which is what {@link CorpusTest} does for the same reason.
+     *
+     * <p>The one made of the corpus as written carries the watch, so what it took in is recorded on
+     * the compile the other questions are asked of rather than on a second one made to record it.
+     * The watch is set for as long as that compile runs and put back after: it is read by whatever
+     * thread the compile is on, and left assigned it would collect from every compile after.
+     */
+    private static Compilation before;
+    private static Compilation after;
+    private static List<ValueName.Behavior> takenIn;
+
+    private static synchronized Compilation before() {
+        if (before == null) {
+            List<ValueName.Behavior> watching = Collections.synchronizedList(new ArrayList<>());
+            AssumedContract.TAKEN_IN = watching;
+            try {
+                before = compiled(Corpus.load("crm").sources());
+            } finally {
+                AssumedContract.TAKEN_IN = null;
+            }
+            takenIn = watching;
+        }
+        return before;
+    }
+
+    private static synchronized Compilation after() {
+        if (after == null) {
+            after = compiled(restated(Corpus.load("crm"), 0));
+        }
+        return after;
+    }
+
+    /**
+     * And given back when the class is done with them.
+     *
+     * <p>A fork runs its classes one after another and keeps the JVM, so two answered compilations
+     * of a model this size, with everything they reached, would be a floor under the heap that every
+     * class after this one runs above.
+     */
+    @AfterAll
+    static void released() {
+        before = null;
+        after = null;
+        takenIn = null;
+    }
+
+    /**
      * The rule the edit rewrites is written in the corpus, once.
      *
      * <p>Once, and not merely somewhere: the edit rewrites every occurrence of the text, so two
@@ -84,13 +137,7 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
      */
     @Test
     void compilingTheCorpusTakesInWhatItStates() {
-        List<ValueName.Behavior> takenIn = Collections.synchronizedList(new ArrayList<>());
-        AssumedContract.TAKEN_IN = takenIn;
-        try {
-            compiled(Corpus.load("crm").sources());
-        } finally {
-            AssumedContract.TAKEN_IN = null;
-        }
+        before();
         assertTrue(takenIn.contains(STATING),
                 () -> "compiling the corpus substituted no rule of " + STATING + " into a call, so"
                         + " the reading a caller depends on is built and not reached. Taken in: "
@@ -101,9 +148,8 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
      *  arrangement rather than the contract being reached from somewhere else. */
     @Test
     void whatThatCallerIsCheckedAgainstIncludesWhatItStates() {
-        Compilation compilation = compiled(Corpus.load("crm").sources());
         Map<ValueName.Behavior, AssumedContract> read =
-                compilation.db().ask(new Bodies.ContractsForBody(MODULE, CALLER)).value();
+                before().db().ask(new Bodies.ContractsForBody(MODULE, CALLER)).value();
         assertNotNull(read, () -> MODULE + "." + CALLER + " has no body to read contracts for");
         AssumedContract assumed = read.get(STATING);
         assertNotNull(assumed, () -> MODULE + "." + CALLER + " reads no contract of " + STATING
@@ -126,20 +172,17 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
     @Test
     void restatingItChangesWhatThatCallerMayAssume() {
         Corpus crm = Corpus.load("crm");
-        List<String> restated = restated(crm, 0);
-        assertNotEquals(crm.sources(), restated,
+        assertNotEquals(crm.sources(), restated(crm, 0),
                 "the relation edit left the corpus as it found it");
         assertEquals(crm.sources(), restated(crm, 1),
                 "two rounds of the relation edit write one text, so the second is no edit and the"
                         + " round after it times the floor");
 
-        Compilation before = compiled(crm.sources());
-        Compilation after = compiled(restated);
-        assertEquals(List.of(), errorsOf(after),
+        assertEquals(List.of(), errorsOf(after()),
                 "the corpus no longer compiles once the relation is restated");
 
-        AssumedContract was = before.db().ask(new Bodies.Assumptions(STATING)).value();
-        AssumedContract now = after.db().ask(new Bodies.Assumptions(STATING)).value();
+        AssumedContract was = before().db().ask(new Bodies.Assumptions(STATING)).value();
+        AssumedContract now = after().db().ask(new Bodies.Assumptions(STATING)).value();
         assertNotNull(was, () -> STATING + " states nothing before the edit");
         assertNotEquals(was, now, "restating the rule left what a caller may assume unchanged, so"
                 + " the store has nothing to re-establish and the round times the floor");
@@ -162,13 +205,9 @@ class TheRelationAnEditRestatesIsOneACallerReadsTest {
      */
     @Test
     void restatingItLeavesTheOtherReadingsOfTheCorpusWhereTheyWere() {
-        Corpus crm = Corpus.load("crm");
-        Compilation before = compiled(crm.sources());
-        Compilation after = compiled(restated(crm, 0));
-
-        assertEquals(diagnosticsOf(before), diagnosticsOf(after),
+        assertEquals(diagnosticsOf(before()), diagnosticsOf(after()),
                 "restating the rule moved what the compiler says about the corpus");
-        assertEquals(before.adequacy(MODULE), after.adequacy(MODULE),
+        assertEquals(before().adequacy(MODULE), after().adequacy(MODULE),
                 "restating the rule moved how well the module's rows are said to cover it, so the"
                         + " round times an edit to that reading as well as to the caller's");
     }

--- a/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheRelationAnEditRestatesIsOneACallerReadsTest.java
@@ -1,0 +1,131 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.AssumedContract;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Severity;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That the edit {@link Incremental} times as a restated relation is one a body of the corpus reads.
+ *
+ * <p>A behavior states what a caller may take as holding of its answer, and a caller that has
+ * matched a case reads it. Nothing about a timing says whether it reached that: a corpus stating no
+ * relation compiles, is timed, and reports a number for a walk that stopped at the declaration.
+ * Which is what this corpus did until the relation was written.
+ *
+ * <p>Three things, because the edit measures nothing if any of them stops holding. The rule is in
+ * the corpus, so there is something to rewrite. A caller reads it, so rewriting it reaches a body.
+ * And the rewrite changes what that caller may assume, so the store has an answer to re-establish
+ * rather than one it finds unchanged and stops at.
+ */
+@Tag("population")
+class TheRelationAnEditRestatesIsOneACallerReadsTest {
+
+    private static final String MODULE = "example.crm";
+    private static final ValueName.Behavior STATING =
+            new ValueName.Behavior(MODULE, "findAccountByDomain");
+    private static final String CALLER = "linkLeadToAccount";
+
+    /**
+     * The rule the edit rewrites is written in the corpus, once.
+     *
+     * <p>Once, and not merely somewhere: the edit rewrites every occurrence of the text, so two
+     * would make one keystroke into two edits and the number would be of neither.
+     */
+    @Test
+    void theCorpusStatesTheRuleTheEditRestates() {
+        Corpus crm = Corpus.load("crm");
+        int written = 0;
+        for (String source : crm.sources()) {
+            int at = source.indexOf(Incremental.STATED_RULE);
+            while (at >= 0) {
+                written++;
+                at = source.indexOf(Incremental.STATED_RULE, at + 1);
+            }
+        }
+        int found = written;
+        assertEquals(1, found, () -> "the crm corpus writes the rule `" + Incremental.STATED_RULE
+                + "` " + found + " time(s), and the relation edit rewrites every one of them");
+    }
+
+    /** A body of the corpus reads what that behavior states. */
+    @Test
+    void aCallerOfItReadsWhatItStates() {
+        Compilation compilation = compiled(Corpus.load("crm").sources());
+        Map<ValueName.Behavior, AssumedContract> read =
+                compilation.db().ask(new Bodies.ContractsForBody(MODULE, CALLER)).value();
+        assertNotNull(read, () -> MODULE + "." + CALLER + " has no body to read contracts for");
+        AssumedContract assumed = read.get(STATING);
+        assertNotNull(assumed, () -> MODULE + "." + CALLER + " reads no contract of " + STATING
+                + ", so nothing here reaches what a caller may assume. It reads: " + read.keySet());
+        assertTrue(!assumed.rules().isEmpty(),
+                () -> STATING + " states a contract with no rule in it");
+    }
+
+    /**
+     * And restating the rule changes what that caller may assume.
+     *
+     * <p>Asked of the reading a caller is handed rather than of the source text. An edit that
+     * changed the file and came out equal here is one the store answers by finding every answer
+     * still holding, which is the floor the re-ask round already measures.
+     *
+     * <p>The restated corpus is compiled and checked for errors as well. A rule that stopped
+     * compiling would be timed as a compile that gives up early, which is faster than one that
+     * finishes and reads as an improvement.
+     */
+    @Test
+    void restatingItChangesWhatThatCallerMayAssume() {
+        Corpus crm = Corpus.load("crm");
+        List<String> restated = new ArrayList<>();
+        for (String source : crm.sources()) {
+            restated.add(Incremental.restated(source, 0));
+        }
+        assertNotEquals(crm.sources(), restated,
+                "the relation edit left the corpus as it found it");
+
+        Compilation before = compiled(crm.sources());
+        Compilation after = compiled(restated);
+        assertEquals(List.of(), errorsOf(after),
+                "the corpus no longer compiles once the relation is restated");
+
+        AssumedContract was = before.db().ask(new Bodies.Assumptions(STATING)).value();
+        AssumedContract now = after.db().ask(new Bodies.Assumptions(STATING)).value();
+        assertNotNull(was, () -> STATING + " states nothing before the edit");
+        assertNotEquals(was, now, "restating the rule left what a caller may assume unchanged, so"
+                + " the store has nothing to re-establish and the round times the floor");
+    }
+
+    private static Compilation compiled(List<String> sources) {
+        Compilation compilation = Compilation.ofSources(sources, ModulePath.EMPTY);
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static List<String> errorsOf(Compilation compilation) {
+        List<String> errors = new ArrayList<>();
+        for (List<Diagnostic> found : Located.diagnosticsOf(compilation.diagnostics()).values()) {
+            for (Diagnostic diagnostic : found) {
+                if (diagnostic.severity() == Severity.ERROR) {
+                    errors.add(diagnostic.code() + " at " + diagnostic.primary());
+                }
+            }
+        }
+        return errors;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/AssumedContract.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AssumedContract.java
@@ -39,6 +39,42 @@ public record AssumedContract(ValueName.Behavior behavior, List<Param> params, T
         rules = List.copyOf(rules);
     }
 
+    /**
+     * Where a test reads the behaviors whose rules a caller took in, one entry per conjunct
+     * substituted into a call, and null everywhere else.
+     *
+     * <p>Beside {@link PathEngine#SEEDED} and for the same reason. Taking a rule in is silent: what
+     * it does is narrow what the caller may hold of the answer, and a body that is correct either
+     * way is checked either way. So a compile that stopped reading contracts at all would say
+     * nothing about it, and the whole of what an author would notice is a diagnostic this analysis
+     * exists to avoid needing.
+     *
+     * <p>What is recorded is the behavior whose contract it is, because that is what a reader of
+     * this wants to name — whether a compile reached the assumption a caller of <em>this</em>
+     * behavior depends on. Where it was taken in is not here: a call carries no occurrence, so the
+     * body would have to be threaded through this analysis for a reader that has the corpus in front
+     * of it and can ask which bodies call what.
+     *
+     * <p>Public because the corpora this is asked over live in another module. Assigned by the test
+     * that is reading and set back to null after; a compile running while it is assigned writes to
+     * it from whatever thread it is on, so what is assigned has to take concurrent writes.
+     */
+    public static List<ValueName.Behavior> TAKEN_IN;
+
+    /**
+     * Records that a rule of this contract was substituted into a caller's arguments.
+     *
+     * <p>Called where the substitution is made and nowhere else, so what lands here is what a caller
+     * took in rather than what it was offered: a contract handed to the analysis and never reached —
+     * because the call went to no arm, or because the hand-over stopped — is not one of these.
+     */
+    void takenIn() {
+        List<ValueName.Behavior> watching = TAKEN_IN;
+        if (watching != null) {
+            watching.add(behavior);
+        }
+    }
+
     /** One rule: when it applies, what {@code value} is where it does, and what it states. */
     public record AssumedRule(Guard guard, BindingId value, List<Conjunct> conjuncts) {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -416,6 +416,7 @@ final class PathEngine {
                     continue;
                 }
                 TermMeaning here = conjunct.means().get().substituted(given);
+                answered.stated().takenIn();
                 out = predicates.assume(here.assumedBy(predicates, in.at(), false), out,
                         Known.Held.OF_THE_VALUE);
             }


### PR DESCRIPTION
Closes #1459.

Nothing measured here read what a caller may assume. `Bodies.Assumptions` answers what a behavior states about its answer, and the discharge analysis reads it at every call that has matched a case; the bench corpus stated no relation at all, and the one the conformance corpus states is on a behavior nothing calls. So the reading was built and never read, the substitution of a call's arguments into a rule ran nowhere a number is taken, and a change to any of it could not be seen to regress.

## A relation the model already wanted

`findAccountByDomain` answers an `Account` or says it found none. The type cannot say the account it answers is the one on the domain it was asked about — one `Account` is the same shape as another — and answering some other account is the failure the behavior exists to avoid. The clause says it, through `accountHasDomain`, which is the predicate the duplicate screen already matches the account book with.

`linkLeadToAccount` calls it and matches the cases, so compiling the corpus now reaches the reading, hands the call's arguments to it, and lets the predicates make something of the result. The `fake` and `example` rows written for that lookup are held to the clause as they are anywhere else.

## An edit that leaves the declaration where it is

The edit measurements added a definition to a module or a comment to the end of one. Adding a definition changes what the module declares, so what is re-asked is everything that reads the declaration list. No shape left a declaration alone and changed only what a caller of it may assume, which is the recomputation this analysis is written against.

A fifth shape rewrites a rule of the clause. It writes the conjunct the rule already states a second time and takes it away again, alternating, so that no round writes what the round before it wrote — two rounds writing one text is no edit, and the second would find every answer holding and time the floor.

Restating the rule with a rule it did not state is what the first writing of this did: it added a bound on the parameter, the way an author tightening a rule would. A comparison in an `ensures` draws a line on what it compares (spec §a-clause-draws-a-line-on-what-it-compares-an-input-against), so that edit moved the adequacy reading with it and the round was timing an edit to two readings under a name that says one.

## What holds the shape up

A timing says nothing about whether it reached anything, so what the measurement needs is asked of the corpus rather than read off the number: that it writes the rule the edit rewrites, that a body of it reads what the behavior states, that restating the rule changes what that body may assume, and that it leaves the other two readings the corpus is held to — what the compiler says about it, and how well the module's rows cover it — where they were. Each was mutated and seen to go red, the last of them by putting the bound edit back.

Renaming the clause instead of the rule changes the file and leaves what a caller assumes exactly as it was: the clause name does not cross into that reading. That is why the edit had to be to the rule, and it is the mutation the third of those refuses.

## Notes for review

- The test carries the population tag, so it runs on the merge into develop rather than in this PR's checks. Its subjects are the models this repository holds and it compiles the corpus to ask, which is what the tag is for. It has been run here.
- Left out: giving the conformance corpus a caller for the behavior that states something there. The measurement is what this issue closes, and moving that corpus moves the documents written beside it.
- The relation edit and the definition edit come out close together, and so does an edit that changes no reading at all. Whether that is the store re-establishing more than the edit reached, or the spans below an edited line moving, is not separated here — the definition edit appends and moves no span, the clause rename does — so it is left as something now watchable rather than as a cause named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
