### PR TITLE
Let the settlement say what a choice left open

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
@@ -1,0 +1,203 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may ask an account of the rules whether a clause of it went unread.
+ *
+ * <p>That an alternative is one nothing could read is a fact about the clause somebody wrote.
+ * Whether the branch beside it still holds a position down is a fact about what the two branches
+ * leave, and the two are not the same question: alternatives narrowing a position the same way
+ * narrow it whether or not either could be read to the end. Derived from the first, the second
+ * comes out as a rule that is false, and a rule holding a position down is reported as holding it
+ * down nowhere.
+ *
+ * <p>So the answer has one owner. What the branches leave is worked out where they are settled and
+ * arrives as an opening ({@code Opening}); an account applies one and works none out. The place
+ * where the two meet — which alternative went unread, and what its going unread opens — is the row
+ * below, and a second row is a second derivation of one fact.
+ *
+ * <p>Read off the compiled classes and named down to the method, so that a reader is licensed for
+ * the question it asks rather than for the class it happens to sit in. Both ways of reaching the
+ * flag count: an accessor called on an account, and the field read straight off it, which is what a
+ * class in the same file compiles to.
+ *
+ * <p><b>The account's own methods are not rows.</b> Composing the flag over a choice is what the
+ * flag is for, and every method that carries one reads it. What holds that composition to carrying
+ * it and nothing else is a law over the operation
+ * ({@code AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest}), which this cannot see and which
+ * says the part this cannot.
+ */
+class WhoMayAskWhetherAClauseWentUnreadTest {
+
+    private static final String ACCOUNT = "souther/compiler/check/Adoption";
+
+    private static final String FLAG = "hasUnreadPart";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * Where an unread alternative is turned into what it left open.
+     *
+     * <p>The one place both halves of that question are in hand: which of the two alternatives this
+     * reading had no word for, and what the settlement could not show the alternatives preserve.
+     * Asked anywhere else, one of the halves has to be fetched from somewhere, and what is fetched
+     * is either a second answer or another reading's.
+     */
+    private static final List<String> MAY_ASK =
+            List.of("souther/compiler/check/StatedByClauses#opens");
+
+    @Test
+    void onlyWhereAnUnreadAlternativeBecomesWhatItLeftOpen() {
+        assertEquals(MAY_ASK, new ArrayList<>(asking()),
+                "whether a branch beside an unread alternative still holds a position down is"
+                        + " settled by what the branches leave: a row that is not this one is that"
+                        + " question being answered again out of the account of the rules");
+    }
+
+    /**
+     * The walk reads every module's classes.
+     *
+     * <p>Asked of the modules the repository has and not of what a build happened to leave: a
+     * module whose classes are missing is one whose reads this cannot see, and the rows from the
+     * rest would match and this would pass while answering about fewer modules than it names.
+     */
+    @Test
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        List<String> unbuilt = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
+                unbuilt.add(module.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), unbuilt,
+                "a module whose classes are not built is one this walk passes over, and a walk that"
+                        + " passes over a module answers about the rest while saying it answers"
+                        + " about all of them");
+    }
+
+    /**
+     * And the walk finds the flag being read where it is read.
+     *
+     * <p>The account composes the flag over every connective, so a walk that can see field reads at
+     * all sees several inside the account itself. Matched on a name nothing has, every row would be
+     * absent and the list above would be empty and equal to itself.
+     */
+    @Test
+    void andTheWalkSeesTheFlagBeingReadWhereItIsCarried() {
+        assertTrue(within(ACCOUNT) > 1,
+                "the account carries the flag across its own operations, so a walk finding none of"
+                        + " those is finding nothing at all");
+    }
+
+    /** Every method outside the account that asks one whether a clause of it went unread. */
+    private static Set<String> asking() {
+        Set<String> found = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                String reader = internalName(module, each);
+                if (reader.equals(ACCOUNT)) {
+                    continue;
+                }
+                for (MethodModel method : parse(each).methods()) {
+                    if (reads(method)) {
+                        found.add(reader + "#" + method.methodName().stringValue());
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /** How many of the account's own methods read it, which is what says the walk can see one. */
+    private static int within(String owner) {
+        int reads = 0;
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                if (!internalName(module, each).equals(owner)) {
+                    continue;
+                }
+                for (MethodModel method : parse(each).methods()) {
+                    if (reads(method)) {
+                        reads++;
+                    }
+                }
+            }
+        }
+        return reads;
+    }
+
+    /** Whether this method asks an account whether a clause of it went unread, either way round. */
+    private static boolean reads(MethodModel method) {
+        CodeModel code = method.code().orElse(null);
+        if (code == null) {
+            return false;
+        }
+        return code.elementStream().anyMatch(element -> switch (element) {
+            case FieldInstruction it -> ACCOUNT.equals(it.owner().name().stringValue())
+                    && FLAG.equals(it.name().stringValue());
+            case InvokeInstruction it -> ACCOUNT.equals(it.owner().name().stringValue())
+                    && FLAG.equals(it.name().stringValue());
+            default -> false;
+        });
+    }
+
+    private static ClassModel parse(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The class's own binary name, taken against the directory it was found under rather than off
+     *  the first {@code classes} in the path, which a checkout under one would be. */
+    private static String internalName(Path module, Path compiled) {
+        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
+        return name.substring(0, name.length() - ".class".length());
+    }
+
+    private static Path classesOf(Path module) {
+        return module.resolve("target").resolve("classes");
+    }
+
+    /** Whether the module has main sources to have been built from. A module holding only tests or
+     *  only a pom leaves no classes and is not one this walk is missing. */
+    private static boolean hasMainSources(Path module) {
+        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
+    }
+
+    private static List<Path> classesUnder(Path module) {
+        Path where = classesOf(module);
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * down nowhere.
  *
  * <p>So the answer has one owner. What the branches leave is worked out where they are settled and
- * arrives as an opening ({@code Opening}); an account applies one and works none out. The place
- * where the two meet — which alternative went unread, and what its going unread opens — is the row
- * below, and a second row is a second derivation of one fact.
+ * arrives as an opening ({@code Opening}); an account applies one and works none out. What the flag
+ * is still good for is written down below, and a row that is not one of those is a second
+ * derivation of one fact.
  *
  * <p>Read off the compiled classes and named down to the method, so that a reader is licensed for
  * the question it asks rather than for the class it happens to sit in. Both ways of reaching the
@@ -58,15 +58,21 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     /**
-     * Where an unread alternative is turned into what it left open.
+     * Where an unread alternative is turned into what it left open, and where an author is sent for
+     * it.
      *
-     * <p>The one place both halves of that question are in hand: which of the two alternatives this
-     * reading had no word for, and what the settlement could not show the alternatives preserve.
-     * Asked anywhere else, one of the halves has to be fetched from somewhere, and what is fetched
-     * is either a second answer or another reading's.
+     * <p>Two questions of the one fact and no more. What the alternative left open is the first,
+     * and it is asked where the width of the same reading is in hand — of one reading throughout,
+     * which is what the method's shape holds it to. Which choice to send an author to is the
+     * second, and it is asked of the values because that is the road that exists
+     * ({@code StatedByClauses.Part#leftOpenByValues}).
+     *
+     * <p>Asked anywhere else, one of the halves has to be fetched from somewhere, and what is
+     * fetched is either a second answer or another reading's.
      */
     private static final List<String> MAY_ASK =
-            List.of("souther/compiler/check/StatedByClauses#opens");
+            List.of("souther/compiler/check/StatedByClauses#openedBy",
+                    "souther/compiler/check/StatedByClauses#opens");
 
     @Test
     void onlyWhereAnUnreadAlternativeBecomesWhatItLeftOpen() {

--- a/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
@@ -146,7 +146,8 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
                                 + "Lsouther/compiler/check/Settlement$Width;",
                         "souther.compiler.check.Settlement$Width#comparing"
                                 + "(Ljava/util/Set;Ljava/util/function/Function;"
-                                + "Ljava/util/function/Function;Ljava/util/function/Function;)"
+                                + "Ljava/util/function/Function;"
+                                + "Ljava/util/function/BinaryOperator;)"
                                 + "Lsouther/compiler/check/Settlement$Width;",
                         "souther.compiler.check.Settlement$Width#none()"
                                 + "Lsouther/compiler/check/Settlement$Width;"),

--- a/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
@@ -115,6 +115,12 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
      * the halves has to be fetched, and what is fetched is either a second answer or the other
      * reading's — which composes without a complaint and reports a clause the reading did not see.
      *
+     * <p><b>And what it takes is what keeps the two halves together.</b> A maker handed a width and
+     * two accounts holds three things of one reading and cannot be given a mixture. One handed a
+     * width and a word for each side takes the same call from any reading at all, so a row of that
+     * shape is this rule saying the opposite of what it means: the seam it names is the one an
+     * author would cross at.
+     *
      * <p>Beside it the empty one, which is what a choice shown to leave every position where it was
      * comes to. It decides nothing and is here because a maker is a maker.
      */
@@ -122,7 +128,10 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
     void oneMethodTurnsAnUnreadAlternativeIntoWhatItLeftOpen() throws Exception {
         assertEquals(List.of("souther.compiler.check.Opening#nothing()"
                                 + "Lsouther/compiler/check/Opening;",
-                        "souther.compiler.check.Settlement$Width#opened(ZZ)"
+                        "souther.compiler.check.StatedByClauses#openedBy"
+                                + "(Lsouther/compiler/check/Settlement$Width;"
+                                + "Lsouther/compiler/check/Adoption;"
+                                + "Lsouther/compiler/check/Adoption;)"
                                 + "Lsouther/compiler/check/Opening;"),
                 whatMakes("souther.compiler.check.Opening"),
                 "an opening made somewhere else is a second answer to what an alternative left"

--- a/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest.java
@@ -33,7 +33,8 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
             "souther.compiler.check.StatedByClauses#opens"
                     + "(Lsouther/compiler/check/ChoiceId;"
                     + "Lsouther/compiler/check/Settlement$WidthDependency;"
-                    + "Lsouther/compiler/check/Adoption;Lsouther/compiler/check/Adoption;)"
+                    + "Lsouther/compiler/check/StatedByClauses$Part;"
+                    + "Lsouther/compiler/check/StatedByClauses$Part;)"
                     + "Lsouther/compiler/check/StatedByClauses$AlternativeOpening;";
 
     /**
@@ -98,12 +99,60 @@ class OnlyOnePlaceDecidesThatAnAlternativeWentUnreadTest {
                                 + "()Lsouther/compiler/check/Settlement$WidthDependency;",
                         "souther.compiler.check.Settlement$WidthDependency#of"
                                 + "(Lsouther/compiler/values/Emptiness;"
-                                + "Lsouther/compiler/values/PlannedValues;"
+                                + "Lsouther/compiler/check/Confinement$Planned;"
                                 + "Lsouther/compiler/values/Emptiness;"
-                                + "Lsouther/compiler/values/PlannedValues;)"
+                                + "Lsouther/compiler/check/Confinement$Planned;)"
                                 + "Lsouther/compiler/check/Settlement$WidthDependency;"),
                 whatMakes("souther.compiler.check.Settlement$WidthDependency"),
                 "somewhere else makes one, and what it made is not what the settlement compared");
+    }
+
+    /**
+     * And one method turns an alternative going unread into what it left open.
+     *
+     * <p>Both halves of that meet in one place and both are one reading's: which alternative it had
+     * no word for, and what it could not show the alternatives preserve. Made anywhere else, one of
+     * the halves has to be fetched, and what is fetched is either a second answer or the other
+     * reading's — which composes without a complaint and reports a clause the reading did not see.
+     *
+     * <p>Beside it the empty one, which is what a choice shown to leave every position where it was
+     * comes to. It decides nothing and is here because a maker is a maker.
+     */
+    @Test
+    void oneMethodTurnsAnUnreadAlternativeIntoWhatItLeftOpen() throws Exception {
+        assertEquals(List.of("souther.compiler.check.Opening#nothing()"
+                                + "Lsouther/compiler/check/Opening;",
+                        "souther.compiler.check.Settlement$Width#opened(ZZ)"
+                                + "Lsouther/compiler/check/Opening;"),
+                whatMakes("souther.compiler.check.Opening"),
+                "an opening made somewhere else is a second answer to what an alternative left"
+                        + " open, and the two agree only until one of them changes");
+    }
+
+    /**
+     * And one method compares what two branches leave, whichever reading is asking.
+     *
+     * <p>The comparison is the same few lines over whatever a reading leaves a position, and each
+     * reading reaches it by handing in its own descriptions. Written once per reading instead, the
+     * two would be two rules about one question, and a third reading would arrive with nowhere
+     * obvious to be added.
+     *
+     * <p>Beside it the empty one and the join over occurrences, which compare nothing.
+     */
+    @Test
+    void oneMethodComparesWhatTwoBranchesLeave() throws Exception {
+        assertEquals(List.of("souther.compiler.check.Settlement$Width#alsoSeen"
+                                + "(Lsouther/compiler/check/Settlement$Width;)"
+                                + "Lsouther/compiler/check/Settlement$Width;",
+                        "souther.compiler.check.Settlement$Width#comparing"
+                                + "(Ljava/util/Set;Ljava/util/function/Function;"
+                                + "Ljava/util/function/Function;Ljava/util/function/Function;)"
+                                + "Lsouther/compiler/check/Settlement$Width;",
+                        "souther.compiler.check.Settlement$Width#none()"
+                                + "Lsouther/compiler/check/Settlement$Width;"),
+                whatMakes("souther.compiler.check.Settlement$Width"),
+                "what a choice is as wide as it is because of is compared in one place, and a"
+                        + " second comparison rests on whichever pair of branches its writer held");
     }
 
     /** Every method that makes a value of {@code type}, each named once. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
@@ -46,6 +46,10 @@ import java.util.Set;
  *
  * @param <A>           what a position is called here. A set algebra and nothing else, so the
  *                      readings' own name for a position is the caller's business
+ * @param <L>           which reading this is the account of. Nothing here reads it: what it is for
+ *                      is that an answer worked out about one reading cannot be applied to the
+ *                      other, which is otherwise the same Java type and composes without a
+ *                      complaint ({@link ReadingLanguage})
  * @param read          the positions a part of this clause put a constraint on. Open to being
  *                      widened: an alternative nothing could read is one a value can satisfy
  *                      instead, and what this part said of the position then binds nothing
@@ -62,7 +66,8 @@ import java.util.Set;
  *                      about is not carried: a branch nothing could read widens the positions the
  *                      other branch spoke about whether or not it names them
  */
-record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnreadPart) {
+record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A> missed,
+                                              boolean hasUnreadPart) {
 
     Adoption {
         read = Set.copyOf(read);
@@ -71,7 +76,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
     }
 
     /** What a clause this reading has no word for comes to. */
-    static <A> Adoption<A> nothing() {
+    static <A, L extends ReadingLanguage> Adoption<A, L> nothing() {
         return new Adoption<>(Set.of(), Set.of(), Set.of(), false);
     }
 
@@ -84,7 +89,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * and not a gap. The same rule {@link #bothDead} states for a whole choice, said of one part of
      * one branch of it.
      */
-    Adoption<A> inADeadBranch() {
+    Adoption<A, L> inADeadBranch() {
         return new Adoption<>(Set.of(), mentions(), Set.of(), false);
     }
 
@@ -102,7 +107,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * has to be told nothing did, because what stands there is what stands at a position no reading
      * reached: everything.
      */
-    Adoption<A> unbuiltAt(Set<A> positions) {
+    Adoption<A, L> unbuiltAt(Set<A> positions) {
         if (positions.isEmpty() || mentions().stream().noneMatch(positions::contains)) {
             return this;
         }
@@ -127,7 +132,8 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * though a reading that has no word for it did give up, which is what each of them says for
      * itself.
      */
-    static <A> Adoption<A> at(Set<A> mentions, Set<A> produced, boolean failed) {
+    static <A, L extends ReadingLanguage> Adoption<A, L> at(Set<A> mentions, Set<A> produced,
+                                                            boolean failed) {
         Set<A> missed = new LinkedHashSet<>(mentions);
         missed.removeAll(produced);
         Set<A> took = new LinkedHashSet<>(mentions);
@@ -141,7 +147,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * <p>Nothing spoils anything: a part nothing read leaves the parts beside it saying what they
      * said, since all of them hold.
      */
-    Adoption<A> both(Adoption<A> other) {
+    Adoption<A, L> both(Adoption<A, L> other) {
         return new Adoption<>(union(read, other.read), union(settled, other.settled),
                 union(missed, other.missed), hasUnreadPart || other.hasUnreadPart);
     }
@@ -154,7 +160,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * of what the branches managed, {@code x == 7 || f(y)} said {@code x} had been read — and what
      * the clause leaves {@code x} is exactly what nothing here can say.
      */
-    Adoption<A> either(Adoption<A> other) {
+    Adoption<A, L> either(Adoption<A, L> other) {
         Set<A> lost = union(missed, other.missed);
         // What the branch beside it put a constraint on, and not what it found the choice imposes
         // nothing on: an alternative nothing could read widens a constraint, and there is nothing
@@ -208,7 +214,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * <p>What this branch missed still wins. {@code (s < "") || f(x)} leaves {@code x} open however
      * dead the first branch is, so the surviving branch's account is the one that outranks.
      */
-    Adoption<A> beside(Adoption<A> dead) {
+    Adoption<A, L> beside(Adoption<A, L> dead) {
         return new Adoption<>(read, union(settled, dead.mentions()), missed, hasUnreadPart);
     }
 
@@ -218,7 +224,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnread
      * <p>Then the choice admits nothing, which settles every position either of them named: the
      * values there are exactly none. No branch is left to have missed anything.
      */
-    Adoption<A> bothDead(Adoption<A> other) {
+    Adoption<A, L> bothDead(Adoption<A, L> other) {
         return new Adoption<>(Set.of(), union(mentions(), other.mentions()), Set.of(), false);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
@@ -26,8 +26,8 @@ import java.util.Set;
  * leaves the parts beside it saying what they said — {@code value >= 1 && f(value)} still bounds the
  * value. Under a choice it does not: a value satisfying the branch nothing could read is under no
  * obligation from the other, so {@code x == 7 || f(y)} says nothing about {@code x} either. That is
- * why {@link #dropped} is here and why {@link #either} spoils across positions the unread branch
- * never named — the same reason {@code AdmissibleValues.join} does.
+ * why {@link #hasUnreadPart} is here and why {@link #either} spoils across positions the unread
+ * branch never named — the same reason {@code AdmissibleValues.join} does.
  *
  * <p>What is recorded is that the reading settled what the clause does to a position, which is not
  * the same as its having narrowed anything there. A branch shown to admit nothing settles every
@@ -44,24 +44,25 @@ import java.util.Set;
  * <p>Composed rather than collected. A set filled as the leaves go by is a fact about the walk and
  * not about the clause, and it cannot be undone by what a later branch failed to read.
  *
- * @param <A>     what a position is called here. A set algebra and nothing else, so the readings'
- *                own name for a position is the caller's business
- * @param read    the positions a part of this clause put a constraint on. Open to being widened:
- *                an alternative nothing could read is one a value can satisfy instead, and what
- *                this part said of the position then binds nothing
- * @param settled the positions a dead alternative named, which the choice imposes nothing on. Not
- *                {@link #read}, and this is what keeps the choice associative: a constraint can be
- *                widened by an alternative beside it, and "this clause imposes nothing here"
- *                cannot — a further choice imposes nothing extra either. Folded into {@code read},
- *                whether it survived turned on where the brackets fell
- * @param missed  the positions a part of it was about, or was widened by a part nothing read, and
- *                so was not settled at
- * @param dropped whether a part of this clause went unread anywhere in it, which is what a choice
- *                needs in order to know that a branch widened it. What that part was about is not
- *                carried: a branch nothing could read widens the positions the other branch spoke
- *                about whether or not it names them
+ * @param <A>           what a position is called here. A set algebra and nothing else, so the
+ *                      readings' own name for a position is the caller's business
+ * @param read          the positions a part of this clause put a constraint on. Open to being
+ *                      widened: an alternative nothing could read is one a value can satisfy
+ *                      instead, and what this part said of the position then binds nothing
+ * @param settled       the positions a dead alternative named, which the choice imposes nothing on.
+ *                      Not {@link #read}, and this is what keeps the choice associative: a
+ *                      constraint can be widened by an alternative beside it, and "this clause
+ *                      imposes nothing here" cannot — a further choice imposes nothing extra
+ *                      either. Folded into {@code read}, whether it survived turned on where the
+ *                      brackets fell
+ * @param missed        the positions a part of it was about, or was widened by a part nothing read,
+ *                      and so was not settled at
+ * @param hasUnreadPart whether a part of this clause went unread anywhere in it, which is what a
+ *                      choice needs in order to know that a branch widened it. What that part was
+ *                      about is not carried: a branch nothing could read widens the positions the
+ *                      other branch spoke about whether or not it names them
  */
-record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean dropped) {
+record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean hasUnreadPart) {
 
     Adoption {
         read = Set.copyOf(read);
@@ -115,7 +116,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean dropped) 
                 lost.add(each);
             }
         });
-        return new Adoption<>(stillRead, stillSettled, lost, dropped);
+        return new Adoption<>(stillRead, stillSettled, lost, hasUnreadPart);
     }
 
     /**
@@ -142,7 +143,7 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean dropped) 
      */
     Adoption<A> both(Adoption<A> other) {
         return new Adoption<>(union(read, other.read), union(settled, other.settled),
-                union(missed, other.missed), dropped || other.dropped);
+                union(missed, other.missed), hasUnreadPart || other.hasUnreadPart);
     }
 
     /**
@@ -158,14 +159,14 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean dropped) 
         // What the branch beside it put a constraint on, and not what it found the choice imposes
         // nothing on: an alternative nothing could read widens a constraint, and there is nothing
         // to widen about a position nothing constrains.
-        if (other.dropped) {
+        if (other.hasUnreadPart) {
             lost = union(lost, read);
         }
-        if (dropped) {
+        if (hasUnreadPart) {
             lost = union(lost, other.read);
         }
         return new Adoption<>(union(read, other.read), union(settled, other.settled), lost,
-                dropped || other.dropped);
+                hasUnreadPart || other.hasUnreadPart);
     }
 
     /** Whether this reading settled what the whole of the clause does to {@code position}. */
@@ -202,13 +203,13 @@ record Adoption<A>(Set<A> read, Set<A> settled, Set<A> missed, boolean dropped) 
      * <p>The dead branch settles the positions it named: nothing satisfies it, so what the choice
      * does to a position only it spoke of is nothing, which is an answer. Its own misses do not
      * come with it — a rule it could not read is a rule about a branch nobody can take — and
-     * neither does its {@link #dropped}, for the same reason.
+     * neither does its {@link #hasUnreadPart}, for the same reason.
      *
      * <p>What this branch missed still wins. {@code (s < "") || f(x)} leaves {@code x} open however
      * dead the first branch is, so the surviving branch's account is the one that outranks.
      */
     Adoption<A> beside(Adoption<A> dead) {
-        return new Adoption<>(read, union(settled, dead.mentions()), missed, dropped);
+        return new Adoption<>(read, union(settled, dead.mentions()), missed, hasUnreadPart);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
@@ -24,10 +24,23 @@ import java.util.Set;
  *
  * <p>So the connectives are not one operation. Under a conjunction, a part nothing could read
  * leaves the parts beside it saying what they said — {@code value >= 1 && f(value)} still bounds the
- * value. Under a choice it does not: a value satisfying the branch nothing could read is under no
- * obligation from the other, so {@code x == 7 || f(y)} says nothing about {@code x} either. That is
- * why {@link #hasUnreadPart} is here and why {@link #either} spoils across positions the unread
- * branch never named — the same reason {@code AdmissibleValues.join} does.
+ * value. Under a choice it need not: a value satisfying the branch nothing could read is under no
+ * obligation from the other, so {@code x == 7 || f(y)} says nothing about {@code x}.
+ *
+ * <p><b>Whether it does is not worked out here.</b> Whether the branch beside an unread one still
+ * holds a position down is a question about what the two branches leave, and the answer is the
+ * settlement's ({@link Settlement.WidthDependency}); what arrives here is that answer
+ * ({@link Opening}), and all this does with it is apply it. Derived from {@link #hasUnreadPart}
+ * instead, the rule that comes out is that a branch narrowing a position its neighbour narrows the
+ * same way binds nothing there — and two alternatives holding a position to the same values hold it
+ * there whether or not either of them could be read to the end.
+ *
+ * <p><b>So two things are held and they are not mixed.</b> {@link #read}, {@link #settled},
+ * {@link #missed} and {@link #hasUnreadPart} are what this reading did with the clause.
+ * {@link #opened} is what a choice above it was settled to do to that evidence, and it is contained
+ * in what was read — there is nothing to open about a position this clause put no constraint on.
+ * Folded into {@code missed}, the two would be one set answering for both, and which of them a
+ * reader was being shown would be gone.
  *
  * <p>What is recorded is that the reading settled what the clause does to a position, which is not
  * the same as its having narrowed anything there. A branch shown to admit nothing settles every
@@ -50,34 +63,41 @@ import java.util.Set;
  *                      is that an answer worked out about one reading cannot be applied to the
  *                      other, which is otherwise the same Java type and composes without a
  *                      complaint ({@link ReadingLanguage})
- * @param read          the positions a part of this clause put a constraint on. Open to being
- *                      widened: an alternative nothing could read is one a value can satisfy
- *                      instead, and what this part said of the position then binds nothing
+ * @param read          the positions a part of this clause put a constraint on
  * @param settled       the positions a dead alternative named, which the choice imposes nothing on.
  *                      Not {@link #read}, and this is what keeps the choice associative: a
  *                      constraint can be widened by an alternative beside it, and "this clause
  *                      imposes nothing here" cannot — a further choice imposes nothing extra
  *                      either. Folded into {@code read}, whether it survived turned on where the
  *                      brackets fell
- * @param missed        the positions a part of it was about, or was widened by a part nothing read,
- *                      and so was not settled at
+ * @param missed        the positions a part of it was about and this reading could not work out
  * @param hasUnreadPart whether a part of this clause went unread anywhere in it, which is what a
- *                      choice needs in order to know that a branch widened it. What that part was
- *                      about is not carried: a branch nothing could read widens the positions the
- *                      other branch spoke about whether or not it names them
+ *                      choice needs in order to ask what its alternatives leave. What that part was
+ *                      about is not carried: a branch nothing could read is a branch a value can
+ *                      satisfy instead, whichever positions it happens to name
+ * @param opened        the positions a choice above was settled to have left open, out of those
+ *                      this clause put a constraint on. The one thing here that is not this
+ *                      reading's own work, and contained in {@link #read} so that it cannot become
+ *                      a second account of what the clause was about
  */
 record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A> missed,
-                                              boolean hasUnreadPart) {
+                                              boolean hasUnreadPart, Set<A> opened) {
 
     Adoption {
         read = Set.copyOf(read);
         settled = Set.copyOf(settled);
         missed = Set.copyOf(missed);
+        opened = Set.copyOf(opened);
+        if (!read.containsAll(opened)) {
+            throw new IllegalArgumentException(
+                    "a choice opens what a clause constrained, and this clause constrained none of "
+                            + opened);
+        }
     }
 
     /** What a clause this reading has no word for comes to. */
     static <A, L extends ReadingLanguage> Adoption<A, L> nothing() {
-        return new Adoption<>(Set.of(), Set.of(), Set.of(), false);
+        return new Adoption<>(Set.of(), Set.of(), Set.of(), false, Set.of());
     }
 
     /**
@@ -88,9 +108,12 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
      * that the positions it named are settled: the choice does nothing to them, which is an answer
      * and not a gap. The same rule {@link #bothDead} states for a whole choice, said of one part of
      * one branch of it.
+     *
+     * <p>What a choice above left open goes with the constraint it was about. There is no
+     * constraint here for an alternative to have widened.
      */
     Adoption<A, L> inADeadBranch() {
-        return new Adoption<>(Set.of(), mentions(), Set.of(), false);
+        return new Adoption<>(Set.of(), mentions(), Set.of(), false, Set.of());
     }
 
     /**
@@ -106,6 +129,10 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
      * <p>Given up on and not merely unsaid. A reader asking what answered a rule at such a position
      * has to be told nothing did, because what stands there is what stands at a position no reading
      * reached: everything.
+     *
+     * <p>And what a choice left open at such a position goes too. What is held is the opening
+     * applied to a constraint that is still standing, not a record of every opening there has been;
+     * kept after the constraint it was about is gone, it would name a position nothing here reads.
      */
     Adoption<A, L> unbuiltAt(Set<A> positions) {
         if (positions.isEmpty() || mentions().stream().noneMatch(positions::contains)) {
@@ -115,13 +142,15 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
         stillRead.removeAll(positions);
         Set<A> stillSettled = new LinkedHashSet<>(settled);
         stillSettled.removeAll(positions);
+        Set<A> stillOpened = new LinkedHashSet<>(opened);
+        stillOpened.removeAll(positions);
         Set<A> lost = new LinkedHashSet<>(missed);
         mentions().forEach(each -> {
             if (positions.contains(each)) {
                 lost.add(each);
             }
         });
-        return new Adoption<>(stillRead, stillSettled, lost, hasUnreadPart);
+        return new Adoption<>(stillRead, stillSettled, lost, hasUnreadPart, stillOpened);
     }
 
     /**
@@ -138,7 +167,7 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
         missed.removeAll(produced);
         Set<A> took = new LinkedHashSet<>(mentions);
         took.retainAll(produced);
-        return new Adoption<>(took, Set.of(), missed, failed);
+        return new Adoption<>(took, Set.of(), missed, failed, Set.of());
     }
 
     /**
@@ -146,56 +175,60 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
      *
      * <p>Nothing spoils anything: a part nothing read leaves the parts beside it saying what they
      * said, since all of them hold.
+     *
+     * <p>What a choice inside either of them left open comes along. A conjunction beside a choice
+     * does not put back what the choice left open — {@code (x == 7 || f(y)) && z > 1} still says
+     * nothing about {@code x} — so an opening reached here outlives the conjunction it is under.
      */
     Adoption<A, L> both(Adoption<A, L> other) {
         return new Adoption<>(union(read, other.read), union(settled, other.settled),
-                union(missed, other.missed), hasUnreadPart || other.hasUnreadPart);
+                union(missed, other.missed), hasUnreadPart || other.hasUnreadPart,
+                union(opened, other.opened));
     }
 
     /**
-     * Either part holding.
+     * Either part holding, under what the choice between them was settled to leave open.
      *
-     * <p>A branch nothing could read widens every position the other branch spoke about, named
-     * there or not: a value satisfying the unread branch owes the read one nothing. Read as a union
-     * of what the branches managed, {@code x == 7 || f(y)} said {@code x} had been read — and what
-     * the clause leaves {@code x} is exactly what nothing here can say.
+     * <p>{@code opening} is the whole of what the choice does to what these two branches said, and
+     * it arrives worked out. Taken at the positions either branch put a constraint on: a position
+     * neither of them constrained is one there is nothing to open about, and the settlement answers
+     * over the branches as they were met rather than over this one written part, so it may well
+     * name one.
      */
-    Adoption<A, L> either(Adoption<A, L> other) {
-        Set<A> lost = union(missed, other.missed);
-        // What the branch beside it put a constraint on, and not what it found the choice imposes
-        // nothing on: an alternative nothing could read widens a constraint, and there is nothing
-        // to widen about a position nothing constrains.
-        if (other.hasUnreadPart) {
-            lost = union(lost, read);
-        }
-        if (hasUnreadPart) {
-            lost = union(lost, other.read);
-        }
-        return new Adoption<>(union(read, other.read), union(settled, other.settled), lost,
-                hasUnreadPart || other.hasUnreadPart);
+    Adoption<A, L> either(Opening<A, L> opening, Adoption<A, L> other) {
+        Set<A> constrained = union(read, other.read);
+        Set<A> nowOpen = new LinkedHashSet<>(union(opened, other.opened));
+        opening.positions().forEach(each -> {
+            if (constrained.contains(each)) {
+                nowOpen.add(each);
+            }
+        });
+        return new Adoption<>(constrained, union(settled, other.settled),
+                union(missed, other.missed), hasUnreadPart || other.hasUnreadPart, nowOpen);
     }
 
     /** Whether this reading settled what the whole of the clause does to {@code position}. */
     boolean took(A position) {
         return (read.contains(position) || settled.contains(position))
-                && !missed.contains(position);
+                && !missed.contains(position) && !opened.contains(position);
     }
 
     /**
      * Whether this reading put a constraint on {@code position} that binds.
      *
-     * <p>{@link #read} and nothing else of the three: a position a dead alternative settled is one
-     * this imposes nothing on, which is an answer and not a constraint. And {@link #missed} taken
-     * off it, because that is what the field is open to — an alternative nothing could read is one
-     * a value can satisfy instead, so what was said of the position beside it binds nothing.
+     * <p>{@link #read} and neither of the other two sets: a position a dead alternative settled is
+     * one this imposes nothing on, which is an answer and not a constraint, and a position this
+     * reading could not work out is one it has nothing to say about.
      *
-     * <p>Here rather than at a caller, so that the subtraction is made wherever the question is
-     * asked. Left to a reader to make, {@code value /= 5 || f(value)} with {@code f} unread answers
-     * that the clause holds the position away from five — and a value satisfying the branch nothing
-     * read owes the other one nothing.
+     * <p>And {@link #opened} taken off it, because a constraint an alternative nothing could read
+     * stands beside is one a value can satisfy the other way. Here rather than at a caller, so that
+     * the subtraction is made wherever the question is asked: left to a reader to make,
+     * {@code value /= 5 || f(value)} with {@code f} unread answers that the clause holds the
+     * position away from five.
      */
     boolean constrains(A position) {
-        return read.contains(position) && !missed.contains(position);
+        return read.contains(position) && !missed.contains(position)
+                && !opened.contains(position);
     }
 
     /** The positions any part of the clause was about. */
@@ -215,17 +248,19 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
      * dead the first branch is, so the surviving branch's account is the one that outranks.
      */
     Adoption<A, L> beside(Adoption<A, L> dead) {
-        return new Adoption<>(read, union(settled, dead.mentions()), missed, hasUnreadPart);
+        return new Adoption<>(read, union(settled, dead.mentions()), missed, hasUnreadPart, opened);
     }
 
     /**
      * Two branches of a choice, both shown to admit nothing.
      *
      * <p>Then the choice admits nothing, which settles every position either of them named: the
-     * values there are exactly none. No branch is left to have missed anything.
+     * values there are exactly none. No branch is left to have missed anything, and none to have
+     * had a constraint of its own widened.
      */
     Adoption<A, L> bothDead(Adoption<A, L> other) {
-        return new Adoption<>(Set.of(), union(mentions(), other.mentions()), Set.of(), false);
+        return new Adoption<>(Set.of(), union(mentions(), other.mentions()), Set.of(), false,
+                Set.of());
     }
 
     private static <A> Set<A> union(Set<A> these, Set<A> those) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
@@ -216,19 +216,26 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
     /**
      * Whether this reading put a constraint on {@code position} that binds.
      *
-     * <p>{@link #read} and neither of the other two sets: a position a dead alternative settled is
-     * one this imposes nothing on, which is an answer and not a constraint, and a position this
-     * reading could not work out is one it has nothing to say about.
+     * <p>{@link #read} and not {@link #settled}: a position a dead alternative settled is one this
+     * imposes nothing on, which is an answer and not a constraint.
      *
-     * <p>And {@link #opened} taken off it, because a constraint an alternative nothing could read
+     * <p><b>And {@link #missed} is not taken off it.</b> A leaf puts a position in one or the
+     * other, so the two meet only after composing, and where they meet some part of the clause did
+     * put a constraint here. Under a conjunction that part still binds, whatever the part beside it
+     * could not be worked out — {@code value /= 5 && f(value)} holds the value away from five.
+     * Under a choice it binds unless an alternative took it back, and which positions those are is
+     * the settlement's answer and arrives as {@link #opened}. Subtracted here, {@code missed}
+     * states that a branch this reading could not work out is a branch that takes a constraint
+     * back — the rule the opening replaced, in the other carrier.
+     *
+     * <p>{@link #opened} is taken off, because a constraint an alternative nothing could read
      * stands beside is one a value can satisfy the other way. Here rather than at a caller, so that
      * the subtraction is made wherever the question is asked: left to a reader to make,
      * {@code value /= 5 || f(value)} with {@code f} unread answers that the clause holds the
      * position away from five.
      */
     boolean constrains(A position) {
-        return read.contains(position) && !missed.contains(position)
-                && !opened.contains(position);
+        return read.contains(position) && !opened.contains(position);
     }
 
     /** The positions any part of the clause was about. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -551,6 +551,20 @@ sealed interface Confinement<A> {
             return values;
         }
 
+        /**
+         * Where this reading's orders stop, for a caller asking a question only that reading
+         * answers.
+         *
+         * <p>Beside {@link #values()} and on the same terms. Neither is handed out for the question
+         * this type owns — whether anything satisfies the pair is {@link #admission} and is not
+         * askable of one half — and a caller comparing what one alternative leaves against what the
+         * choice leaves is asking each reading about its own, which is a question the other has no
+         * word for.
+         */
+        OrderedIntervals<A> ordered() {
+            return ordered;
+        }
+
         @Override
         public Map<A, Carrier> carriers() {
             return carriers;

--- a/souther-compiler/src/main/java/souther/compiler/check/Opening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Opening.java
@@ -1,0 +1,41 @@
+package souther.compiler.check;
+
+import java.util.Set;
+
+/**
+ * What one choice left open, as one reading measures it.
+ *
+ * <p>A choice offering an alternative nothing could read leaves the branch beside it holding
+ * nothing down at some of the positions it spoke of: a value satisfying the unread branch owes the
+ * read one nothing. Which positions those are is a question about what the two branches leave, and
+ * it is settled where the branches are ({@link Settlement.WidthDependency}). This is that answer on
+ * its way to whoever applies it.
+ *
+ * <p><b>What a member says, which is the weaker of the two things it could.</b> A position is here
+ * where this reading could not establish that the alternatives leave it what the choice leaves it —
+ * not where it established that they do not. So the semantic opening is contained in this and is
+ * not this, and the cost of the difference is a reading declining to speak for a position it could
+ * have, never an answer handed out as exact when it is not.
+ *
+ * <p>Stated at the weaker end on purpose. A reading whose descriptions are canonical can answer the
+ * question exactly, and one whose descriptions are written more ways than they are meant can only
+ * answer it one way round; both belong in the same type, and a contract pitched at whichever
+ * reading is sharpest today would have to move the day a third one arrives.
+ *
+ * @param <A>       what a position is called
+ * @param <L>       which reading measured this. A position one reading says a choice left open is
+ *                  not a position the other says anything about, and the two answers are the same
+ *                  Java type once the tag is dropped ({@link ReadingLanguage})
+ * @param positions the positions this reading could not show the alternatives preserve
+ */
+record Opening<A, L extends ReadingLanguage>(Set<A> positions) {
+
+    Opening {
+        positions = Set.copyOf(positions);
+    }
+
+    /** A choice shown to leave every position what it leaves without either alternative. */
+    static <A, L extends ReadingLanguage> Opening<A, L> nothing() {
+        return new Opening<>(Set.of());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Opening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Opening.java
@@ -28,6 +28,10 @@ import java.util.Set;
  *                  Java type once the tag is dropped ({@link ReadingLanguage})
  * @param positions the positions this reading could not show the alternatives preserve
  */
+// Unused in what this holds, which is the whole of what it is for: the tag is here so that the
+// answer cannot be handed to a reading that did not work it out, and a parameter this record read
+// would be one it could answer from.
+@SuppressWarnings("UnusedTypeParameter")
 record Opening<A, L extends ReadingLanguage>(Set<A> positions) {
 
     Opening {

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -33,7 +33,8 @@ import java.util.Set;
  * it names), and there is nothing here that turns a place's reasons back into an account of a rule.
  */
 record ReadByClauses(Confinement.Worked<FactSubject> confinement,
-                     Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
+                     Adoption<FactSubject, ReadingLanguage.Values> byValues,
+                     Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                      java.util.Map<souther.compiler.core.Core, OfAPart> parts) {
 
     /** What every position of this reading may hold. */
@@ -95,7 +96,8 @@ record ReadByClauses(Confinement.Worked<FactSubject> confinement,
      *                     the machine for a rule under an allowance of its own — a second answer to
      *                     what the model admits at a position, made by whoever asked second
      */
-    record OfAPart(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
+    record OfAPart(Adoption<FactSubject, ReadingLanguage.Values> byValues,
+                   Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                    Set<RuleShortfall> aboutARule,
                    java.util.Map<FactSubject, AdmittedStrings> aboutStrings) {
 
@@ -170,8 +172,8 @@ record ReadByClauses(Confinement.Worked<FactSubject> confinement,
         return adopted(byValues, byOrder);
     }
 
-    static Set<FactSubject> adopted(Adoption<FactSubject> byValues,
-                                    Adoption<FactSubject> byOrder) {
+    static Set<FactSubject> adopted(Adoption<FactSubject, ReadingLanguage.Values> byValues,
+                                    Adoption<FactSubject, ReadingLanguage.Order> byOrder) {
         Set<FactSubject> out = new LinkedHashSet<>();
         // Everything either account is about, and not what it put a constraint on: a position a
         // dead branch settled is one the reading answered for and put no constraint on, which is

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingLanguage.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingLanguage.java
@@ -1,0 +1,36 @@
+package souther.compiler.check;
+
+/**
+ * Which of the two readings a fact about a clause is a fact of.
+ *
+ * <p>A name and nothing else. Nothing of this type is ever made — what it is for is standing in the
+ * type of a value so that a fact one reading worked out cannot be handed to the other. The two are
+ * short of different things ({@link Confinement}): which values may stand at a position is a set
+ * and where its order stops is a range, and neither has a word for what the other holds. So a
+ * position one of them says a choice left open is not a position the other says anything about, and
+ * a value carrying such an answer is only meaningful beside the reading that gave it.
+ *
+ * <p><b>Which the type says rather than a comment.</b> Both answers are sets of positions, so the
+ * two are the same Java type once the tag is dropped and either can be passed where the other
+ * belongs. What that costs is not an exception: the reading that receives the wrong answer composes
+ * it perfectly happily and reports a clause it read as one it did not.
+ *
+ * <p>The tag is on the answer and on what consumes it, so an accidental crossing does not compile.
+ * It does not make the underlying set of positions a different type: written out, the positions of
+ * one language's answer can still be put in a value tagged as the other's. What is closed is
+ * handing one to the other, which is the way the two meet in an expression.
+ */
+sealed interface ReadingLanguage {
+
+    /** The reading that says which values may stand at a position. */
+    final class Values implements ReadingLanguage {
+
+        private Values() {}
+    }
+
+    /** The reading that says where a position's order stops. */
+    final class Order implements ReadingLanguage {
+
+        private Order() {}
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.PlannedValues;
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
 /**
@@ -187,7 +189,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
             Set<FactSubject> narrowed = new LinkedHashSet<>(one.adoptedAt());
             narrowed.addAll(other.adoptedAt());
             return comparing(narrowed, one::at, other::at,
-                    position -> AdmittedPlan.joining(List.of(one.at(position), other.at(position))));
+                    (here, there) -> AdmittedPlan.joining(List.of(here, there)));
         }
 
         /**
@@ -208,8 +210,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
                                                     OrderedIntervals<FactSubject> other) {
             Set<FactSubject> bounded = new LinkedHashSet<>(one.boundedAt());
             bounded.addAll(other.boundedAt());
-            return comparing(bounded, one::at, other::at,
-                    position -> one.at(position).join(other.at(position)));
+            return comparing(bounded, one::at, other::at, OrderedInterval::join);
         }
 
         /**
@@ -221,18 +222,24 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
          */
         private static <L extends ReadingLanguage, T> Width<L> comparing(
                 Set<FactSubject> narrowed, Function<FactSubject, T> left,
-                Function<FactSubject, T> right, Function<FactSubject, T> joined) {
+                Function<FactSubject, T> right, BinaryOperator<T> joining) {
             Set<FactSubject> mayRestOnLeft = new LinkedHashSet<>();
             Set<FactSubject> mayRestOnRight = new LinkedHashSet<>();
             for (FactSubject position : narrowed) {
-                T both = joined.apply(position);
+                // Asked of each side once. What a reading leaves a position is worked out and not
+                // looked up — a description is met across every alternative the reading holds — so
+                // a comparison that asked again for what it already had would pay for the branches
+                // twice over.
+                T here = left.apply(position);
+                T there = right.apply(position);
+                T both = joining.apply(here, there);
                 // Equal descriptions say one thing, so this side of each is a proof that dropping
                 // the branch leaves the position where it was. Unequal ones are not a proof of
                 // anything, and the position is kept as one nobody settled.
-                if (!right.apply(position).equals(both)) {
+                if (!there.equals(both)) {
                     mayRestOnLeft.add(position);
                 }
-                if (!left.apply(position).equals(both)) {
+                if (!here.equals(both)) {
                     mayRestOnRight.add(position);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -193,18 +193,23 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
         /**
          * The same asked of where the orders stop.
          *
-         * <p>Complete as well as sound, which the reading of values is not: an interval is written
-         * one way, so two branches that stop a position in the same place say so in the same
-         * description and the positions left out are exactly the positions the choice keeps without
-         * the branch. The contract this is published under ({@link Opening}) is still the weaker
-         * one, since what a reader may act on has to hold of every language that answers.
+         * <p>Complete as well as sound, which the reading of values is not: what this language
+         * leaves a position is a pair of ends and is written one way, so the positions left out are
+         * exactly the positions the choice stops where it would without the branch. The contract
+         * this is published under ({@link Opening}) is still the weaker one, since what a reader may
+         * act on has to hold of every language that answers.
+         *
+         * <p>A position at a time, as the values are. What a choice comes to over a whole reading
+         * is more than the ranges and is composed where both languages are held
+         * ({@link Confinement.Planned}); what is asked here is one position of two branches whose
+         * fates are settled and handed in.
          */
         static Width<ReadingLanguage.Order> ofOrder(OrderedIntervals<FactSubject> one,
                                                     OrderedIntervals<FactSubject> other) {
             Set<FactSubject> bounded = new LinkedHashSet<>(one.boundedAt());
             bounded.addAll(other.boundedAt());
-            OrderedIntervals<FactSubject> joined = one.joinLive(other);
-            return comparing(bounded, one::at, other::at, joined::at);
+            return comparing(bounded, one::at, other::at,
+                    position -> one.at(position).join(other.at(position)));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -160,6 +160,12 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
      * rather than a fact: an occurrence's own widening can be covered by what another occurrence
      * leaves.
      *
+     * <p><b>Which alternative went unread is not here.</b> That is what the account of the rules
+     * says, and turning the two into what the choice left open is done where both are in hand
+     * ({@code StatedByClauses#openedBy}). Answered here, the alternative would have to arrive as a
+     * word for a side rather than as an account, and a word for a side says nothing about which
+     * reading it came from.
+     *
      * @param <L>            which reading measured this ({@link ReadingLanguage})
      * @param mayRestOnLeft  the positions where the choice without its left alternative was not
      *                       shown to leave what the choice with it leaves
@@ -253,25 +259,6 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
             Set<FactSubject> right = new LinkedHashSet<>(mayRestOnRight);
             right.addAll(occurrence.mayRestOnRight());
             return new Width<>(left, right);
-        }
-
-        /**
-         * What the choice leaves open, given which of its alternatives went unread.
-         *
-         * <p>The one place an opening is made. Both halves of the question meet here and both are
-         * this reading's: which alternative it had no word for, and what it could not show the
-         * alternatives preserve. Asked with the other reading's answer to either half, what comes
-         * back is an opening about a choice this reading did not see.
-         */
-        Opening<FactSubject, L> opened(boolean leftUnread, boolean rightUnread) {
-            Set<FactSubject> out = new LinkedHashSet<>();
-            if (leftUnread) {
-                out.addAll(mayRestOnLeft);
-            }
-            if (rightUnread) {
-                out.addAll(mayRestOnRight);
-            }
-            return new Opening<>(out);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realized;
@@ -12,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 /**
  * What settling the met-together reading came to: the values, and the fate of every branch.
@@ -64,7 +66,69 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
     }
 
     /**
-     * Which positions a choice may be as wide as it is at because of one of its alternatives.
+     * Which positions a choice may be as wide as it is at because of one of its alternatives, as
+     * each reading measures it.
+     *
+     * <p>Two readings and one event. A choice offering an alternative nothing could read is one
+     * thing that happened to one written clause; what it left open is a different set in each of
+     * the two languages, because each of them measures what a branch leaves in its own terms and
+     * has no word for what the other holds. So this is made once, where the branches are, and the
+     * two halves are told apart by their type rather than by which caller happens to be holding
+     * one.
+     *
+     * <p>Kept together for the same reason the fates are: a reader deciding what an unread
+     * alternative left open needs both about the same two branches, and made in two places they
+     * would be two answers to one question.
+     *
+     * <p><b>Nothing where either branch admits nothing here.</b> There is no choice at such an
+     * occurrence — what it leaves is the branch beside the dead one — so its width rests on neither
+     * alternative in either language. Another occurrence of the same written choice may still be
+     * one both branches stand at, and what that one's width may rest on is joined in beside this
+     * ({@link #alsoSeen}): a branch is dead for the author only where nobody can be in it anywhere,
+     * and that is not this occurrence's to say.
+     *
+     * @param byValues what the reading of values could not show the alternatives preserve
+     * @param byOrder  the same asked of where the orders stop, which is a different question about
+     *                 the same two branches
+     */
+    record WidthDependency(Width<ReadingLanguage.Values> byValues,
+                           Width<ReadingLanguage.Order> byOrder) {
+
+        /** A choice shown to leave what it leaves without either of its alternatives. */
+        static WidthDependency none() {
+            return new WidthDependency(Width.none(), Width.none());
+        }
+
+        /**
+         * What one occurrence of a choice between these two branches may be as wide as it is
+         * because of, read off the descriptions and building nothing.
+         *
+         * <p>Each reading is asked about its own and neither is asked about the other's. Handed the
+         * whole branch rather than one half of it because the question that decides whether there
+         * is a choice here at all — whether anybody can be in each branch — is about the two of
+         * them together and is already answered.
+         */
+        static WidthDependency of(souther.compiler.values.Emptiness here,
+                                  Confinement.Planned<FactSubject> one,
+                                  souther.compiler.values.Emptiness there,
+                                  Confinement.Planned<FactSubject> other) {
+            if (here == souther.compiler.values.Emptiness.EMPTY
+                    || there == souther.compiler.values.Emptiness.EMPTY) {
+                return none();
+            }
+            return new WidthDependency(Width.ofValues(one.values(), other.values()),
+                    Width.ofOrder(one.ordered(), other.ordered()));
+        }
+
+        /** The width of one more occurrence of the same choice, taken in beside this. */
+        WidthDependency alsoSeen(WidthDependency occurrence) {
+            return new WidthDependency(byValues.alsoSeen(occurrence.byValues()),
+                    byOrder.alsoSeen(occurrence.byOrder()));
+        }
+    }
+
+    /**
+     * One reading's half of that.
      *
      * <p>A relation between two branches and not an attribute of one, which is why it is here
      * rather than in {@link Sided}: what may rest on the left is read off what the <em>right</em>
@@ -72,18 +136,18 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
      *
      * <p><b>What a member and a non-member each say, which is not the same strength.</b> Write
      * {@code D} for the positions where the choice without a branch truly leaves less than the
-     * choice with it. A position left out is one where the two are the same set and dropping the
-     * branch changes nothing — that is proven. A position kept is one where nothing here proved
-     * them the same, which is weaker than their differing: two descriptions of one set written
+     * choice with it. A position left out is one where the two are the same and dropping the branch
+     * changes nothing — that is proven. A position kept is one where nothing here proved them the
+     * same, which is weaker than their differing: two descriptions of one answer written
      * differently are kept apart. So {@code D} is contained in what is held and is not what is
      * held, and a reader may take a non-member as a fact and a member only as a question nobody
      * settled. Read the other way, a position no alternative was really answerable for would be
      * published as one an author has to look at.
      *
-     * <p>Which is what the comparison can be an equality of normalised descriptions and cost
-     * nothing. A choice admits whatever either of its branches admits, so what it leaves without
-     * one of them is contained in what it leaves with both, and equal descriptions are the same
-     * set — the proof runs in the direction a non-member is read in, and no machine is built to
+     * <p>Which is what lets the comparison be an equality of normalised descriptions and cost
+     * nothing. A choice leaves whatever either of its branches leaves, so what it leaves without
+     * one of them is contained in what it leaves with both, and equal descriptions say the same
+     * thing — the proof runs in the direction a non-member is read in, and nothing is built to
      * decide the other.
      *
      * <p><b>An occurrence at a time, and a union over them.</b> The same written choice stands
@@ -92,75 +156,110 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
      * may. Union is associative, commutative and idempotent, which is what lets the order the
      * copies are met in stay out of the answer, and it is the second reason a member is a question
      * rather than a fact: an occurrence's own widening can be covered by what another occurrence
-     * leaves. An occurrence one branch of which admits nothing is not a choice there at all and
-     * contributes neither side.
+     * leaves.
      *
+     * @param <L>            which reading measured this ({@link ReadingLanguage})
      * @param mayRestOnLeft  the positions where the choice without its left alternative was not
      *                       shown to leave what the choice with it leaves
      * @param mayRestOnRight the same for the right
      */
-    record WidthDependency(Set<FactSubject> mayRestOnLeft, Set<FactSubject> mayRestOnRight) {
+    record Width<L extends ReadingLanguage>(Set<FactSubject> mayRestOnLeft,
+                                            Set<FactSubject> mayRestOnRight) {
 
-        WidthDependency {
+        Width {
             mayRestOnLeft = Set.copyOf(mayRestOnLeft);
             mayRestOnRight = Set.copyOf(mayRestOnRight);
         }
 
-        /** A choice shown to leave what it leaves without either of its alternatives. */
-        static WidthDependency none() {
-            return new WidthDependency(Set.of(), Set.of());
+        /** A choice this reading showed it leaves what it leaves without either alternative. */
+        static <L extends ReadingLanguage> Width<L> none() {
+            return new Width<>(Set.of(), Set.of());
         }
 
         /**
-         * What one occurrence of a choice between these two branches may be as wide as it is
-         * because of, read off the descriptions and building nothing.
+         * What the reading of values could not show the alternatives preserve.
          *
          * <p>Over the positions either of them narrowed, since a position neither did is one both
          * of them leave at every value and so is the choice, with or without either.
-         *
-         * <p><b>Nothing where either branch admits nothing here.</b> There is no choice at such an
-         * occurrence — what it leaves is the branch beside the dead one — so its width rests on
-         * neither alternative. Another occurrence of the same written choice may still be one both
-         * branches stand at, and what that one's width may rest on is joined in beside this
-         * ({@link #alsoSeen}): a branch is dead for the author only where nobody can be in it
-         * anywhere, and that is not this occurrence's to say.
          */
-        static WidthDependency of(souther.compiler.values.Emptiness here,
-                                  PlannedValues<FactSubject> one,
-                                  souther.compiler.values.Emptiness there,
-                                  PlannedValues<FactSubject> other) {
-            if (here == souther.compiler.values.Emptiness.EMPTY
-                    || there == souther.compiler.values.Emptiness.EMPTY) {
-                return none();
-            }
-            Set<FactSubject> mayRestOnLeft = new LinkedHashSet<>();
-            Set<FactSubject> mayRestOnRight = new LinkedHashSet<>();
+        static Width<ReadingLanguage.Values> ofValues(PlannedValues<FactSubject> one,
+                                                      PlannedValues<FactSubject> other) {
             Set<FactSubject> narrowed = new LinkedHashSet<>(one.adoptedAt());
             narrowed.addAll(other.adoptedAt());
+            return comparing(narrowed, one::at, other::at,
+                    position -> AdmittedPlan.joining(List.of(one.at(position), other.at(position))));
+        }
+
+        /**
+         * The same asked of where the orders stop.
+         *
+         * <p>Complete as well as sound, which the reading of values is not: an interval is written
+         * one way, so two branches that stop a position in the same place say so in the same
+         * description and the positions left out are exactly the positions the choice keeps without
+         * the branch. The contract this is published under ({@link Opening}) is still the weaker
+         * one, since what a reader may act on has to hold of every language that answers.
+         */
+        static Width<ReadingLanguage.Order> ofOrder(OrderedIntervals<FactSubject> one,
+                                                    OrderedIntervals<FactSubject> other) {
+            Set<FactSubject> bounded = new LinkedHashSet<>(one.boundedAt());
+            bounded.addAll(other.boundedAt());
+            OrderedIntervals<FactSubject> joined = one.joinLive(other);
+            return comparing(bounded, one::at, other::at, joined::at);
+        }
+
+        /**
+         * Both sides of one comparison, whatever a reading leaves a position.
+         *
+         * <p>Private, and the reading it is a width of is settled by whichever of the two above
+         * called it — each of them takes the descriptions of one language and nothing else, so
+         * there is no call here at which the two could be swapped for one another.
+         */
+        private static <L extends ReadingLanguage, T> Width<L> comparing(
+                Set<FactSubject> narrowed, Function<FactSubject, T> left,
+                Function<FactSubject, T> right, Function<FactSubject, T> joined) {
+            Set<FactSubject> mayRestOnLeft = new LinkedHashSet<>();
+            Set<FactSubject> mayRestOnRight = new LinkedHashSet<>();
             for (FactSubject position : narrowed) {
-                AdmittedPlan left = one.at(position);
-                AdmittedPlan right = other.at(position);
-                AdmittedPlan joined = AdmittedPlan.joining(List.of(left, right));
-                // Equal descriptions are one set, so this side of each is a proof that dropping
+                T both = joined.apply(position);
+                // Equal descriptions say one thing, so this side of each is a proof that dropping
                 // the branch leaves the position where it was. Unequal ones are not a proof of
                 // anything, and the position is kept as one nobody settled.
-                if (!right.equals(joined)) {
+                if (!right.apply(position).equals(both)) {
                     mayRestOnLeft.add(position);
                 }
-                if (!left.equals(joined)) {
+                if (!left.apply(position).equals(both)) {
                     mayRestOnRight.add(position);
                 }
             }
-            return new WidthDependency(mayRestOnLeft, mayRestOnRight);
+            return new Width<>(mayRestOnLeft, mayRestOnRight);
         }
 
         /** The width of one more occurrence of the same choice, taken in beside this. */
-        WidthDependency alsoSeen(WidthDependency occurrence) {
+        Width<L> alsoSeen(Width<L> occurrence) {
             Set<FactSubject> left = new LinkedHashSet<>(mayRestOnLeft);
             left.addAll(occurrence.mayRestOnLeft());
             Set<FactSubject> right = new LinkedHashSet<>(mayRestOnRight);
             right.addAll(occurrence.mayRestOnRight());
-            return new WidthDependency(left, right);
+            return new Width<>(left, right);
+        }
+
+        /**
+         * What the choice leaves open, given which of its alternatives went unread.
+         *
+         * <p>The one place an opening is made. Both halves of the question meet here and both are
+         * this reading's: which alternative it had no word for, and what it could not show the
+         * alternatives preserve. Asked with the other reading's answer to either half, what comes
+         * back is an opening about a choice this reading did not see.
+         */
+        Opening<FactSubject, L> opened(boolean leftUnread, boolean rightUnread) {
+            Set<FactSubject> out = new LinkedHashSet<>();
+            if (leftUnread) {
+                out.addAll(mayRestOnLeft);
+            }
+            if (rightUnread) {
+                out.addAll(mayRestOnRight);
+            }
+            return new Opening<>(out);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -381,10 +381,23 @@ sealed interface StatedByClauses {
         return new AlternativeOpening(choice,
                 one.byValues().hasUnreadPart() ? reachedBy(other.byValues()) : Set.of(),
                 other.byValues().hasUnreadPart() ? reachedBy(one.byValues()) : Set.of(),
-                width.byValues().opened(one.byValues().hasUnreadPart(),
-                        other.byValues().hasUnreadPart()),
-                width.byOrder().opened(one.byOrder().hasUnreadPart(),
-                        other.byOrder().hasUnreadPart()));
+                openedBy(width.byValues(), one.byValues(), other.byValues()),
+                openedBy(width.byOrder(), one.byOrder(), other.byOrder()));
+    }
+
+    /**
+     * What one reading says a choice between these two accounts left open.
+     *
+     * <p>Here so that the three of them have to be one reading's. Whether an alternative went
+     * unread is a {@code boolean} by the time a width is asked, and a boolean carries no word for
+     * whose it is — so the width of the ends taken with the flags of the values compiles, and comes
+     * back as an opening about a choice the ends never read. Bound to one {@code L}, that call does
+     * not exist.
+     */
+    private static <L extends ReadingLanguage> Opening<FactSubject, L> openedBy(
+            Settlement.Width<L> width, Adoption<FactSubject, L> one,
+            Adoption<FactSubject, L> other) {
+        return width.opened(one.hasUnreadPart(), other.hasUnreadPart());
     }
 
     /** The positions a reading reached and did not merely settle: what it constrained, and what it

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -273,9 +273,8 @@ sealed interface StatedByClauses {
          *
          * <p><b>Of the reading of values, which is what the name says and not all there is.</b>
          * Where a position's order stops is taken back by an unread alternative the same way, and
-         * an author is sent to the choice for that by nothing here. What is deliberate is only that
-         * this change leaves the set of these findings where it was; the missing half is written
-         * down as its own question rather than folded in beside a correction.
+         * an author is sent to the choice for that by nothing here. Whether they are owed it is a
+         * question of its own and is open.
          */
         private static void leftOpenByValues(RuleShortfall.Site.AtAChoice choice,
                                              Set<FactSubject> these,

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -233,9 +233,11 @@ sealed interface StatedByClauses {
                     : "two alternatives of one choice are answerable for one written place";
             Set<RuleShortfall> shortfalls = new LinkedHashSet<>(ruleShortfalls);
             shortfalls.addAll(other.ruleShortfalls());
-            leftOpenBy(choice, opening.byTheRightGoingUnread(), other.ruleShortfalls(), shortfalls);
-            leftOpenBy(choice, opening.byTheLeftGoingUnread(), ruleShortfalls, shortfalls);
-            return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
+            leftOpenByValues(choice, opening.byTheRightGoingUnread(), other.ruleShortfalls(),
+                    shortfalls);
+            leftOpenByValues(choice, opening.byTheLeftGoingUnread(), ruleShortfalls, shortfalls);
+            return new Part(byValues.either(opening.byValues(), other.byValues()),
+                    byOrder.either(opening.byOrder(), other.byOrder()),
                     StringRestriction.over(aboutStrings, other.aboutStrings(), false),
                     askedIn(asked, other.asked()), held(shortfalls));
         }
@@ -268,9 +270,16 @@ sealed interface StatedByClauses {
          * fact is told from two facts of the same shape. Never their reasons: a rule about which
          * reasons suppress which would be one more place the vocabulary has to be consulted, and a
          * reason added to it would quietly change what a choice says.
+         *
+         * <p><b>Of the reading of values, which is what the name says and not all there is.</b>
+         * Where a position's order stops is taken back by an unread alternative the same way, and
+         * an author is sent to the choice for that by nothing here. What is deliberate is only that
+         * this change leaves the set of these findings where it was; the missing half is written
+         * down as its own question rather than folded in beside a correction.
          */
-        private static void leftOpenBy(RuleShortfall.Site.AtAChoice choice, Set<FactSubject> these,
-                                       Set<RuleShortfall> unread, Set<RuleShortfall> out) {
+        private static void leftOpenByValues(RuleShortfall.Site.AtAChoice choice,
+                                             Set<FactSubject> these,
+                                             Set<RuleShortfall> unread, Set<RuleShortfall> out) {
             these.stream()
                     .filter(each -> !accountedFor(each, unread))
                     .forEach(each -> out.add(new RuleShortfall(each,
@@ -311,11 +320,16 @@ sealed interface StatedByClauses {
      * @param byTheLeftGoingUnread  the positions the right alternative reached, where the left is
      *                              one nothing could read. Empty where it was read
      * @param byTheRightGoingUnread the same the other way round
-     * @param positions             the positions an alternative nothing could read was not shown
-     *                              to leave where they were
+     * @param byValues              what the reading of values could not show the alternatives leave
+     *                              where they were, where one of them went unread there
+     * @param byOrder               the same asked of where the orders stop. A separate answer and
+     *                              not a copy: which alternative went unread is each reading's own,
+     *                              and so is what a branch leaves
      */
     record AlternativeOpening(ChoiceId choice, Set<FactSubject> byTheLeftGoingUnread,
-                              Set<FactSubject> byTheRightGoingUnread, Set<FactSubject> positions) {
+                              Set<FactSubject> byTheRightGoingUnread,
+                              Opening<FactSubject, ReadingLanguage.Values> byValues,
+                              Opening<FactSubject, ReadingLanguage.Order> byOrder) {
 
         // Copied on the way in, as everything a reading publishes is. What is here is handed to the
         // positions and kept in what they came to, so a maker that went on writing to the set it
@@ -326,7 +340,6 @@ sealed interface StatedByClauses {
             }
             byTheLeftGoingUnread = held(byTheLeftGoingUnread);
             byTheRightGoingUnread = held(byTheRightGoingUnread);
-            positions = held(positions);
         }
 
         private static Set<FactSubject> held(Set<FactSubject> these) {
@@ -341,10 +354,11 @@ sealed interface StatedByClauses {
      * <p>Two questions and two sources, and neither answers the other's. Which alternative nothing
      * could read is a fact about the clause somebody wrote and is read off the tree that keeps that
      * shape ({@link Adoption#hasUnreadPart}). Whether anything showed the choice leaves a position
-     * what it would without an alternative is a fact about the values, is worked out where the
-     * branches were settled, and arrives here decided ({@link Settlement.WidthDependency}) — asked
-     * of the positions each branch took in instead, the answer would be that a branch narrowing a
-     * position its neighbour narrows the same way is why the choice is as wide as it is.
+     * what it would without an alternative is a fact about what the branches leave, is worked out
+     * where they were settled, and arrives here decided ({@link Settlement.WidthDependency}) —
+     * asked of the positions each branch took in instead, the answer would be that a branch
+     * narrowing a position its neighbour narrows the same way is why the choice is as wide as it
+     * is.
      *
      * <p>What arrives is the side a reader may act on: a position left out of it is one dropping
      * the alternative was shown not to narrow, and one kept is one nobody settled. So a position
@@ -352,24 +366,25 @@ sealed interface StatedByClauses {
      * a reading declining to speak for a position it could have — never an answer handed out as
      * exact when it is not.
      *
-     * <p>Of the reading of values alone, which is the one a choice is asked of. Where a position's
-     * order stops is not what an alternative takes back — a range says nothing about which values
-     * stand anywhere, so a branch nothing read leaves the ranges beside it saying what they said.
+     * <p><b>Asked of each reading about its own clause and its own branches.</b> Both halves of the
+     * question are the reading's: whether it had a word for an alternative, and whether what that
+     * alternative leaves is what the choice leaves. A range says nothing about which values stand
+     * anywhere and a set of values says nothing about where an order stops, so an answer built from
+     * one reading's half and the other's is about a choice neither of them read.
+     *
+     * <p>Handed the whole part on each side rather than one account of it, for that reason: the two
+     * accounts of one written branch are what this has to put side by side, and a caller picking
+     * one of them out is the place the halves would come apart.
      */
     static AlternativeOpening opens(ChoiceId choice, Settlement.WidthDependency width,
-                                    Adoption<FactSubject, ReadingLanguage.Values> one,
-                                    Adoption<FactSubject, ReadingLanguage.Values> other) {
-        Set<FactSubject> opened = new LinkedHashSet<>();
-        if (one.hasUnreadPart()) {
-            opened.addAll(width.mayRestOnLeft());
-        }
-        if (other.hasUnreadPart()) {
-            opened.addAll(width.mayRestOnRight());
-        }
+                                    Part one, Part other) {
         return new AlternativeOpening(choice,
-                one.hasUnreadPart() ? reachedBy(other) : Set.of(),
-                other.hasUnreadPart() ? reachedBy(one) : Set.of(),
-                opened);
+                one.byValues().hasUnreadPart() ? reachedBy(other.byValues()) : Set.of(),
+                other.byValues().hasUnreadPart() ? reachedBy(one.byValues()) : Set.of(),
+                width.byValues().opened(one.byValues().hasUnreadPart(),
+                        other.byValues().hasUnreadPart()),
+                width.byOrder().opened(one.byOrder().hasUnreadPart(),
+                        other.byOrder().hasUnreadPart()));
     }
 
     /** The positions a reading reached and did not merely settle: what it constrained, and what it
@@ -721,8 +736,8 @@ sealed interface StatedByClauses {
                                                     StatedTogether.Said other,
                                                     Settlement.Sided there) {
             return new Settlement.OfAChoice(here, there,
-                    Settlement.WidthDependency.of(here.emptiness(), one.confinement().values(),
-                            there.emptiness(), other.confinement().values()));
+                    Settlement.WidthDependency.of(here.emptiness(), one.confinement(),
+                            there.emptiness(), other.confinement()));
         }
 
         /**
@@ -1027,8 +1042,7 @@ sealed interface StatedByClauses {
                     Taken beside = keptAs(other, fate.right());
                     yield live.either(
                             new RuleShortfall.Site.AtAChoice(it.id(), it.writtenAt().pos()),
-                            opens(it.id(), fate.width(), live.took().byValues(),
-                                    beside.took().byValues()),
+                            opens(it.id(), fate.width(), live.took(), beside.took()),
                             beside);
                 }
             };
@@ -1133,7 +1147,7 @@ sealed interface StatedByClauses {
         Taken either(RuleShortfall.Site.AtAChoice choice, AlternativeOpening opening, Taken other) {
             return new Taken(took.either(choice, opening, other.took()),
                     joined(parts, other.parts()),
-                    opened(opened(opened, other.opened()), opening.positions()));
+                    opened(opened(opened, other.opened()), opening.byValues().positions()));
         }
 
         private static Map<Core, Part> joined(Map<Core, Part> these, Map<Core, Part> those) {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -339,11 +339,11 @@ sealed interface StatedByClauses {
      *
      * <p>Two questions and two sources, and neither answers the other's. Which alternative nothing
      * could read is a fact about the clause somebody wrote and is read off the tree that keeps that
-     * shape ({@link Adoption#dropped}). Whether anything showed the choice leaves a position what
-     * it would without an alternative is a fact about the values, is worked out where the branches
-     * were settled, and arrives here decided ({@link Settlement.WidthDependency}) — asked of the
-     * positions each branch took in instead, the answer would be that a branch narrowing a position
-     * its neighbour narrows the same way is why the choice is as wide as it is.
+     * shape ({@link Adoption#hasUnreadPart}). Whether anything showed the choice leaves a position
+     * what it would without an alternative is a fact about the values, is worked out where the
+     * branches were settled, and arrives here decided ({@link Settlement.WidthDependency}) — asked
+     * of the positions each branch took in instead, the answer would be that a branch narrowing a
+     * position its neighbour narrows the same way is why the choice is as wide as it is.
      *
      * <p>What arrives is the side a reader may act on: a position left out of it is one dropping
      * the alternative was shown not to narrow, and one kept is one nobody settled. So a position
@@ -358,15 +358,15 @@ sealed interface StatedByClauses {
     static AlternativeOpening opens(ChoiceId choice, Settlement.WidthDependency width,
                                     Adoption<FactSubject> one, Adoption<FactSubject> other) {
         Set<FactSubject> opened = new LinkedHashSet<>();
-        if (one.dropped()) {
+        if (one.hasUnreadPart()) {
             opened.addAll(width.mayRestOnLeft());
         }
-        if (other.dropped()) {
+        if (other.hasUnreadPart()) {
             opened.addAll(width.mayRestOnRight());
         }
         return new AlternativeOpening(choice,
-                one.dropped() ? reachedBy(other) : Set.of(),
-                other.dropped() ? reachedBy(one) : Set.of(),
+                one.hasUnreadPart() ? reachedBy(other) : Set.of(),
+                other.hasUnreadPart() ? reachedBy(one) : Set.of(),
                 opened);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -158,7 +158,8 @@ sealed interface StatedByClauses {
      *                       can be in have both, together with whatever the choice between them
      *                       raised
      */
-    record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
+    record Part(Adoption<FactSubject, ReadingLanguage.Values> byValues,
+                Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                 Map<FactSubject, StringRestriction> aboutStrings,
                 Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls) {
@@ -356,7 +357,8 @@ sealed interface StatedByClauses {
      * stand anywhere, so a branch nothing read leaves the ranges beside it saying what they said.
      */
     static AlternativeOpening opens(ChoiceId choice, Settlement.WidthDependency width,
-                                    Adoption<FactSubject> one, Adoption<FactSubject> other) {
+                                    Adoption<FactSubject, ReadingLanguage.Values> one,
+                                    Adoption<FactSubject, ReadingLanguage.Values> other) {
         Set<FactSubject> opened = new LinkedHashSet<>();
         if (one.hasUnreadPart()) {
             opened.addAll(width.mayRestOnLeft());
@@ -372,7 +374,7 @@ sealed interface StatedByClauses {
 
     /** The positions a reading reached and did not merely settle: what it constrained, and what it
      *  was about and could not manage. */
-    private static Set<FactSubject> reachedBy(Adoption<FactSubject> of) {
+    private static Set<FactSubject> reachedBy(Adoption<FactSubject, ReadingLanguage.Values> of) {
         Set<FactSubject> out = new LinkedHashSet<>(of.read());
         out.addAll(of.missed());
         return out;
@@ -1286,8 +1288,8 @@ sealed interface StatedByClauses {
             Set<FactSubject> opened = new LinkedHashSet<>();
             Map<Core, PartAccount> said = new IdentityHashMap<>();
             Map<K, Set<FactSubject>> narrowed = new LinkedHashMap<>();
-            Adoption<FactSubject> byValues = Adoption.nothing();
-            Adoption<FactSubject> byOrder = Adoption.nothing();
+            Adoption<FactSubject, ReadingLanguage.Values> byValues = Adoption.nothing();
+            Adoption<FactSubject, ReadingLanguage.Order> byOrder = Adoption.nothing();
             // What the answer has left, before an account is made out of it. Every account below
             // reads what was built and builds nothing, so this is what it costs — and an account
             // that spent would be taking the budget the answer is bounded by to say which rule a
@@ -1484,7 +1486,8 @@ sealed interface StatedByClauses {
      * read — so that the plans never reach a reader and the position pays for its own answer in one
      * place.
      */
-    record PartAccount(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
+    record PartAccount(Adoption<FactSubject, ReadingLanguage.Values> byValues,
+                       Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                        Set<RuleShortfall> aboutARule,
                        Map<FactSubject, StringRestriction> aboutStrings) {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -330,9 +330,10 @@ sealed interface StatedByClauses {
                               Opening<FactSubject, ReadingLanguage.Values> byValues,
                               Opening<FactSubject, ReadingLanguage.Order> byOrder) {
 
-        // Copied on the way in, as everything a reading publishes is. What is here is handed to the
-        // positions and kept in what they came to, so a maker that went on writing to the set it
-        // built one from would be changing what an answer already given says.
+        // Copied on the way in, as everything a reading publishes is: what is here is handed to
+        // the positions and kept in what they came to, so a maker that went on writing to the set
+        // it built one from would be changing what an answer already given says. The openings do
+        // it where they are made, which is why only the two sets are copied here.
         public AlternativeOpening {
             if (choice == null) {
                 throw new IllegalArgumentException("an opening is some choice's");

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -388,16 +388,29 @@ sealed interface StatedByClauses {
     /**
      * What one reading says a choice between these two accounts left open.
      *
-     * <p>Here so that the three of them have to be one reading's. Whether an alternative went
-     * unread is a {@code boolean} by the time a width is asked, and a boolean carries no word for
-     * whose it is — so the width of the ends taken with the flags of the values compiles, and comes
-     * back as an opening about a choice the ends never read. Bound to one {@code L}, that call does
-     * not exist.
+     * <p><b>The one place an opening is made, and the place both halves of the question are in
+     * hand.</b> Which alternative this reading had no word for is the account's, and what it could
+     * not show the alternatives preserve is the width's; an opening is the two of them together and
+     * is nothing without either.
+     *
+     * <p>Made here rather than by the width, which is what lets the three of them be held to one
+     * reading. Asked of the width, an alternative can only arrive as a word for a side — and a word
+     * for a side says nothing about which reading it came from, so the width of the ends taken with
+     * the flags of the values composes and comes back as an opening about a choice the ends never
+     * read. Bound to one {@code L}, there is nothing to hand in but accounts, and that call cannot
+     * be written.
      */
     private static <L extends ReadingLanguage> Opening<FactSubject, L> openedBy(
             Settlement.Width<L> width, Adoption<FactSubject, L> one,
             Adoption<FactSubject, L> other) {
-        return width.opened(one.hasUnreadPart(), other.hasUnreadPart());
+        Set<FactSubject> opened = new LinkedHashSet<>();
+        if (one.hasUnreadPart()) {
+            opened.addAll(width.mayRestOnLeft());
+        }
+        if (other.hasUnreadPart()) {
+            opened.addAll(width.mayRestOnRight());
+        }
+        return new Opening<>(opened);
     }
 
     /** The positions a reading reached and did not merely settle: what it constrained, and what it

--- a/souther-compiler/src/test/java/souther/compiler/WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest.java
@@ -1,0 +1,137 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether a branch's constraint still binds under a choice is read off what the alternatives leave.
+ *
+ * <p>Two alternatives holding a position to the same values hold it there whether or not either of
+ * them could be read to the end: the choice is one of them, and both of them say the same thing.
+ * So a clause a reading has no word for, written beside a constraint, does not decide what the
+ * constraint comes to — and the report says the same about a rule however much of the clause beside
+ * it this compiler happens to understand today.
+ *
+ * <p><b>Both directions, because one of them alone is met by saying nothing.</b> Where the
+ * alternatives really do leave the position differently, the unread one is why the choice is as
+ * wide as it is and the rule is not reported as one that drew no line. A reading that opened
+ * nothing would pass the first half of this and publish a finding about a rule that holds nothing
+ * down.
+ */
+class WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest {
+
+    /** A clause about {@code code} that no reading of this compiler's takes in. */
+    private static final String UNREAD = ARuleNoReadingTakesIn.about("code");
+
+    /** {@code tag} held away from one value, beside a clause this reads. */
+    private static final String NARROWS_TAG = "(tag /= \"x\" && code /= \"p\")";
+
+    /** The same, beside a clause it does not. */
+    private static final String NARROWS_TAG_BESIDE_UNREAD = "(tag /= \"x\" && " + UNREAD + ")";
+
+    /**
+     * A clause nothing reads, written beside a constraint, does not take the constraint back.
+     *
+     * <p>All three alternatives hold {@code tag} away from {@code "x"}, so the choice does, and the
+     * rule is one read to the end that draws no line at it. What differs between them is only how
+     * much of the clause standing beside that constraint this compiler has a word for.
+     */
+    @Test
+    void aClauseNothingReadsBesideAConstraintDoesNotTakeItBack() {
+        assertTrue(noLineAboutTag(NARROWS_TAG + " || (tag /= \"x\" && code /= \"q\")"),
+                "both alternatives were read whole");
+        assertTrue(noLineAboutTag(
+                        NARROWS_TAG_BESIDE_UNREAD + " || " + NARROWS_TAG_BESIDE_UNREAD),
+                "and neither of them was");
+        assertTrue(noLineAboutTag(NARROWS_TAG_BESIDE_UNREAD + " || tag /= \"x\""),
+                "and where one of them was and the other was not");
+    }
+
+    /**
+     * An alternative nothing reads that says nothing about the position does take it back.
+     *
+     * <p>{@code tag /= "x" || (code /= "p" && f(code))}: a value satisfying the right alternative
+     * owes the left one nothing and this compiler cannot say which values those are, so what the
+     * clause leaves {@code tag} is every value and no rule of it holds the position down.
+     */
+    @Test
+    void anAlternativeThatSaysNothingAboutThePositionDoesTakeItBack() {
+        assertTrue(noneAboutTag("tag /= \"x\" || (code /= \"p\" && " + UNREAD + ")"),
+                "nothing here holds tag down, so there is no rule to report as drawing no line");
+        assertTrue(noneAboutTag("tag /= \"x\" || code /= \"p\""),
+                "and the same where both alternatives were read: the choice leaves tag open");
+    }
+
+    /**
+     * Where the brackets fall between three alternatives does not move the answer.
+     *
+     * <p>One rule written two ways. Which positions each choice left open is settled for that
+     * choice out of what its own two alternatives leave, so the inner choice of one grouping and
+     * the inner choice of the other are asked about different pairs of branches and answer
+     * differently — and what the rule comes to is the same. Held over sources rather than over
+     * accounts built by hand, since an opening written into a fixture is the answer being assumed.
+     */
+    @Test
+    void whereTheBracketsFallDoesNotMoveTheAnswer() {
+        String held = NARROWS_TAG_BESIDE_UNREAD + " || tag /= \"x\"";
+        assertEquals(noLinesOf("(" + NARROWS_TAG + " || " + held + ")"),
+                noLinesOf(NARROWS_TAG + " || (" + held + ")"),
+                "one rule, one account of it");
+
+        String open = NARROWS_TAG_BESIDE_UNREAD + " || code /= \"q\"";
+        assertEquals(noLinesOf("(" + NARROWS_TAG + " || " + open + ")"),
+                noLinesOf(NARROWS_TAG + " || (" + open + ")"),
+                "and the same where an alternative is why the choice is as wide as it is");
+    }
+
+    /** Whether the report says the invariant drew no line at {@code r.tag}. */
+    private static boolean noLineAboutTag(String clause) {
+        return noLinesOf(clause).stream().anyMatch(line -> line.contains("`r.tag`"));
+    }
+
+    /** And whether it says nothing about that position at all. */
+    private static boolean noneAboutTag(String clause) {
+        return !noLineAboutTag(clause);
+    }
+
+    /**
+     * The lines of the report saying a rule was read to the end without a line, or not read.
+     *
+     * <p>Named by the rule and the position and not by where either was written, so two sources
+     * that put the same clause under different brackets are compared on what they say about the
+     * rule rather than on how many characters stand before it.
+     */
+    private static Set<String> noLinesOf(String clause) {
+        return human(clause).lines()
+                .map(String::trim)
+                .filter(line -> line.contains("no line:") || line.contains("not read:"))
+                .collect(Collectors.toSet());
+    }
+
+    private static String human(String clause) {
+        Compilation compilation = Compilation.ofSource("""
+                module m
+
+                data Ok
+                data R = { tag: String, code: String }
+                    invariant one = %s
+
+                behavior f : (r: R) -> Ok
+                    constructs Ok
+                let f (r) = Ok
+                """.formatted(clause), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest.java
@@ -58,6 +58,27 @@ class WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest {
     }
 
     /**
+     * And the same where the clause nothing reads is about the very position held down.
+     *
+     * <p>The nearer case, and the one a rule reading its own account for an answer gets wrong at
+     * both connectives. What a reading could not work out at a position and what it did work out
+     * there meet only once a clause is composed, and where they meet some part of it did put a
+     * constraint down: under a conjunction that part still binds, and under a choice it binds
+     * unless the alternatives leave the position differently.
+     */
+    @Test
+    void aClauseNothingReadsAboutThePositionItselfDoesNotTakeItBack() {
+        String unread = ARuleNoReadingTakesIn.about("tag");
+        assertTrue(noLineAboutTag("tag /= \"x\" && " + unread),
+                "everything holds, so the part that holds tag down holds it down");
+        assertTrue(noLineAboutTag("(tag /= \"x\" && " + unread + ") || (tag /= \"x\" && "
+                        + unread + ")"),
+                "and both alternatives leave tag where the other does");
+        assertTrue(noLineAboutTag("(tag /= \"x\" && " + unread + ") || tag /= \"x\""),
+                "and the same where one of them was read whole");
+    }
+
+    /**
      * An alternative nothing reads that says nothing about the position does take it back.
      *
      * <p>{@code tag /= "x" || (code /= "p" && f(code))}: a value satisfying the right alternative

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -252,6 +252,9 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 "and the position hears about it, the width there being the unread branch's");
         assertEquals(java.util.Set.of(), opened.byTheLeftGoingUnread(),
                 "the left alternative was read, so nothing is open by its going unread");
+        assertEquals(java.util.Set.of(), opened.byOrder().positions(),
+                "and the reading of order read both alternatives, so the width it could not"
+                        + " account for is not something an unread alternative left open");
     }
 
     /**
@@ -308,11 +311,17 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 Opening.nothing());
     }
 
-    /** A choice the values could not show is as wide as it is without its right alternative. */
+    /**
+     * A choice neither reading could show is as wide as it is without its right alternative.
+     *
+     * <p>Both languages, and the same position in each. What silences the ordered half in the tests
+     * below is that its account read every alternative, and a width of nothing there would silence
+     * it whatever the accounts said.
+     */
     private static Settlement.WidthDependency widthRestingOnTheRight() {
         return new Settlement.WidthDependency(
                 new Settlement.Width<>(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
-                Settlement.Width.none());
+                new Settlement.Width<>(java.util.Set.of(), java.util.Set.of(CONSTRAINED)));
     }
 
     /** One choice somebody wrote, told from every other by being this one. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -241,14 +241,14 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     @Test
     void whatAChoiceLeftOpenIsWhatTheAlternativeBesideTheUnreadOneReachedAndWidened() {
         StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
-                new Settlement.WidthDependency(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
-                theBranchRead(java.util.Set.of()).byValues(),
-                theBranchNothingRead(java.util.Set.of()).byValues());
+                widthRestingOnTheRight(),
+                theBranchRead(java.util.Set.of()),
+                theBranchNothingRead(java.util.Set.of()));
 
         assertEquals(java.util.Set.of(CONSTRAINED), opened.byTheRightGoingUnread(),
                 "an author is sent here about the position the branch beside it constrained, and"
                         + " not about the one it settled");
-        assertEquals(java.util.Set.of(CONSTRAINED), opened.positions(),
+        assertEquals(java.util.Set.of(CONSTRAINED), opened.byValues().positions(),
                 "and the position hears about it, the width there being the unread branch's");
         assertEquals(java.util.Set.of(), opened.byTheLeftGoingUnread(),
                 "the left alternative was read, so nothing is open by its going unread");
@@ -266,10 +266,10 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     void aPositionNoAlternativeWidenedIsNotOpenedByEitherOfThemGoingUnread() {
         StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
                 Settlement.WidthDependency.none(),
-                theBranchNothingRead(java.util.Set.of()).byValues(),
-                theBranchNothingRead(java.util.Set.of()).byValues());
+                theBranchNothingRead(java.util.Set.of()),
+                theBranchNothingRead(java.util.Set.of()));
 
-        assertEquals(java.util.Set.of(), opened.positions(),
+        assertEquals(java.util.Set.of(), opened.byValues().positions(),
                 "the choice is as wide as it is at every position without either of them");
     }
 
@@ -285,11 +285,11 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     @Test
     void whereTwoUnreadAlternativesAreOneTheWidthRestsOnThePositionIsStillOpened() {
         StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
-                new Settlement.WidthDependency(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
-                theBranchNothingRead(java.util.Set.of()).byValues(),
-                theBranchNothingRead(java.util.Set.of()).byValues());
+                widthRestingOnTheRight(),
+                theBranchNothingRead(java.util.Set.of()),
+                theBranchNothingRead(java.util.Set.of()));
 
-        assertEquals(java.util.Set.of(CONSTRAINED), opened.positions(),
+        assertEquals(java.util.Set.of(CONSTRAINED), opened.byValues().positions(),
                 "the right alternative is why the choice is that wide, and nothing read it");
     }
 
@@ -304,7 +304,15 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     private static StatedByClauses.AlternativeOpening opened(
             RuleShortfall.Site.AtAChoice choice) {
         return new StatedByClauses.AlternativeOpening(choice.id(), java.util.Set.of(),
-                java.util.Set.of(CONSTRAINED), java.util.Set.of(CONSTRAINED));
+                java.util.Set.of(CONSTRAINED), new Opening<>(java.util.Set.of(CONSTRAINED)),
+                Opening.nothing());
+    }
+
+    /** A choice the values could not show is as wide as it is without its right alternative. */
+    private static Settlement.WidthDependency widthRestingOnTheRight() {
+        return new Settlement.WidthDependency(
+                new Settlement.Width<>(java.util.Set.of(), java.util.Set.of(CONSTRAINED)),
+                Settlement.Width.none());
     }
 
     /** One choice somebody wrote, told from every other by being this one. */
@@ -316,7 +324,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     private static StatedByClauses.Part theBranchRead(java.util.Set<RuleShortfall> shortfalls) {
         return new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
-                        java.util.Set.of(), false),
+                        java.util.Set.of(), false, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls);
     }
 
@@ -325,7 +333,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
             java.util.Set<RuleShortfall> shortfalls) {
         return new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
-                        true),
+                        true, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -21,6 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * nothing — and "this clause imposes nothing here", which is what a branch admitting nothing leaves,
  * is not: a further choice imposes nothing either. Held as one, whether the second survived turned
  * on where the brackets fell.
+ *
+ * <p><b>Every choice below is handed an opening of nothing, which is the opening it has.</b> No
+ * branch here narrows a position, so there is no position a choice could be narrower without an
+ * alternative, and that is so under either grouping. Where the alternatives do narrow something the
+ * opening differs from one grouping to the next and is not a caller's to write down; that the two
+ * groupings still come to one account is a fact about the whole walk and is held over sources
+ * ({@code AChoiceComposesTheSameHoweverItsAlternativesAreBracketedTest}).
  */
 class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
 
@@ -52,7 +59,7 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
             if (other.dead) {
                 return new Branch(adoption.beside(other.adoption), false);
             }
-            return new Branch(adoption.either(other.adoption), false);
+            return new Branch(adoption.either(Opening.nothing(), other.adoption), false);
         }
     }
 
@@ -92,18 +99,4 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
                 IMPOSSIBLE.or(UNREADABLE).or(UNREADABLE).adoption());
     }
 
-    /**
-     * A constraint is still widened by an alternative nothing could read.
-     *
-     * <p>The half that has to keep working. Settling is not a constraint and a constraint is not
-     * settling: a value satisfying the unread branch owes the read one nothing, so what that branch
-     * said of its position binds nothing.
-     */
-    @Test
-    void aConstraintIsStillWidenedByAnUnreadAlternative() {
-        assertFalse(READ.either(UNREAD).took("y"),
-                "what the read branch said of `y` binds nothing where the other can be taken");
-        assertTrue(READ.both(UNREAD).took("y"),
-                "and a conjunct nothing read leaves the one beside it saying what it said");
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * alternative, and that is so under either grouping. Where the alternatives do narrow something the
  * opening differs from one grouping to the next and is not a caller's to write down; that the two
  * groupings still come to one account is a fact about the whole walk and is held over sources
- * ({@code AChoiceComposesTheSameHoweverItsAlternativesAreBracketedTest}).
+ * ({@code WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest}).
  */
 class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
 
     /** A branch nothing could read, about `x`. */
-    private static final Adoption<String> UNREAD = Adoption.at(Set.of("x"), Set.of(), true);
+    private static final Adoption<String, ReadingLanguage.Values> UNREAD =
+            Adoption.at(Set.of("x"), Set.of(), true);
 
     /** A branch read whole, about `y`. */
-    private static final Adoption<String> READ = Adoption.at(Set.of("y"), Set.of("y"), false);
+    private static final Adoption<String, ReadingLanguage.Values> READ =
+            Adoption.at(Set.of("y"), Set.of("y"), false);
 
     /**
      * One alternative and whether anything satisfies it, composed the way
@@ -38,7 +40,7 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
      * carried beside here. A choice is dead where every alternative is, which is the rule the states
      * are composed by.
      */
-    private record Branch(Adoption<String> adoption, boolean dead) {
+    private record Branch(Adoption<String, ReadingLanguage.Values> adoption, boolean dead) {
 
         Branch or(Branch other) {
             if (dead && other.dead) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
@@ -204,26 +204,49 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
     }
 
     /**
-     * A branch nothing read widens the positions the other branch spoke of, named there or not.
+     * A position the alternatives leave differently is one the choice stands open at.
      *
-     * <p>{@code x == 7 || f(y)} says nothing about {@code x}: a value satisfying the branch nothing
-     * could read owes the other one nothing, so what the clause leaves {@code x} is exactly what
-     * cannot be said here. The reading of values composes its own answer that way already
-     * ({@code AdmissibleValues.join}), and adoption is a projection of the same reading — a rule
-     * that widens one without widening the other reports a position as read on evidence the reading
-     * does not have.
+     * <p>{@code x == 7 || f(y)} says nothing about {@code x}, and what says so is what the two
+     * branches leave: the branch nothing could read leaves {@code x} at every value, the choice
+     * leaves it there too, and dropping the unread branch would not. So the choice is open at
+     * {@code x} and the clause is not one that was read at it.
+     *
+     * <p><b>Not because a branch went unread.</b> Two alternatives holding a position to the same
+     * values hold it there whether or not either could be read to the end, and an account that
+     * answered this from its own flag for an unread clause would say they do not
+     * ({@code WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest}). The flag says
+     * which alternative to ask about; what the alternatives leave says whether it matters, and the
+     * two are settled in different places ({@code Settlement.WidthDependency}).
      *
      * <p>Which makes a choice and a conjunction two operations rather than one. Under
      * {@code x >= 1 && f(y)} the bound on {@code x} still holds, because all of it holds.
      */
     @Test
-    void aBranchNothingReadWidensWhatTheOtherSpokeOf() {
+    void aPositionTheAlternativesLeaveDifferentlyIsOneTheChoiceStandsOpenAt() {
         assertEquals(Set.of("x", "y"), unansweredAbout("x == 7 || Int.abs(y) >= 2"),
                 "neither position is one this clause was read at");
         assertEquals(Set.of(), unansweredAbout("x == 7 || y == 2"),
                 "and a choice both branches were read at leaves nothing standing");
         assertEquals(Set.of("y"), unansweredAbout("x >= 1 && Int.abs(y) >= 2"),
                 "while a conjunct nothing read leaves the one beside it saying what it said");
+    }
+
+    /**
+     * And a position they leave alike is one it does not, however little of the clause was read.
+     *
+     * <p>The other side of the rule above, and the one an account answering from its own flag gets
+     * wrong. Both alternatives hold {@code x} to the same values; the clause standing beside that
+     * constraint in each of them is one no reading has a word for, and the position is held there
+     * all the same.
+     */
+    @Test
+    void andAPositionTheyLeaveAlikeIsOneItDoesNot() {
+        assertEquals(Set.of(), unansweredAbout("x >= 1 || x >= 1"),
+                "the alternatives leave the position where the other does, so nothing stands open");
+        assertEquals(Set.of("y"), unansweredAbout(
+                        "(x >= 1 && Int.abs(y) >= 2) || (x >= 1 && Int.abs(y) >= 2)"),
+                "and the same beside a clause nothing reads, which stands open at its own position"
+                        + " and takes nothing back at the one held down");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
@@ -1,0 +1,172 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An account of the rules applies what a choice left open and never works it out.
+ *
+ * <p>What each component of a choice's account is allowed to depend on, said as laws rather than as
+ * cases. An account holds two things that came from two places — what this reading did with the
+ * clause, and what the settlement decided the choice does to that — and the whole of what keeps
+ * them apart is that neither is reachable from the other. A rule that walked from one to the other
+ * would be a second answer to a question something else has already answered, and the two would
+ * agree only until one of them changed.
+ *
+ * <p><b>Which is the shape the defect had.</b> Told from the flag for a clause nothing read, the
+ * answer that comes out is that a branch narrowing a position its neighbour narrows the same way
+ * binds nothing there. The example that shows it is a model
+ * ({@code WhetherAConstraintStillBindsIsReadOffWhatTheAlternativesLeaveTest}); what is here is the
+ * rule the example is an instance of, so a derivation reintroduced by another road is caught by the
+ * same test.
+ */
+class AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest {
+
+    private static final String CONSTRAINED = "constrained";
+    private static final String SETTLED = "settled";
+    private static final String LEFT_OUT = "left out";
+
+    /** A branch that put a constraint on one position, settled another, and missed a third. */
+    private static Adoption<String, ReadingLanguage.Values> branch(boolean unread) {
+        return new Adoption<>(Set.of(CONSTRAINED), Set.of(SETTLED), Set.of(LEFT_OUT), unread,
+                Set.of());
+    }
+
+    private static Opening<String, ReadingLanguage.Values> opening(String... positions) {
+        return new Opening<>(Set.of(positions));
+    }
+
+    /**
+     * Whether a clause of a branch went unread does not reach what the choice records reading.
+     *
+     * <p>The law the derivation broke. Flipping the flag on either side moves what the choice says
+     * about the clause being unread and nothing else — what was constrained, what was settled and
+     * what was missed are this reading's work, and an alternative going unread is not a thing that
+     * happened to it.
+     */
+    @Test
+    void whetherAPartWentUnreadReachesNothingButItself() {
+        for (boolean left : new boolean[] {false, true}) {
+            for (boolean right : new boolean[] {false, true}) {
+                Adoption<String, ReadingLanguage.Values> said =
+                        branch(left).either(opening(CONSTRAINED), branch(right));
+
+                assertEquals(Set.of(CONSTRAINED), said.read(), "read is the branches' own");
+                assertEquals(Set.of(SETTLED), said.settled(), "and so is settled");
+                assertEquals(Set.of(LEFT_OUT), said.missed(), "and so is missed");
+                assertEquals(Set.of(CONSTRAINED), said.opened(),
+                        "and what the choice opened is what it was handed");
+                assertEquals(left || right, said.hasUnreadPart(),
+                        "which is the one thing the flags decide");
+            }
+        }
+    }
+
+    /**
+     * And what a choice left open does not reach what the branches were read at.
+     *
+     * <p>The same law the other way round. An opening says a constraint does not bind; it does not
+     * say the clause went unread, and an account that wrote it down as one would send an author to
+     * a rule this compiler read whole.
+     */
+    @Test
+    void whatAChoiceLeftOpenReachesNothingButItself() {
+        Adoption<String, ReadingLanguage.Values> shut =
+                branch(true).either(Opening.nothing(), branch(true));
+        Adoption<String, ReadingLanguage.Values> open =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(shut.read(), open.read(), "read is the branches' own");
+        assertEquals(shut.settled(), open.settled(), "and so is settled");
+        assertEquals(shut.missed(), open.missed(), "and so is missed");
+        assertEquals(shut.hasUnreadPart(), open.hasUnreadPart(), "and so is the flag");
+        assertEquals(Set.of(), shut.opened());
+        assertEquals(Set.of(CONSTRAINED), open.opened());
+    }
+
+    /**
+     * What is opened is out of what was constrained, and the account refuses to hold anything else.
+     *
+     * <p>The settlement answers over the branches as they were met, which is not this one written
+     * part, so it names positions this part never put a constraint on. Written down all the same,
+     * the set would grow into a second account of what the clause was about — and the position it
+     * named would be read as one this clause had something to say about.
+     */
+    @Test
+    void whatIsOpenedIsOutOfWhatWasConstrained() {
+        Adoption<String, ReadingLanguage.Values> said =
+                branch(true).either(opening(CONSTRAINED, SETTLED, "elsewhere"), branch(true));
+
+        assertEquals(Set.of(CONSTRAINED), said.opened(),
+                "a position this clause imposes nothing on has nothing to be opened");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Adoption<String, ReadingLanguage.Values>(Set.of(), Set.of(), Set.of(),
+                        false, Set.of(CONSTRAINED)),
+                "and one cannot be made holding an opening of a constraint it does not have");
+    }
+
+    /**
+     * What the choice reached is what its branches reached, opened or not.
+     *
+     * <p>An author is sent to a choice wherever the branch beside the unread one reached a
+     * position, which is read off {@code read} and {@code missed} together. So an opening moves a
+     * position from one answer to another and never out of both, and how much of a clause this
+     * compiler could work out cannot change which choices an author is told to look at.
+     */
+    @Test
+    void whatTheChoiceReachedIsNotMovedByWhatItOpened() {
+        Adoption<String, ReadingLanguage.Values> shut =
+                branch(true).either(Opening.nothing(), branch(true));
+        Adoption<String, ReadingLanguage.Values> open =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(reached(shut), reached(open));
+        assertTrue(reached(open).contains(CONSTRAINED),
+                "the position is still one the branches reached");
+    }
+
+    /**
+     * A conjunction beside a choice does not put back what the choice left open.
+     *
+     * <p>{@code (x == 7 || f(y)) && z > 1} says nothing about {@code x}: everything holds, so what
+     * the choice left open is left open under the conjunction too. Dropped there, an opening would
+     * survive only as long as no author wrote another clause beside it.
+     */
+    @Test
+    void aConjunctionBesideAChoiceKeepsWhatItLeftOpen() {
+        Adoption<String, ReadingLanguage.Values> choice =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(Set.of(CONSTRAINED), choice.both(branch(false)).opened());
+        assertEquals(Set.of(CONSTRAINED), branch(false).both(choice).opened());
+    }
+
+    /**
+     * A position given up on takes its opening with it.
+     *
+     * <p>What is held is an opening applied to a constraint that still stands. Once the constraint
+     * is gone — the position is one whose answer nothing built — there is nothing left for the
+     * opening to be about, and a set that kept it would name a position this account no longer
+     * reads.
+     */
+    @Test
+    void aPositionGivenUpOnTakesItsOpeningWithIt() {
+        Adoption<String, ReadingLanguage.Values> choice =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(Set.of(), choice.unbuiltAt(Set.of(CONSTRAINED)).opened());
+        assertEquals(Set.of(), choice.unbuiltAt(Set.of(CONSTRAINED)).read());
+    }
+
+    /** The positions the account reached: what it constrained, and what it could not manage. */
+    private static Set<String> reached(Adoption<String, ReadingLanguage.Values> said) {
+        Set<String> out = new java.util.LinkedHashSet<>(said.read());
+        out.addAll(said.missed());
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
@@ -163,6 +163,38 @@ class AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest {
         assertEquals(Set.of(), choice.unbuiltAt(Set.of(CONSTRAINED)).read());
     }
 
+    /**
+     * A branch standing beside a dead one keeps what a choice inside it left open.
+     *
+     * <p>The dead branch is not what opened it and does not take it back: what a choice below this
+     * one was settled to have opened is still open, and the branch that stands is the one whose
+     * account outranks. Measured over the models this repository holds, nothing reaches this — so
+     * what says it is this and there is nothing else to notice if it stops.
+     */
+    @Test
+    void aBranchBesideADeadOneKeepsWhatAChoiceInsideItLeftOpen() {
+        Adoption<String, ReadingLanguage.Values> choice =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(Set.of(CONSTRAINED), choice.beside(branch(false)).opened());
+    }
+
+    /**
+     * And a branch nobody can be in has nothing left open, however much stood open in it.
+     *
+     * <p>Nothing satisfies it, so what it said narrows no value and there is no constraint left for
+     * an alternative to have widened. The positions it named are settled, which is an answer and
+     * not a gap — and an opening kept beside that answer would say a constraint stood there.
+     */
+    @Test
+    void aBranchNobodyCanBeInHasNothingLeftOpen() {
+        Adoption<String, ReadingLanguage.Values> choice =
+                branch(true).either(opening(CONSTRAINED), branch(true));
+
+        assertEquals(Set.of(), choice.inADeadBranch().opened());
+        assertEquals(Set.of(), choice.bothDead(branch(false)).opened());
+    }
+
     /** The positions the account reached: what it constrained, and what it could not manage. */
     private static Set<String> reached(Adoption<String, ReadingLanguage.Values> said) {
         Set<String> out = new java.util.LinkedHashSet<>(said.read());

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
@@ -2,12 +2,17 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.UnreadReason;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,11 +58,18 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
         return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
     }
 
+    /** A choice this reading showed it is as wide as it is without either alternative. */
+    private static final Settlement.Width<ReadingLanguage.Values> NEITHER = Settlement.Width.none();
+
     /** What a choice between two branches somebody can be in is as wide as it is because of. */
-    private static Settlement.WidthDependency between(PlannedValues<FactSubject> one,
-                                                      PlannedValues<FactSubject> other) {
-        return Settlement.WidthDependency.of(souther.compiler.values.Emptiness.UNDECIDED, one,
-                souther.compiler.values.Emptiness.UNDECIDED, other);
+    private static Settlement.Width<ReadingLanguage.Values> between(PlannedValues<FactSubject> one,
+                                                                   PlannedValues<FactSubject> other) {
+        return Settlement.Width.ofValues(one, other);
+    }
+
+    /** One branch, with nothing said about where its orders stop. */
+    private static Confinement.Planned<FactSubject> branch(PlannedValues<FactSubject> values) {
+        return new Confinement.Planned<>(values, OrderedIntervals.top(), Map.of());
     }
 
     /**
@@ -69,7 +81,7 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void anAlternativeThatSaysNothingIsWhyTheChoiceSaysNothing() {
-        Settlement.WidthDependency width = between(isA(), unread(Set.of(OTHER)));
+        Settlement.Width<ReadingLanguage.Values> width = between(isA(), unread(Set.of(OTHER)));
 
         assertEquals(Set.of(), width.mayRestOnLeft(),
                 "without the left the choice still admits every value at value");
@@ -87,17 +99,17 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void twoAlternativesNarrowingAPositionAlikeLeaveTheWidthOnNeither() {
-        Settlement.WidthDependency width = between(isA().meet(unread(Set.of(OTHER))),
+        Settlement.Width<ReadingLanguage.Values> width = between(isA().meet(unread(Set.of(OTHER))),
                 isA().meet(unread(Set.of(OTHER))));
 
-        assertEquals(Settlement.WidthDependency.none(), width,
+        assertEquals(NEITHER, width,
                 "either branch dropped leaves the other saying the same thing at every position");
     }
 
     /** And the same where only one of them holds a clause nothing read. */
     @Test
     void andTheSameWhereOnlyOneOfThemHoldsAClauseNothingRead() {
-        assertEquals(Settlement.WidthDependency.none(),
+        assertEquals(NEITHER,
                 between(isA().meet(unread(Set.of(OTHER))), isA()),
                 "the redundant branch is not why the choice admits what it admits");
     }
@@ -111,10 +123,10 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void alternativesCoveringAPositionBetweenThemLeaveTheWidthOnNeither() {
-        Settlement.WidthDependency width =
+        Settlement.Width<ReadingLanguage.Values> width =
                 between(isA().joinLive(notA()), unread(Set.of(OTHER)));
 
-        assertEquals(Settlement.WidthDependency.none(), width,
+        assertEquals(NEITHER, width,
                 "the covered position is every value without either alternative");
     }
 
@@ -126,7 +138,7 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void alternativesNeitherOfWhichCoversTheOtherLeaveTheWidthOnBoth() {
-        Settlement.WidthDependency width = between(isA(),
+        Settlement.Width<ReadingLanguage.Values> width = between(isA(),
                 PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.just(B))));
 
         assertEquals(Set.of(VALUE), width.mayRestOnLeft());
@@ -144,7 +156,7 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void aBranchAnswerableForOnePositionIsNotAnswerableForTheNext() {
-        Settlement.WidthDependency width = between(isA().meet(otherIsA()),
+        Settlement.Width<ReadingLanguage.Values> width = between(isA().meet(otherIsA()),
                 notA().meet(otherIsA()));
 
         assertEquals(Set.of(VALUE), width.mayRestOnLeft(),
@@ -165,14 +177,50 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
     @Test
     void anOccurrenceOneBranchOfWhichAdmitsNothingRestsOnNeitherAndDoesNotSpeakForTheRest() {
         Settlement.WidthDependency dead = Settlement.WidthDependency.of(
-                souther.compiler.values.Emptiness.EMPTY, isA(),
-                souther.compiler.values.Emptiness.UNDECIDED, unread(Set.of(OTHER)));
-        Settlement.WidthDependency live = between(isA(), unread(Set.of(OTHER)));
+                souther.compiler.values.Emptiness.EMPTY, branch(isA()),
+                souther.compiler.values.Emptiness.UNDECIDED, branch(unread(Set.of(OTHER))));
+        Settlement.WidthDependency live = Settlement.WidthDependency.of(
+                souther.compiler.values.Emptiness.UNDECIDED, branch(isA()),
+                souther.compiler.values.Emptiness.UNDECIDED, branch(unread(Set.of(OTHER))));
 
         assertEquals(Settlement.WidthDependency.none(), dead,
                 "the choice is the branch beside the dead one, and no alternative widened it");
         assertEquals(live, dead.alsoSeen(live),
                 "and what the occurrence beside it found is what the written choice is left with");
+    }
+
+    /**
+     * The reading of order is asked the same question about the same two branches, and answers it
+     * about where the positions stop.
+     *
+     * <p>{@code value >= 5 || f(other)}: what the choice leaves {@code value} is every number, and
+     * without the right alternative it is the numbers from five — so the right is why the order
+     * stops nowhere, which is a fact about the order and one the values have no word for. Asked of
+     * the values instead, the answer is about a position they were told nothing about.
+     */
+    @Test
+    void theOrderIsAskedTheSameQuestionAboutWhereItsPositionsStop() {
+        Settlement.Width<ReadingLanguage.Order> width = Settlement.Width.ofOrder(
+                OrderedIntervals.at(VALUE, from(5)), OrderedIntervals.top());
+
+        assertEquals(Set.of(), width.mayRestOnLeft(),
+                "without the left the choice stops the position nowhere, as it does with it");
+        assertEquals(Set.of(VALUE), width.mayRestOnRight(),
+                "without the right it stops at five");
+    }
+
+    /** And two branches stopping a position in the same place leave the width on neither. */
+    @Test
+    void twoAlternativesStoppingAPositionAlikeLeaveTheWidthOnNeither() {
+        assertEquals(Settlement.Width.<ReadingLanguage.Order>none(),
+                Settlement.Width.ofOrder(OrderedIntervals.at(VALUE, from(5)),
+                        OrderedIntervals.at(VALUE, from(5))),
+                "an interval is written one way, so alike is the same description");
+    }
+
+    /** {@code value >= low}. */
+    private static OrderedInterval from(int low) {
+        return new OrderedInterval(Endpoint.inclusive(Count.of(low)), null);
     }
 
     /**
@@ -184,16 +232,16 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      */
     @Test
     void whatTheOccurrencesLeaveIsJoinedWithoutRegardToOrderOrRepetition() {
-        Settlement.WidthDependency here =
-                new Settlement.WidthDependency(Set.of(VALUE), Set.of());
-        Settlement.WidthDependency there =
-                new Settlement.WidthDependency(Set.of(), Set.of(OTHER));
+        Settlement.Width<ReadingLanguage.Values> here =
+                new Settlement.Width<>(Set.of(VALUE), Set.of());
+        Settlement.Width<ReadingLanguage.Values> there =
+                new Settlement.Width<>(Set.of(), Set.of(OTHER));
 
         assertEquals(here.alsoSeen(there), there.alsoSeen(here),
                 "the order the copies were met in is not in the answer");
         assertEquals(here.alsoSeen(there), here.alsoSeen(there).alsoSeen(here),
                 "and neither is a copy met twice");
-        assertEquals(new Settlement.WidthDependency(Set.of(VALUE), Set.of(OTHER)),
+        assertEquals(new Settlement.Width<ReadingLanguage.Values>(Set.of(VALUE), Set.of(OTHER)),
                 here.alsoSeen(there),
                 "a position any occurrence's width rests on is one the whole answer's does");
     }


### PR DESCRIPTION
Closes #1430.

`Adoption.either` moved what one alternative constrained into what the clause missed as soon as the
branch beside it held a clause nothing could read. The rule that comes out of that is that a branch
narrowing a position its neighbour narrows the same way binds nothing there, which is false: two
alternatives holding a position to the same values hold it there whether or not either could be
read to the end. So `constrains` said no, `ReadByClauses.OfAPart.restricts` said no, and the finding
about a rule read to the end that drew no line went unmade.

The same derivation was replaced on the other side by #1421 and left here.

## What owns what

An account of the rules records what a reading did with a clause. Whether the branch beside an
unread alternative still holds a position down is about what the two branches leave, and the
settlement works that out — for the ends as well as for the values, since a range is taken back by
an unread alternative the same way and the answer there is exact rather than one-sided. The account
is handed that answer and applies it.

The two readings answer different questions and both of their answers are sets of positions, so
either can be handed where the other belongs and the receiving reading composes it without
complaint. Which reading an account and an opening belong to is now in their type, and crossing them
does not compile.

The applied opening is held beside the reading's own evidence rather than folded into it. What a
reading could not work out and what a choice above was settled to have opened are two things to be
told, and an account cannot hold an opening of a constraint it does not have.

## What holds it

The model that shows the defect is one instance of the rule that was wrong, so the rule is written
as a law over the composition: no component depends on anything but its own kind, and neither
whether a clause went unread nor what a choice left open reaches the other. Beside it, the one place
outside the account that may ask whether a clause went unread.

Reverting the derivation fails the law and the model. Withholding the ends' opening fails an
existing account of a rule read in one language and not the other. Crossing the two languages fails
to compile.

## Left out

An author is sent to a choice for what it opened in the values and not for what it opened in the
ends. That road is not opened here, because this change is evaluated on the findings not moving and
a new road would be indistinguishable from the correction. The method says so in its name and its
javadoc, and the question is #1462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)