### PR TITLE
Spend a branch's fate on the branch, not on the pair

### DIFF
--- a/souther-bench/src/test/java/souther/bench/APositionsStandingIsNotEvidenceOfWhoseRuleItIsTest.java
+++ b/souther-bench/src/test/java/souther/bench/APositionsStandingIsNotEvidenceOfWhoseRuleItIsTest.java
@@ -84,7 +84,7 @@ class APositionsStandingIsNotEvidenceOfWhoseRuleItIsTest {
         assertFalse(!reached,
                 "nothing reads what asked for a machine, so the check above is passing because"
                         + " neither half is read rather than because the halves are apart");
-        assertEquals(Set.of("souther.compiler.check.StatedByClauses$Reading.keptAs"),
+        assertEquals(Set.of("souther.compiler.check.StatedByClauses$Taken.holding"),
                 Set.copyOf(read),
                 "what asked is routed to the part that asked, and read nowhere else");
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Adoption.java
@@ -106,11 +106,15 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
      * <p>Nothing satisfies the branch, so nothing it said narrows a value of this type — and
      * nothing it missed is missing from what a value of this type is under either. What is left is
      * that the positions it named are settled: the choice does nothing to them, which is an answer
-     * and not a gap. The same rule {@link #bothDead} states for a whole choice, said of one part of
-     * one branch of it.
+     * and not a gap.
      *
      * <p>What a choice above left open goes with the constraint it was about. There is no
      * constraint here for an alternative to have widened.
+     *
+     * <p>The one place that rule is stated. A choice composes alternatives this has already been
+     * applied to, so a choice one alternative of which nobody can be in is this once, and a choice
+     * neither alternative of which anybody can be in is this twice. Neither is a rule of its own,
+     * and a second statement of it would be free to disagree with this one.
      */
     Adoption<A, L> inADeadBranch() {
         return new Adoption<>(Set.of(), mentions(), Set.of(), false, Set.of());
@@ -171,10 +175,16 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
     }
 
     /**
-     * Both parts holding at once.
+     * Both parts holding at once, and what a choice comes to where an alternative of it is one
+     * nobody can be in.
      *
      * <p>Nothing spoils anything: a part nothing read leaves the parts beside it saying what they
      * said, since all of them hold.
+     *
+     * <p>Which is the composition a dead alternative wants and {@link #either} is not. A branch
+     * {@link #inADeadBranch} has been applied to holds no constraint and missed nothing — all it
+     * says is that the positions it named are settled — so there is nothing beside it for an
+     * alternative to have taken back, and no opening for one to arrive under.
      *
      * <p>What a choice inside either of them left open comes along. A conjunction beside a choice
      * does not put back what the choice left open — {@code (x == 7 || f(y)) && z > 1} still says
@@ -241,33 +251,6 @@ record Adoption<A, L extends ReadingLanguage>(Set<A> read, Set<A> settled, Set<A
     /** The positions any part of the clause was about. */
     Set<A> mentions() {
         return union(union(read, settled), missed);
-    }
-
-    /**
-     * This branch of a choice, beside one shown to admit nothing.
-     *
-     * <p>The dead branch settles the positions it named: nothing satisfies it, so what the choice
-     * does to a position only it spoke of is nothing, which is an answer. Its own misses do not
-     * come with it — a rule it could not read is a rule about a branch nobody can take — and
-     * neither does its {@link #hasUnreadPart}, for the same reason.
-     *
-     * <p>What this branch missed still wins. {@code (s < "") || f(x)} leaves {@code x} open however
-     * dead the first branch is, so the surviving branch's account is the one that outranks.
-     */
-    Adoption<A, L> beside(Adoption<A, L> dead) {
-        return new Adoption<>(read, union(settled, dead.mentions()), missed, hasUnreadPart, opened);
-    }
-
-    /**
-     * Two branches of a choice, both shown to admit nothing.
-     *
-     * <p>Then the choice admits nothing, which settles every position either of them named: the
-     * values there are exactly none. No branch is left to have missed anything, and none to have
-     * had a constraint of its own widened.
-     */
-    Adoption<A, L> bothDead(Adoption<A, L> other) {
-        return new Adoption<>(Set.of(), union(mentions(), other.mentions()), Set.of(), false,
-                Set.of());
     }
 
     private static <A> Set<A> union(Set<A> these, Set<A> those) {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -170,10 +170,18 @@ sealed interface StatedByClauses {
         }
 
         /**
-         * Both readings holding at once.
+         * Both readings holding at once, and what a choice comes to where an alternative of it is
+         * one nobody can be in.
          *
          * <p>Nothing spoils anything and nothing is raised: both clauses are the author's, both
          * were read, and a conjunction offers no alternative for anything to have gone unread in.
+         *
+         * <p>Which is why a choice with a dead alternative composes here and not at
+         * {@link #either}. A branch {@link #inADeadBranch} has been applied to is not an
+         * alternative anything can be read in: what is left of it is that the positions it named
+         * are settled, and it says nothing about the strings anywhere. Composed as an alternative,
+         * it would take back what the branch that stands said about the strings at every position,
+         * because a side saying nothing about a position is every string there.
          */
         Part both(Part other) {
             return new Part(byValues.both(other.byValues()), byOrder.both(other.byOrder()),
@@ -196,21 +204,6 @@ sealed interface StatedByClauses {
             // branch for an author to look at, so there is nothing for a shortfall to send them to.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
                     asked, Set.of());
-        }
-
-        /** This part of the branch that stands, beside the same part of one nobody can be in. */
-        Part beside(Part gone) {
-            // The standing branch's own, and nothing from the other. What a rule of a branch
-            // nothing satisfies is answerable for is not a rule of this declaration at all.
-            return new Part(byValues.beside(gone.byValues()), byOrder.beside(gone.byOrder()),
-                    aboutStrings, askedIn(asked, gone.asked()), ruleShortfalls);
-        }
-
-        /** The same part of two branches, neither of which anybody can be in. */
-        Part bothDead(Part other) {
-            return new Part(byValues.bothDead(other.byValues()),
-                    byOrder.bothDead(other.byOrder()), Map.of(),
-                    askedIn(asked, other.asked()), Set.of());
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */
@@ -1048,57 +1041,29 @@ sealed interface StatedByClauses {
                         throw new IllegalStateException(
                                 "a choice of a rule was never met in the settled reading");
                     }
-                    souther.compiler.values.Emptiness here = fate.left().emptiness();
-                    souther.compiler.values.Emptiness there = fate.right().emptiness();
-                    if (here == souther.compiler.values.Emptiness.EMPTY && there == souther.compiler.values.Emptiness.EMPTY) {
-                        yield one.bothDead(other);
-                    }
-                    if (here == souther.compiler.values.Emptiness.EMPTY) {
-                        yield keptAs(other, fate.right()).beside(one);
-                    }
-                    if (there == souther.compiler.values.Emptiness.EMPTY) {
-                        yield keptAs(one, fate.left()).beside(other);
-                    }
                     // Here, where both branches have their fate. What an alternative nothing could
                     // read left open turns on which of them anybody can be in: a branch shown dead
                     // by a clause written elsewhere takes what it could not read with it, and until
                     // the whole declaration is settled that is not known. Asked before, this choice
                     // is answerable for what a branch of a branch it has already lost ever reached.
-                    Taken live = keptAs(one, fate.left());
-                    Taken beside = keptAs(other, fate.right());
-                    yield live.either(
+                    Taken left = one.under(fate.left());
+                    Taken right = other.under(fate.right());
+                    if (fate.left().emptiness() == souther.compiler.values.Emptiness.EMPTY
+                            || fate.right().emptiness() == souther.compiler.values.Emptiness.EMPTY) {
+                        // What is left of a dead alternative is an account and not an alternative,
+                        // so the two are accumulated and not composed as a choice. Which of them
+                        // was the dead one is spent by here, and a choice nobody can take at all is
+                        // this same line with two of them.
+                        yield left.both(right);
+                    }
+                    yield left.either(
                             new RuleShortfall.Site.AtAChoice(it.id(), it.writtenAt().pos()),
-                            opens(it.id(), fate.width(), live.took(), beside.took()),
-                            beside);
+                            opens(it.id(), fate.width(), left.took(), right.took()),
+                            right);
                 }
             };
         }
 
-        /**
-         * A branch of the rule that is being kept, holding what the settlement could not build in
-         * it.
-         *
-         * <p>{@link #keptTogether} for the account: the reasons and the given-up positions were
-         * settled where the branch's occurrences were probed, and are applied to what this rule's
-         * parts said — a part about a position nobody worked out is one the account still calls
-         * taken in until this is applied.
-         */
-        private Taken keptAs(Taken read, Settlement.Sided known) {
-            if (known.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
-                return read;
-            }
-            return read.mapped(part -> new Part(
-                    part.byValues().unbuiltAt(known.unbuilt()),
-                    part.byOrder().unbuiltAt(known.unbuilt()),
-                    part.aboutStrings(), part.asked(),
-                    // What a machine was refused for, said as what a rule is answerable for, at
-                    // the clause that asked for it rather than at the place it was built for. What
-                    // the answer itself was short of is not here: that holds of everything waiting
-                    // on the position and is the position's own, kept by the carrier that answers
-                    // for the position.
-                    shortOf(part.ruleShortfalls(),
-                            askedFor(known.ruleShortfalls(), part.asked()))));
-        }
     }
 
     /**
@@ -1117,7 +1082,15 @@ sealed interface StatedByClauses {
             return new Taken(took, out, opened);
         }
 
-        /** Both holding at once, each part still the part it was. */
+        /**
+         * Both holding at once, each part still the part it was — and what a choice comes to
+         * where an alternative of it is one nobody can be in.
+         *
+         * <p>The reason a choice composes here is {@link Part#both}'s: what is left of a branch
+         * {@link #inADeadBranch} has been applied to is not an alternative, so there is nothing in
+         * it for {@link #either} to be about. Which of the two a choice is asked of turns on the
+         * fates alone, and the fates are spent on the branches before either is reached.
+         */
         Taken both(Taken other) {
             return new Taken(took.both(other.took()), joined(parts, other.parts()),
                     opened(opened, other.opened()));
@@ -1131,32 +1104,68 @@ sealed interface StatedByClauses {
         }
 
         /**
-         * This branch of a choice, beside one nobody can be in.
+         * This branch of a choice with its fate applied, which is what a choice composes.
          *
-         * <p>What the dead one said goes with it, its unread rules included: nothing satisfies it,
-         * so what it left a position is not something a value of this type is under. What it does
-         * leave is that the positions it named are settled — the choice does nothing to them — and
-         * that is an answer only a reading that got to the end of the branch could give.
+         * <p>The one place the account reads a fate. A branch nobody can be in is put in a dead
+         * branch, a branch nothing settled holds what working it out could not build, and a branch
+         * somebody can be in is itself. What a choice does with the two of them turns on nothing
+         * more, so no composition below is told which branch was which — and a rule for a pair of
+         * fates, having no way to reach a branch, cannot say something a rule for one of them
+         * would not.
+         *
+         * <p>Which is what keeps a choice neither branch of which anybody can take from being a
+         * case at all. It is this twice and the composition beside it, and the answer cannot turn
+         * on the order the alternatives were written in because nothing in it looks at the pair.
          */
-        Taken beside(Taken gone) {
-            // And what a choice inside it left open goes with it too, for the same reason: there
-            // is no branch there for a position to be open in.
-            return new Taken(took.beside(gone.took()),
-                    joined(parts, gone.mapped(Part::inADeadBranch).parts()), opened);
+        Taken under(Settlement.Sided fate) {
+            return switch (fate.emptiness()) {
+                case EMPTY -> inADeadBranch();
+                case UNDECIDED -> holding(fate);
+                case NONEMPTY -> this;
+            };
         }
 
         /**
-         * A choice neither branch of which anybody can take.
+         * The whole of this, in a branch nobody can be in.
          *
-         * <p>No one of them speaks for the rest: taking the first to be found impossible out of the
-         * answer would settle the proof by the order the operands were written in, and the same
-         * model written two ways would be refused two ways.
+         * <p>Every part of it and what the subtree came to, by the rule {@link Adoption} states
+         * once for all of them. What a choice inside it left open is not among them and is not
+         * cleared: a choice inside such a branch is one neither alternative of which anybody can be
+         * in, so there is nothing there to clear, and a line clearing it would be one no reading
+         * could reach and nothing could show wrong.
          */
-        Taken bothDead(Taken other) {
-            return new Taken(took.bothDead(other.took()),
-                    joined(mapped(Part::inADeadBranch).parts(),
-                            other.mapped(Part::inADeadBranch).parts()),
-                    Set.of());
+        Taken inADeadBranch() {
+            // An assertion because it is about this compiler and not about any model, and here
+            // rather than in one test because every dead branch a corpus holds goes through it. A
+            // branch is empty wherever the whole of it is met, so every choice inside one nobody
+            // can be in has both its alternatives empty as well, and a walk arriving here holding
+            // an opening would have settled a choice against a tree this branch is not in.
+            assert opened.isEmpty()
+                    : "a choice inside a branch nobody can be in left a position open";
+            Taken dead = mapped(Part::inADeadBranch);
+            return new Taken(dead.took(), dead.parts(), opened);
+        }
+
+        /**
+         * A branch nothing showed empty, holding what working it out could not build.
+         *
+         * <p>A branch shown to admit something is kept and there is nothing more to say; a branch
+         * nothing could work out is kept for the same reason nothing was dropped — nobody showed
+         * it empty — and that is not the same fact. Kept without saying so, the account would call
+         * a position taken in where the truth is that nobody worked it out.
+         */
+        private Taken holding(Settlement.Sided known) {
+            return mapped(part -> new Part(
+                    part.byValues().unbuiltAt(known.unbuilt()),
+                    part.byOrder().unbuiltAt(known.unbuilt()),
+                    part.aboutStrings(), part.asked(),
+                    // What a machine was refused for, said as what a rule is answerable for, at
+                    // the clause that asked for it rather than at the place it was built for. What
+                    // the answer itself was short of is not here: that holds of everything waiting
+                    // on the position and is the position's own, kept by the carrier that answers
+                    // for the position.
+                    shortOf(part.ruleShortfalls(),
+                            askedFor(known.ruleShortfalls(), part.asked()))));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -1056,8 +1056,9 @@ sealed interface StatedByClauses {
                             || fate.right().emptiness() == souther.compiler.values.Emptiness.EMPTY) {
                         // What is left of a dead alternative is an account and not an alternative,
                         // so the two are accumulated and not composed as a choice. Which of them
-                        // was the dead one is spent by here, and a choice nobody can take at all is
-                        // this same line with two of them.
+                        // was the dead one is asked here and nowhere below: both sides arrive with
+                        // their fate already spent, and a choice nobody can take at all is this
+                        // same line with two of them.
                         yield left.both(right);
                     }
                     yield left.either(
@@ -1110,16 +1111,16 @@ sealed interface StatedByClauses {
         /**
          * This branch of a choice with its fate applied, which is what a choice composes.
          *
-         * <p>The one place the account reads a fate. A branch nobody can be in is put in a dead
+         * <p>The one place a fate is spent on a branch. A branch nobody can be in is put in a dead
          * branch, a branch nothing settled holds what working it out could not build, and a branch
-         * somebody can be in is itself. What a choice does with the two of them turns on nothing
-         * more, so no composition below is told which branch was which — and a rule for a pair of
-         * fates, having no way to reach a branch, cannot say something a rule for one of them
-         * would not.
+         * somebody can be in is itself.
          *
-         * <p>Which is what keeps a choice neither branch of which anybody can take from being a
-         * case at all. It is this twice and the composition beside it, and the answer cannot turn
-         * on the order the alternatives were written in because nothing in it looks at the pair.
+         * <p>Which composition the choice then gets is read off the two fates beside this, and that
+         * is the whole of what a pair of them decides. Neither composition is handed a fate, so
+         * neither can say anything about what a branch left that this did not — which is what keeps
+         * a choice neither branch of which anybody can take from being a case at all. It is this
+         * twice and a composition, and the answer cannot turn on the order the alternatives were
+         * written in because the composition a dead branch picks treats its two sides alike.
          */
         Taken under(Settlement.Sided fate) {
             // Asked of what the fate settles and not taken apart by which of the three answers it

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -190,20 +190,24 @@ sealed interface StatedByClauses {
                     shortOf(ruleShortfalls, other.ruleShortfalls()));
         }
 
-        /** The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}. */
+        /**
+         * The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}.
+         *
+         * <p>Nothing an author wrote there is left. What each language took in comes to what that
+         * rule states, and the rest was written where nobody can be: no rule of it is one this
+         * declaration went short on, no line it drew is one the model draws, and there is no branch
+         * for a shortfall to send anybody to.
+         *
+         * <p>What it asked for goes with them, and its reason runs the other way round. A machine
+         * is one answer about a pattern at a position, and the clauses answerable for a refusal are
+         * found by matching those two and nothing that says which branch a clause is in. So a
+         * request kept here recovers no refusal of this branch — nothing was built for it to have
+         * been refused — and offers the refusal of the branch that stands a second written place to
+         * be about.
+         */
         Part inADeadBranch() {
-            // The reasons go with it too. A rule of a branch nothing satisfies is not a rule of
-            // this declaration that went unread; there is no branch for an author to look at.
-            //
-            // And neither is what it said about the strings at a position. A line drawn from a
-            // branch nobody can be in is a line the model does not draw.
-            // What it asked for is kept. A machine refused for a pattern in a branch nobody can be
-            // in was still asked for by that pattern, and a part that forgot it would leave the
-            // refusal with nothing to be about.
-            // And what a rule is answerable for goes with them, for the same reason: there is no
-            // branch for an author to look at, so there is nothing for a shortfall to send them to.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
-                    asked, Set.of());
+                    Set.of(), Set.of());
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -1122,11 +1122,16 @@ sealed interface StatedByClauses {
          * on the order the alternatives were written in because nothing in it looks at the pair.
          */
         Taken under(Settlement.Sided fate) {
-            return switch (fate.emptiness()) {
-                case EMPTY -> inADeadBranch();
-                case UNDECIDED -> holding(fate);
-                case NONEMPTY -> this;
-            };
+            // Asked of what the fate settles and not taken apart by which of the three answers it
+            // is. A branch is one nobody can be in, or one nobody settled, or neither — and the two
+            // questions are asked in that order because the second is about a branch still standing.
+            if (fate.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
+                return inADeadBranch();
+            }
+            if (fate.emptiness() == souther.compiler.values.Emptiness.UNDECIDED) {
+                return holding(fate);
+            }
+            return this;
         }
 
         /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -46,18 +46,23 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
      * <p>Whether a branch admits nothing is the state's to know and not the evidence's, so it is
      * carried beside here. A choice is dead where every alternative is, which is the rule the states
      * are composed by.
+     *
+     * <p>Two cases and not four, which is the shape under test as much as the answers are. A
+     * branch is put in a dead branch by what became of it and by nothing about the branch beside
+     * it, and what is left of it composes with a rule that knows nothing of fates — so a choice
+     * neither alternative of which anybody can be in is not written here at all, and cannot come
+     * out anything but what two dead branches leave.
      */
     private record Branch(Adoption<String, ReadingLanguage.Values> adoption, boolean dead) {
 
+        /** This branch with its fate applied, which is what a choice composes. */
+        Adoption<String, ReadingLanguage.Values> fated() {
+            return dead ? adoption.inADeadBranch() : adoption;
+        }
+
         Branch or(Branch other) {
-            if (dead && other.dead) {
-                return new Branch(adoption.bothDead(other.adoption), true);
-            }
-            if (dead) {
-                return new Branch(other.adoption.beside(adoption), false);
-            }
-            if (other.dead) {
-                return new Branch(adoption.beside(other.adoption), false);
+            if (dead || other.dead) {
+                return new Branch(fated().both(other.fated()), dead && other.dead);
             }
             return new Branch(adoption.either(Opening.nothing(), other.adoption), false);
         }
@@ -65,6 +70,11 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
 
     private static final Branch UNREADABLE = new Branch(UNREAD, false);
     private static final Branch IMPOSSIBLE = new Branch(READ, true);
+
+    /** A second branch nothing satisfies, about a position of its own, so that a choice of two of
+     *  them has two answers to keep apart. */
+    private static final Branch ALSO_IMPOSSIBLE =
+            new Branch(Adoption.at(Set.of("z"), Set.of("z"), false), true);
 
     /**
      * Three alternatives compose the same whichever way the brackets fall.
@@ -99,4 +109,24 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
                 IMPOSSIBLE.or(UNREADABLE).or(UNREADABLE).adoption());
     }
 
+    /**
+     * And a choice no alternative of which anybody can be in composes the same way.
+     *
+     * <p>The one no report reads: such a choice is empty, so either a choice outside it takes the
+     * alternative beside it and puts this whole one in a dead branch, or the declaration is refused
+     * and its account reaches nothing. Held anyway, because what makes it come out one way is that
+     * nothing here is written about a pair of dead branches — and that is a fact about the
+     * composition, which the next alternative does read.
+     */
+    @Test
+    void andTwoAlternativesNobodyCanBeInComposeTheSameWayRound() {
+        assertEquals(IMPOSSIBLE.or(ALSO_IMPOSSIBLE).adoption(),
+                ALSO_IMPOSSIBLE.or(IMPOSSIBLE).adoption(),
+                "neither of them speaks for the choice, so neither order does");
+        assertEquals(UNREADABLE.or(IMPOSSIBLE).or(ALSO_IMPOSSIBLE).adoption(),
+                UNREADABLE.or(IMPOSSIBLE.or(ALSO_IMPOSSIBLE)).adoption(),
+                "and a branch that stands beside them reads the same rule either way");
+        assertTrue(IMPOSSIBLE.or(ALSO_IMPOSSIBLE).dead(),
+                "a choice is dead where every alternative of it is");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
@@ -176,7 +176,7 @@ class AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest {
         Adoption<String, ReadingLanguage.Values> choice =
                 branch(true).either(opening(CONSTRAINED), branch(true));
 
-        assertEquals(Set.of(CONSTRAINED), choice.beside(branch(false)).opened());
+        assertEquals(Set.of(CONSTRAINED), choice.both(branch(false).inADeadBranch()).opened());
     }
 
     /**
@@ -192,7 +192,8 @@ class AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest {
                 branch(true).either(opening(CONSTRAINED), branch(true));
 
         assertEquals(Set.of(), choice.inADeadBranch().opened());
-        assertEquals(Set.of(), choice.bothDead(branch(false)).opened());
+        assertEquals(Set.of(),
+                choice.inADeadBranch().both(branch(false).inADeadBranch()).opened());
     }
 
     /** The positions the account reached: what it constrained, and what it could not manage. */

--- a/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
@@ -88,6 +88,33 @@ class NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest {
             """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
 
     /**
+     * One pattern no machine can be made for, written in a dead branch and beside it.
+     *
+     * <p>A machine is made once for a pattern at a position however many clauses wrote it, so the
+     * refusal is one fact and the clauses that asked for it are where an author is sent. Both
+     * clauses here ask for that machine at that position, and one of them is written where nobody
+     * can be.
+     */
+    private static final String ONE_REFUSED_MACHINE_IS_ASKED_FOR_FROM_A_DEAD_BRANCH = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && x == "B" && String.matches("a{60000}", y))
+                    || String.matches("a{60000}", y)
+            """;
+
+    /** The same pattern in two alternatives that both stand, which is two places to go to. */
+    private static final String THE_SAME_MACHINE_IS_ASKED_FOR_FROM_TWO_BRANCHES_THAT_STAND = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && String.matches("a{60000}", y))
+                    || String.matches("a{60000}", y)
+            """;
+
+    /**
      * A choice inside a branch nobody can be in, one alternative of which nothing reads.
      *
      * <p>Inside the branch the choice does leave {@code b} wider than the rules hold it: the
@@ -146,6 +173,26 @@ class NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest {
         assertEquals(2, placesToLookAt(BOTH_UNREAD_FORMS_ARE_IN_BRANCHES_THAT_STAND, "y"),
                 "and with both branches standing both forms are places to go to, which is what"
                         + " makes the count above a fate's doing");
+    }
+
+    /**
+     * And a refused machine is answered for by the clauses somebody may be in.
+     *
+     * <p>A refusal is matched to the clauses that asked for it by the pattern and the position, and
+     * by nothing that says which branch either of them is in. So the request a dead branch made is
+     * not a request this declaration is answerable for: it recovers no refusal of that branch,
+     * where nothing was built to be refused, and it offers the refusal of the branch that stands a
+     * second written place to be about.
+     */
+    @Test
+    void andARefusedMachineIsAnsweredForByTheClauseThatStands() {
+        assertEquals(1, placesToLookAt(ONE_REFUSED_MACHINE_IS_ASKED_FOR_FROM_A_DEAD_BRANCH, "y"),
+                "the pattern is written twice and one of the two is where nobody can be, so there"
+                        + " is one clause an author can do something about");
+        assertEquals(2,
+                placesToLookAt(THE_SAME_MACHINE_IS_ASKED_FOR_FROM_TWO_BRANCHES_THAT_STAND, "y"),
+                "and where both branches stand both clauses asked for the machine that was"
+                        + " refused, which is what makes the count above a fate's doing");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
@@ -1,0 +1,220 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.AdmissibleSet;
+import souther.compiler.values.UnreadReason;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A branch nobody can be in reaches no question that stands, whatever it was holding.
+ *
+ * <p>What such a branch leaves is that the positions it named are settled, and nothing else: no
+ * rule of it is one this declaration went short on, and no choice inside it left a position wider
+ * than the rules hold it. There is no branch for an author to look at, so there is nothing for
+ * either to send them to.
+ *
+ * <p>Which is a claim about a whole declaration and needs a question that stands to be told to.
+ * Held over a branch nothing else names, both would be true of a reading that kept everything: the
+ * positions the dead branch spoke of are settled, so no question about them is left for what it
+ * kept to reach. So the branch that stands here names the position too, and the position hears
+ * about a rule of the declaration or about how wide it is — and what the dead branch was holding
+ * would arrive at that question if it were kept.
+ *
+ * <p>Each of them beside the same model with the branch standing, which is where the reading does
+ * say both things. What is under test is that a fate decides it, and a pair of models one fate
+ * apart is what says so.
+ */
+class NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest {
+
+    /**
+     * A form nothing reads inside a branch nobody can be in, beside one that names the position.
+     *
+     * <p>The standing alternative is about {@code y}, so a question about {@code y} stands and is
+     * answered by the rule. The branch nobody can be in holds a form nothing reads about the same
+     * position, and what that form is short of is not this declaration's shortfall.
+     */
+    private static final String THE_FORM_IS_IN_A_BRANCH_NOBODY_CAN_BE_IN = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && x == "B" && UNREAD_Y) || (x == "C" && y == "Q")
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /** The same clauses with the branch standing, where the form is one nothing read. */
+    private static final String THE_SAME_WITH_THE_BRANCH_STANDING = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && UNREAD_Y) || (x == "C" && y == "Q")
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /**
+     * Two forms nothing reads about one position, one of them in a branch nobody can be in.
+     *
+     * <p>The question about {@code y} stands and nothing answers it, so what the declaration is
+     * short of at {@code y} is reported — and there is one place to go and look at, not two. The
+     * pair is what tells a shortfall that was dropped from one that was never made: counted alone,
+     * a reading holding the dead branch's would agree with a reading holding nothing.
+     */
+    private static final String ONE_OF_TWO_UNREAD_FORMS_IS_IN_A_DEAD_BRANCH = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && x == "B" && UNREAD_Y) || (x == "C" && UNREAD_Y)
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /** The same two forms with both branches standing, where both are places to look at. */
+    private static final String BOTH_UNREAD_FORMS_ARE_IN_BRANCHES_THAT_STAND = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "A" && UNREAD_Y) || (x == "C" && UNREAD_Y)
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /**
+     * A choice inside a branch nobody can be in, one alternative of which nothing reads.
+     *
+     * <p>Inside the branch the choice does leave {@code b} wider than the rules hold it: the
+     * alternative beside the unread one holds it to one string, and the unread one never names it,
+     * so the choice is the only thing with anything to say about why it is open. The branch is one
+     * nobody can be in, so the declaration is under nothing of the kind.
+     */
+    private static final String THE_CHOICE_IS_IN_A_BRANCH_NOBODY_CAN_BE_IN = """
+            module demo
+
+            data N = { x: String, a: String, b: String }
+                invariant r =
+                    (x == "A" && x == "B" && (UNREAD_A || b == "P")) || x == "C"
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /** The same clauses with that branch standing, where the position is left open. */
+    private static final String THE_SAME_CHOICE_IN_A_BRANCH_THAT_STANDS = """
+            module demo
+
+            data N = { x: String, a: String, b: String }
+                invariant r =
+                    (x == "A" && (UNREAD_A || b == "P")) || x == "C"
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /**
+     * What a rule of a dead branch was short of is no shortfall of the declaration.
+     *
+     * <p>The question about {@code y} stands and is the standing alternative's to answer. A reading
+     * that kept what the dead branch was short of would answer it with a form written where nobody
+     * can be, and an author lifting it would find the question unchanged.
+     */
+    @Test
+    void whatARuleOfADeadBranchWasShortOfReachesNoQuestion() {
+        assertEquals(Set.of(),
+                whatARuleIsAnswerableFor(THE_FORM_IS_IN_A_BRANCH_NOBODY_CAN_BE_IN, "y"),
+                "nothing satisfies the branch the form is written in, so there is no clause for an"
+                        + " author to go and look at");
+        assertEquals(Set.of(UnreadReason.FORM_NOT_READ),
+                whatARuleIsAnswerableFor(THE_SAME_WITH_THE_BRANCH_STANDING, "y"),
+                "and the same form in a branch somebody can be in is one this declaration went"
+                        + " short on, which is what makes the answer above a fate's doing");
+    }
+
+    /**
+     * And it is not a second place to go and look at either.
+     *
+     * <p>Read as a set of reasons, a shortfall of a dead branch and one of the branch beside it are
+     * the same reason twice and one of them hides the other. What tells them apart is the written
+     * place each sends an author to, and that is what is counted here.
+     */
+    @Test
+    void norIsItASecondPlaceForAnAuthorToLookAt() {
+        assertEquals(1, placesToLookAt(ONE_OF_TWO_UNREAD_FORMS_IS_IN_A_DEAD_BRANCH, "y"),
+                "one of the two forms is written where nobody can be, so there is one clause to"
+                        + " lift and not two");
+        assertEquals(2, placesToLookAt(BOTH_UNREAD_FORMS_ARE_IN_BRANCHES_THAT_STAND, "y"),
+                "and with both branches standing both forms are places to go to, which is what"
+                        + " makes the count above a fate's doing");
+    }
+
+    /**
+     * And what a choice inside one left open leaves the position hearing nothing.
+     *
+     * <p>The other half, because the two travel by different roads: a shortfall is filed at the
+     * clause that was short and a widening is told to the position. A reading keeping either would
+     * report a declaration as answering less than it does, on the strength of a branch nobody can
+     * be in.
+     */
+    @Test
+    void andWhatAChoiceInsideOneLeftOpenReachesNoPosition() {
+        assertEquals(List.of(),
+                whyOpen(THE_CHOICE_IS_IN_A_BRANCH_NOBODY_CAN_BE_IN, "b"),
+                "the choice that left it open is inside a branch nobody can be in, so the rules"
+                        + " leave the position exactly where the answer says");
+        assertEquals(List.of(UnreadReason.ALTERNATIVE_NOT_READ),
+                whyOpen(THE_SAME_CHOICE_IN_A_BRANCH_THAT_STANDS, "b"),
+                "and the same choice in a branch somebody can be in does leave it open");
+    }
+
+    /** What a rule of the declaration is answerable for at {@code field}. */
+    private static Set<UnreadReason> whatARuleIsAnswerableFor(String source, String field) {
+        Set<UnreadReason> out = new LinkedHashSet<>();
+        shortfallsAt(source, field).forEach(each -> out.add(each.why()));
+        return out;
+    }
+
+    /** How many written places an author is sent to about {@code field}. */
+    private static int placesToLookAt(String source, String field) {
+        Set<RuleShortfall.Site> out = new LinkedHashSet<>();
+        shortfallsAt(source, field).forEach(each -> out.add(each.site()));
+        return out.size();
+    }
+
+    /** What every question about {@code field} is answerable for, over every rule of the value. */
+    private static Set<RuleShortfall> shortfallsAt(String source, String field) {
+        Set<RuleShortfall> out = new LinkedHashSet<>();
+        read(source).accounting().values().forEach(accounting ->
+                accounting.answers().forEach((owed, outcome) -> {
+                    if (owed.toString().equals(field)
+                            && outcome instanceof RuleAccounting.Outcome.Unaccounted it
+                            && it.why() instanceof RuleAccounting.Why.TheValueReadingSays says) {
+                        out.addAll(says.shortfalls());
+                    }
+                }));
+        return out;
+    }
+
+    /** What the position is told left it open, empty where it is told nothing. */
+    private static List<UnreadReason> whyOpen(String source, String field) {
+        return switch (read(source).admits(RuleKey.of(field)).completeness()) {
+            case AdmissibleSet.Completeness.Complete _ -> List.of();
+            case AdmissibleSet.Completeness.Wider it -> it.why().stream()
+                    .filter(AdmissibleSet.Widening.RuleUnread.class::isInstance)
+                    .map(each -> ((AdmissibleSet.Widening.RuleUnread) each).why())
+                    .toList();
+        };
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
+                ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
@@ -31,11 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * to disagree with the first — and a choice neither alternative of which anybody can be in is a
  * choice nothing publishes an account of, so nothing would notice that it had.
  *
- * <p>So the account reads a fate in one place and spends it on one branch. What composes two
- * branches afterwards is not told which of them was which, and cannot be: a choice one alternative
- * of which is dead and a choice neither alternative of which anybody can be in are the same line
- * with the rule applied once and twice. The one that no report reads travels the road the one every
- * report reads travels.
+ * <p>So a fate is spent on a branch in one place, and what composes two branches afterwards is not
+ * handed one. Which of the two compositions a choice gets is read off the two fates beside that,
+ * and that is the whole of what a pair of them decides — so a choice one alternative of which is
+ * dead and a choice neither alternative of which anybody can be in are the same line with the rule
+ * applied once and twice. The one that no report reads travels the road the one every report reads
+ * travels.
  *
  * <p>Held over the compiled classes and per calling method, because that is the grain the claim is
  * at. Two methods of one class are two places, and a rule stated at the class would let the second
@@ -50,7 +51,7 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
 
     private static final String TAKEN = "souther/compiler/check/StatedByClauses$Taken";
 
-    /** A method that may apply the rule or read a fate, how many times it does, and why. */
+    /** A method that may apply the rule or spend a fate on a branch, how often, and why. */
     private record Licence(String who, int calls, String why) { }
 
     /**
@@ -79,13 +80,18 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
                     "the one place a branch is answered for by what became of it"));
 
     /**
-     * And who reads a fate at all, which is the walk over the tree the author wrote.
+     * And who spends one on a branch, which is the walk over the tree the author wrote.
      *
-     * <p>Twice, for the two alternatives of a choice. A third reader is a second place deciding
-     * what a fate means, and the account of a choice would be back to turning on the pair rather
-     * than on the branches.
+     * <p>Twice, for the two alternatives of a choice. A third caller is a second place deciding
+     * what a fate does to an account, and what a branch left would be back to turning on the pair
+     * rather than on the branch.
+     *
+     * <p>Reading a fate is not that and is not counted here. The walk beside this one reads the two
+     * of them to pick which composition the choice gets, which is a question about the choice: the
+     * compositions are handed no fate, so what one of them does to a branch is what this method
+     * already did.
      */
-    private static final List<Licence> READING_A_FATE = List.of(
+    private static final List<Licence> SPENDING_A_FATE_ON_A_BRANCH = List.of(
             new Licence("souther.compiler.check.StatedByClauses.Reading.accounted", 2,
                     "the account of a rule, asking each alternative of a choice what became of it"));
 
@@ -98,16 +104,16 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
                 "and a part deadened anywhere but over the whole subtree is a part answered for by"
                         + " a caller that has not answered for the rest: " + why(DEADENING_A_PART));
         assertEquals(declared(DEADENING_A_TAKEN), callsTo(TAKEN, "inADeadBranch"),
-                "and a subtree deadened outside the reading of a fate is one deadened for a reason"
+                "and a subtree deadened outside the spending of a fate is one deadened for a reason"
                         + " no fate gave: " + why(DEADENING_A_TAKEN));
     }
 
     @Test
     void andAFateIsSpentOnOneBranchInOnePlace() throws IOException {
-        assertEquals(declared(READING_A_FATE), callsTo(TAKEN, "under"),
-                "a fate read anywhere else is a second answer to what became of a branch, and a"
-                        + " composition that could ask for one would be a rule about a pair: "
-                        + why(READING_A_FATE));
+        assertEquals(declared(SPENDING_A_FATE_ON_A_BRANCH), callsTo(TAKEN, "under"),
+                "a second caller of this is a second place deciding what a fate does to an account,"
+                        + " and what a branch left would be back to turning on the pair: "
+                        + why(SPENDING_A_FATE_ON_A_BRANCH));
     }
 
     private static Map<String, Integer> declared(List<Licence> licences) {

--- a/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
@@ -1,0 +1,178 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.LoadableConstantEntry;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What a branch nobody can be in leaves is said once, and every account of a choice is that rule
+ * applied to a branch.
+ *
+ * <p>The rule is a fact about one branch: nothing satisfies it, so nothing it said narrows a value
+ * and nothing it could not read is missing from what a value is under, and what is left is that the
+ * positions it named are settled. Said again for a pair of branches, the second statement is free
+ * to disagree with the first — and a choice neither alternative of which anybody can be in is a
+ * choice nothing publishes an account of, so nothing would notice that it had.
+ *
+ * <p>So the account reads a fate in one place and spends it on one branch. What composes two
+ * branches afterwards is not told which of them was which, and cannot be: a choice one alternative
+ * of which is dead and a choice neither alternative of which anybody can be in are the same line
+ * with the rule applied once and twice. The one that no report reads travels the road the one every
+ * report reads travels.
+ *
+ * <p>Held over the compiled classes and per calling method, because that is the grain the claim is
+ * at. Two methods of one class are two places, and a rule stated at the class would let the second
+ * of them be written. A method reference is a call here: a rule handed to something that will apply
+ * it is applied.
+ */
+class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
+
+    private static final String ADOPTION = "souther/compiler/check/Adoption";
+
+    private static final String PART = "souther/compiler/check/StatedByClauses$Part";
+
+    private static final String TAKEN = "souther/compiler/check/StatedByClauses$Taken";
+
+    /** A method that may apply the rule or read a fate, how many times it does, and why. */
+    private record Licence(String who, int calls, String why) { }
+
+    /**
+     * Who says what a dead branch leaves each language a clause was read in.
+     *
+     * <p>The part it was read as, and nothing above or below it. Each language is told once,
+     * because a part is what holds both of them and the rule is the same for either.
+     */
+    private static final List<Licence> DEADENING_AN_ADOPTION = List.of(
+            new Licence("souther.compiler.check.StatedByClauses.Part.inADeadBranch", 2,
+                    "the part, telling each of the two languages it was read in the one rule"));
+
+    /**
+     * Who says it of a written part, and who of the whole of a subtree.
+     *
+     * <p>A subtree's parts are the same rule over every one of them, so the walk that says it of a
+     * subtree is the only caller of the part's — and it is where what a choice inside it left open
+     * goes, since there is no branch there for a position to be open in.
+     */
+    private static final List<Licence> DEADENING_A_PART = List.of(
+            new Licence("souther.compiler.check.StatedByClauses.Taken.inADeadBranch", 1,
+                    "the subtree, handing the rule to the walk over every part it holds"));
+
+    private static final List<Licence> DEADENING_A_TAKEN = List.of(
+            new Licence("souther.compiler.check.StatedByClauses.Taken.under", 1,
+                    "the one place a branch is answered for by what became of it"));
+
+    /**
+     * And who reads a fate at all, which is the walk over the tree the author wrote.
+     *
+     * <p>Twice, for the two alternatives of a choice. A third reader is a second place deciding
+     * what a fate means, and the account of a choice would be back to turning on the pair rather
+     * than on the branches.
+     */
+    private static final List<Licence> READING_A_FATE = List.of(
+            new Licence("souther.compiler.check.StatedByClauses.Reading.accounted", 2,
+                    "the account of a rule, asking each alternative of a choice what became of it"));
+
+    @Test
+    void theRuleForABranchNobodyCanBeInIsAppliedDownOneRoad() throws IOException {
+        assertEquals(declared(DEADENING_AN_ADOPTION), callsTo(ADOPTION, "inADeadBranch"),
+                "a second caller states the rule for a language a second time, and the two are free"
+                        + " to disagree: " + why(DEADENING_AN_ADOPTION));
+        assertEquals(declared(DEADENING_A_PART), callsTo(PART, "inADeadBranch"),
+                "and a part deadened anywhere but over the whole subtree is a part answered for by"
+                        + " a caller that has not answered for the rest: " + why(DEADENING_A_PART));
+        assertEquals(declared(DEADENING_A_TAKEN), callsTo(TAKEN, "inADeadBranch"),
+                "and a subtree deadened outside the reading of a fate is one deadened for a reason"
+                        + " no fate gave: " + why(DEADENING_A_TAKEN));
+    }
+
+    @Test
+    void andAFateIsSpentOnOneBranchInOnePlace() throws IOException {
+        assertEquals(declared(READING_A_FATE), callsTo(TAKEN, "under"),
+                "a fate read anywhere else is a second answer to what became of a branch, and a"
+                        + " composition that could ask for one would be a rule about a pair: "
+                        + why(READING_A_FATE));
+    }
+
+    private static Map<String, Integer> declared(List<Licence> licences) {
+        Map<String, Integer> out = new TreeMap<>();
+        licences.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why(List<Licence> licences) {
+        Map<String, String> out = new TreeMap<>();
+        licences.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler names {@code owner.name}. */
+    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                String where = from + "." + method.methodName().stringValue();
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (names(element, owner, name)) {
+                        calls.merge(where, 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    /**
+     * Whether one instruction names {@code owner.name}, called or handed over.
+     *
+     * <p>A method reference compiles to an {@code invokedynamic} whose bootstrap carries the target
+     * as a handle, and the method's instructions name it nowhere else — so a walk over calls alone
+     * would find no caller of a rule that is applied to every part of a subtree, and would pass on
+     * an empty answer.
+     */
+    private static boolean names(Object element, String owner, String name) {
+        if (element instanceof InvokeInstruction call) {
+            return call.owner().asInternalName().equals(owner)
+                    && call.name().stringValue().equals(name);
+        }
+        if (element instanceof InvokeDynamicInstruction handed) {
+            for (LoadableConstantEntry argument
+                    : handed.invokedynamic().bootstrap().arguments()) {
+                if (argument instanceof MethodHandleEntry handle
+                        && handle.reference().owner().name().stringValue().equals(owner)
+                        && handle.reference().name().stringValue().equals(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1422.

A choice was settled in the account by a rule for each pair of fates, and each
of those rules restated what a branch nobody can be in leaves rather than
applying it. The rule for two dead branches came to the same answer as a dead
branch set beside a standing one, because the composition it reached is the
dead-branch rule applied twice -- and nothing publishes an account of a choice
nobody can take, so nothing could tell the two spellings apart. The defect was
not the extra case. It was that the dead-branch rule was written in several
places, and the place no report reads was free to drift from the ones they do.

So the fate is applied to the branch and the composition is told nothing about
it. What is left of a dead alternative is an account and not an alternative, so
it accumulates rather than composing as a choice -- composed as one it would
take back what the branch that stands said about the strings at every position.
A choice neither alternative of which anybody can take is that same line with
the rule applied twice, and is not written down anywhere. The road from
spending a fate on a branch to applying the rule to each carrier is held per
calling method, so a second way of saying it cannot be added without the walk
saying so. Reading a fate to pick which composition a choice gets is a question
about the choice, is written beside that, and is not on the road: the
compositions are handed no fate.

Completing the rule turned up one thing an author could see. A part of a dead
branch kept what it asked a machine for, on the reasoning that a refusal would
otherwise have nothing to be about; a refusal is matched to the clauses that
asked for it by the pattern and the position, and neither says which branch a
clause is in. So the kept request recovered no refusal of the dead branch --
nothing was built for it to have been refused -- and gave the refusal of the
branch that stands a further written place to be about. An author was sent to a
clause nobody can be in. That is the one change of behaviour here.

What a choice inside such a branch left open is asserted empty rather than
cleared: every choice inside a branch nobody can be in is one neither
alternative of which anybody can be in, so a line clearing it would be one no
reading could reach and nothing could show wrong.

Every coordinate of the rule was put to a mutation, over the models that reach a
dead branch at all, and each of them fails something.

Nothing on the side that decides what the values admit is touched. There a
choice neither branch of which stands is an answer a report does read, and the
tests that hold it are the reason it stays a case of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

