### PR TITLE
Do not call a choice's boundary absent where its alternative was not classified

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2039,6 +2039,13 @@ public final class InvariantChecker {
         // would have to change: written over the other, whichever ran second would be the only one
         // an author was sent to.
         runs.undecided(byName).forEach((name, why) -> stopped.merge(name, why, InvariantChecker::alsoSaying));
+        // And the same of the comparisons a choice offers, which nothing else here reaches. The
+        // walk above this goes into a conjunction and stops at a choice, so a comparison standing
+        // under one was never read for the line it states — and a clause holding nothing this could
+        // classify came out as one raising no question about where the values stop, which is what a
+        // rule read to the end and stating no line comes out as.
+        unclassifiedUnderAChoice(clause, at, byName)
+                .forEach((name, why) -> stopped.merge(name, why, InvariantChecker::alsoSaying));
         // What a rule about the strings at a position came to, where this conjunct is one. Such a
         // rule states where the values stop exactly when the strings it admits run between places
         // the order does not already hold them, which is the reading's own answer and not something
@@ -2048,6 +2055,66 @@ public final class InvariantChecker {
         return lines.isEmpty()
                 ? ClauseStates.SomethingElse.naming(found).unread(stopped)
                 : new ClauseStates.ABound(lines, new LinkedHashSet<>(found), stopped);
+    }
+
+    /**
+     * The names a comparison written inside a choice leaves the line undecided at.
+     *
+     * <p><b>What this is for is not deciding what a choice means.</b> Where a choice draws a line is
+     * settled where the branches are, and nothing here asks. What is asked is the question every
+     * comparison raises on its own: this clause states where the values at a name stop, and whether
+     * it does is what reading its form further would answer. A choice standing above it does not
+     * take that question away — it may leave the line where the branch put it, and it may leave it
+     * open, and which of those it is nobody here knows.
+     *
+     * <p>So this is the conservative half of the answer and is not the whole of it. A choice whose
+     * alternatives are read to the end and hold the name nowhere between them draws no line, and
+     * says so from a reading that is not this one; until that reading reaches here, a name under
+     * such a choice is one this compiler declines to speak for. Which is what it is: read as a rule
+     * raising no question at all, the report said the model draws no line, and a limit of this
+     * compiler went out as a sentence about somebody's model.
+     *
+     * <p>Every leaf of the clause and not the alternatives alone: a choice inside a conjunction
+     * inside a choice is one an author wrote, and a binding a helper call was expanded into says
+     * what its body says (ADR-0106). Empty for a comparison, which the reading above it already
+     * asked.
+     */
+    private SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> unclassifiedUnderAChoice(
+            Core clause, Denotations at, Map<FactSubject, Coordinate> byName) {
+        SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> out = new LinkedHashMap<>();
+        // Asked of what the clause was written as and never of the node: a choice is a binary
+        // operator too, so a reader telling them apart by the node skips exactly the clause this is
+        // for. A part of no connective is one the reading above already asked.
+        ClauseExpr written = ClauseExpr.of(clause, true);
+        if (written instanceof ClauseExpr.Leaf) {
+            return out;
+        }
+        unclassifiedIn(written, at, byName, out);
+        return out;
+    }
+
+    /** The same, over whatever the clause was written as. */
+    private void unclassifiedIn(ClauseExpr read, Denotations at,
+                                Map<FactSubject, Coordinate> byName,
+                                SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> out) {
+        switch (read) {
+            case ClauseExpr.Leaf it -> {
+                if (it.of() instanceof Core.Binary bin
+                        && Comparison.of(bin).orElse(null) instanceof Comparison recognised) {
+                    List<RuleKey> found = new ArrayList<>();
+                    namedIn(bin, at, byName, found);
+                    stoppedOnTheFormOf(found, canonicalFormOf(recognised, at, byName), byName)
+                            .forEach((name, why) ->
+                                    out.merge(name, why, InvariantChecker::alsoSaying));
+                }
+            }
+            case ClauseExpr.Scoped it ->
+                    unclassifiedIn(it.body(), terms.inside(it.binding(), at), byName, out);
+            case ClauseExpr.Joined it -> {
+                unclassifiedIn(it.left(), at, byName, out);
+                unclassifiedIn(it.right(), at, byName, out);
+            }
+        }
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceDoesNotSilenceWhatItsAlternativeLeftUnclassifiedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceDoesNotSilenceWhatItsAlternativeLeftUnclassifiedTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A rule this compiler could not classify keeps its question when a choice is written above it.
+ *
+ * <p>What a comparison states about where the values at a name stop is settled by reading its form,
+ * and where that reading stops the question stands: the rule may place a line and may not, and
+ * which of those it is is what reading further would answer. Standing alone, and standing under a
+ * conjunction, such a rule says so. Under a choice it said nothing at all — the walk that classifies
+ * goes into a conjunction and stops at a choice, so the comparison was never read for the line it
+ * states, and the clause came out as one raising no question about where the values stop.
+ *
+ * <p><b>Which is the sentence a document then writes about somebody's model.</b> A behavior whose
+ * rules raise no boundary question is one whose border is not applicable, and what that says is that
+ * the rules draw no line. So a limit of this compiler went out as a fact about the model, and an
+ * author reading it was told to stop looking for a line their own clause may well draw.
+ *
+ * <p><b>What this does not do is decide what a choice means.</b> Where a choice draws a line is
+ * settled where the branches are, and a choice whose alternatives are read to the end and hold a
+ * name nowhere between them draws none — which a reading that composes the branches can say and
+ * this one cannot. So a name under such a choice is one this compiler declines to speak for, which
+ * is weaker than the answer there is and is not a claim about the model.
+ */
+class AChoiceDoesNotSilenceWhatItsAlternativeLeftUnclassifiedTest {
+
+    private static final String NOT_MEASURED =
+            "border      not measured (no line was derived at any position)";
+
+    private static final String NOT_APPLICABLE =
+            "border      not applicable (the rules of this behavior draw no line)";
+
+    /**
+     * The question a comparison raises on its own, which is what the two below are read against.
+     *
+     * <p>Written here so that what the choice does to it is the difference between the models and
+     * not something this test states twice.
+     */
+    @Test
+    void aComparisonNothingClassifiedRaisesItsQuestionOnItsOwn() {
+        assertEquals(List.of(NOT_MEASURED), borderIn("Int.abs(n) >= 5"),
+                "the rule is about a value made from the position, and where it stops the position"
+                        + " is what reading further would answer");
+    }
+
+    /** And keeps it under a conjunction, which the walk that classifies already goes into. */
+    @Test
+    void andKeepsItUnderAConjunction() {
+        assertEquals(List.of("border      borders 1   obligations 0/0"
+                        + "   (not all of it was measured)"),
+                borderIn("n >= 2 && Int.abs(n) >= 5"),
+                "the conjunct beside it draws a line, and the question this one raises still"
+                        + " stands");
+    }
+
+    /** And under a choice, which is what was lost. */
+    @Test
+    void andKeepsItUnderAChoice() {
+        assertEquals(List.of(NOT_MEASURED), borderIn("n >= 2 || Int.abs(n) >= 5"),
+                "whether the choice draws a line at `n` turns on what the alternative holds it to,"
+                        + " which is what nothing here worked out");
+    }
+
+    /**
+     * And where the branch beside it is one nobody can be in.
+     *
+     * <p>The rule is its right half. A reading that composed the branches would say so; this one
+     * does not have to, and what it may not do is answer as though the left half settled anything.
+     */
+    @Test
+    void andWhereTheBranchBesideItIsOneNobodyCanBeIn() {
+        assertEquals(List.of(NOT_MEASURED), borderIn("s < \"\" || Int.abs(n) >= 5"),
+                "nothing satisfies the left alternative, so the rule is the right one — and its"
+                        + " line is what reading further would answer");
+    }
+
+    /**
+     * And a choice whose alternatives were read to the end says what it said before.
+     *
+     * <p>The control, and the half this may not move. Both alternatives place an end and between
+     * them they hold `n` nowhere; nothing about that turns on a reading having stopped, so the
+     * model draws no line and the document says so.
+     */
+    @Test
+    void andAChoiceReadToTheEndDrawsNoLineAsBefore() {
+        assertEquals(List.of(NOT_APPLICABLE), borderIn("n >= 2 || n <= 0"),
+                "both alternatives were read, so what they leave `n` is the model's answer");
+    }
+
+    /** And a rule that draws a line still draws it. */
+    @Test
+    void andARuleThatDrawsALineStillDoesSo() {
+        assertEquals(List.of("border      borders 1   obligations 0/0"), borderIn("n >= 2"),
+                "no choice stands here and nothing about this rule went unclassified");
+    }
+
+    /** What the document says about this behavior's border. */
+    private static List<String> borderIn(String clause) {
+        Compilation compilation = Compilation.ofSource("""
+                module demo
+
+                data Yes
+                data No
+                data Answer = Yes | No
+
+                data N = { n: Int, s: String }
+                    invariant r = %s
+
+                behavior check : (v: N) -> Answer
+                let check (v) = Yes
+                """.formatted(clause), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Predicate<String> border = each -> each.startsWith("border");
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity()).lines()
+                .map(String::strip).filter(border).toList();
+    }
+}


### PR DESCRIPTION
A soundness correction found while working on #1462, and independent of it. #1462 stays open.

## What was said, and what was true

The walk that classifies a rule goes into a conjunction and stops at a choice. So a comparison written under one was never read for the line it states, and a clause holding nothing that could be classified came out as a clause raising no question about where the values stop — which is what a rule read to the end and stating no line comes out as.

A behavior whose rules raise no boundary question has a border that is not applicable, and what a document says there is that the rules of this behavior draw no line. So a limit of this compiler went out as a sentence about somebody's model, and an author reading it was told to stop looking for a line their own clause may well draw.

The same comparison standing alone says what it is, and so does one standing under a conjunction. Under a choice it said nothing.

## What this does not do

It does not decide what a choice means. A choice whose alternatives are read to the end and hold a name nowhere between them draws no line, and a reading that composes the branches can say so; this one cannot, and a name under such a choice is one it declines to speak for. That is weaker than the answer there is, and it is not a claim about the model — which is the difference this is about.

Recovering the precision, and saying which choice is why, is #1462's, and it belongs where the branches were composed rather than where a rule's questions are raised.

## What moves

Two shapes, both of which said `not applicable` and now say `not measured` with the account the rule already had:

- a comparison this compiler cannot follow, offered as an alternative
- the same beside a branch nobody can be in, where the rule is its other half

The corpus does not move. Beside them, controls holding a choice both of whose alternatives were read, and a rule that draws a line, to what they said before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)