### PR TITLE
Hash a value at its own boundary, so the sum above it keeps the pairing

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -45,6 +45,23 @@
         </module>
         <module name="UnusedLocalVariable"/>
         <module name="EqualsHashCode"/>
+        <!--
+          A record that spells its own hash is not asked to spell its own equality.
+
+          What this rule mirrors is one direction: an equality written by hand beside a hash the
+          class did not write is two answers that disagree. Checkstyle also asks the other way
+          round, and CI does not — so unasked, this rule stops a commit CI would have accepted,
+          and the thing it stops is the safer of the two shapes. A record's equality is written by
+          the compiler over every component it has and every component it is given later; a hash
+          written by hand beside it is one a later component costs a collision. Answering this
+          rule by writing the equality out as well is answering it by making the loss of a
+          component take that component out of what the value is.
+        -->
+        <module name="SuppressionXpathSingleFilter">
+            <property name="checks" value="EqualsHashCode"/>
+            <property name="query"
+                      value="//RECORD_DEF//METHOD_DEF[./IDENT[@text='hashCode']]"/>
+        </module>
         <module name="FallThrough"/>
         <module name="ModifierOrder"/>
         <module name="ArrayTypeStyle"/>

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -59,7 +59,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
         List<String> spellingItThemselves = new ArrayList<>();
         for (ClassModel read : valuesClasses()) {
             if (declaresAHash(read) && !reaches(read, THE_ALGEBRA)) {
-                spellingItThemselves.add(read.thisClass().name().stringValue() + " " + shapeOf(read));
+                spellingItThemselves.add(read.thisClass().name().stringValue());
             }
         }
 
@@ -101,22 +101,6 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
             }
         }
         return false;
