### PR TITLE
Publish a module's declarations, and evaluate it without them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -67,8 +67,12 @@ public final class Output {
     private Output() {}
 
     /**
-     * One module's classes, with its declarations stamped on. The declarations go on before anything
-     * loads a class, so what a jar carries is the same bytes this compile checked.
+     * One module's classes as they are published: the program this compilation checked, with the
+     * declarations added for an importer to read back.
+     *
+     * <p>What is added is read and never run, so a jar carries the program this compile checked and
+     * not the same bytes as any other set of classes made from it. {@link Evaluated} is the same
+     * program counted, and carries none of this.
      */
     public record Classes(String name) implements Key<Map<String, ClassFileImage>> {
         @Override
@@ -210,10 +214,11 @@ public final class Output {
          * runs a program. So they go on here and not on {@link Evaluated}, whose classes are run and
          * never read for what the module declares.
          *
-         * <p>Which is also what keeps an author's comment out of what an evaluation is built from.
-         * A declaration is written down as it was written, so the text of a comment beside one is in
-         * these classes; put on the evaluated classes as well, it would make every example of the
-         * module something to establish again whenever anybody typed a comment anywhere near it.
+         * <p>Which is also what keeps a declaration's text out of what an evaluation is built from.
+         * It is written down as it was written, comments and all, so rewording a comment beside a
+         * declaration rewrites these classes; put on the evaluated classes as well, that would make
+         * every example of the module something to establish again. What an edit does to the
+         * positions under it is another matter and reaches an evaluation either way.
          *
          * <p>Nothing here can fail in a way worth reporting. A module with no source of its own was
          * read off the path, and its jar was stamped where it was built; and the declarations are

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -39,6 +39,7 @@ import souther.compiler.frontend.CstFrontend;
 import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.ModuleMetadata;
+import souther.compiler.meta.ModuleReadback;
 import souther.compiler.meta.ModulePath;
 
 import souther.compiler.types.ValueName;
@@ -88,7 +89,7 @@ public final class Output {
                         in.injected(),
                         in.callees(), in.requirements(), in.checked(), in.compositions(),
                         in.dischargeClauses(), in.shapes(), in.checks(), in.standingCalls());
-                stamp(db, emitted);
+                publishDeclarations(db, emitted);
                 return Answer.of(emitted.seal());
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -200,26 +201,25 @@ public final class Output {
         }
 
         /**
-         * Puts this module's declarations on its classes, as its source wrote them.
+         * Puts this module's declarations on the classes that ship, as its source wrote them.
+         *
+         * <p>What ships carries them so that another compilation can import this module from a jar
+         * without its source. That is the whole of what they are for: a declaration written into a
+         * class is read by {@link ModuleReadback} through {@link Output#declarationsRead}, which
+         * reads the classes this compilation publishes and the ones on the path, and by nothing that
+         * runs a program. So they go on here and not on {@link Evaluated}, whose classes are run and
+         * never read for what the module declares.
+         *
+         * <p>Which is also what keeps an author's comment out of what an evaluation is built from.
+         * A declaration is written down as it was written, so the text of a comment beside one is in
+         * these classes; put on the evaluated classes as well, it would make every example of the
+         * module something to establish again whenever anybody typed a comment anywhere near it.
          *
          * <p>Nothing here can fail in a way worth reporting. A module with no source of its own was
          * read off the path, and its jar was stamped where it was built; and the declarations are
          * only asked for once the module has checked, so they are there.
          */
-        private void stamp(Db db, Emissions classes) {
-            stamp(db, name, classes);
-        }
-
-        /**
-         * Puts {@code module}'s declarations on {@code classes}, as its source wrote them.
-         *
-         * <p>Done for the classes an evaluation runs as well as for the ones that ship, so that the
-         * two are the same set of classes and differ only in the counting. A set that ran with one
-         * class missing would be a second program, and whether a row holds would be a fact about
-         * which of the two it met.
-         */
-        static void stamp(Db db, String module, Emissions classes) {
-            String name = module;
+        private void publishDeclarations(Db db, Emissions classes) {
             Front.Layout.Of layout = db.ask(new Front.Layout()).value();
             SourceId id = layout == null ? null : layout.idOfModule().get(name);
             if (id == null) {
@@ -387,7 +387,6 @@ public final class Output {
                         in.callees(), in.requirements(), in.checked(), in.compositions(),
                         in.dischargeClauses(), in.shapes(), in.checks(), in.standingCalls(),
                         instrumentation);
-                Classes.stamp(db, name, emitted);
                 // The classes, what they implement and whose numbers a run through them leaves,
                 // from the one emission that decided all three.
                 return Answer.of(new EvaluationArtifact(emitted.seal(), emitted.implemented(),

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -239,6 +239,10 @@ class ProbedBytecodeTest {
      * <p>An import's arms belong to its own module and are numbered against its own plan. Measuring
      * them here would put hits into a run whose report has no plan to read them by, so the linked set
      * replaces this module's classes and leaves the rest alone.
+     *
+     * <p>Every class that ships and can be run, and the one that cannot. A module's declarations are
+     * written onto a class of their own for an importer to read them off, and nothing loads it to
+     * run it, so what an evaluation is handed is what ships less that one.
      */
     @Test
     void onlyThisModulesClassesAreTheMeasuredOnes() {
@@ -252,7 +256,10 @@ class ProbedBytecodeTest {
         assertNotNull(plain);
         assertNotNull(linked);
 
-        assertEquals(plain.keySet(), linked.keySet(), "the same classes are loadable");
+        Set<String> loadable = new LinkedHashSet<>(plain.keySet());
+        assertTrue(loadable.remove(Emitted.declarations(module)),
+                "what ships carries the class an importer reads the declarations off");
+        assertEquals(loadable, linked.keySet(), "the same classes are loadable");
         for (Map.Entry<String, ClassFileImage> each : linked.entrySet()) {
             ClassFileImage want = measured.containsKey(each.getKey())
                     ? measured.get(each.getKey()) : plain.get(each.getKey());

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest.java
@@ -1,0 +1,182 @@
+package souther.compiler.query;
+
+import souther.compiler.Emitted;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.generated.EvaluationArtifact;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.meta.PublishedClasses;
+import souther.compiler.observe.ArmObservation;
+import souther.compiler.observe.Disposition;
+import souther.compiler.source.SourceId;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A module's declarations are written into the classes it publishes and into nothing else.
+ *
+ * <p>They are there so that another compilation can import the module from a jar without its
+ * source, so they are written down as the author wrote them — a declaration's own text, comments
+ * and all. That makes them move when nothing about the program does, which is the whole reason the
+ * classes an evaluation runs against must not carry them: a row of a module would otherwise be
+ * something to establish again whenever anybody typed a comment near a declaration it names.
+ *
+ * <p>Which is a claim about two artifacts and not about a speed, so it is asked as one. What ships
+ * carries the declarations and reads back; what runs carries none of them and the rows still hold.
+ */
+class WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest {
+
+    /**
+     * Carries a comment of its own, so that the edit below can reword it.
+     *
+     * <p>Reworded rather than written, and to a line of the same width, so that the edit moves no
+     * position: what the two texts differ in is what a declaration publishes and nothing else. An
+     * edit that added the line would move every position under it, and the answers about a module
+     * carry positions, so the round would be timing that as well.
+     */
+    private static final String PRICES = """
+            module shop.prices exposing ( Amount )
+
+            // What an amount is here.
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    private static final String REWORDED = PRICES.replace(
+            "// What an amount is here.",
+            "// What a price is here..");
+
+    /** Imports it, so what an evaluation of this loads is two modules' classes and not one. */
+    private static final String CART = """
+            module shop.cart exposing ( Total )
+
+            import shop.prices ( Amount )
+
+            data Total = { paid: Amount }
+
+            behavior settle : (paid: Amount) -> Total
+                constructs Total
+
+            let settle (paid) = Total { paid = paid }
+            """;
+
+    private static final String ROWS = """
+            examples for shop.cart
+
+            example settle
+                | "one" : (Amount(3)) -> Total
+            """;
+
+    private static final SourceId ROWS_AT = new SourceId("cart-examples.sou");
+
+    private static Map<String, String> workspace(String prices) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("prices.sou", prices);
+        byId.put("cart.sou", CART);
+        byId.put(ROWS_AT.value(), ROWS);
+        return byId;
+    }
+
+    private static Compilation started() {
+        Compilation compilation =
+                Compilation.ofDocuments(workspace(PRICES), Set.of(), ModulePath.EMPTY);
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.db().allReports().stream().map(String::valueOf).toList(),
+                "the workspace compiles to begin with");
+        return compilation;
+    }
+
+    /**
+     * A comment written above a declaration is published, and reaches nothing that runs.
+     *
+     * <p>Both halves, because either alone would pass on a compiler that had this wrong. That the
+     * evaluation artifact was kept says nothing unless the edit was one publication had to take in,
+     * and an edit publication ignores would be kept by everything.
+     */
+    @Test
+    void aCommentIsPublishedAndDoesNotReachWhatTheModuleIsEvaluatedAgainst() {
+        Compilation compilation = started();
+        Answer<?> ships = compilation.db().ask(new Output.Classes("shop.prices"));
+        Answer<?> runs = compilation.db()
+                .ask(new Output.Evaluated("shop.prices", ArmObservation.OMIT));
+
+        compilation.update(workspace(REWORDED), Set.of());
+        compilation.answerEverything();
+
+        assertNotSame(ships, compilation.db().ask(new Output.Classes("shop.prices")),
+                "the classes that ship carry the declaration as it is now written");
+        assertSame(runs, compilation.db()
+                        .ask(new Output.Evaluated("shop.prices", ArmObservation.OMIT)),
+                "and the classes the module is evaluated against are the ones they were");
+    }
+
+    /** The class the declarations go on is published, and is not among the classes that run. */
+    @Test
+    void theClassTheDeclarationsGoOnIsPublishedAndIsNotRun() {
+        Compilation compilation = started();
+        String moduleClass = Emitted.declarations("shop.prices");
+
+        Map<String, ClassFileImage> ships =
+                compilation.db().ask(new Output.Classes("shop.prices")).value();
+        EvaluationArtifact runs = compilation.db()
+                .ask(new Output.Evaluated("shop.prices", ArmObservation.OMIT)).value();
+
+        assertNotNull(ships);
+        assertNotNull(runs);
+        assertTrue(ships.containsKey(moduleClass),
+                "what ships carries the class an importer reads the declarations off");
+        assertFalse(runs.classes().containsKey(moduleClass),
+                "what runs carries no class that exists to be read rather than run");
+    }
+
+    /** And what ships reads back, which is what carrying them is for. */
+    @Test
+    void whatShipsReadsBackAsTheModuleItWasWrittenAs() {
+        Compilation compilation = started();
+        compilation.db().ask(new Output.All());
+
+        PublishedClasses.Carried carried =
+                Output.declarationsRead(compilation.db()).of(Emitted.declarations("shop.prices"));
+
+        PublishedClasses.Carried.Declared declared = assertInstanceOf(
+                PublishedClasses.Carried.Declared.class, carried,
+                "a compile reads the declarations off the classes it publishes");
+        assertNotNull(declared.declarations().module(),
+                "the class the declarations go on carries the module's own");
+        assertTrue(declared.declarations().module().header().contains("shop.prices"),
+                () -> "the header is the module as its source declared it, and says `"
+                        + declared.declarations().module().header() + "`");
+    }
+
+    /**
+     * A row still holds against classes that carry none of this.
+     *
+     * <p>Written across an import, so that what the row runs against is the classes of a module it
+     * names as well as its own — the case where a class missing from one of them would be found by
+     * failing to load rather than by anything about the model.
+     */
+    @Test
+    void aRowHoldsAgainstClassesThatCarryNoDeclarations() {
+        Compilation compilation = started();
+
+        Output.Examples.Of rows = compilation.db()
+                .ask(new Output.Examples("shop.cart", ROWS_AT, ArmObservation.OMIT)).value();
+
+        assertNotNull(rows);
+        assertEquals(List.of(Disposition.HELD),
+                rows.rows().stream().map(row -> row.disposition()).toList(),
+                "the row runs and holds");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest.java
@@ -11,6 +11,7 @@ import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,7 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * something to establish again whenever anybody typed a comment near a declaration it names.
  *
  * <p>Which is a claim about two artifacts and not about a speed, so it is asked as one. What ships
- * carries the declarations and reads back; what runs carries none of them and the rows still hold.
+ * carries the declarations and reads back; what runs carries none of that and the rows still hold.
+ * What a class does is the program either way — what only one of them carries is the declaration
+ * written down for somebody to read.
  */
 class WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest {
 
@@ -104,22 +106,39 @@ class WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest {
      * <p>Both halves, because either alone would pass on a compiler that had this wrong. That the
      * evaluation artifact was kept says nothing unless the edit was one publication had to take in,
      * and an edit publication ignores would be kept by everything.
+     *
+     * <p>Which is read off what publication came to and not off its having been worked out again. An
+     * answer recomputed to what it already was is a different object and the same publication, so a
+     * comment nothing published would pass a reading of the object alone.
      */
     @Test
     void aCommentIsPublishedAndDoesNotReachWhatTheModuleIsEvaluatedAgainst() {
         Compilation compilation = started();
-        Answer<?> ships = compilation.db().ask(new Output.Classes("shop.prices"));
+        byte[] ships = published(compilation);
         Answer<?> runs = compilation.db()
                 .ask(new Output.Evaluated("shop.prices", ArmObservation.OMIT));
 
         compilation.update(workspace(REWORDED), Set.of());
         compilation.answerEverything();
 
-        assertNotSame(ships, compilation.db().ask(new Output.Classes("shop.prices")),
+        assertFalse(Arrays.equals(ships, published(compilation)),
                 "the classes that ship carry the declaration as it is now written");
         assertSame(runs, compilation.db()
                         .ask(new Output.Evaluated("shop.prices", ArmObservation.OMIT)),
                 "and the classes the module is evaluated against are the ones they were");
+    }
+
+    /**
+     * The bytes the declaration of {@code Amount} is published in.
+     *
+     * <p>Its own class and not the one the module-level declarations go on: a data declaration is
+     * written onto the class it produced, as its source wrote it, and the module's class carries the
+     * header, the imports and an index. So a comment beside this declaration is in these bytes and
+     * in no others, which is what makes it an edit publication takes in.
+     */
+    private static byte[] published(Compilation compilation) {
+        return compilation.db().ask(new Output.Classes("shop.prices")).value()
+                .get(Emitted.value("shop.prices", "Amount")).bytes();
     }
 
     /** The class the declarations go on is published, and is not among the classes that run. */
@@ -161,14 +180,14 @@ class WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest {
     }
 
     /**
-     * A row still holds against classes that carry none of this.
+     * A row still holds against classes with no declaration written onto them.
      *
      * <p>Written across an import, so that what the row runs against is the classes of a module it
      * names as well as its own — the case where a class missing from one of them would be found by
      * failing to load rather than by anything about the model.
      */
     @Test
-    void aRowHoldsAgainstClassesThatCarryNoDeclarations() {
+    void aRowHoldsAgainstClassesWithNoDeclarationWrittenOnThem() {
         Compilation compilation = started();
 
         Output.Examples.Of rows = compilation.db()


### PR DESCRIPTION
Closes #1468.

A module's declarations are written onto its classes as its source wrote them, so that another compilation can import it from a jar without the source. They were written onto the classes an evaluation runs against as well, so that the two would be one set of classes — which put the text of a comment into what the module is evaluated against.

So a comment written beside a declaration gave the module an evaluation artifact that was not the one it had, and the linked classes, the examples and the disagreements were all established again from it, while nothing about the program had moved.

What reads the declarations back is the readback, over the classes a compilation publishes and the ones on the path. Nothing that runs a program reads them, and the class they are written onto is emitted to carry them and holds no code — so leaving it out of what runs leaves the program that runs the same program. `Evaluated`'s own doc already said these were never stamped.

The declarations now go on what ships through an operation of `Classes`'s own, so there is no longer one both sides can reach.

## What is held

`WhatShipsCarriesTheDeclarationsAndWhatRunsDoesNotTest`.

A comment reworded to a line of the same width — an edit that moves no position, so what its two texts differ in is what a declaration publishes and nothing else — changes the bytes the declaration is published in and leaves the evaluation artifact where it was. Both halves in one claim: that the artifact was kept says nothing unless the edit was one publication took in, and read off the bytes rather than off publication having been worked out again, since an answer recomputed to what it already was is a different object and the same publication.

The class the declarations are written onto is among the classes that ship and is not among the classes that run. What ships reads back, and its header is the module as its source declared it. A row written across an import holds against classes that carry none of this.

`ProbedBytecodeTest` asked that the classes an evaluation loads are the classes that ship. It now asks for the ones that ship and can be run, taking the declarations' own class out by name and failing if what ships stops carrying it.

## What this does not reach

An edit that writes or removes a whole line still moves every position under it, and the answers about a module carry positions, so the front of the pipeline comes out different for it either way. That is the same walk a declaration edit takes and it is not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
