### PR TITLE
Separate invariant judgments from where their clauses are written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Clause.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clause.java
@@ -1,73 +1,36 @@
 package souther.compiler.check;
 
-import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.Objects;
 import java.util.Optional;
 
 /**
- * One invariant clause, as what identifies it and what a diagnostic knows about it.
+ * What a reading of a declaration's invariants says about one clause of it.
  *
- * <p>Four questions, kept apart because none of them answers another. Which clause it is, is
- * {@link Id}. What a sentence can call it, is {@code name} — a clause MAY be written without one.
- * Where a reader can be sent, is {@code at} — a clause of a published module was written somewhere
- * this compile has no source for. What was proved of it is neither of these and is
+ * <p>Three questions, kept apart because none of them answers another. Which clause it is, is
+ * {@link Id}. What a sentence can call it, is a name — a clause MAY be written without one. Those
+ * two are {@link Ref}, which is what a reading carries. What was proved of it is neither and is
  * {@link InvariantChecker.Judgment}'s, which is why a clause is put on one of its sides rather than
- * carrying a verdict here.
+ * carrying a verdict.
  *
- * <p>{@code name} is optional and {@code at} is not. An absent name is a fact about the
- * declaration: the author wrote none, and every reading of that declaration finds none. Where the
- * clause is written is always answered — a clause of a published module is
- * {@link DiagnosticPlace.Unavailable}, which says where the code came from rather than being the
- * absence of an answer. It used to be absent, and absent is what every reader turned into silence.
- *
- * <p>{@code at} is the same for every reading of one clause, which is what {@link #merge} rests on.
- * Where a clause is written is settled where its text became positions and follows from the
- * declaration it is on, so a walk reaching it down two branches finds one answer twice.
+ * <p>Where a clause is written is a fourth question, and it is asked of the declaration rather than
+ * carried from the reading that judged the clause ({@link ClauseLocations}). It follows from the
+ * text and from nothing a reading did, so a reading that carried it would be worked out again for
+ * an edit that moved the clause and changed nothing it states — and a reader that kept its answer
+ * would keep the place the clause used to be at.
  */
