### PR TITLE
Prepare choice openings for the reading of ends

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
@@ -61,18 +61,18 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
      * Where an unread alternative is turned into what it left open, and where an author is sent for
      * it.
      *
-     * <p>Two questions of the one fact and no more. What the alternative left open is the first,
-     * and it is asked where the width of the same reading is in hand — of one reading throughout,
-     * which is what the method's shape holds it to. Which choice to send an author to is the
-     * second, and it is asked of the values because that is the road that exists
-     * ({@code StatedByClauses.Part#leftOpenByValues}).
+     * <p>Two questions of the one fact, and one place asks both. What the alternative left open is
+     * the first; which choice to send an author to is the second. Both are answered off the same
+     * reading's two accounts and the same reading's width, so both are asked where all three are in
+     * hand, bound to one reading — which is what the method's shape holds it to.
      *
-     * <p>Asked anywhere else, one of the halves has to be fetched from somewhere, and what is
-     * fetched is either a second answer or another reading's.
+     * <p>One row and not two, which is the whole of it. Asked at a second site, one reading's flag
+     * stands beside a set of positions reached by whichever reading the writer had in hand, and
+     * that composes without a complaint: an author is sent to a choice on the strength of an
+     * alternative the reading that named the positions read to the end.
      */
     private static final List<String> MAY_ASK =
-            List.of("souther/compiler/check/StatedByClauses#openedBy",
-                    "souther/compiler/check/StatedByClauses#opens");
+            List.of("souther/compiler/check/StatedByClauses#openedBy");
 
     @Test
     void onlyWhereAnUnreadAlternativeBecomesWhatItLeftOpen() {

--- a/souther-compiler/src/main/java/souther/compiler/check/Opening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Opening.java
@@ -61,9 +61,10 @@ record Opening<A, L extends ReadingLanguage>(Set<A> positions, Set<A> byTheLeftG
     /**
      * A choice this reading has nothing to say about.
      *
-     * <p>Every position where the choice leaves what it leaves without either alternative, and
-     * nobody to send an author to — which is what a choice both of whose alternatives this reading
-     * read comes to, and the only state in which all three are empty together.
+     * <p>An opening with no position it could not show the alternatives preserve, and nobody to
+     * send an author to. A choice both of whose alternatives this reading read comes to it — and so
+     * does one whose unread alternative stands beside a branch reaching no position, so a reader
+     * may not take it for the first.
      */
     static <A, L extends ReadingLanguage> Opening<A, L> nothing() {
         return new Opening<>(Set.of(), Set.of(), Set.of());

--- a/souther-compiler/src/main/java/souther/compiler/check/Opening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Opening.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -11,11 +13,20 @@ import java.util.Set;
  * it is settled where the branches are ({@link Settlement.WidthDependency}). This is that answer on
  * its way to whoever applies it.
  *
- * <p><b>What a member says, which is the weaker of the two things it could.</b> A position is here
- * where this reading could not establish that the alternatives leave it what the choice leaves it —
- * not where it established that they do not. So the semantic opening is contained in this and is
- * not this, and the cost of the difference is a reading declining to speak for a position it could
- * have, never an answer handed out as exact when it is not.
+ * <p><b>Two things are owed about it and this holds both.</b> A position has to be told it may be
+ * wider than the rules leave it, and an author has to be sent to the choice they wrote. The two are
+ * not the same set — a position hears about it only where nothing showed the choice leaves it what
+ * it would without the unread alternative, and an author is sent wherever the alternative beside
+ * the unread one <em>reached</em> a position, whether or not the answer there turned on it. Both
+ * are read off this reading's account of this reading's clause, and holding them apart from one
+ * another but together under one {@code L} is what keeps a half of one from being answered with a
+ * half of the other's.
+ *
+ * <p><b>What a member of {@link #positions} says, which is the weaker of the two things it could.</b>
+ * A position is there where this reading could not establish that the alternatives leave it what
+ * the choice leaves it — not where it established that they do not. So the semantic opening is
+ * contained in it and is not it, and the cost of the difference is a reading declining to speak for
+ * a position it could have, never an answer handed out as exact when it is not.
  *
  * <p>Stated at the weaker end on purpose. A reading whose descriptions are canonical can answer the
  * question exactly, and one whose descriptions are written more ways than they are meant can only
@@ -27,19 +38,38 @@ import java.util.Set;
  *                  not a position the other says anything about, and the two answers are the same
  *                  Java type once the tag is dropped ({@link ReadingLanguage})
  * @param positions the positions this reading could not show the alternatives preserve
+ * @param byTheLeftGoingUnread  the positions this reading reached in the right alternative, where
+ *                              the left is one it had no word for. Empty where it read the left
+ * @param byTheRightGoingUnread the same the other way round
  */
-// Unused in what this holds, which is the whole of what it is for: the tag is here so that the
+// L unused in what this holds, which is the whole of what it is for: the tag is here so that the
 // answer cannot be handed to a reading that did not work it out, and a parameter this record read
 // would be one it could answer from.
 @SuppressWarnings("UnusedTypeParameter")
-record Opening<A, L extends ReadingLanguage>(Set<A> positions) {
+record Opening<A, L extends ReadingLanguage>(Set<A> positions, Set<A> byTheLeftGoingUnread,
+                                             Set<A> byTheRightGoingUnread) {
 
+    // Copied on the way in, as everything a reading publishes is: what is here is handed to the
+    // positions and kept in what they came to, so a maker that went on writing to the set it built
+    // one from would be changing what an answer already given says.
     Opening {
-        positions = Set.copyOf(positions);
+        positions = held(positions);
+        byTheLeftGoingUnread = held(byTheLeftGoingUnread);
+        byTheRightGoingUnread = held(byTheRightGoingUnread);
     }
 
-    /** A choice shown to leave every position what it leaves without either alternative. */
+    /**
+     * A choice this reading has nothing to say about.
+     *
+     * <p>Every position where the choice leaves what it leaves without either alternative, and
+     * nobody to send an author to — which is what a choice both of whose alternatives this reading
+     * read comes to, and the only state in which all three are empty together.
+     */
     static <A, L extends ReadingLanguage> Opening<A, L> nothing() {
-        return new Opening<>(Set.of());
+        return new Opening<>(Set.of(), Set.of(), Set.of());
+    }
+
+    private static <A> Set<A> held(Set<A> these) {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(these));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -8,8 +8,11 @@ import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.Place;
 import souther.compiler.types.Type;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The clauses reaching a value, read for where each of its positions stops.
@@ -61,6 +64,8 @@ final class OrderedReading {
     private final Terms terms;
     /** What each position's values are ordered on, for the positions that are ordered at all. */
     private final Map<FactSubject, Carrier> carriers;
+    /** The leaves this reading could not account for, written down as they are met. */
+    private final Set<Core> gaveUp = Collections.newSetFromMap(new IdentityHashMap<>());
 
     private OrderedReading(Terms terms, Map<FactSubject, Carrier> carriers) {
         this.terms = terms;
@@ -98,13 +103,41 @@ final class OrderedReading {
     /**
      * A comparison places an end; nothing else here is read.
      *
-     * <p>A rule of another shape says nothing here, and nothing is what it contributes. It is not
-     * recorded as something that went unread: which positions this reading can speak for is the
-     * value sets' answer, and a second account of it kept here would be a second thing to hold in
-     * step.
+     * <p>Which of them this reading could account for is written down as they are met, and
+     * {@link #gaveUpAt} is where a reader asks. Every leaf that leaves the positions where they
+     * were looks alike from the ranges, and they are not alike: a rule this reading understood and
+     * that bounds nothing is one it read, and a rule it could not follow is one it did not.
      */
     OrderedIntervals<FactSubject> leaf(Core e, boolean positive, Denotations at) {
-        return e instanceof Core.Binary bin ? comparison(bin, positive, at) : OrderedIntervals.top();
+        // A rule of another shape. Whether it holds a value down anywhere is not something this
+        // reading has a word for, so it is not a rule it can be said to have read.
+        return e instanceof Core.Binary bin ? comparison(bin, positive, at) : gaveUp(e);
+    }
+
+    /**
+     * Whether this reading could not account for what {@code e} does to the orders.
+     *
+     * <p>Asked at the leaf it was decided at, and answered out of what was written down when the
+     * decision was made. False exactly where this reading followed the rule to the end: it named a
+     * position it counts, and it either placed an end or found the rule places none. A disequality
+     * is the second of those — it states neither end, that is the whole of what it does to a range,
+     * and a reader taking it for a rule this reading could not follow sends an author to a clause
+     * nothing failed at.
+     *
+     * <p>True everywhere else, and each of those is this reading losing the thread rather than
+     * finding nothing: a rule of another shape, a comparison whose subject is a term this reading
+     * cannot name ({@code Int.abs(n) >= 2}), one whose bound is not a literal of the order. What
+     * such a rule holds a value down to is unknown here, so a choice offering one is a choice this
+     * reading cannot speak for.
+     */
+    boolean gaveUpAt(Core e) {
+        return gaveUp.contains(e);
+    }
+
+    /** A leaf this reading could not follow, which leaves every position where it was. */
+    private OrderedIntervals<FactSubject> gaveUp(Core e) {
+        gaveUp.add(e);
+        return OrderedIntervals.top();
     }
 
     /** Where one comparison leaves the position it names, or nothing where it names none. */
@@ -112,7 +145,8 @@ final class OrderedReading {
                                                      Denotations at) {
         Comparison read = Comparison.of(bin).orElse(null);
         if (read == null) {
-            return OrderedIntervals.top();
+            // Written with an operator and not a comparison. The same as a rule of another shape.
+            return gaveUp(bin);
         }
         // The position-bearing side read as the left one, as `0 <= value` says what `value >= 0`
         // says.
@@ -126,7 +160,10 @@ final class OrderedReading {
         }
         Carrier carrier = position == null ? null : carriers.get(position);
         if (carrier == null) {
-            return OrderedIntervals.top();
+            // Neither side is a position this counts. The rule may still be about one — a length,
+            // an absolute value, a reversal — and what it holds that position to is then something
+            // this reading cannot follow rather than something it found to be nothing.
+            return gaveUp(bin);
         }
         Hir.Expr written = Terms.asWrittenValue(bound, at);
         // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` is an
@@ -135,27 +172,29 @@ final class OrderedReading {
         ComparisonClaim said = positive ? claim : claim.denied();
         return switch (said) {
             // The value the rule is met at, which is a range with one value in it. What a denial
-            // leaves is every other value, and that is a set rather than a range, so this says
-            // nothing about it.
+            // leaves is every other value, and that is a set rather than a range — which is the
+            // whole of what the rule does to a range, so it is one this reading followed.
             case ComparisonClaim.Singled singled -> singled.holdsAtTheValue()
-                    ? onlyTheValue(position, carrier, written)
+                    ? onlyTheValue(bin, position, carrier, written)
                     : OrderedIntervals.top();
-            case ComparisonClaim.Cut cut -> ends(position, carrier,
+            case ComparisonClaim.Cut cut -> ends(bin, position, carrier,
                     InvariantBound.at(cut, written, carrier));
         };
     }
 
     /** The range of one value, or nothing where the rule names none this order reads. */
-    private OrderedIntervals<FactSubject> onlyTheValue(FactSubject position, Carrier carrier,
-                                                       Hir.Expr written) {
+    private OrderedIntervals<FactSubject> onlyTheValue(Core e, FactSubject position,
+                                                       Carrier carrier, Hir.Expr written) {
         Place only = written == null ? null : carrier.literalOf(written);
-        return only == null ? OrderedIntervals.top()
+        // The rule meets the position at something this order has no literal for, so where it
+        // leaves the position is not something this reading found to be nothing.
+        return only == null ? gaveUp(e)
                 : leaves(position, carrier, new OrderedInterval(
                         Endpoint.inclusive(only), Endpoint.inclusive(only)));
     }
 
     /** What the end an ordering placed leaves the position. */
-    private OrderedIntervals<FactSubject> ends(FactSubject position, Carrier carrier,
+    private OrderedIntervals<FactSubject> ends(Core e, FactSubject position, Carrier carrier,
                                                InvariantBound.Read read) {
         return switch (read) {
             case InvariantBound.Read.AnEnd it -> leaves(position, carrier, it.bound().lower()
@@ -166,7 +205,10 @@ final class OrderedReading {
             // whose ends cross come to.
             case InvariantBound.Read.PastWhereTheOrderStops _ ->
                     leaves(position, carrier, carrier.nothing());
-            case InvariantBound.Read.NoEnd _ -> OrderedIntervals.top();
+            // A cut on a position this counts, against something the order has no literal for. The
+            // other reasons NoEnd stands for are answered before this call, so what arrives is
+            // always this one.
+            case InvariantBound.Read.NoEnd _ -> gaveUp(e);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -54,10 +54,15 @@ import java.util.Set;
  * they happened to be empty at the same position: {@code a < "" || a < ""} was refused and
  * {@code a < "" || b < ""} was not.
  *
- * <p><b>Equalities are read and disequalities are not.</b> An equality states both ends at once,
- * which is a range with one value in it and is exactly what this holds; {@code /=} states neither
- * end, and the values a denial leaves are a set rather than a range. Under a denial the two swap
- * places, which is the same rule read once.
+ * <p><b>An equality places both ends and a disequality places none, and both are read.</b> An
+ * equality states both at once, which is a range with one value in it and is exactly what this
+ * holds; {@code /=} states neither, and the values a denial leaves are a set rather than a range —
+ * which is the whole of what such a rule does to a range and is an answer, not a reading that
+ * stopped. Under a denial the two swap places, which is the same rule read once.
+ *
+ * <p>Told apart from a rule this has no word for by {@link #gaveUpAt} and never by the ranges: both
+ * leave every position where it was, and reading that back as "nothing was read here" is what made
+ * every denial written beside a bound into a choice this reading declined to speak for.
  */
 final class OrderedReading {
 
@@ -166,9 +171,9 @@ final class OrderedReading {
             return gaveUp(bin);
         }
         Hir.Expr written = Terms.asWrittenValue(bound, at);
-        // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` is an
-        // equality and is read; `!(value == x)` is a disequality and is not, which is the same
-        // answer the disequality gets when it is written directly.
+        // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` places
+        // both ends and `!(value == x)` places none, which is the same answer each of them gets
+        // written directly — and neither is a rule this reading failed at.
         ComparisonClaim said = positive ? claim : claim.denied();
         return switch (said) {
             // The value the rule is met at, which is a range with one value in it. What a denial

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -233,9 +233,10 @@ sealed interface StatedByClauses {
                     : "two alternatives of one choice are answerable for one written place";
             Set<RuleShortfall> shortfalls = new LinkedHashSet<>(ruleShortfalls);
             shortfalls.addAll(other.ruleShortfalls());
-            leftOpenByValues(choice, opening.byTheRightGoingUnread(), other.ruleShortfalls(),
-                    shortfalls);
-            leftOpenByValues(choice, opening.byTheLeftGoingUnread(), ruleShortfalls, shortfalls);
+            leftOpenByValues(choice, opening.byValues().byTheRightGoingUnread(),
+                    other.ruleShortfalls(), shortfalls);
+            leftOpenByValues(choice, opening.byValues().byTheLeftGoingUnread(),
+                    ruleShortfalls, shortfalls);
             return new Part(byValues.either(opening.byValues(), other.byValues()),
                     byOrder.either(opening.byOrder(), other.byOrder()),
                     StringRestriction.over(aboutStrings, other.aboutStrings(), false),
@@ -273,8 +274,11 @@ sealed interface StatedByClauses {
          *
          * <p><b>Of the reading of values, which is what the name says and not all there is.</b>
          * Where a position's order stops is taken back by an unread alternative the same way, and
-         * an author is sent to the choice for that by nothing here. Whether they are owed it is a
-         * question of its own and is open.
+         * the ends' opening now says where it would send an author
+         * ({@link Opening#byTheLeftGoingUnread}). What stands between that and this call is that
+         * the ends call an alternative unread wherever it placed no end, so a disequality beside a
+         * bound comes here as a choice nothing could read. Routed before that is the ends' own
+         * answer, an author is sent to clauses this compiler read perfectly well.
          */
         private static void leftOpenByValues(RuleShortfall.Site.AtAChoice choice,
                                              Set<FactSubject> these,
@@ -305,45 +309,26 @@ sealed interface StatedByClauses {
      * choice both of whose alternatives went unread is two things to answer for, and each is
      * weighed against what the branch beside it is already answerable for.
      *
-     * <p><b>Two sets and not one, because the two sides ask two questions of it.</b> An author has
-     * to look at this choice wherever the alternative beside the unread one <em>reached</em> a
-     * position, whether or not the answer there turned on it — that is a fact about clauses
-     * somebody wrote, and it is read off the tree that keeps their shape. A position is reported
-     * wider than the rules only where nothing showed the choice leaves it what it would without
-     * the unread alternative, which is a fact about values and is settled where the branches are
-     * ({@link Settlement.WidthDependency}). Made one,
-     * {@code (P(a) && f(b)) || (P(a) && f(b))} came out with {@code a} reported wider than the
-     * rules hold it: both alternatives reached {@code a}, and dropping either was shown to leave
-     * it where it was.
+     * <p><b>One opening per reading, and nothing here that is not one reading's.</b> Both things
+     * owed about a choice — that a position may be wider than the rules leave it, and that an
+     * author has to look at the choice they wrote — are read off a reading's account of its own
+     * clause, and each {@link Opening} holds its reading's answer to both. What the two languages
+     * say is never mixed until a shortfall is made, where the reading a fact arrived by has stopped
+     * being part of what is said.
      *
-     * @param byTheLeftGoingUnread  the positions the right alternative reached, where the left is
-     *                              one nothing could read. Empty where it was read
-     * @param byTheRightGoingUnread the same the other way round
-     * @param byValues              what the reading of values could not show the alternatives leave
-     *                              where they were, where one of them went unread there
-     * @param byOrder               the same asked of where the orders stop. A separate answer and
-     *                              not a copy: which alternative went unread is each reading's own,
-     *                              and so is what a branch leaves
+     * @param byValues what the reading of values says this choice left open
+     * @param byOrder  the same asked of where the orders stop. A separate answer and not a copy:
+     *                 which alternative went unread is each reading's own, and so is what a branch
+     *                 leaves and where the branch beside it reached
      */
-    record AlternativeOpening(ChoiceId choice, Set<FactSubject> byTheLeftGoingUnread,
-                              Set<FactSubject> byTheRightGoingUnread,
+    record AlternativeOpening(ChoiceId choice,
                               Opening<FactSubject, ReadingLanguage.Values> byValues,
                               Opening<FactSubject, ReadingLanguage.Order> byOrder) {
 
-        // Copied on the way in, as everything a reading publishes is: what is here is handed to
-        // the positions and kept in what they came to, so a maker that went on writing to the set
-        // it built one from would be changing what an answer already given says. The openings do
-        // it where they are made, which is why only the two sets are copied here.
         public AlternativeOpening {
             if (choice == null) {
                 throw new IllegalArgumentException("an opening is some choice's");
             }
-            byTheLeftGoingUnread = held(byTheLeftGoingUnread);
-            byTheRightGoingUnread = held(byTheRightGoingUnread);
-        }
-
-        private static Set<FactSubject> held(Set<FactSubject> these) {
-            return Collections.unmodifiableSet(new LinkedHashSet<>(these));
         }
     }
 
@@ -379,8 +364,6 @@ sealed interface StatedByClauses {
     static AlternativeOpening opens(ChoiceId choice, Settlement.WidthDependency width,
                                     Part one, Part other) {
         return new AlternativeOpening(choice,
-                one.byValues().hasUnreadPart() ? reachedBy(other.byValues()) : Set.of(),
-                other.byValues().hasUnreadPart() ? reachedBy(one.byValues()) : Set.of(),
                 openedBy(width.byValues(), one.byValues(), other.byValues()),
                 openedBy(width.byOrder(), one.byOrder(), other.byOrder()));
     }
@@ -410,12 +393,22 @@ sealed interface StatedByClauses {
         if (other.hasUnreadPart()) {
             opened.addAll(width.mayRestOnRight());
         }
-        return new Opening<>(opened);
+        return new Opening<>(opened,
+                one.hasUnreadPart() ? reachedBy(other) : Set.of(),
+                other.hasUnreadPart() ? reachedBy(one) : Set.of());
     }
 
-    /** The positions a reading reached and did not merely settle: what it constrained, and what it
-     *  was about and could not manage. */
-    private static Set<FactSubject> reachedBy(Adoption<FactSubject, ReadingLanguage.Values> of) {
+    /**
+     * The positions a reading reached and did not merely settle: what it constrained, and what it
+     * was about and could not manage.
+     *
+     * <p>Of whichever reading is asking, and the reading it is asked of is the one that had no word
+     * for the alternative beside this one. Taken from one and the flag from the other, the answer
+     * would say that a branch the ends read whole leaves a position's order open because the values
+     * had no word for it — two halves of two questions, composing without a complaint.
+     */
+    private static <L extends ReadingLanguage> Set<FactSubject> reachedBy(
+            Adoption<FactSubject, L> of) {
         Set<FactSubject> out = new LinkedHashSet<>(of.read());
         out.addAll(of.missed());
         return out;

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -272,13 +272,13 @@ sealed interface StatedByClauses {
          * reasons suppress which would be one more place the vocabulary has to be consulted, and a
          * reason added to it would quietly change what a choice says.
          *
-         * <p><b>Of the reading of values, which is what the name says and not all there is.</b>
-         * Where a position's order stops is taken back by an unread alternative the same way, and
-         * the ends' opening now says where it would send an author
-         * ({@link Opening#byTheLeftGoingUnread}). What stands between that and this call is that
-         * the ends call an alternative unread wherever it placed no end, so a disequality beside a
-         * bound comes here as a choice nothing could read. Routed before that is the ends' own
-         * answer, an author is sent to clauses this compiler read perfectly well.
+         * <p><b>Of the reading of values, and the ends' opening is not joined to it.</b> The
+         * positions each reading reaches in a branch are the branch's mentions either way, so
+         * joining the two adds an entry exactly where the ends could not follow an alternative and
+         * the values read it — and what would be said there is that nothing could read it, which
+         * is false. The ends are owed a sentence about a choice that took back where a position
+         * stops, in the vocabulary that can say the ends were the reading that stopped
+         * ({@code RuleAccounting.Why.TheEndReadingSays}); this reason is not it.
          */
         private static void leftOpenByValues(RuleShortfall.Site.AtAChoice choice,
                                              Set<FactSubject> these,
@@ -530,13 +530,14 @@ sealed interface StatedByClauses {
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
-            Set<FactSubject> bounded = range.boundedAt();
             return new Said(new Confinement.Planned<>(said, range, ordered.carriers()), new Part(
-                    // Each language says whether it gave up on the leaf. The reading of values
-                    // carries it; the reading of order has nothing to hand back but its ranges, and
-                    // a leaf it read leaves at least one.
+                    // Each language says for itself whether it could account for the leaf, and each
+                    // is asked. Read off what a language produced instead, a rule it followed to
+                    // the end and found bounds nothing is one it gave up on — which is what every
+                    // disequality is to the ends, and a bound written beside one comes out as a
+                    // choice offering an alternative nothing could read.
                     Adoption.at(mentions, said.adoptedAt(), values.gaveUpAt(e)),
-                    Adoption.at(mentions, bounded, bounded.isEmpty()),
+                    Adoption.at(mentions, range.boundedAt(), ordered.gaveUpAt(e)),
                     // And what the leaf states about the strings at a position, where it is a rule
                     // about them. Asked of the reading that recognises one, so this is where the
                     // answer enters and the connectives below are what compose it.

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -328,6 +328,55 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Settlement.Width<>(java.util.Set.of(), java.util.Set.of(CONSTRAINED)));
     }
 
+    /**
+     * And the reading of ends is sent to the choice by its own alternative going unread.
+     *
+     * <p>The other half of the same fact, and the one nothing else here reaches. Which alternative
+     * a reading had no word for is that reading's, and so is where the branch beside it reached —
+     * so an opening of the ends is not the values' answer with another name on it, and holding only
+     * the empty case would leave a half that is always empty passing for one that is right.
+     *
+     * <p>The values read both alternatives here, which is what makes the two answers differ: the
+     * ends send an author to this choice and the values send them nowhere, over one written
+     * {@code ||}.
+     */
+    @Test
+    void andTheEndsAreSentToTheChoiceByTheirOwnAlternativeGoingUnread() {
+        StatedByClauses.AlternativeOpening opened = StatedByClauses.opens(new ChoiceId(),
+                widthRestingOnTheRight(),
+                theBranchTheEndsCouldNotRead(), theBranchTheEndsRead());
+
+        assertEquals(java.util.Set.of(CONSTRAINED), opened.byOrder().byTheLeftGoingUnread(),
+                "the ends had no word for the left alternative, so an author is sent here about"
+                        + " the position the right one reached");
+        assertEquals(java.util.Set.of(), opened.byOrder().byTheRightGoingUnread(),
+                "and nowhere for the right, which they read");
+        assertEquals(java.util.Set.of(), opened.byValues().byTheLeftGoingUnread(),
+                "and the values read both, so what they send an author to is not this");
+        assertEquals(java.util.Set.of(), opened.byValues().byTheRightGoingUnread(),
+                "either way round");
+    }
+
+    /** A branch the ends had no word for, the values having read it. */
+    private static StatedByClauses.Part theBranchTheEndsCouldNotRead() {
+        return new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
+                        java.util.Set.of(), false, java.util.Set.of()),
+                new Adoption<>(java.util.Set.of(), java.util.Set.of(),
+                        java.util.Set.of(UNREAD), true, java.util.Set.of()),
+                Map.of(), java.util.Set.of(), java.util.Set.of());
+    }
+
+    /** And the alternative beside it that both of them read, constraining one position. */
+    private static StatedByClauses.Part theBranchTheEndsRead() {
+        return new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
+                        java.util.Set.of(), false, java.util.Set.of()),
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
+                        java.util.Set.of(), false, java.util.Set.of()),
+                Map.of(), java.util.Set.of(), java.util.Set.of());
+    }
+
     /** One choice somebody wrote, told from every other by being this one. */
     private static RuleShortfall.Site.AtAChoice aChoice() {
         return new RuleShortfall.Site.AtAChoice(new ChoiceId(), new SourcePos(1, 1));

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -245,16 +245,19 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 theBranchRead(java.util.Set.of()),
                 theBranchNothingRead(java.util.Set.of()));
 
-        assertEquals(java.util.Set.of(CONSTRAINED), opened.byTheRightGoingUnread(),
+        assertEquals(java.util.Set.of(CONSTRAINED), opened.byValues().byTheRightGoingUnread(),
                 "an author is sent here about the position the branch beside it constrained, and"
                         + " not about the one it settled");
         assertEquals(java.util.Set.of(CONSTRAINED), opened.byValues().positions(),
                 "and the position hears about it, the width there being the unread branch's");
-        assertEquals(java.util.Set.of(), opened.byTheLeftGoingUnread(),
+        assertEquals(java.util.Set.of(), opened.byValues().byTheLeftGoingUnread(),
                 "the left alternative was read, so nothing is open by its going unread");
         assertEquals(java.util.Set.of(), opened.byOrder().positions(),
                 "and the reading of order read both alternatives, so the width it could not"
                         + " account for is not something an unread alternative left open");
+        assertEquals(java.util.Set.of(), opened.byOrder().byTheRightGoingUnread(),
+                "and it sends an author nowhere for the same reason: which alternative went"
+                        + " unread is each reading's own, and the ends had a word for both");
     }
 
     /**
@@ -306,8 +309,9 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
      */
     private static StatedByClauses.AlternativeOpening opened(
             RuleShortfall.Site.AtAChoice choice) {
-        return new StatedByClauses.AlternativeOpening(choice.id(), java.util.Set.of(),
-                java.util.Set.of(CONSTRAINED), new Opening<>(java.util.Set.of(CONSTRAINED)),
+        return new StatedByClauses.AlternativeOpening(choice.id(),
+                new Opening<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
+                        java.util.Set.of(CONSTRAINED)),
                 Opening.nothing());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest.java
@@ -37,8 +37,9 @@ class AnOpeningIsAppliedToAnAccountAndNeverDerivedFromItTest {
                 Set.of());
     }
 
+    /** What the choice was settled to leave open, which is the half of an opening this applies. */
     private static Opening<String, ReadingLanguage.Values> opening(String... positions) {
-        return new Opening<>(Set.of(positions));
+        return new Opening<>(Set.of(positions), Set.of(), Set.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/TheEndsSayForThemselvesWhichRuleTheyCouldNotFollowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheEndsSayForThemselvesWhichRuleTheyCouldNotFollowTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.UnreadReason;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Whether the reading of ends could follow a rule is that reading's to say, and not read off the
+ * ranges it produced.
+ *
+ * <p>Every rule that bounds nothing leaves the positions where they were, and they are not alike. A
+ * denial states neither end: this reading has a word for that, what it leaves is every value the
+ * order holds, and the rule is one it followed to the end. A comparison whose subject is a term it
+ * cannot name leaves them there too, and it is a rule this reading lost the thread of — what such a
+ * rule holds a value down to is unknown here.
+ *
+ * <p><b>Why the difference is worth a test.</b> A branch this reading could not follow is what a
+ * choice needs in order to know that the alternative widened it, and a branch it followed is not.
+ * Answered off the ranges, every denial written beside a bound made the choice one this reading
+ * declined to speak for — so a question about the bounded position stood, with an account naming a
+ * clause nothing failed at.
+ *
+ * <p>Asked at the accounting rather than at the flag, because that is where the difference is a
+ * fact about a model. The pair below is the whole of it: the same shape twice, one alternative the
+ * ends read and one they could not, and the answers are not the same.
+ */
+class TheEndsSayForThemselvesWhichRuleTheyCouldNotFollowTest {
+
+    /**
+     * A denial of one position beside a bound on another.
+     *
+     * <p>Nothing about {@code n} rests on this reading having failed at anything: the left
+     * alternative admits every {@code n} there is, the right holds it above two, and where the
+     * choice leaves {@code n} is every value — which is what the rule says and what this reading
+     * arrived at.
+     */
+    private static final String A_DENIAL_BESIDE_A_BOUND = """
+            module demo
+
+            data N = { m: Int, n: Int }
+                invariant r = m /= 5 || n >= 2
+            """;
+
+    /**
+     * The same shape, with a subject the reading of ends cannot name.
+     *
+     * <p>{@code Int.abs(m)} is not a position this counts, so what the left alternative holds
+     * {@code m} to is unknown here — and a value satisfying it owes the right one nothing. The
+     * question at {@code n} stands, and this is what says the flag still fires where it should.
+     */
+    private static final String A_SUBJECT_THE_ENDS_CANNOT_NAME = """
+            module demo
+
+            data N = { m: Int, n: Int }
+                invariant r = Int.abs(m) >= 5 || n >= 2
+            """;
+
+    /** A denial is a rule this reading followed, so the choice is one it can speak for. */
+    @Test
+    void aDenialBesideABoundLeavesNothingStandingAtTheBoundedPosition() {
+        assertEquals(List.of(), standingAt(A_DENIAL_BESIDE_A_BOUND, "n"),
+                "the ends read both alternatives and the choice leaves `n` every value, which is"
+                        + " an answer — read off the ranges, the denial bounded nothing and the"
+                        + " choice was one nothing could speak for");
+    }
+
+    /** And a rule whose subject it cannot name is one it did not, so the question stands. */
+    @Test
+    void andASubjectTheEndsCannotNameLeavesTheQuestionStanding() {
+        assertFalse(standingAt(A_SUBJECT_THE_ENDS_CANNOT_NAME, "n").isEmpty(),
+                "what the left alternative holds `m` to is unknown to this reading, so the choice"
+                        + " is one it cannot speak for and `n` is left open by it");
+    }
+
+    /** What every question about {@code field} was left standing on, over every rule of the value. */
+    private static List<UnreadReason> standingAt(String source, String field) {
+        List<UnreadReason> out = new ArrayList<>();
+        read(source).accounting().values().forEach(accounting ->
+                accounting.answers().forEach((owed, outcome) -> {
+                    if (owed.toString().equals(field)
+                            && outcome instanceof RuleAccounting.Outcome.Unaccounted it
+                            && it.why() instanceof RuleAccounting.Why.TheValueReadingSays says) {
+                        out.addAll(says.why());
+                    }
+                }));
+        return out;
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        return FieldDomains.of(
+                TypeSymbols.declared(new TypeKey(symbols.module(), "N")),
+                RuleReadings.of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}


### PR DESCRIPTION
Groundwork under #1462, which stays open. Neither of these is what that issue asks for; both are things it ran into, and both are wrong on their own terms.

## An opening holds both of a reading's answers

Two things are owed about a choice that offers an alternative nothing could read: a position has to hear it may be wider than the rules leave it, and an author has to be sent to the choice they wrote. The first was held per reading; the second stood beside it as loose sets. Those sets were the values' and nothing in their type said so — which is why the ends' half was never written, while every neighbour of it had a reading and they did not.

So they move inside the opening. A maker is handed one reading's width and one reading's two accounts, and can build nothing out of a mixture; the flag saying an alternative went unread is read at one site rather than two.

## The ends say which rule they could not follow

The account of the ends called an alternative unread wherever it placed no end. Every rule that bounds nothing looks alike from the ranges, and they are not alike: a denial states neither end, which this reading has a word for and is the whole of what such a rule does to a range; a comparison whose subject is a term it cannot name is a rule it lost the thread of. Read off the ranges, every denial written beside a bound made the choice one this reading declined to speak for, and a question about the bounded position stood with an account naming a clause nothing failed at.

So the reading says it for itself, as the reading of values already does — beside a control holding the flag to still firing where the subject is one the ends cannot name.

## What is not here

An earlier form of this branch also carried the ends' half of #1462: which names a choice leaves the line undecided at, folded over the clause an author wrote. It is withdrawn. The readings already compose choices, where the branches are settled and where which branch nobody can be in is known, and a fold over the shape has to work that out again and cannot — `s < "" || Int.abs(x) >= 2` came back saying the rule states no line at `x`, and the rule is the right half of it.

The counterexamples that found each round of that are in #1462, for whatever satisfies them next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)