### PR TITLE
Ask a fake's row what it answers for

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -248,9 +248,29 @@ public interface Ast {
      */
     record Fake(Var target, List<FakeRow> rows, SourcePos pos) implements Ast {}
 
-    /** One fake row: input argument expressions mapped to an output, or the default ({@code inputs}
-     * null / {@code isDefault} true). */
-    record FakeRow(List<Expr> inputs, Expr output, boolean isDefault, SourcePos pos) implements Ast {}
+    /** One fake row: what it answers for, and what it answers with. */
+    record FakeRow(Matched matched, Expr output, SourcePos pos) implements Ast {}
+
+    /**
+     * What a fake's row answers for.
+     *
+     * <p>Two states and the source says which: a row written {@code (a, b) -> out} answers for those
+     * arguments and for no others, and a row written {@code _ -> out} answers for anything, with no
+     * arguments written in it to read. The parse decides which, and nothing below it decides again.
+     */
+    sealed interface Matched permits Matched.Arguments, Matched.Anything {
+
+        /** The row names the arguments it answers for, and these are they. */
+        record Arguments(List<Expr> inputs) implements Matched {
+
+            public Arguments {
+                inputs = List.copyOf(inputs);
+            }
+        }
+
+        /** The row answers for anything: {@code _ -> out}. */
+        record Anything() implements Matched {}
+    }
 
     /** {@code with <dep> = <value>} on an example row — a value fake for an injected dependency
      * (a zero-argument behavior whose faked result is a constant). The dependency is named as a

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -424,9 +424,46 @@ public interface Hir {
         }
     }
 
-    /** One fake row: input argument expressions mapped to an output, or the default ({@code inputs}
-     * null / {@code isDefault} true). */
-    record FakeRow(List<Expr> inputs, Expr output, boolean isDefault, SourcePos pos) implements Hir {}
+    /** One fake row: what it answers for, and what it answers with. */
+    record FakeRow(Matched matched, Expr output, SourcePos pos) implements Hir {}
+
+    /**
+     * What a fake's row answers for.
+     *
+     * <p>Two states and the source says which. A row written {@code (a, b) -> out} answers for those
+     * arguments and for no others; a row written {@code _ -> out} answers for anything, and there are
+     * no arguments written in it to read.
+     *
+     * <p>Not a list of arguments that may be absent. A walk over what the source writes has to be
+     * told which of the two a row is before it can ask for arguments, and an absence it is free to
+     * walk into is one a walk reads as a row that names none — which is a different row, and one no
+     * author can write.
+     */
+    sealed interface Matched permits Matched.Arguments, Matched.Anything {
+
+        /**
+         * The same, with the arguments rewritten where there are any to rewrite.
+         *
+         * <p>For a pass that rewrites what a row answers for without changing whether it names
+         * anything. A caller taking the list out and building a {@code Matched} back around it would
+         * be deciding a second time which of the two this is.
+         */
+        default Matched map(UnaryOperator<Expr> rewrite) {
+            return this instanceof Arguments(List<Expr> written)
+                    ? new Arguments(written.stream().map(rewrite).toList()) : this;
+        }
+
+        /** The row names the arguments it answers for, and these are they. */
+        record Arguments(List<Expr> inputs) implements Matched {
+
+            public Arguments {
+                inputs = List.copyOf(inputs);
+            }
+        }
+
+        /** The row answers for anything: {@code _ -> out}. */
+        record Anything() implements Matched {}
+    }
 
     /** {@code with <dep> = <value>} on an example row — a value fake for an injected dependency
      * (a zero-argument behavior whose faked result is a constant). The dependency is named as a

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -84,15 +84,8 @@ public final class HelperNames {
     static Hir.Fake qualifyImportsIn(Hir.Fake fake, String self) {
         List<Hir.FakeRow> rows = new ArrayList<>();
         for (Hir.FakeRow row : fake.rows()) {
-            List<Hir.Expr> inputs = null;
-            if (row.inputs() != null) {   // a default row matches anything and writes none
-                inputs = new ArrayList<>();
-                for (Hir.Expr in : row.inputs()) {
-                    inputs.add(qualifyForeign(in, self));
-                }
-            }
-            rows.add(new Hir.FakeRow(inputs, qualifyForeign(row.output(), self),
-                    row.isDefault(), row.pos()));
+            rows.add(new Hir.FakeRow(row.matched().map(in -> qualifyForeign(in, self)),
+                    qualifyForeign(row.output(), self), row.pos()));
         }
         return new Hir.Fake(fake.target(), rows, fake.pos());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -603,9 +603,13 @@ public final class Resolve {
             Hir.Var target = r.standsInFor(f.target());
             List<Hir.FakeRow> rows = new ArrayList<>();
             for (Ast.FakeRow row : f.rows()) {
-                rows.add(new Hir.FakeRow(
-                        row.inputs() == null ? null : r.exprs(row.inputs(), Reading.A_FIXTURE),
-                        r.expr(row.output(), Reading.A_FIXTURE), row.isDefault(), row.pos()));
+                Hir.Matched matched = switch (row.matched()) {
+                    case Ast.Matched.Arguments(List<Ast.Expr> inputs) ->
+                            new Hir.Matched.Arguments(r.exprs(inputs, Reading.A_FIXTURE));
+                    case Ast.Matched.Anything _ -> new Hir.Matched.Anything();
+                };
+                rows.add(new Hir.FakeRow(matched, r.expr(row.output(), Reading.A_FIXTURE),
+                        row.pos()));
             }
             fakes.add(new Hir.Fake(target, rows, f.pos()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/RowFixtures.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RowFixtures.java
@@ -108,10 +108,15 @@ public final class RowFixtures {
             Sig sig = occurrence instanceof FakeTables.Occurrence.Resolved resolved
                     ? sigOf(signatures, resolved.behavior()) : null;
             for (Hir.FakeRow row : occurrence.read().rows()) {
-                if (row.inputs() != null) {
-                    for (int i = 0; i < row.inputs().size(); i++) {
-                        out.add(new Placed(row.inputs().get(i), supplies(sig, i)));
+                switch (row.matched()) {
+                    case Hir.Matched.Arguments(List<Hir.Expr> inputs) -> {
+                        for (int i = 0; i < inputs.size(); i++) {
+                            out.add(new Placed(inputs.get(i), supplies(sig, i)));
+                        }
                     }
+                    // A row that answers for anything names no argument, so there is no position
+                    // for one to be supplied at.
+                    case Hir.Matched.Anything _ -> { }
                 }
                 out.add(new Placed(row.output(), new RowPosition.Supplies(answersWith(sig))));
             }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Reads the statements a module writes about one of its behaviors, and reports where two of them
@@ -153,7 +154,7 @@ public final class ExampleStatements {
                                     BuiltTable built) {
         Hir.Fake fk = table.read();
         List<Diagnostic> said = new ArrayList<>();
-        for (Standin standin : built.standins().explicit()) {
+        for (Standin.Explicit standin : built.standins().explicit()) {
             // The behavior the table stands in for, which is what declares the clause its rows are
             // held to. Taken from the classification: a dependency another module declares states
             // its own, and minting a name in this module would hold the row to nothing.
@@ -887,7 +888,7 @@ public final class ExampleStatements {
      * fake answers for a table the proxy refuses to build at all. What the report says a fake answers
      * has to be what the fake answers.
      */
-    record Standins(List<Standin> explicit, Standin fallback) {
+    record Standins(List<Standin.Explicit> explicit, Standin.Fallback fallback) {
 
         /**
          * Every row here is one {@link #answering} can return.
@@ -901,7 +902,8 @@ public final class ExampleStatements {
         public Standins {
             explicit = List.copyOf(explicit);
             for (int i = 0; i < explicit.size(); i++) {
-                if (answering(explicit.subList(0, i), null, explicit.get(i).arguments()) != null) {
+                if (answering(explicit.subList(0, i), null, Standin.Explicit::arguments,
+                        explicit.get(i).arguments()) != null) {
                     throw new IllegalArgumentException(
                             "a table holds no row its dispatch cannot return, and the row at " + i
                                     + " states what an earlier one states");
@@ -920,7 +922,7 @@ public final class ExampleStatements {
          * is one, and adding another means writing it somewhere it plainly does not belong.
          */
         Standin answering(Object[] arguments) {
-            return answering(explicit, fallback, arguments);
+            return answering(explicit, fallback, Standin.Explicit::arguments, arguments);
         }
 
         /**
@@ -931,10 +933,16 @@ public final class ExampleStatements {
          * built into says nothing about whether the row is ever asked — so it is asked of what states
          * rather than of what answers, and a row whose answer has not been built (and, being
          * unreachable, never will be) is decided by the same walk as the rest.
+         *
+         * <p>Only the rows that name arguments are compared, and {@code states} is how this reads
+         * them: the {@code _} row arrives as the fallback and is the answer where none of them
+         * matched, so it is never asked what it names — which is why its type does not have to have
+         * an answer to that.
          */
-        static <T extends Stated> T answering(List<T> explicit, T fallback, Object[] arguments) {
-            for (T stated : explicit) {
-                if (sameArguments(stated.arguments(), arguments)) {
+        static <R, E extends R> R answering(List<E> explicit, R fallback,
+                                            Function<E, Object[]> states, Object[] arguments) {
+            for (E stated : explicit) {
+                if (sameArguments(states.apply(stated), arguments)) {
                     return stated;
                 }
             }
@@ -966,20 +974,55 @@ public final class ExampleStatements {
      */
     sealed interface Stated {
 
-        /** The arguments this row states, or null for the {@code _} row. */
-        Object[] arguments();
-
         /** Where the row is written. */
         Hir.FakeRow row();
     }
 
-    /** A row as written, with its arguments read and nothing else of it built. */
+    /** A row as written, with the arguments it names read and nothing else of it built. */
     record Written(Object[] arguments, Hir.FakeRow row) implements Stated {}
 
-    /** One row of the table the fake dispatches with: what it states, and the answer it was built
-     * into. */
-    record Standin(Object[] arguments, Hir.FakeRow row, FixtureReader.BuiltFixture answer)
-            implements Stated {}
+    /** The {@code _} row as written. It names no arguments, so there are none here to have been
+     *  read: what it answers for is every call the rows beside it do not. */
+    record WroteAnything(Hir.FakeRow row) implements Stated {}
+
+    /**
+     * One row of the table the fake dispatches with: what it states, and the answer it was built
+     * into.
+     *
+     * <p>The two rows are two types, because what may be asked of them differs. A row that names
+     * arguments is the one a reader of the table enumerates, and reading what it names is reading
+     * the source it was written from; the {@code _} row names none, and a reader holding one has
+     * nothing of that kind to ask for. Held as one type, every such reader would have to decide for
+     * itself which it had, and a reader that decided wrongly would read a row that answers for
+     * anything as one that answers for no arguments — which is a row nobody can write.
+     */
+    sealed interface Standin extends Stated {
+
+        /** The answer this row was built into. */
+        FixtureReader.BuiltFixture answer();
+
+        /** A row that answers for the arguments it names. */
+        record Explicit(Object[] arguments, Hir.FakeRow row, FixtureReader.BuiltFixture answer)
+                implements Standin {
+
+            public Explicit {
+                if (!(row.matched() instanceof Hir.Matched.Arguments)) {
+                    throw new IllegalArgumentException(
+                            "an explicit row names the arguments it answers for");
+                }
+            }
+
+            /** Where those arguments are written, which is a question this row has an answer to
+             *  because that is what made it one of these. */
+            List<Hir.Expr> names() {
+                return ((Hir.Matched.Arguments) row.matched()).inputs();
+            }
+        }
+
+        /** The {@code _} row: what the table answers with where no row above it names the call's
+         *  arguments. */
+        record Fallback(Hir.FakeRow row, FixtureReader.BuiltFixture answer) implements Standin {}
+    }
 
     /**
      * One row of a built table, as something that did not read the source can hold it.
@@ -994,15 +1037,12 @@ public final class ExampleStatements {
      * value that could not be carried is on, an author is left to work out which of them nothing
      * could be made of.
      */
-    static RowStatements.StandInRead.EntryRead carried(FixtureReader fixtures, Standin entry) {
-        // An entry carries arguments because its row named them, so the places they were written at
-        // are the row's; the fallback carries none and is not read here.
-        List<Hir.Expr> written = entry.row().matched()
-                instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs) ? inputs : List.of();
+    static RowStatements.StandInRead.EntryRead carried(FixtureReader fixtures,
+                                                       Standin.Explicit entry) {
         List<RowStatements.StandInRead.Written> arguments = new ArrayList<>();
         for (int i = 0; i < entry.arguments().length; i++) {
             arguments.add(new RowStatements.StandInRead.Written(
-                    fixtures.observed(entry.arguments()[i]), written.get(i).pos()));
+                    fixtures.observed(entry.arguments()[i]), entry.names().get(i).pos()));
         }
         return new RowStatements.StandInRead.EntryRead(arguments,
                 new RowStatements.StandInRead.Written(fixtures.observed(entry.answer().value()),
@@ -1076,9 +1116,9 @@ public final class ExampleStatements {
             }
         }
         List<Written> reachable = new ArrayList<>();
-        List<Standin> explicit = new ArrayList<>();
+        List<Standin.Explicit> explicit = new ArrayList<>();
         List<Shadowed> shadowed = new ArrayList<>();
-        Standin fallback = null;
+        Standin.Fallback fallback = null;
         // In the order the rows are written, each read as far as it is reached: what a row states,
         // then — for a row the table can return — what it answers. A row the dispatch never returns
         // is a row nothing asks for what it states, so building its answer would be work done for a
@@ -1093,7 +1133,8 @@ public final class ExampleStatements {
                         shadowed.add(new Shadowed(r, lastDefault));
                         continue;
                     }
-                    fallback = new Standin(null, r, fixtures.buildFixture(r.output(), outType));
+                    fallback = new Standin.Fallback(r,
+                            fixtures.buildFixture(r.output(), outType));
                     continue;
                 }
                 Object[] arguments = new Object[ins.size()];
@@ -1109,8 +1150,9 @@ public final class ExampleStatements {
                 // rule that decides which row answers is the rule that decides which row cannot.
                 List<Written> with = new ArrayList<>(reachable);
                 with.add(written);
-                Written answers = Standins.answering(with,
-                        lastDefault == null ? null : new Written(null, lastDefault), arguments);
+                Stated answers = Standins.answering(with,
+                        lastDefault == null ? null : new WroteAnything(lastDefault),
+                        Written::arguments, arguments);
                 if (answers != written) {
                     shadowed.add(new Shadowed(r, answers.row()));
                     continue;
@@ -1118,7 +1160,8 @@ public final class ExampleStatements {
                 reachable.add(written);
                 // A dependency that returns a sum has no single decoder; each row names one case, so
                 // decode the row's output against that case's type (as an expected value is).
-                explicit.add(new Standin(arguments, r, fixtures.buildFixture(r.output(), outType)));
+                explicit.add(new Standin.Explicit(arguments, r,
+                        fixtures.buildFixture(r.output(), outType)));
             }
         } catch (FixtureException fe) {
             out.add(unbuildableFake(fk.pos(), wrote(fk), fe.getMessage()));

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -995,10 +995,14 @@ public final class ExampleStatements {
      * could be made of.
      */
     static RowStatements.StandInRead.EntryRead carried(FixtureReader fixtures, Standin entry) {
+        // An entry carries arguments because its row named them, so the places they were written at
+        // are the row's; the fallback carries none and is not read here.
+        List<Hir.Expr> written = entry.row().matched()
+                instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs) ? inputs : List.of();
         List<RowStatements.StandInRead.Written> arguments = new ArrayList<>();
         for (int i = 0; i < entry.arguments().length; i++) {
             arguments.add(new RowStatements.StandInRead.Written(
-                    fixtures.observed(entry.arguments()[i]), entry.row().inputs().get(i).pos()));
+                    fixtures.observed(entry.arguments()[i]), written.get(i).pos()));
         }
         return new RowStatements.StandInRead.EntryRead(arguments,
                 new RowStatements.StandInRead.Written(fixtures.observed(entry.answer().value()),
@@ -1055,8 +1059,9 @@ public final class ExampleStatements {
     static BuiltTable standins(FixtureReader fixtures, Hir.Fake fk, List<BoundaryInput> ins,
                                      BoundaryOutput outType, List<Diagnostic> out) {
         for (Hir.FakeRow r : fk.rows()) {
-            if (!r.isDefault() && r.inputs().size() != ins.size()) {
-                out.add(unbuildableFake(r.pos(), wrote(fk), "a row has " + r.inputs().size()
+            if (r.matched() instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs)
+                    && inputs.size() != ins.size()) {
+                out.add(unbuildableFake(r.pos(), wrote(fk), "a row has " + inputs.size()
                         + " input(s) where the dependency takes " + ins.size()));
                 return null;
             }
@@ -1066,7 +1071,7 @@ public final class ExampleStatements {
         // built either.
         Hir.FakeRow lastDefault = null;
         for (Hir.FakeRow r : fk.rows()) {
-            if (r.isDefault()) {
+            if (r.matched() instanceof Hir.Matched.Anything) {
                 lastDefault = r;
             }
         }
@@ -1083,7 +1088,7 @@ public final class ExampleStatements {
         // wrong wherever a later row's arguments take their time.
         try {
             for (Hir.FakeRow r : fk.rows()) {
-                if (r.isDefault()) {
+                if (!(r.matched() instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs))) {
                     if (r != lastDefault) {
                         shadowed.add(new Shadowed(r, lastDefault));
                         continue;
@@ -1093,7 +1098,7 @@ public final class ExampleStatements {
                 }
                 Object[] arguments = new Object[ins.size()];
                 for (int i = 0; i < ins.size(); i++) {
-                    arguments[i] = fixtures.built(r.inputs().get(i), ins.get(i));
+                    arguments[i] = fixtures.built(inputs.get(i), ins.get(i));
                 }
                 Written written = new Written(arguments, r);
                 // Whether the table would return this row when asked what this row states, asked of
@@ -1135,7 +1140,7 @@ public final class ExampleStatements {
      */
     static Diagnostic cannotAnswer(Hir.Fake fk, Shadowed dead) {
         return Diagnostic.at(dead.row().pos())
-                .say(dead.row().isDefault()
+                .say(dead.row().matched() instanceof Hir.Matched.Anything
                         ? new ExampleMessage.ALaterDefaultRowAnswersInstead(wrote(fk))
                         : new ExampleMessage.AnEarlierRowAnswersTheseArguments(wrote(fk)))
                 .secondary(souther.compiler.diag.Region.point(dead.answeredBy().pos()),

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -629,9 +629,13 @@ public final class ExampleVerifier {
         // written with, and there is no grain below that for it to have stated instead.
         Expectation.Asserts stated;
         try {
+            // An entry is a row that named the arguments it answers for; the fallback names none
+            // and is not one of these.
+            List<Hir.Expr> written = entry.written().matched()
+                    instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs) ? inputs : List.of();
             args = new Object[sig.ins().size()];
             for (int i = 0; i < args.length; i++) {
-                args[i] = fixtures.built(entry.written().inputs().get(i), sig.ins().get(i));
+                args[i] = fixtures.built(written.get(i), sig.ins().get(i));
             }
             stated = new Expectation.TheValue(
                     fixtures.assertedExpected(entry.written().output(), sig.out()).asserted());

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -310,7 +310,7 @@ public final class ExampleVerifier {
         }
         List<StandinEntry> entries = new ArrayList<>();
         List<StatedRow> rows = recordedRowsOf(of, behavior, fixtures, sig);
-        for (ExampleStatements.Standin entry : built.standins().explicit()) {
+        for (ExampleStatements.Standin.Explicit entry : built.standins().explicit()) {
             // What the row states, read the one way a table's row is read. What a person is shown
             // is beside it and is this reader's own: the two are not one string, which is the
             // whole reason a machine-readable half is carried at all.
@@ -331,7 +331,7 @@ public final class ExampleVerifier {
                     alsoBy.add(stated.handle());
                 }
             }
-            entries.add(new StandinEntry(of, behavior, first.pos(), entry.row(),
+            entries.add(new StandinEntry(of, behavior, first.pos(), entry,
                     inputs, carried.answer().value(), shownInputs,
                     fixtures.shown(fixtures.structured(entry.answer().value()), sig.outputType()),
                     alsoBy));
@@ -629,16 +629,12 @@ public final class ExampleVerifier {
         // written with, and there is no grain below that for it to have stated instead.
         Expectation.Asserts stated;
         try {
-            // An entry is a row that named the arguments it answers for; the fallback names none
-            // and is not one of these.
-            List<Hir.Expr> written = entry.written().matched()
-                    instanceof Hir.Matched.Arguments(List<Hir.Expr> inputs) ? inputs : List.of();
             args = new Object[sig.ins().size()];
             for (int i = 0; i < args.length; i++) {
-                args[i] = fixtures.built(written.get(i), sig.ins().get(i));
+                args[i] = fixtures.built(entry.written().names().get(i), sig.ins().get(i));
             }
-            stated = new Expectation.TheValue(
-                    fixtures.assertedExpected(entry.written().output(), sig.out()).asserted());
+            stated = new Expectation.TheValue(fixtures.assertedExpected(
+                    entry.written().row().output(), sig.out()).asserted());
         } catch (FixtureException fe) {
             return new StandinObservation.Unobserved(
                     new StandinObservation.Reason.TheEntryWasNotRead(
@@ -2232,12 +2228,12 @@ public final class ExampleVerifier {
         // it cannot dispatch to are not among them: a reader walking these is walking answers the
         // stand-in can give, and which rows those are is the table's own rule to have decided.
         List<RowStatements.StandInRead.EntryRead> entries = new ArrayList<>();
-        for (ExampleStatements.Standin entry : table.explicit()) {
+        for (ExampleStatements.Standin.Explicit entry : table.explicit()) {
             entries.add(ExampleStatements.carried(fixtures, entry));
         }
         // The `_` row's answer, quoted where that answer is written rather than where the row
         // begins: it is the only value the row states, and it is the one a reader is sent to.
-        ExampleStatements.Standin fallback = table.fallback();
+        ExampleStatements.Standin.Fallback fallback = table.fallback();
         StoodIn.Otherwise otherwise = fallback == null ? new StoodIn.Otherwise.NothingStated()
                 : new StoodIn.Otherwise.Answer(fixtures.observed(fallback.answer().value()),
                         fallback.row().output().pos());

--- a/souther-compiler/src/main/java/souther/compiler/examples/StandinEntry.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/StandinEntry.java
@@ -32,14 +32,15 @@ public final class StandinEntry {
     private final BoundExamples of;
     private final String behavior;
     private final SourcePos table;
-    private final Hir.FakeRow written;
+    private final ExampleStatements.Standin.Explicit written;
     private final List<ObservedValue> inputs;
     private final ObservedValue stated;
     private final List<String> shownInputs;
     private final String shownStated;
     private final List<RecordedRow> alsoBy;
 
-    StandinEntry(BoundExamples of, String behavior, SourcePos table, Hir.FakeRow written,
+    StandinEntry(BoundExamples of, String behavior, SourcePos table,
+                 ExampleStatements.Standin.Explicit written,
                  List<ObservedValue> inputs, ObservedValue stated, List<String> shownInputs,
                  String shownStated, List<RecordedRow> alsoBy) {
         this.of = of;
@@ -72,7 +73,7 @@ public final class StandinEntry {
 
     /** Where this entry itself is written. */
     public SourcePos at() {
-        return written.pos();
+        return written.row().pos();
     }
 
     /** The inputs the entry states. */
@@ -132,7 +133,7 @@ public final class StandinEntry {
         return of;
     }
 
-    Hir.FakeRow written() {
+    ExampleStatements.Standin.Explicit written() {
         return written;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -1683,10 +1683,10 @@ public final class AstBuilder {
                 inputs.add(expr(a));
             }
         });
-        boolean isDefault = args.isEmpty();
         List<SyntaxNode> exprs = exprChildren(n);   // the output (not inside ARG_LIST)
         Ast.Expr output = exprs.isEmpty() ? null : expr(exprs.get(0));
-        return new Ast.FakeRow(isDefault ? null : inputs, output, isDefault, pos(n));
+        return new Ast.FakeRow(args.isEmpty() ? new Ast.Matched.Anything()
+                : new Ast.Matched.Arguments(inputs), output, pos(n));
     }
 
     }

--- a/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
@@ -8,6 +8,7 @@ import souther.compiler.source.SourceId;
 
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -244,8 +245,11 @@ public final class AuthoredSites {
         private void fake(Hir.Fake fake) {
             expr(fake.target());
             for (Hir.FakeRow row : fake.rows()) {
-                for (Hir.Expr input : row.inputs()) {
-                    expr(input);
+                switch (row.matched()) {
+                    case Hir.Matched.Arguments(List<Hir.Expr> inputs) -> inputs.forEach(this::expr);
+                    // A row that answers for anything writes no arguments, so there is nothing
+                    // written for a site to be at.
+                    case Hir.Matched.Anything _ -> { }
                 }
                 expr(row.output());
             }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ATableHoldsNoRowItCannotAnswerWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ATableHoldsNoRowItCannotAnswerWithTest.java
@@ -29,7 +29,7 @@ class ATableHoldsNoRowItCannotAnswerWithTest {
 
     private static ExampleStatements.Standin stating(String argument) {
         return new ExampleStatements.Standin(new Object[] {argument},
-                new Hir.FakeRow(List.of(), null, false, SOMEWHERE), null);
+                new Hir.FakeRow(new Hir.Matched.Arguments(List.of()), null, SOMEWHERE), null);
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/examples/ATableHoldsNoRowItCannotAnswerWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ATableHoldsNoRowItCannotAnswerWithTest.java
@@ -27,15 +27,15 @@ class ATableHoldsNoRowItCannotAnswerWithTest {
 
     private static final SourcePos SOMEWHERE = new SourcePos(1, 1);
 
-    private static ExampleStatements.Standin stating(String argument) {
-        return new ExampleStatements.Standin(new Object[] {argument},
+    private static ExampleStatements.Standin.Explicit stating(String argument) {
+        return new ExampleStatements.Standin.Explicit(new Object[] {argument},
                 new Hir.FakeRow(new Hir.Matched.Arguments(List.of()), null, SOMEWHERE), null);
     }
 
     @Test
     void aTableRefusesARowAnEarlierRowAlreadyStates() {
-        ExampleStatements.Standin first = stating("m-1");
-        ExampleStatements.Standin second = stating("m-1");
+        ExampleStatements.Standin.Explicit first = stating("m-1");
+        ExampleStatements.Standin.Explicit second = stating("m-1");
 
         assertThrows(IllegalArgumentException.class,
                 () -> new ExampleStatements.Standins(List.of(first, second), null),
@@ -44,8 +44,8 @@ class ATableHoldsNoRowItCannotAnswerWithTest {
 
     @Test
     void aTableOfRowsStatingDifferentThingsIsWhatItSays() {
-        ExampleStatements.Standin one = stating("m-1");
-        ExampleStatements.Standin nine = stating("m-9");
+        ExampleStatements.Standin.Explicit one = stating("m-1");
+        ExampleStatements.Standin.Explicit nine = stating("m-9");
 
         ExampleStatements.Standins table = assertDoesNotThrow(
                 () -> new ExampleStatements.Standins(List.of(one, nine), null));

--- a/souther-compiler/src/test/java/souther/compiler/sites/AnOccurrenceIsNamedByWhatItWasWrittenOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/sites/AnOccurrenceIsNamedByWhatItWasWrittenOverTest.java
@@ -106,6 +106,39 @@ class AnOccurrenceIsNamedByWhatItWasWrittenOverTest {
         assertInstanceOf(AuthoredSites.Census.Identified.class, AuthoredSites.of(module));
     }
 
+    /**
+     * And a row that answers for anything is a row of the table.
+     *
+     * <p>What it answers with is written in the source like any other row's, so it is an occurrence
+     * like any other row's. What it answers <em>for</em> is not written at all — a walk asks the row
+     * which of the two it is, and never asks a row that names no arguments for its arguments.
+     */
+    @Test
+    void aRowThatAnswersForAnythingIsWalkedLikeTheRowsBesideIt() {
+        Hir.Module module = resolved("""
+                module m
+
+                behavior dep : (x: Int) -> Int
+
+                behavior use : (x: Int) -> Int
+                    depends on dep
+                let use (x, dep) = dep(x)
+
+                fake dep
+                    | (1) -> 2
+                    | _   -> 0
+                """);
+        AuthoredSites sites = identified(module);
+
+        List<Hir.FakeRow> rows = module.fakes().getFirst().rows();
+        Hir.Matched.Arguments named =
+                assertInstanceOf(Hir.Matched.Arguments.class, rows.getFirst().matched());
+        assertNotNull(sites.site(named.inputs().getFirst().region()), "the `1` is written");
+        assertNotNull(sites.site(rows.getFirst().output().region()), "and so is the `2`");
+        assertInstanceOf(Hir.Matched.Anything.class, rows.get(1).matched());
+        assertNotNull(sites.site(rows.get(1).output().region()), "and so is the `0` under the `_`");
+    }
+
     @Test
     void theSameSourceCensusesToTheSameAnswer() {
         // What stops work in the query graph: an answer equal to the one it replaces is an edit


### PR DESCRIPTION
A `fake` row written `_ -> out` answers for anything, and it was held as a row
whose input list is null with a boolean beside it saying so. Two fields say one
thing, and a walk over what the source writes could ask for the arguments
without being told which of the two rows it had.

`AuthoredSites` did. It walks the resolved module to name every occurrence by
the characters it was written over, and it went into the absence — so a module
with a `_` row in any of its tables censused to nothing, `Sites.Authored` threw,
and `SemanticSnapshot.of` could not be built. Every editor answer that rests on
the snapshot was refused for that document. `textDocument/inlayHint` is the one
that shows: it is asked again on every keystroke and scroll, and the client
reports each refusal.

Nothing publishes a diagnostic for it, because the diagnose route does not walk
the sites — so the file looks clean while the editor is answering nothing.

`Matched` is now what a row answers for, in the AST and in the HIR alike, beside
`Expected` on the answer side: `Arguments` names them, `Anything` does not. A
reader is told which before it can ask, so the walk has no absence to go into
and a switch over it is exhaustive.

Reproduced from a workspace where it happens, and pinned in
`AnOccurrenceIsNamedByWhatItWasWrittenOverTest`: a table with a `_` row is
walked like the rows beside it, and the arguments the row above it names are
occurrences. Dropping the walk of those arguments turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)