-public record Clause(Id id, Optional<ClauseName> name, DiagnosticPlace at) {
+public final class Clause {
 
-    public Clause {
-        Objects.requireNonNull(id, "a clause is one clause");
-        Objects.requireNonNull(name, "a clause was written with a name or without one");
-        Objects.requireNonNull(at, "a clause is written somewhere, quotable here or not");
-        // As the declaration knows it, with no reader's route in it. Where the clause is written is
-        // a fact about the declaration and the same for every reading of it; the name a reading
-        // reached the code by is a fact about that reading. Carried, two readings of one clause are
-        // two values, and `merge` stops being the same operation whichever way round it is asked.
-        if (at instanceof DiagnosticPlace.Unavailable out) {
-            at = new DiagnosticPlace.Unavailable(out.provenance().asDeclared());
-        }
-    }
-
+    private Clause() {}
 
     /**
-     * The clause a walk over a declaration's invariants arrived at.
+     * Which clause it is and what a report calls it.
      *
-     * <p>The one way to make one. Everything that names a clause — a diagnostic about what it could
-     * not prove, a line a bound of it drew — is naming the same rule, and a second construction is a
-     * second chance for two surfaces to call one clause by different words.
-     */
-    public static Clause of(TypeOps.Declared declared) {
-        return new Clause(new Id(declared.declaredOn(), declared.ordinal()),
-                declared.clause().name().map(ClauseName::new),
-                DiagnosticPlace.of(declared.clause().reportedAt()));
-    }
-
-    /** This clause, as what identifies it and what to call it. */
-    public Ref ref() {
-        return new Ref(id, name);
-    }
-
-    /**
-     * Which clause it is and what a report calls it, without where a reader can be sent.
-     *
-     * <p>Two of the four questions above, for the readers that ask only those. What names a line is
-     * which clause drew it, and where a reader can be sent is a question only a diagnostic asks —
-     * asked of every clause a bound was read from, a clause whose region names no source could not
-     * be recorded at all, and the rule that placed the edge would go unnamed for want of an answer
-     * nobody wanted.
+     * <p>What a walk over a declaration's invariants hands on, and the one way to name a clause.
+     * Everything that names one — a diagnostic about what it could not prove, a line a bound of it
+     * drew — is naming the same rule, and a second construction is a second chance for two surfaces
+     * to call one clause by different words.
      *
      * <p>Inside the reading of a declaration's clauses, and no further. This says which clause of
      * which declaration, which is what a walk over a declaration's invariants has to hand; a clause
@@ -87,6 +50,32 @@ public record Clause(Id id, Optional<ClauseName> name, DiagnosticPlace at) {
         public static Ref of(TypeOps.Declared declared) {
             return new Ref(new Id(declared.declaredOn(), declared.ordinal()),
                     declared.clause().name().map(ClauseName::new));
+        }
+
+        /**
+         * The two readings of one clause, together.
+         *
+         * <p>Commutative, associative and idempotent, so the order the readings of a construction
+         * are combined in does not decide what is reported. Which is the whole of what this is for:
+         * two branches of a conditional read one construction once each, and a first-wins union
+         * would let the walk's order decide what a warning names.
+         *
+         * <p>Two readings of one clause say the same thing about it, or the model contradicts
+         * itself. Nothing here picks between them, which is what makes the three properties above
+         * hold rather than being claimed: an operation that preferred one reading to another is a
+         * first-wins union whichever rule it prefers by, and one that refused some disagreements
+         * while absorbing others finds a contradiction or not depending on which pair was merged
+         * first.
+         */
+        public static Ref merge(Ref a, Ref b) {
+            if (!a.id.equals(b.id)) {
+                throw new NotOneClause("two clauses, " + a.id + " and " + b.id + ", merged as one");
+            }
+            if (!a.name.equals(b.name)) {
+                throw new NotOneClause("clause " + a.id + " is named " + a.name.orElse(null)
+                        + " in one reading and " + b.name.orElse(null) + " in another");
+            }
+            return a;
         }
 
         @Override
@@ -112,48 +101,12 @@ public record Clause(Id id, Optional<ClauseName> name, DiagnosticPlace at) {
     }
 
     /**
-     * The two readings of one clause, together.
-     *
-     * <p>Commutative, associative and idempotent, so the order the readings of a construction are
-     * combined in does not decide what is reported. Which is the whole of what this is for: two
-     * branches of a conditional read one construction once each, and a first-wins union would let
-     * the walk's order decide whether a warning points anywhere.
-     *
-     * <p>Two readings of one clause say the same thing about it, or the model contradicts itself.
-     * Nothing here picks between them, which is what makes the three properties above hold rather
-     * than being claimed: an operation that preferred one reading to another is a first-wins union
-     * whichever rule it prefers by, and one that refused some disagreements while absorbing others
-     * finds a contradiction or not depending on which pair was merged first.
-     *
-     * <p>It used to prefer the reading that could point somewhere, and there used to be a reason: a
-     * reading that could not was an absent value, so which representation a clause was reached
-     * through decided how much a reading knew. Where a clause is written is now settled where its
-     * text became positions and is the same for every reading of it — a clause is quotable or it is
-     * out of sight because of the declaration it is on, not because of the path a walk took to it,
-     * and "no place at all" is not a thing a reading can produce. Measured over the whole suite: no
-     * compile produces two readings of one clause that differ.
-     */
-    public static Clause merge(Clause a, Clause b) {
-        if (!a.id.equals(b.id)) {
-            throw new NotOneClause("two clauses, " + a.id + " and " + b.id + ", merged as one");
-        }
-        if (!a.name.equals(b.name)) {
-            throw new NotOneClause("clause " + a.id + " is named " + a.name.orElse(null)
-                    + " in one reading and " + b.name.orElse(null) + " in another");
-        }
-        if (!a.at.equals(b.at)) {
-            throw new NotOneClause("clause " + a.id + " is written at " + a.at
-                    + " in one reading and at " + b.at + " in another");
-        }
-        return a;
-    }
-
-    /**
      * Two readings of one clause that do not agree about the clause.
      *
      * <p>What a declaration says is one thing, and two readings of it are two accounts of that one
-     * thing. Where they disagree about where a clause is written, one of them is about a clause the
-     * other is not, and everything either says of it is filed against the wrong obligation. There is
+     * thing. Where they disagree about which clause it is or what it is called, one of them is about
+     * a clause the other is not, and everything either says of it is filed against the wrong
+     * obligation. There is
      * no answer to compose out of the two: taking one publishes a reading the model does not decide,
      * and a body that came back with nothing to say for that reason is a body whose invariants all
      * discharge, said in the same words.

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseLocations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseLocations.java
@@ -1,0 +1,41 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.DiagnosticPlace;
+
+/**
+ * Where a clause a report names is written.
+ *
+ * <p>Asked here and not carried from the reading that judged the clause. Which clause it is, is
+ * {@link Clause.Id} and follows from the declaration; where it is written follows from the text of
+ * that declaration and from nothing the reading did. Carried along with the judgment, an edit that
+ * moves the clause and changes nothing it states leaves every reader of the judgment to be worked
+ * out again — and the reader that keeps its answer keeps the place the clause used to be at.
+ *
+ * <p>So a place is looked up where a sentence is written, by the reader that is about to point
+ * somewhere, and by nobody else. What a clause states and where it is written are two facts about
+ * one declaration, and a reader asks for the one it uses.
+ *
+ * <p>Every clause is answered. A clause of a module this compile has no source for is
+ * {@link DiagnosticPlace.Unavailable}, which says where the code came from — the absence of a file
+ * is not the absence of an answer.
+ */
+@FunctionalInterface
+public interface ClauseLocations {
+
+    /** Where {@code clause} is written. */
+    DiagnosticPlace of(Clause.Id clause);
+
+    /**
+     * Nothing declared anywhere — the other half of {@link ExpandedClauseLookup#NONE}, for a reading
+     * over primitives.
+     *
+     * <p>It refuses rather than answering. A reading that has no clauses has no clause to report
+     * about, so an ask here is a reader pointing at something nothing declared; answered with a
+     * place that points nowhere, that reader would publish a sentence about a clause no author
+     * wrote.
+     */
+    ClauseLocations NONE = clause -> {
+        throw new IllegalStateException("nothing declares a clause, so " + clause
+                + " is written nowhere");
+    };
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -33,6 +33,7 @@ final class Clauses {
 
     private final Symbols symbols;
     private final ExpandedClauseLookup expandedClauses;
+    private final ClauseLocations written;
     private final DeclarationReadings machines;
     private final Map<TypeSymbol.AtModule, Map<String, Type>> fields = new HashMap<>();
     private final Map<TypeSymbol.AtModule, Map<String, BindingId>> bindings =
@@ -52,14 +53,18 @@ final class Clauses {
      *        that was: a type this module declares and one it imports are read alike, because what
      *        a clause is read as is what its own module expanded (spec
      *        §invariant-discharge-representation).
+     * @param written where a clause of a declaration is written, handed on to the readers that
+     *        publish a sentence pointing at one and read by nothing here. Beside the clauses and
+     *        not among them, for the reason {@link ClauseLocations} gives.
      * @param machines where the answers about a declaration's string machines are asked for,
      *        handed on to every reading of a declaration made through here and kept by none of
      *        what those readings answer with.
      */
-    Clauses(Symbols symbols,
-            ExpandedClauseLookup expandedClauses, DeclarationReadings machines) {
+    Clauses(Symbols symbols, ExpandedClauseLookup expandedClauses, ClauseLocations written,
+            DeclarationReadings machines) {
         this.symbols = symbols;
         this.expandedClauses = expandedClauses;
+        this.written = written;
         this.machines = machines;
     }
 
@@ -67,6 +72,12 @@ final class Clauses {
      *  on rather than ask for one of its own. */
     ExpandedClauseLookup expandedClauses() {
         return expandedClauses;
+    }
+
+    /** Where a clause of a declaration is written, for the same reader — asked where a sentence
+     *  points and read by nothing here. */
+    ClauseLocations written() {
+        return written;
     }
 
     /** Where the answers about a declaration's string machines are asked for, for the same
@@ -177,16 +188,16 @@ final class Clauses {
         List<Stated> stated = new ArrayList<>();
         List<RuleRef.Invariant> lost = new ArrayList<>();
         for (TypeOps.Declared inv : declared(named)) {
-            Clause clause = Clause.of(inv);
+            Clause.Ref clause = Clause.Ref.of(inv);
             Core one = statedAt(inv.asExpanded(), named, given);
             if (one != null) {
                 // The clause as one reading, and the parts its author wrote as subtrees of that
                 // very reading. Read apart instead, a conjunct would be read without the conjunct
                 // beside it, and a branch one of them rules out would stand.
                 stated.add(new Stated(clause, one,
-                        inv.shape().onto(one, new RuleRef.Invariant(clause.ref()))));
+                        inv.shape().onto(one, new RuleRef.Invariant(clause))));
             } else {
-                lost.add(new RuleRef.Invariant(clause.ref()));
+                lost.add(new RuleRef.Invariant(clause));
             }
         }
         return new StatedClauses(List.copyOf(stated), List.copyOf(lost));
@@ -229,16 +240,17 @@ final class Clauses {
      * its author wrote it in.
      *
      * <p>A check that judges the clauses one at a time has something to say about the one it could
-     * not settle, and what it says it by is what {@link Clause} holds — which the clauses were
+     * not settle, and what it says it by is what {@link Clause.Ref} holds — which the clauses were
      * flattened out of before reaching here, leaving every unproven clause reported as "the
-     * invariant".
+     * invariant". Where the clause is written is not among it and is looked up where a sentence
+     * points ({@link ClauseLocations}).
      *
      * <p>The parts are two views of one reading and not two readings. What a clause states is read
      * as one thing — its conjuncts meet there, and a branch one of them rules out is ruled out
      * there — and what an author is answerable for is a part; each part is a subtree of
      * {@code expr} and not a tree read beside it.
      */
-    record Stated(Clause clause, Core expr, List<StatedPart> parts) {
+    record Stated(Clause.Ref clause, Core expr, List<StatedPart> parts) {
 
         public Stated {
             parts = List.copyOf(parts);

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -81,7 +81,8 @@ public record ContractDischarge(List<RuleDischarge> rules,
         // declaration through the values it names, and the representation those are read in is the
         // one every other reader of this module's rules uses.
         Terms naming = new Terms(source.symbols(), Terms.Of.THE_DISCHARGE_TREE, policy,
-                new Clauses(source.symbols(), source.invariants(), DeclarationReadings.NONE));
+                new Clauses(source.symbols(), source.invariants(), source.written(),
+                        DeclarationReadings.NONE));
         Denotations locations =
                 Denotations.none().locations(named, naming::placeSubject, naming::placeTerm);
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -221,9 +221,12 @@ public final class InvariantChecker {
      * <p>What it may answer instead is that a declaration's clauses could not be worked out at all.
      * That is a rule this check did not reach and is recorded as one; it is never read as a
      * declaration with no rules, which is the same empty list and the opposite fact.
+     *
+     * <p>{@code written} is where a clause this check reports about is written, asked separately for
+     * the reason {@link ClauseLocations} gives.
      */
     public record Source(Hir.Expr body, ElementProvenance elements, ExpandedClauseLookup invariants,
-                         DeclarationReadings machines,
+                         ClauseLocations written, DeclarationReadings machines,
                          Map<ValueName.Behavior, AssumedContract> contracts) {
 
         public Source {
@@ -255,6 +258,9 @@ public final class InvariantChecker {
     private final Terms terms;
     /** What a clause owes and what a guard settles. */
     private final Predicates predicates;
+    /** Where a clause this check reports about is written, asked where a sentence points and not
+     * carried by the judgment that named the clause ({@link ClauseLocations}). */
+    private final ClauseLocations written;
     /** Whether an evaluation can answer, which is what decides that a continuation is reached. */
     private final PathCompletion completion;
     /**
@@ -273,19 +279,22 @@ public final class InvariantChecker {
     private final List<Diagnostic> warnings = new ArrayList<>();
 
     private InvariantChecker(Symbols symbols,
-                             ExpandedClauseLookup dischargeInvariants, DeclarationReadings machines,
-                             ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, machines, Map.of(), policy);
+                             ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
+                             DeclarationReadings machines, ReadingPolicy policy) {
+        this(symbols, dischargeInvariants, written, machines, Map.of(), policy);
     }
 
     private InvariantChecker(Symbols symbols,
-                             ExpandedClauseLookup dischargeInvariants, DeclarationReadings machines,
+                             ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
+                             DeclarationReadings machines,
                              Map<ValueName.Behavior, AssumedContract> contracts,
                              ReadingPolicy policy) {
+        this.written = written;
         // Where the answers about a declaration's string machines are asked for, for every
         // declaration this check reads: a capability handed on to the engine, which hands it to
         // every reading made through it, and kept by nothing any of them answers with.
-        this.engine = new PathEngine(symbols, dischargeInvariants, machines, contracts, policy);
+        this.engine = new PathEngine(symbols, dischargeInvariants, written, machines, contracts,
+                policy);
         // Borrowing nothing, since no declaration is being seeded yet, and knowing what the
         // revision knows: where a set stops is the same answer whoever met it.
         this.answers = StringMachineAnswers.unborrowed(machines.extents());
@@ -308,7 +317,7 @@ public final class InvariantChecker {
                                                TypeSymbol.AtModule named,
                                                RuleReadingSource source, ReadingPolicy policy) {
         InvariantChecker c = new InvariantChecker(source.symbols(), source.invariants(),
-                DeclarationReadings.NONE, policy);
+                source.written(), DeclarationReadings.NONE, policy);
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built. These
         // stand for a value rather than holding one, so they are entered as locations and nothing is
@@ -356,7 +365,7 @@ public final class InvariantChecker {
     static ClauseDischarge capabilityOf(StatedContract.Conjunct conjunct,
                                         Denotations locations, RuleReadingSource source,
                                         ReadingPolicy policy, String describing) {
-        return new InvariantChecker(source.symbols(), source.invariants(),
+        return new InvariantChecker(source.symbols(), source.invariants(), source.written(),
                 DeclarationReadings.NONE, policy)
                 .capabilityOf(conjunct.stated(), conjunct.at(), locations, describing);
     }
@@ -736,7 +745,8 @@ public final class InvariantChecker {
         READINGS.incrementAndGet();
         Symbols symbols = source.symbols();
         InvariantChecker c =
-                new InvariantChecker(symbols, source.invariants(), machines, policy);
+                new InvariantChecker(symbols, source.invariants(), source.written(), machines,
+                        policy);
         c.answers = answers;
         // A newtype's value is the same location as the newtype, so it is at no name of its own and
         // its fields are the first step there is. Read from the world rather than off a node handed
@@ -2870,11 +2880,12 @@ public final class InvariantChecker {
      * analysis representation could not be built or typed for, and is not analyzed at all, which is
      * the {@code ABANDONED} this answers with.
      */
-    static Findings analyze(Core body, ExpandedClauseLookup invariants, DeclarationReadings machines,
+    static Findings analyze(Core body, ExpandedClauseLookup invariants, ClauseLocations written,
+                            DeclarationReadings machines,
                             Map<ValueName.Behavior, AssumedContract> contracts,
                             Scope params, Symbols symbols, ReadingPolicy policy) {
         InvariantChecker c =
-                new InvariantChecker(symbols, invariants, machines, contracts, policy);
+                new InvariantChecker(symbols, invariants, written, machines, contracts, policy);
         if (body == null) {
             return new Findings(c.errors, c.warnings, Status.ABANDONED);
         }
@@ -3555,7 +3566,7 @@ public final class InvariantChecker {
      * it under either answer would report a clause the value does not fail, or leave one it does.
      */
     private static ClauseStatus statusOf(Predicates.Clause owed, NumericDomain<FactSubject> dom, Known k,
-                                         Clause clause) {
+                                         Clause.Ref clause) {
         boolean established = owed.dischargedBy(dom, k.facts());
         boolean refused = owed.refutedBy(dom, k.facts());
         if (established && refused) {
@@ -3571,7 +3582,7 @@ public final class InvariantChecker {
     /** Records what was proved about {@code clause}, joining it with what is already there for it:
      * one clause reached twice — through two spreads, or read again under a rewrite — is one
      * clause. */
-    private static void put(SequencedMap<Clause.Id, Judged> found, Clause clause,
+    private static void put(SequencedMap<Clause.Id, Judged> found, Clause.Ref clause,
                             ClauseStatus status) {
         found.merge(clause.id(), new Judged(clause, status), Judged::merge);
     }
@@ -3583,10 +3594,10 @@ public final class InvariantChecker {
      * them: which of the three a clause came out as is one answer, and the set of clauses this check
      * read is partitioned by it rather than covered by sets that have to be kept apart.
      */
-    record Judged(Clause clause, ClauseStatus status) {
+    record Judged(Clause.Ref clause, ClauseStatus status) {
 
         static Judged merge(Judged a, Judged b) {
-            return new Judged(Clause.merge(a.clause(), b.clause()),
+            return new Judged(Clause.Ref.merge(a.clause(), b.clause()),
                     ClauseStatus.of(a.status(), b.status()));
         }
 
@@ -3599,10 +3610,10 @@ public final class InvariantChecker {
     /** One obligation and the clause it was owed by. */
     private record Owing(Clauses.Stated from, Predicates.Clause owed) {
 
-        /** The clause this was owed by: which one it is, what a sentence may call it, and where a
-         * reader can be sent. None of those is read here — this hands the clause on whole, so that
-         * a site choosing what to say asks it rather than being handed one of its answers. */
-        Clause clause() {
+        /** The clause this was owed by: which one it is and what a sentence may call it. Neither is
+         * read here — this hands the clause on whole, so that a site choosing what to say asks it
+         * rather than being handed one of its answers. */
+        Clause.Ref clause() {
             return from.clause();
         }
     }
@@ -3663,18 +3674,18 @@ public final class InvariantChecker {
 
         /** The clauses nothing known there establishes — the ones this check could not settle and
          * the ones the value fails, which is what E2011 is about. */
-        SequencedMap<Clause.Id, Clause> unsettled() {
+        SequencedMap<Clause.Id, Clause.Ref> unsettled() {
             return where(ClauseStatus::unsettled);
         }
 
         /** The clauses the guards establish. */
-        SequencedMap<Clause.Id, Clause> settled() {
+        SequencedMap<Clause.Id, Clause.Ref> settled() {
             return where(status -> status == ClauseStatus.SETTLED);
         }
 
         /** The clauses the value being built fails wherever it is built, which is what E2010 is
          * about — and not every clause left standing beside them. */
-        SequencedMap<Clause.Id, Clause> refuted() {
+        SequencedMap<Clause.Id, Clause.Ref> refuted() {
             return where(status -> status == ClauseStatus.REFUTED);
         }
 
@@ -3686,12 +3697,12 @@ public final class InvariantChecker {
          * is depends on the path, so none of them is one the value fails and the reader is sent to
          * each of them under what is true of it.
          */
-        SequencedMap<Clause.Id, Clause> refutedSomewhere() {
+        SequencedMap<Clause.Id, Clause.Ref> refutedSomewhere() {
             return where(status -> status == ClauseStatus.REFUTED_SOMEWHERE);
         }
 
-        private SequencedMap<Clause.Id, Clause> where(Predicate<ClauseStatus> which) {
-            SequencedMap<Clause.Id, Clause> side = new LinkedHashMap<>();
+        private SequencedMap<Clause.Id, Clause.Ref> where(Predicate<ClauseStatus> which) {
+            SequencedMap<Clause.Id, Clause.Ref> side = new LinkedHashMap<>();
             found.forEach((id, one) -> {
                 if (which.test(one.status())) {
                     side.put(id, one.clause());
@@ -3717,15 +3728,21 @@ public final class InvariantChecker {
             return canName(refuted());
         }
 
-        private static boolean canName(SequencedMap<Clause.Id, Clause> side) {
+        private static boolean canName(SequencedMap<Clause.Id, Clause.Ref> side) {
             return side.values().stream().anyMatch(clause -> clause.name().isPresent());
         }
 
-        /** Where the clauses on a side are, in the order they were declared — every one of them,
-         * whether or not this compile has a file to quote it from. */
+        /**
+         * Where the clauses on a side are, in the order they were declared — every one of them,
+         * whether or not this compile has a file to quote it from.
+         *
+         * <p>Asked of {@code written} rather than read off the clauses. A judgment says which
+         * clauses it is about, and where each of them is written is the declaration's answer: taken
+         * from the judgment, a report would point where the clause was when the judgment was made.
+         */
         static Stream<souther.compiler.diag.DiagnosticPlace> pointsTo(
-                SequencedMap<Clause.Id, Clause> side) {
-            return side.values().stream().map(Clause::at);
+                SequencedMap<Clause.Id, Clause.Ref> side, ClauseLocations written) {
+            return side.keySet().stream().map(written::of);
         }
     }
 
@@ -3767,8 +3784,8 @@ public final class InvariantChecker {
      * a set with no names in it renders as, and reading it back as an answer puts "no clause was
      * named" and "there is no clause" into one value.
      */
-    private static String names(SequencedMap<Clause.Id, Clause> clauses) {
-        return clauses.values().stream().map(Clause::name).flatMap(Optional::stream)
+    private static String names(SequencedMap<Clause.Id, Clause.Ref> clauses) {
+        return clauses.values().stream().map(Clause.Ref::name).flatMap(Optional::stream)
                 .map(ClauseName::value).collect(Collectors.joining(", "));
     }
 
@@ -4349,8 +4366,8 @@ public final class InvariantChecker {
      * module path. What the message says is a different question with a different answer — whether
      * the clause could be named — and neither decides the other.
      */
-    private static <M extends Message & Supporting> Diagnostic finish(
-            Diagnostic.Builder said, SourcePos at, SequencedMap<Clause.Id, Clause> clauses,
+    private <M extends Message & Supporting> Diagnostic finish(
+            Diagnostic.Builder said, SourcePos at, SequencedMap<Clause.Id, Clause.Ref> clauses,
             M label) {
         said.at(at);
         // One label per place, and the clauses are what there are several of. A label is a sentence
@@ -4360,7 +4377,7 @@ public final class InvariantChecker {
         // reads as a repeat rather than as two clauses. Which clauses they are is in the message,
         // which names them.
         java.util.Set<souther.compiler.diag.DiagnosticPlace> already = new java.util.LinkedHashSet<>();
-        Judgment.pointsTo(clauses).forEach(place -> {
+        Judgment.pointsTo(clauses, written).forEach(place -> {
             if (!already.add(place)) {
                 return;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -258,9 +258,6 @@ public final class InvariantChecker {
     private final Terms terms;
     /** What a clause owes and what a guard settles. */
     private final Predicates predicates;
-    /** Where a clause this check reports about is written, asked where a sentence points and not
-     * carried by the judgment that named the clause ({@link ClauseLocations}). */
-    private final ClauseLocations written;
     /** Whether an evaluation can answer, which is what decides that a continuation is reached. */
     private final PathCompletion completion;
     /**
@@ -289,7 +286,6 @@ public final class InvariantChecker {
                              DeclarationReadings machines,
                              Map<ValueName.Behavior, AssumedContract> contracts,
                              ReadingPolicy policy) {
-        this.written = written;
         // Where the answers about a declaration's string machines are asked for, for every
         // declaration this check reads: a capability handed on to the engine, which hands it to
         // every reading made through it, and kept by nothing any of them answers with.
@@ -4377,7 +4373,7 @@ public final class InvariantChecker {
         // reads as a repeat rather than as two clauses. Which clauses they are is in the message,
         // which names them.
         java.util.Set<souther.compiler.diag.DiagnosticPlace> already = new java.util.LinkedHashSet<>();
-        Judgment.pointsTo(clauses, written).forEach(place -> {
+        Judgment.pointsTo(clauses, this.clauses.written()).forEach(place -> {
             if (!already.add(place)) {
                 return;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -70,17 +70,17 @@ final class PathEngine {
     /** What each behavior a body may call states about its answer, by the name it is called under. */
     private final Map<ValueName.Behavior, AssumedContract> contracts;
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
                DeclarationReadings machines, ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, machines, Map.of(), Terms.Of.THE_DISCHARGE_TREE,
-                policy);
+        this(symbols, dischargeInvariants, written, machines, Map.of(),
+                Terms.Of.THE_DISCHARGE_TREE, policy);
     }
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
                DeclarationReadings machines, Map<ValueName.Behavior, AssumedContract> contracts,
                ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, machines, contracts, Terms.Of.THE_DISCHARGE_TREE,
-                policy);
+        this(symbols, dischargeInvariants, written, machines, contracts,
+                Terms.Of.THE_DISCHARGE_TREE, policy);
     }
 
     /**
@@ -91,16 +91,16 @@ final class PathEngine {
      * recorded the fold as a shape this compiler has no term for would be answering about the
      * representation under the name of a gap.
      */
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
                DeclarationReadings machines, Terms.Of reading, ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, machines, Map.of(), reading, policy);
+        this(symbols, dischargeInvariants, written, machines, Map.of(), reading, policy);
     }
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
                DeclarationReadings machines, Map<ValueName.Behavior, AssumedContract> contracts,
                Terms.Of reading, ReadingPolicy policy) {
         this.symbols = symbols;
-        this.clauses = new Clauses(symbols, dischargeInvariants, machines);
+        this.clauses = new Clauses(symbols, dischargeInvariants, written, machines);
         this.terms = new Terms(symbols, reading, policy, clauses);
         this.predicates = terms.predicates();
         this.guarantees = terms.guarantees();

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -204,7 +204,8 @@ public final class PathReachability {
             return Answers.NONE;
         }
         PathEngine engine =
-                new PathEngine(source.symbols(), source.invariants(), DeclarationReadings.NONE,
+                new PathEngine(source.symbols(), source.invariants(), source.written(),
+                        DeclarationReadings.NONE,
                         Terms.Of.THE_TREE_THAT_RUNS, policy);
         Map<ControlPointId, Reachability> out = new LinkedHashMap<>();
         Map<souther.compiler.coverage.ComparisonOccurrence,

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleReadingSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleReadingSource.java
@@ -2,19 +2,20 @@ package souther.compiler.check;
 
 /**
  * What reading a module's declarations as a static analysis takes: the scope the names resolve in,
- * and where the clauses in the representation it reads come from.
+ * where the clauses in the representation it reads come from, and where a clause it reports about
+ * is written.
  *
- * <p>The two together because a reading takes both, and for no reason beyond that. Most of what
- * carries this reads only the scope and hands the pair on; separated, those would thread two
- * arguments where they thread one, which is plumbing rather than a distinction anyone makes.
+ * <p>Together because a reading takes them all, and for no reason beyond that. Most of what carries
+ * this reads only the scope and hands the rest on; separated, those would thread several arguments
+ * where they thread one, which is plumbing rather than a distinction anyone makes.
  *
  * <p><b>It states no relation between them.</b> Not that they are the same module's, not that one
  * answers for the other, not that a declaration reached through the scope is one the lookup has.
  * There is nothing of that kind to state: a scope belongs to the module being read, and a clause
- * belongs to the declaration that wrote it, wherever that was. This pair used to require that the
- * two named one module, which is exactly the claim that made an imported declaration's clauses come
- * back in whatever representation the reader happened to hold, so the requirement is gone and
- * nothing here or in a constructor puts it back.
+ * belongs to the declaration that wrote it, wherever that was. This used to require that the scope
+ * and the lookup named one module, which is exactly the claim that made an imported declaration's
+ * clauses come back in whatever representation the reader happened to hold, so the requirement is
+ * gone and nothing here or in a constructor puts it back.
  *
  * <p>Nothing else about the reading goes in here. What a reading may spend is a bound on the work
  * and not part of what is being read ({@link ReadingPolicy}), and it stays a separate argument:
@@ -30,21 +31,28 @@ package souther.compiler.check;
  *
  * @param symbols    the module's resolved scope
  * @param invariants where a declaration's clauses in the representation this reads are answered from
+ * @param written    where a clause of a declaration is written, for the sentences this reading
+ *                   produces that point at one. Beside {@code invariants} and not inside it: what a
+ *                   clause states is what the reading is built on, and where it is written is what
+ *                   one sentence puts a caret under. Answered together, an edit that moves a clause
+ *                   and changes nothing it states is an edit that changes what the model says
  * @param origin     which source this is, for a reader telling two of them apart
  */
-public record RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants, Origin origin) {
+public record RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants,
+                                ClauseLocations written, Origin origin) {
 
     public RuleReadingSource {
-        if (symbols == null || invariants == null || origin == null) {
+        if (symbols == null || invariants == null || written == null || origin == null) {
             throw new IllegalArgumentException(
                     "reading a declaration's rules takes a scope, somewhere to read clauses from,"
-                            + " and which source that is");
+                            + " somewhere to read where one is written, and which source that is");
         }
     }
 
     /** A source made for a reading of its own, which nobody else can name. */
-    public RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants) {
-        this(symbols, invariants, AReadingOfItsOwn.next());
+    public RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants,
+                             ClauseLocations written) {
+        this(symbols, invariants, written, AReadingOfItsOwn.next());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -455,7 +455,8 @@ public final class SpecChecker {
         InvariantChecker.Findings inv = discharge == null
                 ? InvariantChecker.Findings.notRun()
                 : InvariantChecker.analyze(dischargeBody, discharge.invariants(),
-                        discharge.machines(), discharge.contracts(), env, symbols, policy);
+                        discharge.written(), discharge.machines(), discharge.contracts(), env,
+                        symbols, policy);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -328,7 +328,7 @@ final class Terms {
      */
     Terms(Symbols symbols, Of reading, ReadingPolicy policy, Clauses clauses) {
         this.symbols = symbols;
-        this.rules = new RuleReadingSource(symbols, clauses.expandedClauses());
+        this.rules = new RuleReadingSource(symbols, clauses.expandedClauses(), clauses.written());
         this.reading = reading;
         this.policy = policy;
         this.predicates = new Predicates(this);

--- a/souther-compiler/src/main/java/souther/compiler/check/TheCompilationsSources.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TheCompilationsSources.java
@@ -32,26 +32,31 @@ public final class TheCompilationsSources {
 
     private final Function<String, Symbols> scopeOf;
     private final ExpandedClauseLookup clauses;
+    private final ClauseLocations written;
 
     /** Which mint this is, told to nobody: what it stamps says this and what another stamps says
      *  another, which is the whole of how a source of one is told from a source of the other. */
     private final long mint = MINTS.incrementAndGet();
 
     /**
-     * Makes the sources of a compilation whose modules resolve under {@code scopeOf} and whose
-     * declarations' clauses are read from {@code clauses}.
+     * Makes the sources of a compilation whose modules resolve under {@code scopeOf}, whose
+     * declarations' clauses are read from {@code clauses}, and where a clause is written is read
+     * from {@code written}.
      *
-     * <p>Both are the compilation's own, and this is the whole of what it takes to be one: whoever
-     * builds this is answering for a compilation, which is a different thing from a reader asking
-     * one where to read.
+     * <p>All the compilation's own, and this is the whole of what it takes to be one: whoever builds
+     * this is answering for a compilation, which is a different thing from a reader asking one where
+     * to read.
      */
-    public TheCompilationsSources(Function<String, Symbols> scopeOf, ExpandedClauseLookup clauses) {
-        if (scopeOf == null || clauses == null) {
+    public TheCompilationsSources(Function<String, Symbols> scopeOf, ExpandedClauseLookup clauses,
+                                  ClauseLocations written) {
+        if (scopeOf == null || clauses == null || written == null) {
             throw new IllegalArgumentException(
-                    "a compilation reads its modules under a scope and reads clauses somewhere");
+                    "a compilation reads its modules under a scope, reads clauses somewhere, and"
+                            + " reads where one is written somewhere");
         }
         this.scopeOf = scopeOf;
         this.clauses = clauses;
+        this.written = written;
     }
 
     /** The source {@code module}'s rules are read under, or null where the compilation resolves no
@@ -59,6 +64,7 @@ public final class TheCompilationsSources {
     public RuleReadingSource of(String module) {
         Symbols scope = scopeOf.apply(module);
         return scope == null ? null
-                : new RuleReadingSource(scope, clauses, new AModulesRules(mint, module));
+                : new RuleReadingSource(scope, clauses, written,
+                        new AModulesRules(mint, module));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -67,7 +67,7 @@ public final class TypeCardinality {
         // through a spread, which the graph below does not follow, so a set taken from the graph
         // would leave out exactly the rules that arrive from somewhere else.
         Asked asked = new Asked(source.invariants());
-        source = new RuleReadingSource(symbols, asked);
+        source = new RuleReadingSource(symbols, asked, source.written());
         Map<TypeSymbol, Hir.Def> declared = reached(declarations, symbols);
         Map<TypeSymbol, Set<TypeSymbol>> edges = new LinkedHashMap<>();
         declared.forEach((name, def) -> edges.put(name, read(def, symbols, declared.keySet())));

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -98,7 +98,7 @@ final class TypeGuarantees {
             Clauses.StatedClauses stated =
                     clauses.statedAt(owner.named(), given);
             for (Clauses.Stated one : stated.clauses()) {
-                if (already.add(one.clause().ref())) {
+                if (already.add(one.clause())) {
                     here.add(read(one, denotations, withoutParts));
                 }
             }
@@ -136,7 +136,7 @@ final class TypeGuarantees {
         ValueReading there = ValueReading.of(type, symbols);
         for (ValueReading.Owner owner : there.owners()) {
             for (TypeOps.Declared each : clauses.declared(owner.named())) {
-                if (!stated.contains(Clause.of(each).ref())) {
+                if (!stated.contains(Clause.Ref.of(each))) {
                     return true;
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1965,7 +1965,7 @@ public final class Bodies {
                     discharge.present()
                     ? new InvariantChecker.Source(discharge.value().value().writtenBody(),
                             discharge.value().provenance(),
-                            Shapes.expandedClauses(db), db.readings(),
+                            Shapes.expandedClauses(db), Shapes.clauseLocations(db), db.readings(),
                             contracts.present() ? contracts.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -173,7 +173,8 @@ public final class Db implements StoreWork {
     RuleReadingSource ruleReadingFor(String module) {
         if (sources == null) {
             sources = new TheCompilationsSources(this::scopeOf,
-                    named -> ask(new Shapes.ClausesExpandedFor(named)).value());
+                    named -> ask(new Shapes.ClausesExpandedFor(named)).value(),
+                    Shapes.clauseLocations(this));
         }
         return sources.of(module);
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -706,7 +706,7 @@ public final class Shapes {
     }
 
     /**
-     * Where a declaration's own clauses are written, in the order it writes them.
+     * Where one clause is written.
      *
      * <p>Beside {@link ClausesExpandedFor} and not inside it, because they are two facts about one
      * declaration and a reader uses one of them. What a clause states is what every reading of the
@@ -715,40 +715,38 @@ public final class Shapes {
      * what the model says, and every reading of every module that imports the declaration is worked
      * out again for it.
      *
+     * <p><b>One clause and not a declaration's.</b> A report is sent to the clause it is about, and
+     * that is the whole of what it reads here. Answered a declaration at a time, a reader that
+     * points at the first clause would depend on where the third is: the list is one answer, an edit
+     * moving any clause in it makes a new one, and what re-reads is everything that read the list.
+     * The clause a reader means is the grain the reader means, so it is the grain of the question.
+     *
      * <p>The ordinal is the one {@link souther.compiler.check.Clause.Id} counts by — which of the
      * declaration's own clauses this is, in written order. Every representation of a declaration
      * writes its clauses in that order, which is what lets a reader holding a judgment about clause
-     * <i>n</i> ask here for where clause <i>n</i> is.
+     * <i>n</i> ask here where clause <i>n</i> is written.
      *
-     * <p>A declaration that writes no clauses answers with none, and so does a kind that has no
-     * {@code invariant} to write: what a reader needs is where the clause it is about is, and a
-     * declaration that wrote none has no such clause to be asked about.
-     *
-     * <p>Nothing declaring one is the other answer and is absent. A declaration that wrote no
-     * clauses and a name nothing in this compilation declares are opposite facts and the same empty
-     * list, and a reader handed the list cannot tell them apart — which is the shape
-     * {@link ClausesExpandedFor} keeps three answers to avoid.
+     * <p>Absent where the declaration writes no such clause — nothing declares the name, its kind
+     * has no {@code invariant} to write, or it writes fewer clauses than this. Those are one answer
+     * because they are one fact for a reader: there is no such clause to be pointed at. Which of
+     * them it was is a question about the declaration, and this is a question about a clause.
      */
-    public record ClauseLocationsFor(TypeKey named) implements Key<List<DiagnosticPlace>> {
+    public record ClauseLocation(souther.compiler.check.Clause.Id clause)
+            implements Key<DiagnosticPlace> {
         @Override
         public String module() {
-            return named.module();
+            return clause.declaredOn().key().module();
         }
 
         @Override
-        public Answer<List<DiagnosticPlace>> compute(Db db) {
-            Hir.Def declared = ClausesExpandedFor.declarationOf(db, named);
-            if (declared == null) {
+        public Answer<DiagnosticPlace> compute(Db db) {
+            Hir.Def declared =
+                    ClausesExpandedFor.declarationOf(db, clause.declaredOn().key());
+            if (!(declared instanceof Hir.Data data)
+                    || clause.ordinal() < 0 || clause.ordinal() >= data.invariants().size()) {
                 return Answer.absent();
             }
-            if (!(declared instanceof Hir.Data data)) {
-                return Answer.of(List.of());
-            }
-            List<DiagnosticPlace> places = new ArrayList<>();
-            for (Hir.InvariantClause clause : data.invariants()) {
-                places.add(placeOf(clause));
-            }
-            return Answer.of(List.copyOf(places));
+            return Answer.of(placeOf(data.invariants().get(clause.ordinal())));
         }
 
         /** Where {@code clause} is written, as the declaration knows it — with no reader's route in
@@ -761,20 +759,18 @@ public final class Shapes {
     }
 
     /**
-     * Where any declaration's clauses are written, for a reader that is about to point at one.
+     * Where any clause is written, for a reader that is about to point at one.
      *
      * <p>One of these for the whole compilation, for the reason {@link #expandedClauses} gives: which
      * clause is being asked about is the only input there is.
      */
     public static ClauseLocations clauseLocations(Db db) {
         return clause -> {
-            Answer<List<DiagnosticPlace>> written =
-                    db.ask(new ClauseLocationsFor(clause.declaredOn().key()));
-            if (!written.present() || clause.ordinal() < 0
-                    || clause.ordinal() >= written.value().size()) {
+            Answer<DiagnosticPlace> written = db.ask(new ClauseLocation(clause));
+            if (!written.present()) {
                 throw new NoSuchClauseIsWritten(clause);
             }
-            return written.value().get(clause.ordinal());
+            return written.value();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
+import souther.compiler.check.ClauseLocations;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.ExpandedClauseResult;
 import souther.compiler.check.ExpandedClauses;
@@ -19,6 +20,7 @@ import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.ResolvedSymbols;
 import souther.compiler.core.ValueShape;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -700,6 +702,88 @@ public final class Shapes {
             }
             Answer<souther.compiler.stdlib.Stdlib> library = db.ask(new Front.Library());
             return library.present() ? library.value().languageDeclaration(named) : null;
+        }
+    }
+
+    /**
+     * Where a declaration's own clauses are written, in the order it writes them.
+     *
+     * <p>Beside {@link ClausesExpandedFor} and not inside it, because they are two facts about one
+     * declaration and a reader uses one of them. What a clause states is what every reading of the
+     * model is built on; where it is written is what one sentence puts a caret under. Answered
+     * together, an edit that moves a clause and changes nothing it states is an edit that changes
+     * what the model says, and every reading of every module that imports the declaration is worked
+     * out again for it.
+     *
+     * <p>The ordinal is the one {@link souther.compiler.check.Clause.Id} counts by — which of the
+     * declaration's own clauses this is, in written order. Every representation of a declaration
+     * writes its clauses in that order, which is what lets a reader holding a judgment about clause
+     * <i>n</i> ask here for where clause <i>n</i> is.
+     *
+     * <p>A declaration that writes no clauses answers with none, and a kind that has no
+     * {@code invariant} to write answers with none: what a reader of this needs is where the clause
+     * it is about is, and a reader asking about a clause of a declaration that wrote none is asking
+     * about a clause that does not exist.
+     */
+    public record ClauseLocationsFor(TypeKey named) implements Key<List<DiagnosticPlace>> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<List<DiagnosticPlace>> compute(Db db) {
+            if (!(ClausesExpandedFor.declarationOf(db, named) instanceof Hir.Data data)) {
+                return Answer.of(List.of());
+            }
+            List<DiagnosticPlace> places = new ArrayList<>();
+            for (Hir.InvariantClause clause : data.invariants()) {
+                places.add(placeOf(clause));
+            }
+            return Answer.of(List.copyOf(places));
+        }
+
+        /** Where {@code clause} is written, as the declaration knows it — with no reader's route in
+         *  it, for the reason {@link souther.compiler.check.Clause} gives. */
+        private static DiagnosticPlace placeOf(Hir.InvariantClause clause) {
+            DiagnosticPlace at = DiagnosticPlace.of(clause.reportedAt());
+            return at instanceof DiagnosticPlace.Unavailable out
+                    ? new DiagnosticPlace.Unavailable(out.provenance().asDeclared()) : at;
+        }
+    }
+
+    /**
+     * Where any declaration's clauses are written, for a reader that is about to point at one.
+     *
+     * <p>One of these for the whole compilation, for the reason {@link #expandedClauses} gives: which
+     * clause is being asked about is the only input there is.
+     */
+    public static ClauseLocations clauseLocations(Db db) {
+        return clause -> {
+            List<DiagnosticPlace> places =
+                    db.ask(new ClauseLocationsFor(clause.declaredOn().key())).value();
+            if (clause.ordinal() < 0 || clause.ordinal() >= places.size()) {
+                throw new NoSuchClauseIsWritten(clause);
+            }
+            return places.get(clause.ordinal());
+        };
+    }
+
+    /**
+     * Raised where a report asks where a clause is and the declaration writes no such clause.
+     *
+     * <p>Two of this compiler's answers disagreeing. A judgment is about a clause a reading of the
+     * declaration reached, and the declaration is the one that wrote it; a clause judged and not
+     * written is a reading and a declaration that are not of one model. Answered with a place that
+     * points nowhere, the report would send a reader to a clause nobody wrote.
+     */
+    public static final class NoSuchClauseIsWritten extends IllegalStateException {
+
+        private static final long serialVersionUID = 1L;
+
+        NoSuchClauseIsWritten(souther.compiler.check.Clause.Id clause) {
+            super("nothing at " + clause.declaredOn().name() + " writes a clause numbered "
+                    + clause.ordinal());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -720,10 +720,14 @@ public final class Shapes {
      * writes its clauses in that order, which is what lets a reader holding a judgment about clause
      * <i>n</i> ask here for where clause <i>n</i> is.
      *
-     * <p>A declaration that writes no clauses answers with none, and a kind that has no
-     * {@code invariant} to write answers with none: what a reader of this needs is where the clause
-     * it is about is, and a reader asking about a clause of a declaration that wrote none is asking
-     * about a clause that does not exist.
+     * <p>A declaration that writes no clauses answers with none, and so does a kind that has no
+     * {@code invariant} to write: what a reader needs is where the clause it is about is, and a
+     * declaration that wrote none has no such clause to be asked about.
+     *
+     * <p>Nothing declaring one is the other answer and is absent. A declaration that wrote no
+     * clauses and a name nothing in this compilation declares are opposite facts and the same empty
+     * list, and a reader handed the list cannot tell them apart — which is the shape
+     * {@link ClausesExpandedFor} keeps three answers to avoid.
      */
     public record ClauseLocationsFor(TypeKey named) implements Key<List<DiagnosticPlace>> {
         @Override
@@ -733,7 +737,11 @@ public final class Shapes {
 
         @Override
         public Answer<List<DiagnosticPlace>> compute(Db db) {
-            if (!(ClausesExpandedFor.declarationOf(db, named) instanceof Hir.Data data)) {
+            Hir.Def declared = ClausesExpandedFor.declarationOf(db, named);
+            if (declared == null) {
+                return Answer.absent();
+            }
+            if (!(declared instanceof Hir.Data data)) {
                 return Answer.of(List.of());
             }
             List<DiagnosticPlace> places = new ArrayList<>();
@@ -760,12 +768,13 @@ public final class Shapes {
      */
     public static ClauseLocations clauseLocations(Db db) {
         return clause -> {
-            List<DiagnosticPlace> places =
-                    db.ask(new ClauseLocationsFor(clause.declaredOn().key())).value();
-            if (clause.ordinal() < 0 || clause.ordinal() >= places.size()) {
+            Answer<List<DiagnosticPlace>> written =
+                    db.ask(new ClauseLocationsFor(clause.declaredOn().key()));
+            if (!written.present() || clause.ordinal() < 0
+                    || clause.ordinal() >= written.value().size()) {
                 throw new NoSuchClauseIsWritten(clause);
             }
-            return places.get(clause.ordinal());
+            return written.value().get(clause.ordinal());
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseReachedTwiceIsOneClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseReachedTwiceIsOneClauseTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -107,8 +108,9 @@ class AClauseReachedTwiceIsOneClauseTest {
 
         assertEquals(1, judgment.unsettled().size(),
                 "one clause, read once down each branch: " + judgment.unsettled());
-        assertEquals(List.of(7, 7), linesPointedAtIn(READ_ON_TWO_BRANCHES),
-                "and each branch's construction sends a reader to the one line it is written on");
+        assertEquals(Set.of(7), Set.copyOf(linesPointedAtIn(READ_ON_TWO_BRANCHES)),
+                "and however many constructions are reported, there is one line to send a reader"
+                        + " to, because there is one clause");
     }
 
     // --- reading the check ----------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseReachedTwiceIsOneClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseReachedTwiceIsOneClauseTest.java
@@ -90,13 +90,13 @@ class AClauseReachedTwiceIsOneClauseTest {
                 "in the order they were written");
     }
 
-    /** Each of them is a place of its own to send a reader to. */
+    /** Each of them is a place of its own to send a reader to. Read off what the report points at,
+     *  which is where a place is asked for — the judgment says which clauses it is about, and the
+     *  declaration says where each of them is written. */
     @Test
     void eachOfTheTwoIsWrittenSomewhereOfItsOwn() {
-        List<Integer> lines = judgmentOn(TWO_UNNAMED).unsettled().values().stream()
-                .map(c -> ((souther.compiler.diag.DiagnosticPlace.InSource) c.at()).region().start().line()).toList();
-
-        assertEquals(List.of(7, 8), lines, "the two `invariant` lines the declaration writes");
+        assertEquals(List.of(7, 8), linesPointedAtIn(TWO_UNNAMED),
+                "the two `invariant` lines the declaration writes");
     }
 
     // --- one clause reached twice is one --------------------------------------------------------
@@ -107,11 +107,24 @@ class AClauseReachedTwiceIsOneClauseTest {
 
         assertEquals(1, judgment.unsettled().size(),
                 "one clause, read once down each branch: " + judgment.unsettled());
-        assertEquals(7, ((souther.compiler.diag.DiagnosticPlace.InSource) judgment.unsettled().firstEntry().getValue().at())
-                .region().start().line(), "and it is still where the declaration writes it");
+        assertEquals(List.of(7, 7), linesPointedAtIn(READ_ON_TWO_BRANCHES),
+                "and each branch's construction sends a reader to the one line it is written on");
     }
 
     // --- reading the check ----------------------------------------------------------------------
+
+    /** The lines the warning about {@code Bound}'s construction sends a reader to, in the order it
+     *  writes them. */
+    private static List<Integer> linesPointedAtIn(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> "E2011".equals(d.code()))
+                .flatMap(d -> d.secondary().stream())
+                .map(label -> label.place())
+                .filter(place -> place instanceof souther.compiler.diag.DiagnosticPlace.InSource)
+                .map(place -> ((souther.compiler.diag.DiagnosticPlace.InSource) place)
+                        .region().start().line())
+                .toList();
+    }
 
     /**
      * The judgment for the construction of {@code Bound}, taken through the seam the check reports

--- a/souther-compiler/src/test/java/souther/compiler/check/ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest.java
@@ -68,7 +68,8 @@ class ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest {
         TypeKey held = new TypeKey(module, "Held");
         RuleReadingSource shortOfOne = new RuleReadingSource(whole.symbols(),
                 named -> named.equals(held)
-                        ? new ExpandedClauseResult.Unavailable(named) : whole.invariants().of(named));
+                        ? new ExpandedClauseResult.Unavailable(named) : whole.invariants().of(named),
+                whole.written());
 
         assertFalse(TypeCardinality.solve(declarations, shortOfOne, policy).everyRuleReached(),
                 "a count that walked into a declaration whose rules could not be worked out has not"

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeclarationIsReadOnceForEveryQuestionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeclarationIsReadOnceForEveryQuestionThatReachesItTest.java
@@ -198,7 +198,7 @@ class ADeclarationIsReadOnceForEveryQuestionThatReachesItTest {
         // The nearest thing a reader can assemble: the compilation's own scope, and a lookup that
         // answers for no clause anybody wrote.
         RuleReadingSource ofItsOwn = new RuleReadingSource(asTheCompilationReads.symbols(),
-                RuleReadings.noClauseFiled());
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE);
         long beforeItsOwn = InvariantChecker.readingsMade();
         InvariantChecker.seedFields(code, ofItsOwn, AS_THE_COMPILE_READS, readings);
 
@@ -209,7 +209,8 @@ class ADeclarationIsReadOnceForEveryQuestionThatReachesItTest {
         // And the same, minted: sources of its own over the compilation's scope and a lookup that
         // answers for nothing, saying of what they make the name the compilation writes.
         RuleReadingSource minted = new TheCompilationsSources(
-                _ -> asTheCompilationReads.symbols(), RuleReadings.noClauseFiled()).of("demo");
+                _ -> asTheCompilationReads.symbols(), RuleReadings.noClauseFiled(),
+                ClauseLocations.NONE).of("demo");
         long beforeMinted = InvariantChecker.readingsMade();
         InvariantChecker.seedFields(code, minted, AS_THE_COMPILE_READS, readings);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -96,7 +96,8 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
     /** The clauses as the module named {@code reading} reads them. */
     private static Clauses readBy(Compilation c, String reading) {
         return new Clauses(Scopes.resolved(c.db(), reading).value(),
-                RuleReadings.declaredBy(c.db(), reading), DeclarationReadings.NONE);
+                RuleReadings.declaredBy(c.db(), reading), ClauseLocations.NONE,
+                DeclarationReadings.NONE);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
@@ -76,7 +76,8 @@ class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), DeclarationReadings.NONE,
+    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.written(),
+            DeclarationReadings.NONE,
             Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueFailsTheClausesItFailsAndNotTheOnesLeftStandingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueFailsTheClausesItFailsAndNotTheOnesLeftStandingTest.java
@@ -193,8 +193,8 @@ class AValueFailsTheClausesItFailsAndNotTheOnesLeftStandingTest {
 
     // --- reading the check ----------------------------------------------------------------------
 
-    private static java.util.SequencedMap<Clause.Id, Clause> unknown(Judgment judgment) {
-        java.util.SequencedMap<Clause.Id, Clause> side = new java.util.LinkedHashMap<>();
+    private static java.util.SequencedMap<Clause.Id, Clause.Ref> unknown(Judgment judgment) {
+        java.util.SequencedMap<Clause.Id, Clause.Ref> side = new java.util.LinkedHashMap<>();
         judgment.found().forEach((id, one) -> {
             if (one.status() == ClauseStatus.UNKNOWN) {
                 side.put(id, one.clause());

--- a/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
@@ -260,7 +260,7 @@ class AWarningAboutAClauseSendsAReaderToItTest {
                 "the clause is read and judged like any other: " + judgment.found());
         assertEquals(List.of(new souther.compiler.diag.DiagnosticPlace.Unavailable(
                         new souther.compiler.diag.SourceProvenance.APublishedModule("model"))),
-                InvariantChecker.Judgment.pointsTo(judgment.unsettled()).toList(),
+                warnings.get(0).secondary().stream().map(label -> label.place()).toList(),
                 "written where this compile has no file, and saying which module that is");
 
         assertInstanceOf(InvariantMessage.NothingKnownHereEstablishesTheInvariant.class,

--- a/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
@@ -261,14 +261,10 @@ class AWarningAboutAClauseSendsAReaderToItTest {
         assertEquals(List.of(new souther.compiler.diag.DiagnosticPlace.Unavailable(
                         new souther.compiler.diag.SourceProvenance.APublishedModule("model"))),
                 warnings.get(0).secondary().stream().map(label -> label.place()).toList(),
-                "written where this compile has no file, and saying which module that is");
+                "one label, written where this compile has no file, saying which module that is");
 
         assertInstanceOf(InvariantMessage.NothingKnownHereEstablishesTheInvariant.class,
                 warnings.get(0).said(), "the clause was written without a name");
-        assertEquals(List.of(), lines(warnings.get(0)),
-                "and there is no source here to send the reader to");
-        assertEquals(1, warnings.get(0).secondary().size(),
-                "the label is there all the same, saying what it can");
         assertTrue(new HumanRenderer(false)
                         .render(warnings.get(0), new SourceContext("app.sou", USING),
                                 java.util.Locale.ENGLISH)

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -58,7 +58,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
+                Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     @Test
@@ -190,7 +191,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
         Core.Binder y = CoreBinders.of(binders.binder("y", POS));
         PathEngine reading = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
                 Map.of(FIND, statesThatTheIntIsPositive()), Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
@@ -282,7 +283,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     void aRuleHoldsOfAnArmWhoseValuesAreAllOnesItIsAbout() {
         Symbols symbols = symbolsOf(NESTED);
         PathEngine reading = new PathEngine(symbols, RuleReadings.noClauseFiled(),
-                DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                ClauseLocations.NONE, DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");
@@ -302,7 +303,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     void anArmNamingSeveralTakesARuleThatIsAboutAllOfThem() {
         Symbols symbols = symbolsOf(NESTED);
         PathEngine reading = new PathEngine(symbols, RuleReadings.noClauseFiled(),
-                DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                ClauseLocations.NONE, DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -112,7 +112,8 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
             assertNotNull(declared);
             assertNotNull(prepared);
 
-            Clauses clauses = new Clauses(symbols, declared, DeclarationReadings.NONE);
+            Clauses clauses =
+                    new Clauses(symbols, declared, ClauseLocations.NONE, DeclarationReadings.NONE);
             int read = 0;
             for (Hir.Def def : prepared.defs().stream().map(each -> each.declaration().node()).toList()) {
                 if (!(def instanceof Hir.Data data)) {

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
@@ -156,7 +156,7 @@ class EveryTermIsReadForWhatItSaysTest {
     @Test
     void twoReadingsOfOneTermAreAssumedAlike() {
         PathEngine engine = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
                 Terms.Of.THE_DISCHARGE_TREE, ReadAs.THE_COMPILATION_DOES);
         Predicates predicates = engine.predicates();
 

--- a/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
@@ -51,7 +51,7 @@ class FollowingWhatANameWasGivenCostsTheChainOnceTest {
      * link is a name for the one before it and the first is arithmetic. */
     private static long followedOver(int links) {
         PathEngine engine = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
                 Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Hir.Binders binders = new Hir.Binders(OWNER);
         Core.Binder first = CoreBinders.of(binders.binder("x0", POS));

--- a/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
@@ -42,7 +42,7 @@ public final class RuleReadings {
      *  about a declaration is asking for a reading this never had, and it answers that nothing
      *  declares one rather than the tree the declaration happens to carry. */
     public static RuleReadingSource ofNoClauseFiled(Symbols symbols) {
-        return new RuleReadingSource(symbols, noClauseFiled());
+        return new RuleReadingSource(symbols, noClauseFiled(), ClauseLocations.NONE);
     }
 
     /** Where a reading with nothing expanded anywhere gets its clauses. */
@@ -78,6 +78,7 @@ public final class RuleReadings {
      *  and never by handing over a scope alone. */
     static Terms termsOfNoClauseFiled(Symbols symbols, ReadingPolicy policy) {
         return new Terms(symbols, Terms.Of.THE_DISCHARGE_TREE, policy,
-                new Clauses(symbols, noClauseFiled(), DeclarationReadings.NONE));
+                new Clauses(symbols, noClauseFiled(), ClauseLocations.NONE,
+                        DeclarationReadings.NONE));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/TheAbsenceOfANameIsNotTheAbsenceOfAClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheAbsenceOfANameIsNotTheAbsenceOfAClauseTest.java
@@ -260,8 +260,8 @@ class TheAbsenceOfANameIsNotTheAbsenceOfAClauseTest {
     }
 
     /** The names of the clauses on a side that carry one, which is what a message writes out. */
-    private static List<String> names(java.util.SequencedMap<Clause.Id, Clause> clauses) {
-        return clauses.values().stream().map(Clause::name)
+    private static List<String> names(java.util.SequencedMap<Clause.Id, Clause.Ref> clauses) {
+        return clauses.values().stream().map(Clause.Ref::name)
                 .flatMap(java.util.Optional::stream).map(ClauseName::value).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest.java
@@ -1,11 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.source.SourceId;
-
-import souther.compiler.diag.DiagnosticPlace;
-import souther.compiler.diag.Region;
-import souther.compiler.diag.SourcePos;
-import souther.compiler.diag.SourceProvenance;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
@@ -21,15 +15,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * What two readings of one clause come to, and what they may not come to.
  *
  * <p>One construction is read once per branch of a conditional above it, and the two readings are
- * combined. They differ in what they could prove and not in what the declaration says, so the one
- * fact that may be in one and missing from the other is whether this compile can quote where the
- * clause was written. Everything else differing is the compiler having called two clauses one, or
- * one clause two, and answering that with a clause would report a declaration nobody wrote.
+ * combined. They differ in what they could prove and not in what the declaration says, so anything
+ * else differing is the compiler having called two clauses one, or one clause two, and answering
+ * that with a clause would report a declaration nobody wrote.
  *
  * <p>Commutative, associative and idempotent, because the order the walk combines branches in is not
  * something a reader should be able to see. A first-wins union reads as one of these until a clause
- * is reached by two paths that know different amounts, and then the warning points somewhere or
- * nowhere depending on which branch the walk read first.
+ * is reached by two paths that know different amounts, and then what the warning says depends on
+ * which branch the walk read first.
  */
 class TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest {
 
@@ -44,21 +37,20 @@ class TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest {
      */
     @Test
     void mergingIsCommutativeAssociativeAndIdempotent() {
-        Clause one = clause(FIRST, "ordered", at("model.sou", 8));
-        Clause two = clause(FIRST, "ordered", at("model.sou", 8));
-        Clause three = clause(FIRST, "ordered", at("model.sou", 8));
+        Clause.Ref one = clause(FIRST, "ordered");
+        Clause.Ref two = clause(FIRST, "ordered");
+        Clause.Ref three = clause(FIRST, "ordered");
 
-        assertEquals(Clause.merge(one, two), Clause.merge(two, one));
-        assertEquals(Clause.merge(Clause.merge(one, two), three),
-                Clause.merge(one, Clause.merge(two, three)));
-        assertEquals(one, Clause.merge(one, one));
+        assertEquals(Clause.Ref.merge(one, two), Clause.Ref.merge(two, one));
+        assertEquals(Clause.Ref.merge(Clause.Ref.merge(one, two), three),
+                Clause.Ref.merge(one, Clause.Ref.merge(two, three)));
+        assertEquals(one, Clause.Ref.merge(one, one));
     }
 
     /**
      * Two readings that reached the clause by two names are one reading.
      *
-     * <p>Where the clause is written is a fact about the declaration and the same for every reading;
-     * the name a reading reached the code by is a fact about that reading, and two readings of one
+     * <p>The name a reading reached the code by is a fact about that reading, and two readings of one
      * clause reach it by two names as easily as one. Carried into what a clause holds, the two are
      * different values and the merge has a pair to choose between — which is a first-wins union
      * whichever rule it chooses by. A clause takes the declaration's own form, so there is nothing
@@ -66,14 +58,12 @@ class TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest {
      */
     @Test
     void twoReadingsThatReachedTheSameClauseByTwoNamesAreOneReading() {
-        Clause viaOne = clause(FIRST, "ordered", new DiagnosticPlace.Unavailable(
-                new SourceProvenance.APublishedModule("lib.rule", "A.Code")));
-        Clause viaTwo = clause(FIRST, "ordered", new DiagnosticPlace.Unavailable(
-                new SourceProvenance.APublishedModule("lib.rule", "B.Code")));
+        Clause.Ref viaOne = clause(FIRST, "ordered");
+        Clause.Ref viaTwo = clause(FIRST, "ordered");
 
-        assertEquals(viaOne, viaTwo, "a clause holds where it is written, not how it was reached");
-        assertEquals(viaOne, Clause.merge(viaOne, viaTwo));
-        assertEquals(viaOne, Clause.merge(viaTwo, viaOne));
+        assertEquals(viaOne, viaTwo, "a clause is which one it is, not how it was reached");
+        assertEquals(viaOne, Clause.Ref.merge(viaOne, viaTwo));
+        assertEquals(viaOne, Clause.Ref.merge(viaTwo, viaOne));
     }
 
     private static final TypeSymbol.AtModule BOUND = TypeSymbols.declared(new TypeKey("demo", "Bound"));
@@ -82,61 +72,20 @@ class TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest {
     private static final Clause.Id FIRST = new Clause.Id(BOUND, 0);
     private static final Clause.Id SECOND = new Clause.Id(BOUND, 1);
 
-    private static DiagnosticPlace at(String sourceId, int line) {
-        return DiagnosticPlace.of(new Region(new SourcePos(line, 5, new SourceId(sourceId)),
-                new SourcePos(line, 30, new SourceId(sourceId))));
-    }
-
-    /** A clause of a module this compile holds no file for: written somewhere, quotable nowhere. */
-    private static DiagnosticPlace outOfSight() {
-        return new DiagnosticPlace.Unavailable(
-                new SourceProvenance.APublishedModule("lib.rule"));
-    }
-
-    private static Clause clause(Clause.Id id, String name, DiagnosticPlace at) {
-        return new Clause(id, Optional.ofNullable(name).map(ClauseName::new), at);
-    }
-
-    // --- what may not differ ----------------------------------------------------------------
-
-    /**
-     * A reading that can quote the clause and one that cannot are two answers about where one
-     * clause is written, and one of them is wrong.
-     *
-     * <p>This used to be the tolerance the merge was built around, and it had a reason: a reading
-     * that could not point was an absent value, so which representation a clause was reached
-     * through decided how much a reading knew. It decides nothing now. A clause is quotable or it is
-     * out of sight because of the declaration it is on, and "no place at all" is not something a
-     * reading can produce — so a pair like this is the compiler saying one declaration is in two
-     * places. Measured over the whole suite before it was refused: no compile produces one.
-     */
-    @Test
-    void aQuotableReadingAndAnUnquotableOneAreNotTwoReadingsOfOneClause() {
-        Clause quotable = clause(FIRST, "ordered", at("model.sou", 8));
-        Clause outOfSight = clause(FIRST, "ordered", outOfSight());
-
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(quotable, outOfSight));
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(outOfSight, quotable),
-                "and the same the other way round, or the walk's order decides what is noticed");
-    }
-
-    @Test
-    void twoReadingsThatKnowNothingStillKnowNothing() {
-        Clause blind = clause(FIRST, "ordered", outOfSight());
-
-        assertEquals(blind, Clause.merge(blind, blind));
+    private static Clause.Ref clause(Clause.Id id, String name) {
+        return new Clause.Ref(id, Optional.ofNullable(name).map(ClauseName::new));
     }
 
     // --- what may not differ ----------------------------------------------------------------
 
     @Test
     void twoClausesAreNotMergedIntoOne() {
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", outOfSight()),
-                clause(SECOND, "ordered", outOfSight())));
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", outOfSight()),
-                clause(new Clause.Id(OTHER, 0), "ordered", outOfSight())));
+        assertThrows(Clause.NotOneClause.class, () -> Clause.Ref.merge(
+                clause(FIRST, "ordered"),
+                clause(SECOND, "ordered")));
+        assertThrows(Clause.NotOneClause.class, () -> Clause.Ref.merge(
+                clause(FIRST, "ordered"),
+                clause(new Clause.Id(OTHER, 0), "ordered")));
     }
 
     /**
@@ -146,27 +95,14 @@ class TwoReadingsOfOneClauseAgreeOrTheModelIsWrongTest {
      */
     @Test
     void oneClauseIsNotNamedTwoWays() {
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", outOfSight()),
-                clause(FIRST, "lowNonNegative", outOfSight())));
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", outOfSight()),
-                clause(FIRST, null, outOfSight())));
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, null, outOfSight()),
-                clause(FIRST, "ordered", outOfSight())));
+        assertThrows(Clause.NotOneClause.class, () -> Clause.Ref.merge(
+                clause(FIRST, "ordered"),
+                clause(FIRST, "lowNonNegative")));
+        assertThrows(Clause.NotOneClause.class, () -> Clause.Ref.merge(
+                clause(FIRST, "ordered"),
+                clause(FIRST, null)));
+        assertThrows(Clause.NotOneClause.class, () -> Clause.Ref.merge(
+                clause(FIRST, null),
+                clause(FIRST, "ordered")));
     }
-
-    /** Nor written in two places. Which of them is right is not a question with an answer here:
-     *  either the ordinal or what carries a clause through a rewrite is wrong. */
-    @Test
-    void oneClauseIsNotWrittenInTwoPlaces() {
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", at("model.sou", 8)),
-                clause(FIRST, "ordered", at("model.sou", 20))));
-        assertThrows(Clause.NotOneClause.class, () -> Clause.merge(
-                clause(FIRST, "ordered", at("model.sou", 8)),
-                clause(FIRST, "ordered", at("other.sou", 8))));
-    }
-
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
@@ -2,7 +2,9 @@ package souther.compiler.check;
 
 import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.Key;
 import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
 
@@ -18,6 +20,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a construction was judged against, and where the clause it was judged against is written.
@@ -84,6 +87,27 @@ class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
                 "and the line it writes it on once a line is inserted above it");
 
         assertNotEquals(clauseLines(DECLARING), clauseLines(MOVED));
+    }
+
+    /**
+     * And the check that reports about the construction depends on where the clause is written.
+     *
+     * <p>The edge is what this is all for, and it is the one thing neither answer above shows: two
+     * answers that differ say nothing about whether the reader of the first asks for the second. A
+     * report that worked the place out without recording that it had would go on saying where the
+     * clause was, on the day a cut lets the reading itself stand.
+     */
+    @Test
+    void andTheCheckThatReportsAboutTheConstructionDependsOnWhereTheClauseIsWritten() {
+        Compilation compilation = answered(DECLARING);
+
+        Set<Key<?>> read =
+                compilation.db().dependenciesOf(new Bodies.CheckedBehavior("app", "make"));
+
+        assertTrue(read.contains(new Shapes.ClauseLocationsFor(SMALL)),
+                "checking the body asks where the clause it reports about is written");
+        assertFalse(read.contains(new Shapes.ClauseLocationsFor(new TypeKey("limits", "Large"))),
+                "and what it read is what it asked for: nothing declares a `Large` to ask about");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.DiagnosticPlace;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What a construction was judged against, and where the clause it was judged against is written.
+ *
+ * <p>Two answers to two questions, and an edit that moves the clause without changing a word of it
+ * moves one of them. What the judgment says is what the declaration states, which the edit leaves
+ * alone; where a report sends a reader is where the text is now, which the edit decides.
+ *
+ * <p>They used to be one answer. A judgment held the clause with the place it is written at, so a
+ * line inserted above the declaration made a judgment that was not the judgment before it — of the
+ * same clause, stating the same thing, about the same construction. Every reader of a judgment was
+ * a reader of where the clause is written, whether it pointed anywhere or not.
+ *
+ * <p>What this fixes is not a report this compiler gets wrong today. It is what a cut at the module
+ * boundary would get wrong: a boundary that let a reading stand because the clauses still mean what
+ * they meant would leave the judgment cached, and a judgment carrying a place is a report pointing
+ * at where the clause used to be. Asked of the declaration instead, the place is worked out again
+ * whether or not the judgment was.
+ */
+class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
+
+    private static final String DECLARING = """
+            module limits exposing ( Small )
+
+            data Small = String
+                invariant String.length(value) <= 3
+            """;
+
+    /** Constructs the imported value, which is what makes its clause something to be judged by. */
+    private static final String CONSTRUCTING = """
+            module app
+
+            import limits ( Small )
+
+            behavior make : (s: String) -> Small
+                constructs Small
+
+            let make (s) = Small(s)
+            """;
+
+    /** The same declaration, a line further down, with nothing it states changed. */
+    private static final String MOVED = DECLARING.replace("data Small",
+            "// what an author types while reading their own model back\ndata Small");
+
+    private static final TypeKey SMALL = new TypeKey("limits", "Small");
+
+    @Test
+    void anEditThatMovesTheClauseLeavesWhatTheConstructionWasJudgedAgainst() {
+        InvariantChecker.Judgment before = judgmentOn(DECLARING);
+        InvariantChecker.Judgment after = judgmentOn(MOVED);
+
+        assertFalse(before.found().isEmpty(),
+                "the construction is judged against the clause the import declares, or the two"
+                        + " answers below are being compared over nothing");
+        assertEquals(before, after,
+                "the clause states what it stated, so the judgment is the judgment it was");
+    }
+
+    @Test
+    void andTheSameEditMovesWhereAReportIsSentToFindIt() {
+        assertEquals(List.of(4), clauseLines(DECLARING),
+                "the `invariant` line the declaration writes");
+        assertEquals(List.of(5), clauseLines(MOVED),
+                "and the line it writes it on once a line is inserted above it");
+
+        assertNotEquals(clauseLines(DECLARING), clauseLines(MOVED));
+    }
+
+    /**
+     * The judgment for the construction in {@code app}, taken through the seam the check reports
+     * through.
+     *
+     * <p>Only {@code limits} is edited between the two compiles, so nothing about the constructing
+     * module — where its body is, what it names — differs. What is left to differ is what the
+     * imported declaration says, and the edit says nothing new.
+     */
+    private static InvariantChecker.Judgment judgmentOn(String declaring) {
+        List<InvariantChecker.Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            answered(declaring);
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        return said.stream().filter(one -> one.type().equals("Small")).findFirst().orElseThrow()
+                .judgment();
+    }
+
+    /** The lines a reader is sent to for {@code Small}'s clauses, asked of the declaration. */
+    private static List<Integer> clauseLines(String declaring) {
+        return answered(declaring).db().ask(new Shapes.ClauseLocationsFor(SMALL)).value().stream()
+                .map(place -> ((DiagnosticPlace.InSource) place).region().start().line())
+                .toList();
+    }
+
+    private static Compilation answered(String declaring) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("limits.sou", declaring);
+        byId.put("app.sou", CONSTRUCTING);
+        Compilation compilation = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        compilation.answerEverything();
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest.java
@@ -7,6 +7,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Key;
 import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
 
 import org.junit.jupiter.api.Test;
 
@@ -67,6 +68,20 @@ class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
 
     private static final TypeKey SMALL = new TypeKey("limits", "Small");
 
+    /** Two clauses, so that an edit can move one of them and leave the other. */
+    private static final String TWO_CLAUSES = """
+            module limits exposing ( Small )
+
+            data Small = String
+                invariant String.length(value) <= 3
+                invariant String.length(value) >= 1
+            """;
+
+    /** The same, with only the second clause moved down. */
+    private static final String SECOND_MOVED = TWO_CLAUSES.replace(
+            "    invariant String.length(value) >= 1",
+            "    // and it is at least this long\n    invariant String.length(value) >= 1");
+
     @Test
     void anEditThatMovesTheClauseLeavesWhatTheConstructionWasJudgedAgainst() {
         InvariantChecker.Judgment before = judgmentOn(DECLARING);
@@ -81,12 +96,26 @@ class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
 
     @Test
     void andTheSameEditMovesWhereAReportIsSentToFindIt() {
-        assertEquals(List.of(4), clauseLines(DECLARING),
-                "the `invariant` line the declaration writes");
-        assertEquals(List.of(5), clauseLines(MOVED),
+        assertEquals(4, clauseLine(DECLARING, 0), "the `invariant` line the declaration writes");
+        assertEquals(5, clauseLine(MOVED, 0),
                 "and the line it writes it on once a line is inserted above it");
+    }
 
-        assertNotEquals(clauseLines(DECLARING), clauseLines(MOVED));
+    /**
+     * A clause is asked about one at a time, so an edit that moves one of them leaves the others
+     * where they were.
+     *
+     * <p>Which is what the question is for. Asked a declaration at a time, the answer would be the
+     * places of every clause it writes, and a reader pointing at the first would be re-read for a
+     * line inserted above the second — an edge answering a question that reader never asked. The
+     * clause a report is about is the grain the report means.
+     */
+    @Test
+    void aClauseThatDidNotMoveIsWhereItWas() {
+        assertEquals(clauseLine(TWO_CLAUSES, 0), clauseLine(SECOND_MOVED, 0),
+                "the first clause is written where it was, and the edit is below it");
+        assertNotEquals(clauseLine(TWO_CLAUSES, 1), clauseLine(SECOND_MOVED, 1),
+                "the control: the edit does move the second");
     }
 
     /**
@@ -104,9 +133,10 @@ class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
         Set<Key<?>> read =
                 compilation.db().dependenciesOf(new Bodies.CheckedBehavior("app", "make"));
 
-        assertTrue(read.contains(new Shapes.ClauseLocationsFor(SMALL)),
+        assertTrue(read.contains(new Shapes.ClauseLocation(firstClauseOf(SMALL))),
                 "checking the body asks where the clause it reports about is written");
-        assertFalse(read.contains(new Shapes.ClauseLocationsFor(new TypeKey("limits", "Large"))),
+        assertFalse(read.contains(new Shapes.ClauseLocation(
+                        new Clause.Id(TypeSymbols.declared(new TypeKey("limits", "Large")), 0))),
                 "and what it read is what it asked for: nothing declares a `Large` to ask about");
     }
 
@@ -130,11 +160,16 @@ class WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest {
                 .judgment();
     }
 
-    /** The lines a reader is sent to for {@code Small}'s clauses, asked of the declaration. */
-    private static List<Integer> clauseLines(String declaring) {
-        return answered(declaring).db().ask(new Shapes.ClauseLocationsFor(SMALL)).value().stream()
-                .map(place -> ((DiagnosticPlace.InSource) place).region().start().line())
-                .toList();
+    private static Clause.Id firstClauseOf(TypeKey declaration) {
+        return new Clause.Id(TypeSymbols.declared(declaration), 0);
+    }
+
+    /** The line a reader is sent to for the {@code nth} clause of {@code Small}. */
+    private static int clauseLine(String declaring, int nth) {
+        DiagnosticPlace place = answered(declaring).db()
+                .ask(new Shapes.ClauseLocation(new Clause.Id(TypeSymbols.declared(SMALL), nth)))
+                .value();
+        return ((DiagnosticPlace.InSource) place).region().start().line();
     }
 
     private static Compilation answered(String declaring) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
@@ -43,7 +43,7 @@ class WhatANameIsAboutIsWhatItWasGivenIsAboutTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
                 Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -69,7 +69,8 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), DeclarationReadings.NONE,
+    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.written(),
+            DeclarationReadings.NONE,
             Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
@@ -230,7 +230,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         Scope params = heldTo(new Type.Ref(TypeSymbols.declared(new TypeKey("demo", "制限木"))));
 
         assertEquals(InvariantChecker.Status.COMPLETE,
-                InvariantChecker.analyze(body, lookupOf(c), DeclarationReadings.NONE, Map.of(), params,
+                InvariantChecker.analyze(body, lookupOf(c), ClauseLocations.NONE,
+                        DeclarationReadings.NONE, Map.of(), params,
                         symbolsOf(c), POLICY).status(),
                 "the control: read through a lookup that answers, this analysis runs to the end");
 
@@ -238,7 +239,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
             throw new IllegalStateException("this compiler could not read its own answer");
         };
         IllegalStateException why = assertThrows(IllegalStateException.class,
-                () -> InvariantChecker.analyze(body, broken, DeclarationReadings.NONE, Map.of(), params,
+                () -> InvariantChecker.analyze(body, broken, ClauseLocations.NONE,
+                        DeclarationReadings.NONE, Map.of(), params,
                         symbolsOf(c), POLICY),
                 "the analysis has no rule that makes this the program's problem");
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
@@ -47,7 +47,7 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                    RuleReadings.noClauseFiled(), DeclarationReadings.NONE,
+                    RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
                     Terms.Of.THE_DISCHARGE_TREE,
                     souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 

--- a/souther-compiler/src/test/java/souther/compiler/query/AReportAboutAnImportedClauseNamesWhereItIsNowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReportAboutAnImportedClauseNamesWhereItIsNowTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticPlace;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Primary;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.source.SourceId;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A report that names a clause of another module names where that clause is now.
+ *
+ * <p>A body constructing a value of an imported type is judged against the invariant that type
+ * declares, and what it is told points at the clause — in the declaring module's source, not in its
+ * own. So the reader is one module's and the place is another's, and nothing about the reader
+ * changed when the clause moved.
+ *
+ * <p>Held against a compile of the same text rather than against a line number written down here. A
+ * number would say where the clause is in this fixture and would be edited whenever the fixture was;
+ * what is being asked is whether a store that absorbed the edit says what a store that never saw the
+ * old text says, which is a question about the two and not about either.
+ */
+class AReportAboutAnImportedClauseNamesWhereItIsNowTest {
+
+    private static final String DECLARING = """
+            module limits exposing ( Small )
+
+            data Small = String
+                invariant String.length(value) <= 3
+            """;
+
+    /** Constructs the imported value, which is what makes its clause something to be judged by. */
+    private static final String CONSTRUCTING = """
+            module app
+
+            import limits ( Small )
+
+            behavior make : (s: String) -> Small
+                constructs Small
+
+            let make (s) = Small(s)
+            """;
+
+    /** The same, with the declaration a line further down. */
+    private static final String MOVED = DECLARING.replace("data Small",
+            "// what an author types while reading their own model back\ndata Small");
+
+    private static Map<String, String> workspace(String declaring) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("limits.sou", declaring);
+        byId.put("app.sou", CONSTRUCTING);
+        return byId;
+    }
+
+    private static Compilation answered(Map<String, String> sources) {
+        Compilation compilation = Compilation.ofDocuments(sources, Set.of(), ModulePath.EMPTY);
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /**
+     * Every place a report of one source points into another, as text.
+     *
+     * <p>Read off what a reader is sent to rather than off the message: the message says what the
+     * finding is, and where it sends somebody is the thing that goes out of date.
+     */
+    private static List<String> placesElsewhere(Compilation compilation) {
+        List<String> said = new ArrayList<>();
+        for (Map.Entry<SourceId, List<Diagnostic>> at
+                : Located.diagnosticsOf(compilation.diagnostics()).entrySet()) {
+            for (Diagnostic diagnostic : at.getValue()) {
+                List<DiagnosticPlace> places = new ArrayList<>();
+                if (diagnostic.primary() instanceof Primary.InSource here) {
+                    places.add(here.place());
+                }
+                diagnostic.secondary().forEach(label -> places.add(label.place()));
+                for (DiagnosticPlace place : places) {
+                    if (place instanceof DiagnosticPlace.InSource there
+                            && !there.source().equals(at.getKey())) {
+                        said.add(at.getKey() + " " + diagnostic.code() + " points at "
+                                + there.source() + " " + there.region().start());
+                    }
+                }
+            }
+        }
+        said.sort(null);
+        return said;
+    }
+
+    /**
+     * The fixture reports about the other module at all, and the edit moves what it points at.
+     *
+     * <p>Asked first and of two compiles, because the claim below is that two answers agree: two
+     * that agreed by both saying nothing would pass it, and so would two that agreed because the
+     * edit reached nothing.
+     */
+    @Test
+    void theEditMovesWhatAReportOfTheOtherModulePointsAt() {
+        List<String> before = placesElsewhere(answered(workspace(DECLARING)));
+        List<String> after = placesElsewhere(answered(workspace(MOVED)));
+
+        assertEquals(1, before.size(),
+                () -> "one report of the constructing module points into the declaring one: "
+                        + before);
+        assertNotEquals(before, after, "and the edit moves the place it points at");
+    }
+
+    /** And a store that absorbed the edit says what a compile of the same text says. */
+    @Test
+    void aStoreThatAbsorbedTheEditSaysWhereTheClauseIsNow() {
+        Compilation absorbed = answered(workspace(DECLARING));
+        absorbed.update(workspace(MOVED), Set.of());
+        absorbed.answerEverything();
+
+        assertEquals(placesElsewhere(answered(workspace(MOVED))), placesElsewhere(absorbed),
+                "the store names where the clause is, not where it was");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -581,6 +581,15 @@ final class AnswerClosure {
                     part("souther.compiler.partition.MeasuredInput", "written"),
                     part("souther.compiler.partition.BehaviorInputs", "rules"),
                     part("souther.compiler.check.RuleReadingSource", "invariants")),
+            // Where a clause of a declaration is written, beside the clauses above and for the same
+            // reason: a capability, whose only input is which clause is being asked about. Held as
+            // an answer here it would be this reading's copy of where the declaring module wrote
+            // its text, which is the copy that goes on pointing at where the clause used to be.
+            generationReader("souther.compiler.check.ClauseLocations",
+                    Traversal.Why.NOTHING_CLOSES_IT,
+                    part("souther.compiler.partition.MeasuredInput", "written"),
+                    part("souther.compiler.partition.BehaviorInputs", "rules"),
+                    part("souther.compiler.check.RuleReadingSource", "written")),
             generationReader("souther.compiler.inputs.ReadQuantities",
                     part("souther.compiler.partition.MeasuredInput", "quantities"),
                     arm("souther.compiler.inputs.ReadQuantities")),


### PR DESCRIPTION
A judgment held the clause together with the place it is written at, so an edit that moved a clause and changed nothing it states produced a judgment that was not the judgment before it — same clause, same verdict, same status, a different value.

**Before:** a judgment carried `Clause`, and `Clause` carried a `DiagnosticPlace`.

**After:** a judgment carries `Clause.Ref` — which clause it is, and what a sentence calls it. A diagnostic that needs to point at the clause asks `Shapes.ClauseLocationsFor`, answered from the declaration's own text.

`Clause.merge` moves to `Clause.Ref.merge` and loses its comparison of places. That is not a check relaxed: two readings of one clause can no longer hold a place, so there is nothing left to disagree about. Where the clause is written is asked once, of the declaration, wherever the reading came from.

## Why merge this on its own

It does not reduce incremental work, and it does not fix a report this compiler gets wrong today. It establishes the location dependency that a semantic cut at the module boundary needs.

A boundary that let a reading stand because the imported clauses still mean what they meant would leave the judgment cached — and a judgment carrying a place is a cached report pointing at where the clause used to be. Asked of the declaration instead, the place is worked out again whether or not the judgment was.

Worth stating plainly, because an earlier note on #1472 had it the other way round: the stale report is not an existing defect on `develop`. It is a latent dependency the intended optimisation would expose. The two halves have to land in this order.

## What holds it

`WhatAClauseMeansAndWhereItIsWrittenAreTwoAnswersTest` fixes both halves against one edit — a line inserted above an imported declaration:

- what the construction was judged against is what it was
- where a reader is sent to find the clause has moved

Run against `develop`, the first half fails, and the two judgments it prints differ in the place and in nothing else.

`AReportAboutAnImportedClauseNamesWhereItIsNowTest` is the integration guard for the cut that comes next: a store that absorbed the edit agrees with a compile that never saw the old text. It passes on `develop` too, which is right — it is what will catch the boundary cut going wrong, not something this change repairs.

Toward #1472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)