-    }
-
-    /** What the class's hash is made of, for saying so where one is reported. */
-    private static String shapeOf(ClassModel read) {
-        for (MethodModel method : read.methods()) {
-            if ("hashCode".equals(method.methodName().stringValue())
-                    && "()I".equals(method.methodType().stringValue())) {
-                return method.code().map(code -> code.elementList().stream()
-                        .map(element -> element instanceof InvokeDynamicInstruction dynamic
-                                ? "indy:" + dynamic.invokedynamic().bootstrap().bootstrapMethod()
-                                        .reference().owner().name().stringValue()
-                                : element.getClass().getSimpleName())
-                        .toList().toString()).orElse("(no code)");
-            }
-        }
-        return "(no hash)";
     }
 
     /** Whether {@code element} is the handing-over a compiler writes for a record. */

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -1,0 +1,149 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value about a relation that works its own hash out takes it from the one place that says how.
+ *
+ * <p>These values are handed to things that add hashes up: a set sums what it holds, a map sums its
+ * entries, a record carries its last component into its own number unchanged. So a hash gathered
+ * from a value's parts and handed up as gathered leaves those parts separable there, and the sum
+ * above cancels whatever the value was arranged to say about which part went with which. What
+ * closes that is one finishing at the boundary of the value that owns the parts, and where the
+ * finishing happens matters as much as that it happens — finishing a total after the sum has been
+ * taken finishes a number the pairing has already left.
+ *
+ * <p>Which is why this is asked of the package rather than left to each value. Every one of these
+ * hashes was written by somebody deciding afresh how to gather two things symmetrically, and the
+ * one that decided on the plainest answer — the ends added — was the one that lost the pairing.
+ *
+ * <p><b>What this does not reach.</b> A value whose hash the compiler derives for it is not one
+ * this can ask anything of, so a record here that leaves its hash alone is outside this population
+ * however it is held. That is the right default: a hash written out by hand is one a component
+ * added later can be left out of, which is a worse fault than the one this is about. What a record
+ * here is held in is a question for whoever adds it to a set.
+ */
+class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
+
+    private static final String WHERE = "souther/compiler/values/";
+
+    private static final String THE_ALGEBRA = WHERE + "ValueHash";
+
+    /** What a record's own hash is left to, which is nobody here deciding anything. */
+    private static final String DERIVED = "java/lang/runtime/ObjectMethods";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    @Test
+    void everyValueThereThatWorksOutItsOwnHashTakesItFromTheAlgebra() {
+        List<String> spellingItThemselves = new ArrayList<>();
+        for (ClassModel read : valuesClasses()) {
+            if (declaresAHash(read) && !reaches(read, THE_ALGEBRA)) {
+                spellingItThemselves.add(read.thisClass().name().stringValue());
+            }
+        }
+
+        assertEquals(List.of(), spellingItThemselves,
+                "a value that gathers its own parts and hands the number up as gathered is one"
+                        + " whose parts the sum above it can still take apart");
+    }
+
+    /**
+     * And the population is the classes, not what a build happened to leave.
+     *
+     * <p>A walk finding no class would find no class spelling its own hash, and would pass while
+     * answering about nothing.
+     */
+    @Test
+    void andTheValuesThoseRulesAreAboutWereRead() {
+        List<ClassModel> read = valuesClasses();
+
+        assertTrue(read.size() > 1, "the classes about relations were not built here");
+        assertTrue(read.stream().anyMatch(AValueSpellsItsHashWithTheAlgebraThePackageHasTest
+                ::declaresAHash), "no value there works out a hash, which is not what these hold");
+    }
+
+    /**
+     * Whether the class works out a number of its own rather than being given one.
+     *
+     * <p>A record has a {@code hashCode} whatever it does, and the one the compiler writes is a
+     * handing-over: the whole of it is an {@code invokedynamic} that leaves the work to the runtime
+     * and names the components it is over. That is not a hash anybody here decided, so it is not
+     * one this is about.
+     */
+    private static boolean declaresAHash(ClassModel read) {
+        for (MethodModel method : read.methods()) {
+            if ("hashCode".equals(method.methodName().stringValue())
+                    && "()I".equals(method.methodType().stringValue())) {
+                return method.code().map(code -> code.elementList().stream()
+                        .noneMatch(AValueSpellsItsHashWithTheAlgebraThePackageHasTest::handedOver))
+                        .orElse(false);
+            }
+        }
+        return false;
+    }
+
+    /** Whether {@code element} is the handing-over a compiler writes for a record. */
+    private static boolean handedOver(CodeElement element) {
+        return element instanceof InvokeDynamicInstruction dynamic
+                && DERIVED.equals(dynamic.invokedynamic().bootstrap().bootstrapMethod()
+                        .reference().owner().name().stringValue());
+    }
+
+    /** Whether the class names {@code named} anywhere — a hash held in a field is worked out in a
+     *  constructor, so the question is about the class and not about the method. */
+    private static boolean reaches(ClassModel read, String named) {
+        for (PoolEntry entry : read.constantPool()) {
+            if (entry instanceof ClassEntry it && named.equals(it.name().stringValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<ClassModel> valuesClasses() {
+        List<ClassModel> out = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            Path where = module.resolve("target").resolve("classes").resolve(WHERE);
+            if (!Files.isDirectory(where)) {
+                continue;
+            }
+            try (Stream<Path> found = Files.list(where)) {
+                for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
+                    out.add(parse(each));
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return out;
+    }
+
+    private static ClassModel parse(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -6,24 +6,30 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.lang.classfile.CodeElement;
+import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
-import java.lang.classfile.constantpool.ClassEntry;
-import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.LoadInstruction;
+import java.lang.classfile.instruction.ReturnInstruction;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A value about a relation that works its own hash out takes it from the one place that says how.
+ * A value about a relation that works its own hash out takes it from the one place that says how,
+ * and a value the compiler works one out for is left alone.
  *
  * <p>These values are handed to things that add hashes up: a set sums what it holds, a map sums its
  * entries, a record carries its last component into its own number unchanged. So a hash gathered
@@ -37,11 +43,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * hashes was written by somebody deciding afresh how to gather two things symmetrically, and the
  * one that decided on the plainest answer — the ends added — was the one that lost the pairing.
  *
- * <p><b>What this does not reach.</b> A value whose hash the compiler derives for it is not one
- * this can ask anything of, so a record here that leaves its hash alone is outside this population
- * however it is held. That is the right default: a hash written out by hand is one a component
- * added later can be left out of, which is a worse fault than the one this is about. What a record
- * here is held in is a question for whoever adds it to a set.
+ * <p><b>Asked of the number the hash hands back, and not of what the class mentions.</b> A class
+ * that names the algebra somewhere and gathers its own parts in {@code hashCode} is the defect this
+ * is about, written next to its own remedy. So what is followed here is where the number comes
+ * from: the hash asks the algebra, or it hands back a field nothing puts a number into but the
+ * algebra. The second is what a value that is asked its number far more often than one is made
+ * does, and it is not a way around the first.
+ *
+ * <p><b>And what a record leaves to the compiler is left there.</b> A hash written out by hand is
+ * one a component added later can be left out of, and an equality written out by hand is one a
+ * component added later is not part of at all — the first costs a collision, the second takes the
+ * component out of what the value is. So a record here spells its own number where the number is
+ * what this is about, and never its own equality: the generated one is over every component it has
+ * and over every component it is given.
  */
 class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
 
@@ -49,23 +63,58 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
 
     private static final String THE_ALGEBRA = WHERE + "ValueHash";
 
-    /** What a record's own hash is left to, which is nobody here deciding anything. */
+    /** What a record's own equality and hash are left to, which is nobody here deciding anything. */
     private static final String DERIVED = "java/lang/runtime/ObjectMethods";
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     @Test
     void everyValueThereThatWorksOutItsOwnHashTakesItFromTheAlgebra() {
-        List<String> spellingItThemselves = new ArrayList<>();
+        List<String> gatheringItThemselves = new ArrayList<>();
         for (ClassModel read : valuesClasses()) {
-            if (declaresAHash(read) && !reaches(read, THE_ALGEBRA)) {
-                spellingItThemselves.add(read.thisClass().name().stringValue());
+            Optional<MethodModel> spelled = spelledOut(read, "hashCode", "()I");
+            if (spelled.isPresent() && !fromTheAlgebra(read, spelled.get())) {
+                gatheringItThemselves.add(read.thisClass().name().stringValue());
             }
         }
 
-        assertEquals(List.of(), spellingItThemselves,
+        assertEquals(List.of(), gatheringItThemselves,
                 "a value that gathers its own parts and hands the number up as gathered is one"
                         + " whose parts the sum above it can still take apart");
+    }
+
+    /**
+     * And a record spells its own equality where, and only where, its equality is not what its
+     * components in their places come to.
+     *
+     * <p>Which the number says: a record asks the algebra for the shape its equality has, and one
+     * of those shapes is a pair with no order between its ends. That one the compiler cannot write
+     * — the generated equality is component by component, so a pair stated the other way round
+     * would be another value while being one number, and the pair would not be unordered at all.
+     * Every other shape here is what the generated one already says, and writing it out again is
+     * writing something the next component this record is given is not part of.
+     */
+    @Test
+    void andARecordThereSpellsItsOwnEqualityWhereAndOnlyWhereTheGeneratedOneWouldSayAnother() {
+        List<String> disagreeing = new ArrayList<>();
+        for (ClassModel read : valuesClasses()) {
+            if (read.findAttribute(Attributes.record()).isEmpty()) {
+                continue;
+            }
+            boolean spellsIt = spelledOut(read, "equals", "(Ljava/lang/Object;)Z").isPresent();
+            boolean unordered = spelledOut(read, "hashCode", "()I")
+                    .filter(hash -> asks(hash, "ofAnUnorderedPair")).isPresent();
+            if (spellsIt != unordered) {
+                disagreeing.add(read.thisClass().name().stringValue()
+                        + (spellsIt ? " writes an equality the compiler would have written"
+                                : " leaves an equality that says another thing than its number"));
+            }
+        }
+
+        assertEquals(List.of(), disagreeing,
+                "an equality written out by hand is one the next component this record is given is"
+                        + " not part of, and one left generated beside an unordered number is one"
+                        + " that reads the ends in the order they were written");
     }
 
     /**
@@ -79,46 +128,109 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
         List<ClassModel> read = valuesClasses();
 
         assertTrue(read.size() > 1, "the classes about relations were not built here");
-        assertTrue(read.stream().anyMatch(AValueSpellsItsHashWithTheAlgebraThePackageHasTest
-                ::declaresAHash), "no value there works out a hash, which is not what these hold");
+        assertTrue(read.stream().anyMatch(each -> spelledOut(each, "hashCode", "()I").isPresent()),
+                "no value there works out a hash, which is not what these hold");
+        assertTrue(read.stream().anyMatch(
+                        each -> each.findAttribute(Attributes.record()).isPresent()),
+                "no value there is a record, which is not what these hold either");
     }
 
     /**
-     * Whether the class works out a number of its own rather than being given one.
+     * The method of that name the class wrote itself, where it wrote one.
      *
-     * <p>A record has a {@code hashCode} whatever it does, and the one the compiler writes is a
-     * handing-over: the whole of it is an {@code invokedynamic} that leaves the work to the runtime
-     * and names the components it is over. That is not a hash anybody here decided, so it is not
-     * one this is about.
+     * <p>A record has both of these whatever it does, and the ones the compiler writes are a
+     * handing-over: the whole of each is an {@code invokedynamic} that leaves the work to the
+     * runtime and names the components it is over. That is nobody here deciding anything.
      */
-    private static boolean declaresAHash(ClassModel read) {
+    private static Optional<MethodModel> spelledOut(ClassModel read, String named, String taking) {
         for (MethodModel method : read.methods()) {
-            if ("hashCode".equals(method.methodName().stringValue())
-                    && "()I".equals(method.methodType().stringValue())) {
-                return method.code().map(code -> code.elementList().stream()
-                        .noneMatch(AValueSpellsItsHashWithTheAlgebraThePackageHasTest::handedOver))
-                        .orElse(false);
+            if (named.equals(method.methodName().stringValue())
+                    && taking.equals(method.methodType().stringValue())) {
+                boolean handedOver = instructionsOf(method).stream().anyMatch(
+                        AValueSpellsItsHashWithTheAlgebraThePackageHasTest::handedOver);
+                return handedOver ? Optional.empty() : Optional.of(method);
             }
         }
-        return false;
+        return Optional.empty();
     }
 
-    /** Whether {@code element} is the handing-over a compiler writes for a record. */
-    private static boolean handedOver(CodeElement element) {
-        return element instanceof InvokeDynamicInstruction dynamic
+    /** Whether the number {@code hash} hands back is one the algebra answered. */
+    private static boolean fromTheAlgebra(ClassModel read, MethodModel hash) {
+        if (asks(hash)) {
+            return true;
+        }
+        return handedBack(read, hash).filter(field -> putThereByTheAlgebra(read, field)).isPresent();
+    }
+
+    /** Whether the method asks the algebra for a number. */
+    private static boolean asks(MethodModel method) {
+        return instructionsOf(method).stream().anyMatch(instruction ->
+                instruction instanceof InvokeInstruction call
+                        && THE_ALGEBRA.equals(call.owner().name().stringValue()));
+    }
+
+    /** Whether the method asks the algebra for a number of that shape. */
+    private static boolean asks(MethodModel method, String shape) {
+        return instructionsOf(method).stream().anyMatch(instruction ->
+                instruction instanceof InvokeInstruction call
+                        && THE_ALGEBRA.equals(call.owner().name().stringValue())
+                        && shape.equals(call.name().stringValue()));
+    }
+
+    /** The field a hash hands back where the whole of it is handing one back, which is what a value
+     *  asked its number far more often than one is made holds. */
+    private static Optional<String> handedBack(ClassModel read, MethodModel hash) {
+        List<Instruction> body = instructionsOf(hash);
+        if (body.size() == 3 && body.get(0) instanceof LoadInstruction
+                && body.get(1) instanceof FieldInstruction field
+                && field.opcode() == Opcode.GETFIELD
+                && read.thisClass().name().equals(field.owner().name())
+                && body.get(2) instanceof ReturnInstruction) {
+            return Optional.of(field.name().stringValue());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Whether nothing but the algebra puts a number into {@code field}.
+     *
+     * <p>Read as the instruction before each of the puts, which is where the number being put comes
+     * from when it comes from a call. A put that took its number from anywhere else — a gathering
+     * written out beside the call, a number handed in — is one this does not admit, and the class
+     * that wrote it is reported as gathering its own.
+     */
+    private static boolean putThereByTheAlgebra(ClassModel read, String field) {
+        boolean put = false;
+        for (MethodModel method : read.methods()) {
+            Instruction before = null;
+            for (Instruction instruction : instructionsOf(method)) {
+                if (instruction instanceof FieldInstruction it && it.opcode() == Opcode.PUTFIELD
+                        && read.thisClass().name().equals(it.owner().name())
+                        && field.equals(it.name().stringValue())) {
+                    put = true;
+                    if (!(before instanceof InvokeInstruction call)
+                            || !THE_ALGEBRA.equals(call.owner().name().stringValue())) {
+                        return false;
+                    }
+                }
+                before = instruction;
+            }
+        }
+        return put;
+    }
+
+    /** Whether {@code instruction} is the handing-over a compiler writes for a record. */
+    private static boolean handedOver(Instruction instruction) {
+        return instruction instanceof InvokeDynamicInstruction dynamic
                 && DERIVED.equals(dynamic.invokedynamic().bootstrap().bootstrapMethod()
                         .reference().owner().name().stringValue());
     }
 
-    /** Whether the class names {@code named} anywhere — a hash held in a field is worked out in a
-     *  constructor, so the question is about the class and not about the method. */
-    private static boolean reaches(ClassModel read, String named) {
-        for (PoolEntry entry : read.constantPool()) {
-            if (entry instanceof ClassEntry it && named.equals(it.name().stringValue())) {
-                return true;
-            }
-        }
-        return false;
+    private static List<Instruction> instructionsOf(MethodModel method) {
+        return method.code().map(code -> code.elementList().stream()
+                .filter(Instruction.class::isInstance)
+                .map(Instruction.class::cast)
+                .toList()).orElse(List.of());
     }
 
     private static List<ClassModel> valuesClasses() {

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -59,7 +59,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
         List<String> spellingItThemselves = new ArrayList<>();
         for (ClassModel read : valuesClasses()) {
             if (declaresAHash(read) && !reaches(read, THE_ALGEBRA)) {
-                spellingItThemselves.add(read.thisClass().name().stringValue());
+                spellingItThemselves.add(read.thisClass().name().stringValue() + " " + shapeOf(read));
             }
         }
 
@@ -101,6 +101,22 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
             }
         }
         return false;
+    }
+
+    /** What the class's hash is made of, for saying so where one is reported. */
+    private static String shapeOf(ClassModel read) {
+        for (MethodModel method : read.methods()) {
+            if ("hashCode".equals(method.methodName().stringValue())
+                    && "()I".equals(method.methodType().stringValue())) {
+                return method.code().map(code -> code.elementList().stream()
+                        .map(element -> element instanceof InvokeDynamicInstruction dynamic
+                                ? "indy:" + dynamic.invokedynamic().bootstrap().bootstrapMethod()
+                                        .reference().owner().name().stringValue()
+                                : element.getClass().getSimpleName())
+                        .toList().toString()).orElse("(no code)");
+            }
+        }
+        return "(no hash)";
     }
 
     /** Whether {@code element} is the handing-over a compiler writes for a record. */

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -66,6 +66,10 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
     /** What a record's own equality and hash are left to, which is nobody here deciding anything. */
     private static final String DERIVED = "java/lang/runtime/ObjectMethods";
 
+    /** Asked of the number a hash hands back where which shape it was asked for is not the
+     *  question. */
+    private static final String ANY_SHAPE = "";
+
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     @Test
@@ -103,7 +107,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
             }
             boolean spellsIt = spelledOut(read, "equals", "(Ljava/lang/Object;)Z").isPresent();
             boolean unordered = spelledOut(read, "hashCode", "()I")
-                    .filter(hash -> asks(hash, "ofAnUnorderedPair")).isPresent();
+                    .filter(hash -> handsBack(hash, "ofAnUnorderedPair")).isPresent();
             if (spellsIt != unordered) {
                 disagreeing.add(read.thisClass().name().stringValue()
                         + (spellsIt ? " writes an equality the compiler would have written"
@@ -156,25 +160,30 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
 
     /** Whether the number {@code hash} hands back is one the algebra answered. */
     private static boolean fromTheAlgebra(ClassModel read, MethodModel hash) {
-        if (asks(hash)) {
+        if (handsBack(hash, ANY_SHAPE)) {
             return true;
         }
         return handedBack(read, hash).filter(field -> putThereByTheAlgebra(read, field)).isPresent();
     }
 
-    /** Whether the method asks the algebra for a number. */
-    private static boolean asks(MethodModel method) {
-        return instructionsOf(method).stream().anyMatch(instruction ->
-                instruction instanceof InvokeInstruction call
-                        && THE_ALGEBRA.equals(call.owner().name().stringValue()));
-    }
-
-    /** Whether the method asks the algebra for a number of that shape. */
-    private static boolean asks(MethodModel method, String shape) {
-        return instructionsOf(method).stream().anyMatch(instruction ->
-                instruction instanceof InvokeInstruction call
-                        && THE_ALGEBRA.equals(call.owner().name().stringValue())
-                        && shape.equals(call.name().stringValue()));
+    /**
+     * Whether the method hands back what the algebra answered, of {@code shape} where one is named.
+     *
+     * <p>Read as the answer being returned and not as the call being made. A method that asks the
+     * algebra and hands back something else has asked and answered separately, which is the defect
+     * this is about with its own remedy standing beside it.
+     */
+    private static boolean handsBack(MethodModel method, String shape) {
+        List<Instruction> body = instructionsOf(method);
+        for (int at = 0; at + 1 < body.size(); at++) {
+            if (body.get(at) instanceof InvokeInstruction call
+                    && THE_ALGEBRA.equals(call.owner().name().stringValue())
+                    && (ANY_SHAPE.equals(shape) || shape.equals(call.name().stringValue()))
+                    && body.get(at + 1) instanceof ReturnInstruction) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** The field a hash hands back where the whole of it is handing one back, which is what a value

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -858,9 +858,12 @@ public final class AdmissibleValues<A> {
         return other instanceof AdmissibleValues<?> it && parts.equals(it.parts);
     }
 
+    /** What it holds, as this kind of value — see {@link ValueHash}. The parts are a record, and a
+     *  record's number is one its last component joins unchanged, so handing that up is handing up
+     *  a number whatever hashes this next can still take apart. */
     @Override
     public int hashCode() {
-        return parts.hashCode();
+        return ValueHash.ofOnePart(AdmissibleValues.class, parts.hashCode());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -368,9 +368,12 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
                         && commonSameness.equals(it.commonSameness) && across.equals(it.across);
             }
 
+            /** The boxes, what is held as one across them and what each block is left — each in
+             *  its own place, see {@link ValueHash}. */
             @Override
             public int hashCode() {
-                return (boxes.hashCode() * 31 + commonSameness.hashCode()) * 31 + across.hashCode();
+                return ValueHash.ofItsParts(Alternatives.class, boxes.hashCode(),
+                        commonSameness.hashCode(), across.hashCode());
             }
 
             @Override
@@ -534,6 +537,27 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         /** One alternative that states no denial. */
         public static <A> Alternative<A> of(Box<A> product) {
             return new Alternative<>(product, Apartness.nothing());
+        }
+
+        /**
+         * The product and the relation over it, each in its own place — see {@link ValueHash}.
+         *
+         * <p>Said here rather than left to what a record answers, because these are held several to
+         * a set and a set adds up what it holds. A record carries its last component up unchanged,
+         * so two alternatives would come to one number whenever they held each other's relation —
+         * and an alternative is a product and the denials over that product together.
+         */
+        @Override
+        public int hashCode() {
+            return ValueHash.ofItsParts(Alternative.class, product.hashCode(), apart.hashCode());
+        }
+
+        /** The product and the relation over it. Spelled out beside the number, so that the two
+         *  are read together wherever either is changed. */
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Alternative<?> it && product.equals(it.product)
+                    && apart.equals(it.apart);
         }
 
         /** One alternative over positions that are each their own block, stating no denial. */

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -561,14 +561,6 @@ public final class AdmissibleValues<A> {
             return ValueHash.ofItsParts(Alternative.class, product.hashCode(), apart.hashCode());
         }
 
-        /** The product and the relation over it. Spelled out beside the number, so that the two
-         *  are read together wherever either is changed. */
-        @Override
-        public boolean equals(Object other) {
-            return other instanceof Alternative<?> it && product.equals(it.product)
-                    && apart.equals(it.apart);
-        }
-
         /** One alternative over positions that are each their own block, stating no denial. */
         public static <A> Alternative<A> at(Map<A, ValueSet> said) {
             return of(Box.at(said));

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -889,9 +889,10 @@ public final class Apartness<A> {
         return other instanceof Apartness<?> it && edges.equals(it.edges);
     }
 
+    /** The pairs it holds — see {@link ValueHash}. */
     @Override
     public int hashCode() {
-        return edges.hashCode();
+        return ValueHash.ofWhatItHolds(Apartness.class, edges.hashCode(), edges.size());
     }
 
     /** The pairs written in one order whichever order they were stated in — see

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -754,8 +754,8 @@ public final class Apartness<A> {
         // beside two blocks nothing wrote the values of is two sets that leave one. What the count
         // then shows of them is one lack, shown twice.
         //
-        // Told by what is claimed and not by the blocks the count was taken of. A lack says where
-        // it is filed ({@link RelationalLack#scattering}), where a set of blocks is a number its
+        // Told by what is claimed and not by the blocks the count was taken of. A lack works out
+        // where it is filed at its own boundary (ValueHash), so a set of blocks is not a number its
         // subsets share — and the sets one relation is short of are subsets of the same few blocks.
         Set<RelationalLack<A>> already = new LinkedHashSet<>();
         for (Set<Sameness.Block<A>> apart : walked.get()) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -936,9 +936,19 @@ public final class Apartness<A> {
                             || (one.equals(it.other) && other.equals(it.one)));
         }
 
+        /**
+         * A pair of blocks with no order between its ends — see {@link ValueHash}.
+         *
+         * <p>Taken as a pair and not as its ends added. The ends added is what a pair stated either
+         * way round most easily comes to one number by, and it is also what leaves a set of pairs
+         * at the sum over every block any of its pairs names: the pair of {@code A} with {@code B}
+         * beside the pair of {@code C} with {@code D}, and the pair of {@code A} with {@code C}
+         * beside the pair of {@code B} with {@code D}, add up the same. Which block was stated to
+         * differ from which is what a relation is, and it is the one thing that sum does not say.
+         */
         @Override
         public int hashCode() {
-            return one.hashCode() + other.hashCode();
+            return ValueHash.ofAnUnorderedPair(Edge.class, one.hashCode(), other.hashCode());
         }
 
         /** The two ends, written in one order whichever way round they were stated. Which end is

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -382,9 +382,12 @@ public final class ConjoinedAdmissibleValues<A> {
         return other instanceof ConjoinedAdmissibleValues<?> it && factors.equals(it.factors);
     }
 
+    /** The factors it holds, as this kind of value — see {@link ValueHash}. A list hands up a
+     *  number its elements join one at a time, so handing that up is handing up a number whatever
+     *  hashes this next can still take apart. */
     @Override
     public int hashCode() {
-        return factors.hashCode();
+        return ValueHash.ofOnePart(ConjoinedAdmissibleValues.class, factors.hashCode());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
@@ -170,13 +170,14 @@ public final class Lacks<A> {
         return true;
     }
 
+    /** What was shown, in no order — see {@link ValueHash}. */
     @Override
     public int hashCode() {
-        int out = 0;
+        int summed = 0;
         for (Shown<A> shown : each) {
-            out += shown.hashCode();
+            summed += shown.hashCode();
         }
-        return out;
+        return ValueHash.ofWhatItHolds(Lacks.class, summed, each.size());
     }
 
     /** Written in one order whichever they arrived in — see {@link InOneOrder}. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
@@ -23,12 +23,11 @@ import java.util.function.Predicate;
  * to answer for.
  *
  * <p><b>Which is why what is inside is not what is handed out.</b> These are held in the order they
- * arrived, because a lack about several blocks hashes through the set of blocks it names and the
- * sets of blocks one relation is short of fall together — measured on the shape the walk is
- * admitted at, putting them somewhere that hashes them on the way in was what a reduction cost
- * rather than a part of it. An order nobody may read is not an order a value may show, so nothing
- * here answers with one: a reader asks what was claimed, what a report may name, or whether every
- * lack is of some kind.
+ * arrived, because a lack about several blocks hashes through the set of blocks it names — measured
+ * on the shape the walk is admitted at, and on the numbers a lack had then, putting them somewhere
+ * that hashes them on the way in was what a reduction cost rather than a part of it. An order
+ * nobody may read is not an order a value may show, so nothing here answers with one: a reader asks
+ * what was claimed, what a report may name, or whether every lack is of some kind.
  *
  * <p>And what a lack claims is what these are looked up by, which is a question asked of every lack
  * of one of these against every lack of another wherever two are put together. Asked by walking,

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -128,9 +128,12 @@ public sealed interface PlannedValues<A> {
             return other instanceof Settled<?> it && parts.equals(it.parts);
         }
 
+        /** What it holds, as this kind of value — see {@link ValueHash}. The parts are a record,
+         *  and a record's number is one its last component joins unchanged, so handing that up is
+         *  handing up a number whatever hashes this next can still take apart. */
         @Override
         public int hashCode() {
-            return parts.hashCode();
+            return ValueHash.ofOnePart(Settled.class, parts.hashCode());
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
@@ -97,6 +97,30 @@ public final class Provenance<A> {
             return block + " lost " + value + " in round " + round + " to "
                     + InOneOrder.of(blockers);
         }
+
+        /**
+         * What was taken, from where, when and by what — each in its own place, see
+         * {@link ValueHash}.
+         *
+         * <p>Said here rather than left to what a record answers, because a route holds several of
+         * these and what several of them come to is their numbers added. The blockers are a set and
+         * a record carries its last component up unchanged, so two removals would come to one
+         * number whenever the same blockers were shared out between them the other way — and what
+         * a removal says is which of them left this value nowhere to go.
+         */
+        @Override
+        public int hashCode() {
+            return ValueHash.ofItsParts(Removal.class, block.hashCode(), value.hashCode(), round,
+                    blockers.hashCode());
+        }
+
+        /** What was taken, from where, when and by what. Spelled out beside the number, so that
+         *  the two are read together wherever either is changed. */
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof Removal<?> it && round == it.round && block.equals(it.block)
+                    && value.equals(it.value) && blockers.equals(it.blockers);
+        }
     }
 
     /**
@@ -153,9 +177,10 @@ public final class Provenance<A> {
         return said instanceof Provenance<?> it && removals.equals(it.removals);
     }
 
+    /** The removals it holds, in no order — see {@link ValueHash}. */
     @Override
     public int hashCode() {
-        return removals.hashCode();
+        return ValueHash.ofWhatItHolds(Provenance.class, removals.hashCode(), removals.size());
     }
 
     /** One block, asked of the rounds before {@code before}. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
@@ -113,14 +113,6 @@ public final class Provenance<A> {
             return ValueHash.ofItsParts(Removal.class, block.hashCode(), value.hashCode(), round,
                     blockers.hashCode());
         }
-
-        /** What was taken, from where, when and by what. Spelled out beside the number, so that
-         *  the two are read together wherever either is changed. */
-        @Override
-        public boolean equals(Object said) {
-            return said instanceof Removal<?> it && round == it.round && block.equals(it.block)
-                    && value.equals(it.value) && blockers.equals(it.blockers);
-        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -109,9 +109,12 @@ public final class Realized<A> {
         return other instanceof Realized<?> it && parts.equals(it.parts);
     }
 
+    /** What it holds, as this kind of value — see {@link ValueHash}. The parts are a record, and a
+     *  record's number is one its last component joins unchanged, so handing that up is handing up
+     *  a number whatever hashes this next can still take apart. */
     @Override
     public int hashCode() {
-        return parts.hashCode();
+        return ValueHash.ofOnePart(Realized.class, parts.hashCode());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalEvidence.java
@@ -99,12 +99,13 @@ public final class RelationalEvidence<A> {
         return InOneOrder.of(routes);
     }
 
+    /** The routes it holds, in no order — see {@link ValueHash}. */
     @Override
     public int hashCode() {
-        int out = 0;
+        int summed = 0;
         for (Provenance<A> route : routes) {
-            out += route.hashCode();
+            summed += route.hashCode();
         }
-        return out;
+        return ValueHash.ofWhatItHolds(RelationalEvidence.class, summed, routes.size());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
@@ -72,12 +72,6 @@ public sealed interface RelationalLack<A> {
         public int hashCode() {
             return ValueHash.ofOnePart(ABlockApartFromItself.class, block.hashCode());
         }
-
-        /** The block it is about, and this case of a lack. */
-        @Override
-        public boolean equals(Object said) {
-            return said instanceof ABlockApartFromItself<?> it && block.equals(it.block);
-        }
     }
 
     /**
@@ -111,12 +105,6 @@ public sealed interface RelationalLack<A> {
         @Override
         public int hashCode() {
             return ValueHash.ofOnePart(NoValueLeftForIt.class, block.hashCode());
-        }
-
-        /** The block it is about, and this case of a lack. */
-        @Override
-        public boolean equals(Object said) {
-            return said instanceof NoValueLeftForIt<?> it && block.equals(it.block);
         }
     }
 
@@ -155,12 +143,6 @@ public sealed interface RelationalLack<A> {
         public int hashCode() {
             return ValueHash.ofItsParts(TooFewValuesBetweenThem.class, blocks.hashCode(),
                     available.hashCode());
-        }
-
-        @Override
-        public boolean equals(Object said) {
-            return said instanceof TooFewValuesBetweenThem<?> it && blocks.equals(it.blocks)
-                    && available.equals(it.available);
         }
     }
 
@@ -218,11 +200,6 @@ public sealed interface RelationalLack<A> {
         public int hashCode() {
             return ValueHash.ofWhatItHolds(NoAssignmentTellsThemApart.class, blocks.hashCode(),
                     blocks.size());
-        }
-
-        @Override
-        public boolean equals(Object said) {
-            return said instanceof NoAssignmentTellsThemApart<?> it && blocks.equals(it.blocks);
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
@@ -35,28 +35,6 @@ public sealed interface RelationalLack<A> {
     /** Every block the lack is about, which is what a report has to name to say what has nothing. */
     Set<Sameness.Block<A>> blocks();
 
-    /**
-     * A number for a set of blocks that two different sets rarely share.
-     *
-     * <p>A set's own is the sum of what it holds, and the sets of blocks one relation is short of
-     * are all drawn from the same few blocks — so their sums fall together, and a reader that filed
-     * these under it would compare nearly every one of them with every other. Each block's number is
-     * scattered before the sum is taken, which leaves the sum as free of the order they come in as
-     * it was and the sets as far apart as they are.
-     *
-     * <p>Which is a thing a lack works out for itself and not a thing a caller does to it. A lack
-     * is what a refusal is looked up by, so where it is filed is settled by the lack rather than by
-     * whoever is filing it.
-     */
-    private static int scattering(Set<?> these) {
-        int out = 0;
-        for (Object each : these) {
-            int mixed = each.hashCode() * 0x9E3779B9;
-            out += mixed ^ (mixed >>> 16);
-        }
-        return out;
-    }
-
     /** The same argument about the blocks {@code naming} calls these. */
     default <B> RelationalLack<B> renamed(java.util.function.Function<A, B> naming) {
         return switch (this) {
@@ -88,6 +66,18 @@ public sealed interface RelationalLack<A> {
         public Set<Sameness.Block<A>> blocks() {
             return Set.of(block);
         }
+
+        /** The block, as this case of a lack — see {@link ValueHash}. */
+        @Override
+        public int hashCode() {
+            return ValueHash.ofOnePart(ABlockApartFromItself.class, block.hashCode());
+        }
+
+        /** The block it is about, and this case of a lack. */
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof ABlockApartFromItself<?> it && block.equals(it.block);
+        }
     }
 
     /**
@@ -109,6 +99,24 @@ public sealed interface RelationalLack<A> {
         @Override
         public Set<Sameness.Block<A>> blocks() {
             return Set.of(block);
+        }
+
+        /**
+         * The block, as this case of a lack — see {@link ValueHash}.
+         *
+         * <p>Which case it is is part of the number, and here that is the whole of what tells this
+         * from a block stated apart from itself: both name one block and claim different things,
+         * and an argument holds several lacks in no order.
+         */
+        @Override
+        public int hashCode() {
+            return ValueHash.ofOnePart(NoValueLeftForIt.class, block.hashCode());
+        }
+
+        /** The block it is about, and this case of a lack. */
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof NoValueLeftForIt<?> it && block.equals(it.block);
         }
     }
 
@@ -142,10 +150,11 @@ public sealed interface RelationalLack<A> {
             return "TooFewValuesBetweenThem" + InOneOrder.of(blocks) + InOneOrder.of(available);
         }
 
-        /** The blocks and the values, scattered — see {@link #scattering}. */
+        /** The blocks and the values, each in its own place — see {@link ValueHash}. */
         @Override
         public int hashCode() {
-            return 31 * scattering(blocks) + scattering(available);
+            return ValueHash.ofItsParts(TooFewValuesBetweenThem.class, blocks.hashCode(),
+                    available.hashCode());
         }
 
         @Override
@@ -204,10 +213,11 @@ public sealed interface RelationalLack<A> {
             return "NoAssignmentTellsThemApart" + InOneOrder.of(blocks);
         }
 
-        /** The blocks, scattered — see {@link #scattering}. */
+        /** The blocks it names, in no order — see {@link ValueHash}. */
         @Override
         public int hashCode() {
-            return scattering(blocks);
+            return ValueHash.ofWhatItHolds(NoAssignmentTellsThemApart.class, blocks.hashCode(),
+                    blocks.size());
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -267,20 +267,6 @@ public final class Sameness<A> {
      */
     public static final class Block<A> {
 
-        /** What the number of members is multiplied by before it joins their sum, so that two
-         *  blocks whose members sum alike are still told apart where they hold different numbers of
-         *  positions. Odd, so that no bit of the number is lost in the multiplication. */
-        private static final int COUNTED = 0x9e3779b9;
-
-        /** The rounds of the mixing. The members reach it as the sum a {@code Set} hashes them to,
-         *  so what is mixed is that sum and the count beside it rather than the members one at a
-         *  time. Each multiplication carries what the shift before it folded downwards back up into
-         *  the high bits, which is what stops a sum of block hashes coming to a function of the sum
-         *  over all their positions. */
-        private static final int SCATTER = 0x85ebca6b;
-
-        private static final int SPREAD = 0xc2b2ae35;
-
         private final Set<A> members;
 
         /**
@@ -294,25 +280,18 @@ public final class Sameness<A> {
          * reads. Derived from the members on each of those, the answer is a walk of the set and a
          * hash of every position in it, over and over, for a value that cannot change.
          *
-         * <p><b>And mixed, because a set's hash is the sum of its members'.</b> Left as that sum, a
-         * block's hash carries no mark of where the block ends: a set of blocks hashes to the sum
-         * over every position in all of them, so {@code {{p}, {q, r}}} and {@code {{p, q}, {r}}}
-         * come to one hash whatever those positions are. A set of blocks is what a refusal names
-         * and what a lack is about, so the grouping a block exists to state would be the one thing
-         * its hash does not say. One mixing at the block's edge is what stops the sum above it
-         * cancelling that grouping out.
-         *
-         * <p>The mixing is work of its own, a fixed few operations paid where the block is made,
-         * and it is not paid back: the blocks a compile makes are nearly all of one position and
-         * the sets of them are small, so nothing measured here is spending what it saves. It is
-         * here because this hash is spelled out rather than derived, and a sum spelled out is a sum
-         * kept.
+         * <p><b>And taken as what a collection holds rather than as their sum.</b> A set of blocks
+         * is what a refusal names and what a lack is about, and a set hashes what it holds by
+         * adding them up — so a block that handed up the sum over its own members would leave
+         * {@code {{p}, {q, r}}} and {@code {{p, q}, {r}}} at one number whatever those positions
+         * are, and the grouping a block exists to state would be the one thing it does not say.
+         * {@link ValueHash} is where that is closed and why.
          */
         private final int hash;
 
         private Block(Set<A> members) {
             this.members = members;
-            this.hash = hashOf(members);
+            this.hash = ValueHash.ofWhatItHolds(Block.class, members.hashCode(), members.size());
         }
 
         /**
@@ -400,16 +379,6 @@ public final class Sameness<A> {
             List<A> sorted = new ArrayList<>(members);
             sorted.sort(Comparator.comparing(String::valueOf));
             return Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
-        }
-
-        /** The members' hash, taken so that the block's edge survives being summed with others. */
-        private static int hashOf(Set<?> members) {
-            int gathered = members.hashCode() ^ (members.size() * COUNTED);
-            gathered ^= (gathered >>> 16);
-            gathered *= SCATTER;
-            gathered ^= (gathered >>> 13);
-            gathered *= SPREAD;
-            return gathered ^ (gathered >>> 16);
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -240,9 +240,10 @@ public final class Sameness<A> {
         return other instanceof Sameness<?> it && blocks.equals(it.blocks);
     }
 
+    /** Which block each position is on — see {@link ValueHash}. */
     @Override
     public int hashCode() {
-        return blocks.hashCode();
+        return ValueHash.ofWhatItHolds(Sameness.class, blocks.hashCode(), blocks.size());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/Shown.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Shown.java
@@ -56,11 +56,4 @@ public record Shown<A>(RelationalLack<A> lack, RelationalEvidence<A> reached) {
     public int hashCode() {
         return ValueHash.ofItsParts(Shown.class, lack.hashCode(), reached.hashCode());
     }
-
-    /** The lack it claims and the routes that reached it, which is what it holds. Spelled out
-     *  beside the number, so that the two are read together wherever either is changed. */
-    @Override
-    public boolean equals(Object said) {
-        return said instanceof Shown<?> it && lack.equals(it.lack) && reached.equals(it.reached);
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Shown.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Shown.java
@@ -42,4 +42,25 @@ public record Shown<A>(RelationalLack<A> lack, RelationalEvidence<A> reached) {
     public <B> Shown<B> renamed(Function<A, B> naming) {
         return new Shown<>(lack.renamed(naming), reached.renamed(naming));
     }
+
+    /**
+     * The lack and how it was reached, each in its own place — see {@link ValueHash}.
+     *
+     * <p>Said here rather than left to what a record answers, because these are what an argument
+     * holds several of and what several of them come to is their numbers added. A record's own
+     * carries its last component up unchanged, so two of these would come to one number whenever
+     * the same lacks and the same routes were shared out between them the other way — and which
+     * route reached which lack is what an author is sent to read.
+     */
+    @Override
+    public int hashCode() {
+        return ValueHash.ofItsParts(Shown.class, lack.hashCode(), reached.hashCode());
+    }
+
+    /** The lack it claims and the routes that reached it, which is what it holds. Spelled out
+     *  beside the number, so that the two are read together wherever either is changed. */
+    @Override
+    public boolean equals(Object said) {
+        return said instanceof Shown<?> it && lack.equals(it.lack) && reached.equals(it.reached);
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Standing.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Standing.java
@@ -244,9 +244,12 @@ public final class Standing<A> {
                 && openedByAlternative.equals(it.openedByAlternative);
     }
 
+    /** What it holds and what an alternative opened, each in its own place — see
+     *  {@link ValueHash}. */
     @Override
     public int hashCode() {
-        return entries.hashCode() * 31 + openedByAlternative.hashCode();
+        return ValueHash.ofItsParts(Standing.class, entries.hashCode(),
+                openedByAlternative.hashCode());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
@@ -63,6 +63,12 @@ final class ValueHash {
         return finished(GATHER * (GATHER * (GATHER * seed(kind) + first) + second) + third);
     }
 
+    /** A value of {@code kind} holding four, each in its own place. */
+    static int ofItsParts(Class<?> kind, int first, int second, int third, int fourth) {
+        int gathered = GATHER * (GATHER * (GATHER * seed(kind) + first) + second) + third;
+        return finished(GATHER * gathered + fourth);
+    }
+
     /**
      * A value of {@code kind} that is two things with no order between them, so that it is hashed
      * alike whichever way round its two ends were written.

--- a/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
@@ -30,6 +30,10 @@ package souther.compiler.values;
  * <p>The kind is taken in because two values of different kinds holding alike are two values, and
  * where both are cases of one sum type nothing else here tells them apart — a block stated apart
  * from itself and a block left no value name the same block and claim different things.
+ *
+ * <p><b>How many parts a value has is not asked here.</b> There are as many of these as there are
+ * values here to write, and a value of five parts is a fifth one written when there is one. What
+ * they are for is the shape of an equality, and the shapes are what the shapes are.
  */
 final class ValueHash {
 
@@ -47,13 +51,27 @@ final class ValueHash {
     private ValueHash() {
     }
 
-    /** A value of {@code kind} holding one thing. */
+    /**
+     * A value of {@code kind} that holds one thing.
+     *
+     * <p>Which is what a value holding its parts in a value of its own holds: what it is equal by
+     * is that one, and what that one is made of is that one's own question. So this is where such
+     * a value comes, and not because it is simple.
+     */
     static int ofOnePart(Class<?> kind, int part) {
         return finished(GATHER * seed(kind) + part);
     }
 
-    /** A value of {@code kind} holding two, each in its own place: exchanging them is another
-     *  value, and this answers another number. */
+    /**
+     * A value of {@code kind} holding two, each in its own place: exchanging them is another value,
+     * and this answers another number.
+     *
+     * <p>A part that is itself a collection joins as the number that collection hands over, and how
+     * many it holds joins nothing. So two values whose collections sum alike are one number here,
+     * which is a collision and not the cancelling above: the parts of neither are recoverable from
+     * it. Where a value <em>is</em> a collection, how many it holds is part of the number
+     * ({@link #ofWhatItHolds}), because there is nothing else there to tell two of them apart.
+     */
     static int ofItsParts(Class<?> kind, int first, int second) {
         return finished(GATHER * (GATHER * seed(kind) + first) + second);
     }

--- a/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ValueHash.java
@@ -1,0 +1,110 @@
+package souther.compiler.values;
+
+/**
+ * How a value here is hashed from what it holds.
+ *
+ * <p>A value whose hash is worked out from its parts is nearly always handed to something that adds
+ * hashes up: a set of them sums what it holds, a map sums its entries, and a record built over one
+ * carries its last component into its own hash unchanged. So a hash that is an affine function of
+ * its parts — a sum of them, or a sum with each part multiplied by something — is a hash whose
+ * parts are still separable once it arrives there, and the sum above cancels what the value was
+ * built to state. Two pairs over four blocks come to one number whenever the same four blocks are
+ * paired the other way round; two lacks over four blocks come to one number whenever the same
+ * blocks are shared out between them differently. What is lost in each is the pairing, which is the
+ * one thing those values exist to say.
+ *
+ * <p><b>So the parts are gathered and then finished, once, at the boundary of the value that owns
+ * them.</b> Finishing is not distributive over the sum above it, which is what stops the two levels
+ * cancelling. Where the finishing is matters as much as that it happens: finishing a whole set of
+ * lacks after the sum has already been taken finishes a number the pairing has already left, and
+ * recovers nothing. Every value gathers its own parts and finishes its own number, and hands the
+ * finished one up.
+ *
+ * <p><b>What a caller names here is the shape of the value's equality, not a mixing step.</b> A
+ * roled pair and an unordered pair are hashed differently because they are equal differently, and a
+ * caller that reached for a mixing function would still have to decide how to gather two parts
+ * symmetrically — which is the decision that went wrong. So there is no mixing step to call: each
+ * of these takes the parts and answers the whole number, and a value's hash is one call to one of
+ * them. Which one is the same question as which equality the value has, and is readable beside it.
+ *
+ * <p>The kind is taken in because two values of different kinds holding alike are two values, and
+ * where both are cases of one sum type nothing else here tells them apart — a block stated apart
+ * from itself and a block left no value name the same block and claim different things.
+ */
+final class ValueHash {
+
+    /** What a part already gathered is multiplied by before the next joins it, so that the parts
+     *  keep their places. Odd, so no bit of what is already there is lost in the multiplication. */
+    private static final int GATHER = 31;
+
+    /** The two odd multipliers the finishing is built from. Each carries what the shift before it
+     *  folded downwards back up into the high bits, which is what leaves the answer depending on
+     *  every bit of what was gathered rather than on the low ones a multiplication reaches. */
+    private static final int SCATTER = 0x85ebca6b;
+
+    private static final int SPREAD = 0xc2b2ae35;
+
+    private ValueHash() {
+    }
+
+    /** A value of {@code kind} holding one thing. */
+    static int ofOnePart(Class<?> kind, int part) {
+        return finished(GATHER * seed(kind) + part);
+    }
+
+    /** A value of {@code kind} holding two, each in its own place: exchanging them is another
+     *  value, and this answers another number. */
+    static int ofItsParts(Class<?> kind, int first, int second) {
+        return finished(GATHER * (GATHER * seed(kind) + first) + second);
+    }
+
+    /** A value of {@code kind} holding three, each in its own place. */
+    static int ofItsParts(Class<?> kind, int first, int second, int third) {
+        return finished(GATHER * (GATHER * (GATHER * seed(kind) + first) + second) + third);
+    }
+
+    /**
+     * A value of {@code kind} that is two things with no order between them, so that it is hashed
+     * alike whichever way round its two ends were written.
+     *
+     * <p>Gathered from the two numbers a pair of numbers has that do not depend on their order:
+     * what they come to added, and what they come to exclusive-ored. The sum alone is what an
+     * unordered pair is most easily hashed by and it is what makes such a pair collapse — but here
+     * it is what the finishing is given rather than what is handed up, so what the second number
+     * adds is not that. It is that two pairs adding alike are two numbers here: {@code 0} with
+     * {@code 4} and {@code 1} with {@code 3} add to one number and exclusive-or to two, and a
+     * relation's pairs are drawn from few blocks, so pairs adding alike is what it has.
+     */
+    static int ofAnUnorderedPair(Class<?> kind, int one, int other) {
+        return finished(GATHER * (GATHER * seed(kind) + (one + other)) + (one ^ other));
+    }
+
+    /**
+     * A value of {@code kind} that is however many things with no order between them, from what
+     * they come to summed and how many of them there are.
+     *
+     * <p>Which is what a set or a map hands over: its own hash is the sum of what it holds, and a
+     * sum is what a reader wants of it, since two collections holding alike in different orders are
+     * one value and have to be one number. The count joins it so that two of them whose contents
+     * sum alike are still told apart where they hold different numbers of things.
+     */
+    static int ofWhatItHolds(Class<?> kind, int summed, int size) {
+        return finished(GATHER * (GATHER * seed(kind) + summed) + size);
+    }
+
+    /** Which kind of value it is, which is a fact about the program and the same on every run —
+     *  unlike what {@code Object.hashCode} would answer about the class. */
+    private static int seed(Class<?> kind) {
+        return kind.getName().hashCode();
+    }
+
+    /** What the gathered parts come to, taken so that adding this to another of these does not
+     *  give back a function of the parts. */
+    private static int finished(int gathered) {
+        int out = gathered ^ (gathered >>> 16);
+        out *= SCATTER;
+        out ^= (out >>> 13);
+        out *= SPREAD;
+        return out ^ (out >>> 16);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -69,6 +69,24 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     }
 
     /**
+     * The same four blocks paired two ways are two relations, and two numbers.
+     *
+     * <p>Which is what a pair hashed as its ends added would lose: a set of pairs would come to the
+     * sum over every block any of its pairs names, and both of these name all four. So this needs
+     * no blocks chosen for it — any four distinct ones are one number under that arithmetic — and
+     * what it holds the pair to is that its number is not arranged to be lost that way.
+     */
+    @Test
+    void andTheSameBlocksPairedTwoWaysAreTwoRelations() {
+        Apartness<String> paired = Apartness.of("p", "q").and(Apartness.of("r", "s"));
+        Apartness<String> otherwise = Apartness.of("p", "r").and(Apartness.of("q", "s"));
+
+        assertNotEquals(paired, otherwise);
+        assertNotEquals(paired.hashCode(), otherwise.hashCode(),
+                "the same blocks paired two ways came to one number");
+    }
+
+    /**
      * A conjunction that holds two blocks as one carries a denial onto the block it leaves.
      *
      * <p>{@code q /= r} stated of {@code q} on its own is a denial between {@code r} and whatever

--- a/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
@@ -177,10 +177,10 @@ class ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest {
      * them.
      *
      * <p>Put together by walking, that is every lack of one reading against every lack of the
-     * other, and this relation is inside what a declaration may ask for. So a lack says where it is
-     * filed ({@link RelationalLack#scattering}) and two readings are put together by asking: the
-     * sets of blocks one relation is short of are drawn from the same few blocks, and a number that
-     * is their sum is one nearly all of them share.
+     * other, and this relation is inside what a declaration may ask for. So a lack works out where
+     * it is filed at its own boundary ({@link ValueHash}) and two readings are put together by
+     * asking: the sets of blocks one relation is short of are drawn from the same few blocks, and a
+     * number that was their sum would be one nearly all of them share.
      *
      * <p>Held by being here rather than by a figure. A run that asked this by walking takes long
      * enough to be the whole of what the suite costs, which is what a reader of a broken one sees.

--- a/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
@@ -1,0 +1,113 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What a value's parts come to is settled by the value that owns them, and what is handed up is not
+ * a function anything above can take apart again.
+ *
+ * <p>Whatever hashes a value is nearly always something that adds hashes: a set sums what it holds,
+ * a map sums its entries, a record carries its last component into its own number unchanged. So a
+ * number gathered from parts and handed up as gathered is one whose parts are still separable
+ * there, and the sum above cancels whatever the value was arranged to say about which part went
+ * with which. These are about that cancelling, said of the algebra rather than of any one value
+ * that uses it.
+ *
+ * <p>None of them asks that two different values never come to one number, which nothing can
+ * promise of an {@code int}. What each asks is that a way of losing the value's structure is not
+ * arithmetic — that two of these added are not, as an identity over every input, the same as two
+ * others added.
+ */
+class AValueIsHashedAtItsOwnBoundaryTest {
+
+    private static final Class<?> A_KIND = Apartness.Edge.class;
+
+    private static final Class<?> ANOTHER_KIND = Shown.class;
+
+    /**
+     * Four things paired two ways, each pair hashed and the two pairs added.
+     *
+     * <p>Gathered as the ends added and handed up, these two are one number whatever the four
+     * things are: both come to what the four of them come to. That is what a set of pairs would
+     * hash to, and which end was paired with which is the one thing it would not say.
+     */
+    @Test
+    void twoUnorderedPairsAddedDoNotForgetWhichEndWentWithWhich() {
+        int a = 11;
+        int b = 22;
+        int c = 33;
+        int d = 44;
+
+        int paired = ValueHash.ofAnUnorderedPair(A_KIND, a, b)
+                + ValueHash.ofAnUnorderedPair(A_KIND, c, d);
+        int otherwise = ValueHash.ofAnUnorderedPair(A_KIND, a, c)
+                + ValueHash.ofAnUnorderedPair(A_KIND, b, d);
+
+        assertNotEquals(paired, otherwise,
+                "the same four ends paired two ways came to one number");
+    }
+
+    /** And the same of two things held in places, which a record's own number would lose in the
+     *  same way: the second part joins it unchanged, so exchanging the seconds is arithmetic. */
+    @Test
+    void andTwoValuesOfTwoPartsAddedDoNotForgetWhichPartWentWithWhich() {
+        int first = 11;
+        int second = 22;
+        int another = 33;
+        int itsSecond = 44;
+
+        int held = ValueHash.ofItsParts(ANOTHER_KIND, first, second)
+                + ValueHash.ofItsParts(ANOTHER_KIND, another, itsSecond);
+        int exchanged = ValueHash.ofItsParts(ANOTHER_KIND, first, itsSecond)
+                + ValueHash.ofItsParts(ANOTHER_KIND, another, second);
+
+        assertNotEquals(held, exchanged,
+                "the same parts shared out two ways came to one number");
+    }
+
+    /** A pair with no order between its ends is one pair written either way round. */
+    @Test
+    void andAnUnorderedPairIsOneNumberWhicheverEndWasWrittenFirst() {
+        assertEquals(ValueHash.ofAnUnorderedPair(A_KIND, 11, 22),
+                ValueHash.ofAnUnorderedPair(A_KIND, 22, 11));
+    }
+
+    /**
+     * Two pairs whose ends add alike.
+     *
+     * <p>Which is a different question from the one above, and it is why an unordered pair is
+     * gathered from two numbers rather than from the sum alone. The sum is what the ends have that
+     * does not depend on their order; it is not all they have. Pairs adding alike is what a
+     * relation drawn from few blocks has, and telling those apart is what the second number is for
+     * — dropping it leaves the cancelling above still closed and these two still one number.
+     */
+    @Test
+    void andTwoPairsWhoseEndsAddAlikeAreNotOnePair() {
+        assertNotEquals(ValueHash.ofAnUnorderedPair(A_KIND, 0, 4),
+                ValueHash.ofAnUnorderedPair(A_KIND, 1, 3),
+                "two pairs were told apart by nothing but what their ends add to");
+    }
+
+    /** Two things in places are in their places: exchanging them is another value. */
+    @Test
+    void andPartsHeldInPlacesAreNotAPair() {
+        assertNotEquals(ValueHash.ofItsParts(ANOTHER_KIND, 11, 22),
+                ValueHash.ofItsParts(ANOTHER_KIND, 22, 11));
+    }
+
+    /** Two kinds holding alike are two values, which is what a sum type's cases need of this. */
+    @Test
+    void andTwoKindsHoldingAlikeAreTwoValues() {
+        assertNotEquals(ValueHash.ofOnePart(A_KIND, 11), ValueHash.ofOnePart(ANOTHER_KIND, 11));
+    }
+
+    /** And what a collection holds is how much of it there is as well as what it sums to. */
+    @Test
+    void andWhatACollectionHoldsIsHowManyOfThemThereAreAsWell() {
+        assertNotEquals(ValueHash.ofWhatItHolds(A_KIND, 100, 2),
+                ValueHash.ofWhatItHolds(A_KIND, 100, 3));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
@@ -30,16 +30,19 @@ class AValueIsHashedAtItsOwnBoundaryTest {
     /**
      * Four things paired two ways, each pair hashed and the two pairs added.
      *
-     * <p>Gathered as the ends added and handed up, these two are one number whatever the four
-     * things are: both come to what the four of them come to. That is what a set of pairs would
-     * hash to, and which end was paired with which is the one thing it would not say.
+     * <p>Gathered and handed up, these two are one number: both pairings come to the same sum of
+     * sums and the same sum of exclusive-ors, so neither of the two numbers a pair is gathered
+     * from tells them apart once the sum above has been taken. What tells them apart is the
+     * finishing, and it has to be at each pair's own boundary — which is what this holds, and it
+     * holds it for the gathering as well, since four things that separated under the
+     * exclusive-ors alone would let the finishing go and stay green.
      */
     @Test
     void twoUnorderedPairsAddedDoNotForgetWhichEndWentWithWhich() {
-        int a = 11;
-        int b = 22;
-        int c = 33;
-        int d = 44;
+        int a = 0;
+        int b = 1;
+        int c = 2;
+        int d = 4;
 
         int paired = ValueHash.ofAnUnorderedPair(A_KIND, a, b)
                 + ValueHash.ofAnUnorderedPair(A_KIND, c, d);

--- a/souther-compiler/src/test/java/souther/compiler/values/TwoValuesThatAreNotOneAreNotOneNumberByArithmeticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/TwoValuesThatAreNotOneAreNotOneNumberByArithmeticTest.java
@@ -1,0 +1,101 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What one of these values holds several of, it holds in no order — and what went with what is
+ * still part of what it says.
+ *
+ * <p>A value that gathered its parts and handed the number up as gathered would leave those parts
+ * separable in whatever hashes it next, and what hashes it next adds numbers up: a set sums what it
+ * holds and a record carries its last component up unchanged. So the sum above cancels the pairing,
+ * and the same parts shared out the other way come to one number.
+ *
+ * <p>Written as the arithmetic and not as a choice of values. Each of these holds under the old
+ * shape for any parts at all, so nothing here is arranged to fail — which is what makes it a
+ * witness rather than an example. None of them asks that two values never share a number, which
+ * nothing can promise of an {@code int}.
+ */
+class TwoValuesThatAreNotOneAreNotOneNumberByArithmeticTest {
+
+    private static final Sameness.Block<String> P = Sameness.Block.of("p");
+    private static final Sameness.Block<String> Q = Sameness.Block.of("q");
+    private static final Sameness.Block<String> R = Sameness.Block.of("r");
+
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    /** Two lacks and two routes, shared out both ways: which route reached which lack is what an
+     *  author is sent to read. */
+    @Test
+    void twoLacksReachedTwoWaysAreNotOneArgument() {
+        RelationalLack<String> one = new RelationalLack.NoValueLeftForIt<>(P);
+        RelationalLack<String> other = new RelationalLack.NoValueLeftForIt<>(Q);
+        RelationalEvidence<String> byOne = route(P, A, 1, Q);
+        RelationalEvidence<String> byAnother = route(Q, B, 2, R);
+
+        Lacks<String> reached = Lacks.of(List.of(new Shown<>(one, byOne),
+                new Shown<>(other, byAnother)));
+        Lacks<String> otherwise = Lacks.of(List.of(new Shown<>(one, byAnother),
+                new Shown<>(other, byOne)));
+
+        assertNotEquals(reached, otherwise);
+        assertNotEquals(reached.hashCode(), otherwise.hashCode(),
+                "the same lacks and routes shared out two ways came to one number");
+    }
+
+    /** And two removals with each other's blockers: what a removal says is which neighbours left
+     *  the value nowhere to go. */
+    @Test
+    void andTwoRemovalsBlockedByEachOthersNeighboursAreNotOneRoute() {
+        Provenance<String> blocked = new Provenance<>(ordered(
+                new Provenance.Removal<>(P, A, 1, ordered(Q)),
+                new Provenance.Removal<>(Q, B, 2, ordered(R))));
+        Provenance<String> otherwise = new Provenance<>(ordered(
+                new Provenance.Removal<>(P, A, 1, ordered(R)),
+                new Provenance.Removal<>(Q, B, 2, ordered(Q))));
+
+        assertNotEquals(blocked, otherwise);
+        assertNotEquals(blocked.hashCode(), otherwise.hashCode(),
+                "the same removals blocked two ways came to one number");
+    }
+
+    /**
+     * And two claims about one block are two claims.
+     *
+     * <p>Which case a lack is is the whole of what tells these two apart — a block stated apart
+     * from itself and a block the denials left no value name one block and say different things —
+     * and an argument holds several lacks in no order.
+     */
+    @Test
+    void andTwoCasesOfALackAboutOneBlockAreTwoClaims() {
+        RelationalLack<String> itself = new RelationalLack.ABlockApartFromItself<>(P);
+        RelationalLack<String> nothingLeft = new RelationalLack.NoValueLeftForIt<>(P);
+
+        assertNotEquals(itself, nothingLeft);
+        assertNotEquals(itself.hashCode(), nothingLeft.hashCode(),
+                "two claims about one block came to one number");
+    }
+
+    /** One route, of one removal. */
+    private static RelationalEvidence<String> route(Sameness.Block<String> block, Value value,
+                                                    int round, Sameness.Block<String> blocker) {
+        return RelationalEvidence.of(new Provenance<>(
+                ordered(new Provenance.Removal<>(block, value, round, ordered(blocker)))));
+    }
+
+    @SafeVarargs
+    private static <T> Set<T> ordered(T... these) {
+        Set<T> out = new LinkedHashSet<>();
+        for (T each : these) {
+            out.add(each);
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
`Apartness.Edge` was a pair of blocks hashed as its two ends added. The sum is
there so that a pair stated either way round is one pair, which is right; what
it costs is that a set of pairs then comes to the sum over every block any of
its pairs names, and which block was stated to differ from which is the one
thing that sum does not say.

The cause is not the symmetry. It is that the symmetry was got by borrowing the
operation the container above uses. A hash that is an affine function of its
parts leaves those parts separable in whatever hashes it next, and what hashes
it next adds numbers up — a set sums what it holds, and a record carries its
last component into its own number unchanged. So the sum above cancels the
pairing. Sweeping the package for that shape found it in more than the pair:
an argument's lacks and the routes that reached them, a route's removals and
the neighbours that blocked them, a set of alternatives and the relations over
them, and the cases of a lack, which named one block and claimed different
things under one number.

Closed by gathering a value's parts and finishing them once, at the boundary of
the value that owns them. Where that happens is the whole of it: finishing a
total after the sum has been taken finishes a number the pairing has already
left, so `Lacks` is not the place to close what `Shown` exposes.

`ValueHash` is where the rule lives. What a caller names there is the shape of
the value's equality — a part, parts in places, an unordered pair, what a
collection holds — rather than a mixing step to remember, because deciding
afresh how to gather two things symmetrically is the decision that went wrong.
An architecture test holds the package to it: a value that works out its own
hash takes it from the algebra. What a record leaves to the compiler is outside
that population, and deliberately — a hash written out by hand is one a
component added later can be left out of, which is a worse fault than this one.

A lack scattered the blocks it names on the way into its own sum. That was the
block's number being a plain sum of its positions', which it has not been since
#1449, so it goes.

Nothing pays for this: no model here states a denial between two positions, and
the corpora compiled for measurement reach the pair never. It is a defect in
the design of the hash, and the PR makes no claim about speed.

Closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)