### PR TITLE
Say once which of a let's parameters its signature speaks for

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.coverage.ArmProbe;
-import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.coverage.ComparisonOccurrence;
@@ -176,16 +175,21 @@ public final class PathReachability {
      * reading, and a walk of a body against one made up says about this compilation having stopped
      * what it would say about the model. A caller without one measures nothing here.
      */
-    public static Answers of(Core body, ReadingPolicy policy, Hir.SpecBehavior spec, Hir.FnDef fn,
+    public static Answers of(Core body, ReadingPolicy policy,
+                             SpecImplementation.Implemented implemented,
                              CoverageSites.Plan plan, InputDomain read, RuleReadingSource source) {
         Objects.requireNonNull(read, "a reachability reading is made against an input that was read");
-        if (fn == null || spec == null) {
+        if (implemented == null) {
             return Answers.NONE;
         }
+        // Which binder each declared input arrives in, asked of the reading that divides an
+        // implementation's parameters. A behavior takes the behaviors it depends on beside its
+        // inputs, so which of the binders are the inputs is that reading's and not a prefix
+        // measured here.
         Scope params = Scope.NONE;
-        for (int i = 0; i < spec.params().size() && i < fn.params().size(); i++) {
-            params = params.with(fn.params().get(i).binder(),
-                    TypeOps.successType(spec.params().get(i).type()));
+        for (SpecImplementation.ParameterBinding.AnInput input : implemented.declaredInputs()) {
+            params = params.with(input.written().binder(),
+                    TypeOps.successType(input.declared().type()));
         }
         return of(body, params, plan, read, source, policy);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -72,7 +72,7 @@ public final class SpecChecker {
                     if (fn != null) {
                         for (ValueName.Behavior called
                                 : requiredCalls(fn.writtenBody(), names,
-                                        dependencyBindings(SpecImplementation.align(spec, fn)))) {
+                                        SpecImplementation.align(spec, fn).injectedBindings())) {
                             if (!out.contains(called)) {
                                 out.add(called);
                             }
@@ -322,7 +322,7 @@ public final class SpecChecker {
         // implementation names its own parameters, and the behaviors it depends on may be declared
         // by different modules under one name.
         Map<souther.compiler.types.BindingId, ValueName.Behavior> dependsOn =
-                dependencyBindings(implemented);
+                implemented.injectedBindings();
         Type output = TypeOps.successType(spec.ret());
         // recursive helpers this behavior calls resolve through their signatures (spec §fn-declaration); merged
         // only for typing, so the construction and dependency walks below still see the business params alone.
@@ -875,23 +875,6 @@ public final class SpecChecker {
         List<ValueName.Behavior> calls = new java.util.ArrayList<>();
         collectRequiredCalls(body, requiredNames, dependencies, calls);
         return calls;
-    }
-
-    /**
-     * Which behavior each injected parameter of an implementation stands for.
-     *
-     * <p>Read off the division rather than paired by name: an implementation names its own
-     * parameters, and two modules may declare a behavior of one name.
-     */
-    public static Map<souther.compiler.types.BindingId, ValueName.Behavior> dependencyBindings(
-            SpecImplementation.Implemented implemented) {
-        Map<souther.compiler.types.BindingId, ValueName.Behavior> bound = new LinkedHashMap<>();
-        for (SpecImplementation.ParameterBinding binding : implemented.bindings()) {
-            if (binding instanceof SpecImplementation.ParameterBinding.AnInjection injected) {
-                bound.put(injected.written().binder().id(), injected.behavior());
-            }
-        }
-        return bound;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -72,7 +72,7 @@ public final class SpecChecker {
                     if (fn != null) {
                         for (ValueName.Behavior called
                                 : requiredCalls(fn.writtenBody(), names,
-                                        dependencyBindings(spec, fn))) {
+                                        dependencyBindings(SpecImplementation.align(spec, fn)))) {
                             if (!out.contains(called)) {
                                 out.add(called);
                             }
@@ -272,13 +272,14 @@ public final class SpecChecker {
                 throw new Unanswerable(required.pos());
             }
         }
-        // What this fn has to take, asked of the behavior rather than added up here (§fn-declaration).
-        List<SpecImplementation.Parameter> shape = SpecImplementation.parameters(spec);
-        int nBusiness = spec.params().size();
-        if (fn.params().size() != shape.size()) {
+        // What each parameter this fn wrote stands for, asked of the behavior rather than worked
+        // out here (§fn-declaration). Every question below about which parameter is which is read
+        // off this one division.
+        SpecImplementation.Implemented implemented = SpecImplementation.align(spec, fn);
+        if (!implemented.hasExactArity()) {
             throw CompileException.of(Diagnostic
                             .at(fn.pos())
-                            .say(new BehaviorMessage.TheImplementationTakesAnotherNumberOfParameters(fn.name(), String.valueOf(fn.params().size()), spec.name(), String.valueOf(nBusiness), String.valueOf(shape.size() - nBusiness))).build());
+                            .say(new BehaviorMessage.TheImplementationTakesAnotherNumberOfParameters(fn.name(), String.valueOf(fn.params().size()), spec.name(), String.valueOf(spec.params().size()), String.valueOf(spec.dependsOn().size()))).build());
         }
         for (Hir.FnParam p : fn.params()) {
             // a pattern in parameter position names a type, but it is not an annotation: it opens
@@ -288,18 +289,21 @@ public final class SpecChecker {
                                 .at(p.pos()).say(new BehaviorMessage.AnImplementationsParametersTakeTheirTypesFromIt(fn.name(), spec.name(), p.name())).build());
             }
         }
-        for (int i = 0; i < shape.size(); i++) {
-            switch (shape.get(i)) {
+        for (SpecImplementation.ParameterBinding binding : implemented.bindings()) {
+            switch (binding) {
                 // An input's name is the implementation's to choose.
-                case SpecImplementation.Parameter.Input _ -> { }
+                case SpecImplementation.ParameterBinding.AnInput _ -> { }
                 // A clause naming nothing names no parameter for this one to be out of order
                 // against, and it was refused above, at the clause rather than at this list.
-                case SpecImplementation.Parameter.Unanswered _ -> { }
-                case SpecImplementation.Parameter.Injected injected -> {
-                    String got = fn.params().get(i).name();
-                    if (!got.equals(injected.name())) {
+                case SpecImplementation.ParameterBinding.Unanswered _ -> { }
+                // The arity is exact by here, so no parameter is standing past what the
+                // declaration asks for.
+                case SpecImplementation.ParameterBinding.Extraneous _ -> { }
+                case SpecImplementation.ParameterBinding.AnInjection injected -> {
+                    String got = injected.written().name();
+                    if (!got.equals(injected.behavior().name())) {
                         throw CompileException.of(Diagnostic
-                                        .at(fn.pos()).say(new BehaviorMessage.AnInjectedParameterIsOutOfOrder(fn.name(), got, injected.name())).build());
+                                        .at(fn.pos()).say(new BehaviorMessage.AnInjectedParameterIsOutOfOrder(fn.name(), got, injected.behavior().name())).build());
                     }
                 }
             }
@@ -310,16 +314,15 @@ public final class SpecChecker {
             Elaborator.rejectBuiltinShadow(p.name(), p.pos());
         }
         Elaborator.rejectBuiltinShadowing(fn.writtenBody());
-        for (int i = 0; i < nBusiness; i++) {
-            env = env.with(fn.params().get(i).binder(),
-                    TypeOps.successType(spec.params().get(i).type()));
+        for (SpecImplementation.ParameterBinding.AnInput input : implemented.declaredInputs()) {
+            env = env.with(input.written().binder(),
+                    TypeOps.successType(input.declared().type()));
         }
-        // Which behavior each trailing parameter stands for. The clause and the parameter list are
-        // held in the same order above, so the two are read together here rather than paired by
-        // name — an implementation names its own parameters, and the behaviors it depends on may be
-        // declared by different modules under one name.
+        // Which behavior each injected parameter stands for, read off the same division — an
+        // implementation names its own parameters, and the behaviors it depends on may be declared
+        // by different modules under one name.
         Map<souther.compiler.types.BindingId, ValueName.Behavior> dependsOn =
-                dependencyBindings(spec, fn);
+                dependencyBindings(implemented);
         Type output = TypeOps.successType(spec.ret());
         // recursive helpers this behavior calls resolve through their signatures (spec §fn-declaration); merged
         // only for typing, so the construction and dependency walks below still see the business params alone.
@@ -875,20 +878,17 @@ public final class SpecChecker {
     }
 
     /**
-     * Which behavior each trailing parameter of {@code fn} stands for.
+     * Which behavior each injected parameter of an implementation stands for.
      *
-     * <p>The clause and the parameter list are held in the same order (checked just above), so the
-     * two are read together rather than paired by name: an implementation names its own parameters,
-     * and two modules may declare a behavior of one name.
+     * <p>Read off the division rather than paired by name: an implementation names its own
+     * parameters, and two modules may declare a behavior of one name.
      */
     public static Map<souther.compiler.types.BindingId, ValueName.Behavior> dependencyBindings(
-            Hir.SpecBehavior spec, Hir.FnDef fn) {
+            SpecImplementation.Implemented implemented) {
         Map<souther.compiler.types.BindingId, ValueName.Behavior> bound = new LinkedHashMap<>();
-        int business = spec.params().size();
-        for (int i = 0; i < spec.dependsOn().size() && business + i < fn.params().size(); i++) {
-            ValueName.Behavior named = behaviorReached(spec.dependsOn().get(i));
-            if (named != null) {
-                bound.put(fn.params().get(business + i).binder().id(), named);
+        for (SpecImplementation.ParameterBinding binding : implemented.bindings()) {
+            if (binding instanceof SpecImplementation.ParameterBinding.AnInjection injected) {
+                bound.put(injected.written().binder().id(), injected.behavior());
             }
         }
         return bound;

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -23,6 +23,12 @@ import java.util.Map;
  * a body is. Worked out again at a reader, it is the same rule with a strictness of its own, and the
  * three that existed disagreed about what a list too short to divide meant.
  *
+ * <p>Inside, the declaration and the definition are two things and are read in that order. What the
+ * behavior requires is worked out from its inputs and its clause alone, and both things this offers
+ * — the list a caller writing an implementation is held to, and the division of one already
+ * written — read that. Read the clause twice instead, the two agree because one private method
+ * answers both, which is what having one place is supposed to stop anybody resting on.
+ *
  * <p>Nothing here is about how a parameter is written. Where it goes in a line, and whether the line
  * breaks, is the formatter's.
  */
@@ -122,11 +128,26 @@ public final class SpecImplementation {
      * about the whole shape are here to be asked, and none of them is enforced here — a reading that
      * refused to divide would be deciding for all three.
      */
-    public record Implemented(Hir.FnDef definition, List<ParameterBinding> bindings,
-                              int required, boolean everyDependencyAnswered) {
+    public static final class Implemented {
 
-        public Implemented {
-            bindings = List.copyOf(bindings);
+        private final Hir.FnDef definition;
+        private final List<ParameterBinding> bindings;
+        private final Shape shape;
+
+        private Implemented(Hir.FnDef definition, List<ParameterBinding> bindings, Shape shape) {
+            this.definition = definition;
+            this.bindings = List.copyOf(bindings);
+            this.shape = shape;
+        }
+
+        /** The {@code let} this is the reading of. */
+        public Hir.FnDef definition() {
+            return definition;
+        }
+
+        /** What each parameter it wrote stands for, in the order it wrote them. */
+        public List<ParameterBinding> bindings() {
+            return bindings;
         }
 
         /** The parameters the declaration says are its inputs, in order, each with the input it
@@ -153,18 +174,19 @@ public final class SpecImplementation {
         /** Whether the definition wrote a parameter for each position the declaration asks for, and
          *  no others. Where it did not, E1614 says so where the definition is written. */
         public boolean hasExactArity() {
-            return definition.params().size() == required;
+            return definition.params().size() == shape.size();
         }
 
         /**
          * Whether every {@code depends on} entry reaches a declaration.
          *
-         * <p>Asked of the clause rather than of the parameters. A definition that wrote too few
-         * parameters has no position for the entry that reaches nothing, and a reading that looked
-         * for one would call the clause answered because the parameter list ran out first.
+         * <p>Asked of what the declaration requires rather than of the parameters. A definition
+         * that wrote too few parameters has no position for the entry that reaches nothing, and a
+         * reading that looked for one would call the clause answered because the parameter list ran
+         * out first.
          */
         public boolean hasAnsweredDependencies() {
-            return everyDependencyAnswered;
+            return shape.everyDependencyAnswered();
         }
 
         /**
@@ -179,19 +201,85 @@ public final class SpecImplementation {
         }
     }
 
-    /** What an implementation of {@code spec} is required to take, in order. */
-    public static List<Parameter> parameters(Hir.SpecBehavior spec) {
-        List<Parameter> required = new ArrayList<>(spec.params().size() + spec.dependsOn().size());
-        for (Hir.Param input : spec.params()) {
-            required.add(new Parameter.Input(input.name()));
+    /**
+     * One position a behavior requires an implementation to have, as the declaration settles it.
+     *
+     * <p>About the declaration and nothing else. Which parameter of a {@code let} fills a position
+     * is {@link ParameterBinding}'s, and is a second question — this list is as long as the
+     * declaration says and that one is as long as the {@code let} the author typed.
+     */
+    private sealed interface RequiredParameter {
+
+        /** A declared input, at the position the signature holds its type at. */
+        record Input(Hir.Param declared, int at) implements RequiredParameter {}
+
+        /** A behavior the clause names. */
+        record Injection(ValueName.Behavior behavior) implements RequiredParameter {}
+
+        /** A clause entry that reaches no declaration. */
+        record Unanswered() implements RequiredParameter {}
+    }
+
+    /**
+     * What a behavior requires of whatever implements it.
+     *
+     * <p>The inputs first and then the clause, which is where that order is written. Both readers of
+     * the rule — the list a caller writing a declaration is offered, and the division of the
+     * parameters one already wrote — are projections of this, so what the clause reaches is decided
+     * once. Two walks of the clause agreed because the same private reading answered both, which is
+     * the shape this component exists to stop being relied on.
+     */
+    private record Shape(List<RequiredParameter> parameters) {
+
+        private Shape {
+            parameters = List.copyOf(parameters);
+        }
+
+        /** How many parameters an implementation is required to write. */
+        int size() {
+            return parameters.size();
+        }
+
+        /** Whether every entry of the clause reaches a declaration. */
+        boolean everyDependencyAnswered() {
+            for (RequiredParameter required : parameters) {
+                if (required instanceof RequiredParameter.Unanswered) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /** What {@code spec} requires, which is the one reading of its inputs and its clause. */
+    private static Shape shapeOf(Hir.SpecBehavior spec) {
+        List<RequiredParameter> required =
+                new ArrayList<>(spec.params().size() + spec.dependsOn().size());
+        for (int at = 0; at < spec.params().size(); at++) {
+            required.add(new RequiredParameter.Input(spec.params().get(at), at));
         }
         for (Hir.Var dependency : spec.dependsOn()) {
             ValueName.Behavior named = behaviorReached(dependency);
             required.add(named == null
-                    ? new Parameter.Unanswered()
-                    : new Parameter.Injected(named.name()));
+                    ? new RequiredParameter.Unanswered()
+                    : new RequiredParameter.Injection(named));
         }
-        return List.copyOf(required);
+        return new Shape(required);
+    }
+
+    /** What an implementation of {@code spec} is required to take, in order. */
+    public static List<Parameter> parameters(Hir.SpecBehavior spec) {
+        List<Parameter> offered = new ArrayList<>();
+        for (RequiredParameter required : shapeOf(spec).parameters()) {
+            offered.add(switch (required) {
+                case RequiredParameter.Input(Hir.Param declared, int _) ->
+                        new Parameter.Input(declared.name());
+                case RequiredParameter.Injection(ValueName.Behavior behavior) ->
+                        new Parameter.Injected(behavior.name());
+                case RequiredParameter.Unanswered _ -> new Parameter.Unanswered();
+            });
+        }
+        return List.copyOf(offered);
     }
 
     /**
@@ -208,27 +296,23 @@ public final class SpecImplementation {
      * {@link Implemented#hasExactArity} is the fact a caller that may not go on asks for.
      */
     public static Implemented align(Hir.SpecBehavior spec, Hir.FnDef definition) {
+        Shape shape = shapeOf(spec);
         List<Hir.FnParam> written = definition.params();
         List<ParameterBinding> bindings = new ArrayList<>(written.size());
-        int inputs = spec.params().size();
-        for (int at = 0; at < inputs && at < written.size(); at++) {
-            bindings.add(new ParameterBinding.AnInput(written.get(at), spec.params().get(at), at));
+        for (int at = 0; at < shape.size() && at < written.size(); at++) {
+            Hir.FnParam wrote = written.get(at);
+            bindings.add(switch (shape.parameters().get(at)) {
+                case RequiredParameter.Input(Hir.Param declared, int held) ->
+                        new ParameterBinding.AnInput(wrote, declared, held);
+                case RequiredParameter.Injection(ValueName.Behavior behavior) ->
+                        new ParameterBinding.AnInjection(wrote, behavior);
+                case RequiredParameter.Unanswered _ -> new ParameterBinding.Unanswered(wrote);
+            });
         }
-        boolean answered = true;
-        for (int nth = 0; nth < spec.dependsOn().size(); nth++) {
-            ValueName.Behavior named = behaviorReached(spec.dependsOn().get(nth));
-            answered &= named != null;
-            int at = inputs + nth;
-            if (at < written.size()) {
-                bindings.add(named == null
-                        ? new ParameterBinding.Unanswered(written.get(at))
-                        : new ParameterBinding.AnInjection(written.get(at), named));
-            }
-        }
-        for (int at = inputs + spec.dependsOn().size(); at < written.size(); at++) {
+        for (int at = shape.size(); at < written.size(); at++) {
             bindings.add(new ParameterBinding.Extraneous(written.get(at)));
         }
-        return new Implemented(definition, bindings, inputs + spec.dependsOn().size(), answered);
+        return new Implemented(definition, bindings, shape);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -162,6 +163,29 @@ public final class SpecImplementation {
             return List.copyOf(inputs);
         }
 
+        /**
+         * Which behavior each injected parameter stands for, under the binding a body reads it
+         * through.
+         *
+         * <p>A name written at a call inside the body denotes the parameter and not the behavior,
+         * so what a reader typing that call needs is the binding. Read off the division and not
+         * paired with the clause by name: an implementation names its own parameters, and two
+         * modules may declare a behavior of one name.
+         *
+         * <p>Here rather than at any of the readers, for the reason {@link #inputs} is: a caller
+         * that filtered the bindings itself would be deciding which arm answers this question, and
+         * three of them would each have decided.
+         */
+        public Map<BindingId, ValueName.Behavior> injectedBindings() {
+            Map<BindingId, ValueName.Behavior> injected = new LinkedHashMap<>();
+            for (ParameterBinding binding : bindings) {
+                if (binding instanceof ParameterBinding.AnInjection stands) {
+                    injected.put(stands.written().binder().id(), stands.behavior());
+                }
+            }
+            return Collections.unmodifiableMap(injected);
+        }
+
         /** The same, as the parameters alone — what a caller binding a local to an input needs. */
         public List<Hir.FnParam> inputs() {
             List<Hir.FnParam> written = new ArrayList<>();
@@ -172,7 +196,7 @@ public final class SpecImplementation {
         }
 
         /** Whether the definition wrote a parameter for each position the declaration asks for, and
-         *  no others. Where it did not, E1614 says so where the definition is written. */
+         *  no others. Where it did not, E1615 says so where the definition is written. */
         public boolean hasExactArity() {
             return definition.params().size() == shape.size();
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -1,23 +1,27 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The formal parameters the {@code let} implementing a behavior is required to take (spec
- * §fn-declaration, §depends-on).
+ * §fn-declaration, §depends-on), and what each parameter it actually wrote stands for.
  *
  * <p>The behavior's inputs, then the behaviors it depends on in the order they were declared. The
  * order is not a matter of layout: it is what {@link SpecChecker} holds an implementation to, and
- * writing an injected parameter out of that order is E1615. Said here once so that a reader wanting
- * to know the shape — the checker that refuses one, an editor offering to write one — asks rather
- * than works it out again from the signature. Two readings of one rule agree until either moves.
+ * writing an injected parameter out of that order is E1615.
  *
- * <p>Which definition implements a behavior is answered here as well ({@link #implementedBy}), and
- * for the same reason: a caller that found the definition itself would then divide its parameters
- * itself, and the division is this rule.
+ * <p>That boundary — where the inputs stop and the injected behaviors begin — is written here and
+ * nowhere else. Every reader that needs it asks {@link #align}: the checker deciding whether an
+ * implementation is legal, the emitter binding a local to an input, an editor saying what a name in
+ * a body is. Worked out again at a reader, it is the same rule with a strictness of its own, and the
+ * three that existed disagreed about what a list too short to divide meant.
  *
  * <p>Nothing here is about how a parameter is written. Where it goes in a line, and whether the line
  * breaks, is the formatter's.
@@ -31,6 +35,10 @@ public final class SpecImplementation {
      *
      * <p>A reader has to do something different with each, which is why they are three and not one
      * name and a flag. What an editor may offer as a hole is exactly what nothing here settles.
+     *
+     * <p>What the behavior asks for, and not what an implementation wrote. {@link ParameterBinding}
+     * is the second question: this list is as long as the declaration requires, and that one is as
+     * long as the {@code let} the author typed.
      */
     public sealed interface Parameter {
 
@@ -58,59 +66,117 @@ public final class SpecImplementation {
     }
 
     /**
-     * The definition implementing a behavior, and which of its parameters are the declared inputs.
+     * One parameter a {@code let} wrote, and what the declaration above it says that parameter is.
      *
-     * <p>A value rather than the list alone, so that having found a definition and having found one
-     * that takes nothing stay two answers. A behavior of no inputs is implemented by a {@code let}
-     * of no parameters, and a caller handed an empty list for both would have to decide which it
-     * was looking at.
+     * <p>One of these per parameter the author typed, however many the behavior asked for. A
+     * definition is read while it is being written, and a reader handed only the ones that lined up
+     * would be handed a list whose positions are not the positions in the source.
      *
-     * <p>The inputs and not also the trailing parameters the {@code depends on} clause is answered
-     * by. Nothing reads those as a list: {@link SpecChecker#dependencyBindings} walks them against
-     * the clause, and it runs while E1614 is still being decided — where this refuses a list too
-     * short to divide, that one carries on and lets the diagnostic be the report. Divided here as
-     * well, the two would be one rule with two strictnesses.
+     * <p>The two ways a parameter can stand for nothing are two arms, because a reader does
+     * different things with them. {@link Unanswered} has a place in the declaration and no name to
+     * hold it to — the clause that would have named it reaches nothing, said where the clause is
+     * written. {@link Extraneous} has no place in the declaration at all. Read as one "unknown",
+     * they would be one arm that means "do not ask", and the next reader to want the difference
+     * would work it out again from the lengths.
      */
-    public record Implemented(Hir.FnDef definition, List<Hir.FnParam> inputs) {
+    public sealed interface ParameterBinding {
 
-        public Implemented {
-            inputs = List.copyOf(inputs);
-        }
+        /** The parameter as the {@code let} wrote it. */
+        Hir.FnParam written();
+
+        /**
+         * An input the behavior declares, with the declaration it stands for.
+         *
+         * <p>The declaration itself and not only where it sits. What a reader wants of an input is
+         * the type on the {@code behavior} line, and one holding the position alone would go back to
+         * the signature and index into it — which is this alignment made a second time, through a
+         * number. {@code at} is here because the checked signature is a list of its own and is
+         * reached by position.
+         */
+        record AnInput(Hir.FnParam written, Hir.Param declared, int at) implements ParameterBinding {}
+
+        /** A parameter the {@code depends on} clause names a behavior for. */
+        record AnInjection(Hir.FnParam written, ValueName.Behavior behavior)
+                implements ParameterBinding {}
+
+        /** A parameter standing where a {@code depends on} entry that reaches no declaration would
+         *  have named one. */
+        record Unanswered(Hir.FnParam written) implements ParameterBinding {}
+
+        /** A parameter the declaration asks for no position for. */
+        record Extraneous(Hir.FnParam written) implements ParameterBinding {}
     }
 
     /**
-     * The {@code let} of {@code module} implementing {@code spec}, or null where the module has
-     * none — an injected behavior and an unwritten one both reach this and neither has a definition.
+     * A definition read as the implementation of a behavior: every parameter it wrote, and what the
+     * declaration says each of them is.
      *
-     * <p>Among what the module declared, and not among what it took on to emit. What a module emits
-     * without declaring is a recursion another module wrote and a method minted for a row's operand
-     * ({@code Hir.Module#takenOn}); a behavior's implementation is a {@code let} of its name and is
-     * always a declaration. {@link Requirements#implementationOf} decides whether a behavior has one
-     * by looking in the same place, so a name found here is a name that reading called implemented.
+     * <p>A value rather than the list alone, so that having found a definition and having found one
+     * that takes nothing stay two answers. A behavior of no inputs is implemented by a {@code let}
+     * of no parameters, and a caller handed an empty list for both would have to decide which it was
+     * looking at.
      *
-     * <p>How many parameters the definition is required to have is {@link SpecChecker}'s, reported
-     * as E1614 where it disagrees. Nothing is restated here: what this refuses is the state where
-     * the division cannot be made at all, which is not a program being wrong but that check not
-     * having run. So this is for a reader standing after the check — the emitter, the snapshot — and
-     * not for the checker deciding it.
+     * <p>The division stands whether or not the definition is legal. What a reader does about an
+     * implementation that is not is its own: the checker reports it, the emitters refuse to run on
+     * it, and an editor answers what it can about the parameters that did line up. So the facts
+     * about the whole shape are here to be asked, and none of them is enforced here — a reading that
+     * refused to divide would be deciding for all three.
      */
-    public static Implemented implementedBy(Hir.Module module, Hir.SpecBehavior spec) {
-        Hir.FnDef definition = null;
-        for (Hir.FnDef fn : module.fns()) {
-            if (fn.name().equals(spec.name())) {
-                definition = fn;   // the last, as every reader keying these by name keeps
+    public record Implemented(Hir.FnDef definition, List<ParameterBinding> bindings,
+                              int required, boolean everyDependencyAnswered) {
+
+        public Implemented {
+            bindings = List.copyOf(bindings);
+        }
+
+        /** The parameters the declaration says are its inputs, in order, each with the input it
+         *  stands for. */
+        public List<ParameterBinding.AnInput> declaredInputs() {
+            List<ParameterBinding.AnInput> inputs = new ArrayList<>();
+            for (ParameterBinding binding : bindings) {
+                if (binding instanceof ParameterBinding.AnInput input) {
+                    inputs.add(input);
+                }
             }
+            return List.copyOf(inputs);
         }
-        if (definition == null) {
-            return null;
+
+        /** The same, as the parameters alone — what a caller binding a local to an input needs. */
+        public List<Hir.FnParam> inputs() {
+            List<Hir.FnParam> written = new ArrayList<>();
+            for (ParameterBinding.AnInput input : declaredInputs()) {
+                written.add(input.written());
+            }
+            return List.copyOf(written);
         }
-        int inputs = spec.params().size();
-        if (definition.params().size() < inputs) {
-            throw new IllegalStateException("`" + module.name() + "." + spec.name() + "` takes "
-                    + inputs + " and its implementation has " + definition.params().size()
-                    + " parameters to divide");
+
+        /** Whether the definition wrote a parameter for each position the declaration asks for, and
+         *  no others. Where it did not, E1614 says so where the definition is written. */
+        public boolean hasExactArity() {
+            return definition.params().size() == required;
         }
-        return new Implemented(definition, definition.params().subList(0, inputs));
+
+        /**
+         * Whether every {@code depends on} entry reaches a declaration.
+         *
+         * <p>Asked of the clause rather than of the parameters. A definition that wrote too few
+         * parameters has no position for the entry that reaches nothing, and a reading that looked
+         * for one would call the clause answered because the parameter list ran out first.
+         */
+        public boolean hasAnsweredDependencies() {
+            return everyDependencyAnswered;
+        }
+
+        /**
+         * Whether the parameters line up with the declaration and every dependency reaches one.
+         *
+         * <p>What an implementation has to be for a reader to divide it and act on every part. It is
+         * not the same as the implementation being legal: a parameter standing for an injection it
+         * spells wrongly is placed and is refused (E1615), and this says nothing about it.
+         */
+        public boolean hasCompleteShape() {
+            return hasExactArity() && hasAnsweredDependencies();
+        }
     }
 
     /** What an implementation of {@code spec} is required to take, in order. */
@@ -120,11 +186,97 @@ public final class SpecImplementation {
             required.add(new Parameter.Input(input.name()));
         }
         for (Hir.Var dependency : spec.dependsOn()) {
-            Hir.Var.Denoting named = dependency.answered();
+            ValueName.Behavior named = behaviorReached(dependency);
             required.add(named == null
                     ? new Parameter.Unanswered()
-                    : new Parameter.Injected(named.denotes().name()));
+                    : new Parameter.Injected(named.name()));
         }
         return List.copyOf(required);
+    }
+
+    /**
+     * {@code definition} read as the implementation of {@code spec}.
+     *
+     * <p>The one place the inputs are told from the injections. A definition writes them in one
+     * list — the behavior's inputs, then what it depends on — and which is which is settled by how
+     * many inputs the behavior declares and by nothing about the parameters themselves.
+     *
+     * <p>Total. A definition may have too few parameters to fill the positions the declaration asks
+     * for, or more than it asks for at all, and both are states an editor reads a module in as it is
+     * typed. What is wrong with either is reported where the definition is written; here they are a
+     * shorter list of bindings and an {@link ParameterBinding.Extraneous} arm, and
+     * {@link Implemented#hasExactArity} is the fact a caller that may not go on asks for.
+     */
+    public static Implemented align(Hir.SpecBehavior spec, Hir.FnDef definition) {
+        List<Hir.FnParam> written = definition.params();
+        List<ParameterBinding> bindings = new ArrayList<>(written.size());
+        int inputs = spec.params().size();
+        for (int at = 0; at < inputs && at < written.size(); at++) {
+            bindings.add(new ParameterBinding.AnInput(written.get(at), spec.params().get(at), at));
+        }
+        boolean answered = true;
+        for (int nth = 0; nth < spec.dependsOn().size(); nth++) {
+            ValueName.Behavior named = behaviorReached(spec.dependsOn().get(nth));
+            answered &= named != null;
+            int at = inputs + nth;
+            if (at < written.size()) {
+                bindings.add(named == null
+                        ? new ParameterBinding.Unanswered(written.get(at))
+                        : new ParameterBinding.AnInjection(written.get(at), named));
+            }
+        }
+        for (int at = inputs + spec.dependsOn().size(); at < written.size(); at++) {
+            bindings.add(new ParameterBinding.Extraneous(written.get(at)));
+        }
+        return new Implemented(definition, bindings, inputs + spec.dependsOn().size(), answered);
+    }
+
+    /**
+     * Each behavior of {@code module} that a {@code let} implements, under the name it is declared
+     * by.
+     *
+     * <p>Every behavior in one walk, rather than a way to ask about one. Asked one at a time, a
+     * caller looking at each behavior of a module searches its definitions once per behavior, and
+     * every reader of this rule is a caller looking at each behavior of a module.
+     *
+     * <p>Among what the module declared, and not among what it took on to emit. What a module emits
+     * without declaring is a recursion another module wrote and a method minted for a row's operand
+     * ({@code Hir.Module#takenOn}); a behavior's implementation is a {@code let} of its name and is
+     * always a declaration. {@link Requirements#implementationOf} decides whether a behavior has one
+     * by looking in the same place, so a name found here is a name that reading called implemented.
+     *
+     * <p>A behavior with no definition is absent rather than present with nothing: an injected
+     * behavior and an unwritten one both reach this and neither has parameters to divide.
+     */
+    public static Map<String, Implemented> implementationsOf(Hir.Module module) {
+        Map<String, Hir.FnDef> defined = new LinkedHashMap<>();
+        for (Hir.FnDef fn : module.fns()) {
+            defined.put(fn.name(), fn);   // the last, as every reader keying these by name keeps
+        }
+        Map<String, Implemented> implementations = new LinkedHashMap<>();
+        for (Hir.BehaviorDef declared : module.behaviors()) {
+            if (declared instanceof Hir.SpecBehavior spec) {
+                Hir.FnDef definition = defined.get(spec.name());
+                if (definition != null) {
+                    implementations.put(spec.name(), align(spec, definition));
+                }
+            }
+        }
+        // In the order the module declares them, so that a reader listing what it found lists it the
+        // way the source reads.
+        return Collections.unmodifiableMap(implementations);
+    }
+
+    /**
+     * The behavior {@code named} reaches, or null where resolution found none.
+     *
+     * <p>Asked of the declaration and not of the name it was written under. A call to another
+     * module's behavior and a call to one this module declares can be written the same, and what a
+     * requirement is about is one of the two.
+     */
+    private static ValueName.Behavior behaviorReached(Hir.Var named) {
+        return named.answered() != null
+                && named.answered().denotes() instanceof ValueName.Behavior behavior
+                ? behavior : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -452,6 +452,12 @@ public final class Backend {
             behaviorDeps.put(new ValueName.Behavior(module.name(), e.getKey()),
                     Requirements.names(e.getValue()));
         }
+        // Which definition implements each behavior, and which of that definition's parameters are
+        // the declared inputs, asked once for the module rather than worked out here: the snapshot's
+        // assembler reads its binders from the same answer, so which local an input arrives in
+        // cannot be one thing there and another here.
+        Map<String, SpecImplementation.Implemented> implementations =
+                SpecImplementation.implementationsOf(module);
         for (Hir.BehaviorDef bd : module.behaviors()) {
             emitting(bd.written(), () -> {
                 // The class a declared relation is checked by, emitted by the module that declares
@@ -467,15 +473,21 @@ public final class Backend {
                 }
                 switch (bd) {
                     case Hir.SpecBehavior spec -> {
-                        // Which definition implements it, and which of that definition's parameters
-                        // are the declared inputs, is asked rather than worked out here: the
-                        // snapshot's assembler reads its binders from the same answer, so which
-                        // local an input arrives in cannot be one thing there and another here.
                         // Bodies arrive with their helper calls already inlined (the Lower stage,
                         // ADR-0021), and are emitted as-is.
                         SpecImplementation.Implemented implemented =
-                                SpecImplementation.implementedBy(module, spec);
+                                implementations.get(spec.name());
                         if (implemented != null) {
+                            // What this emitter takes, said here rather than by the reading that
+                            // divided the parameters: an editor reads a definition whose parameters
+                            // do not line up and answers what it can about it, and this may not run
+                            // on one at all. The division is the same either way; what differs is
+                            // who may act on it.
+                            if (!implemented.hasCompleteShape()) {
+                                throw new IllegalStateException("`" + module.name() + "."
+                                        + spec.name() + "` is emitted from an implementation whose"
+                                        + " parameters the declaration does not account for");
+                            }
                             // a fn-implemented behavior: the $Impl holds the logic, the public interface
                             // (behaviorClass) is what Java code declares (spec §jvm-anonymous-union).
                             out.put(new GeneratedClass.BehaviorImpl(module.name(), spec.name()),
@@ -1313,13 +1325,15 @@ public final class Backend {
                 gen.armsAreCounted();
                 gen.injectsInto(successType(spec.ret()));
                 gen.requireds(requiredNames, requiredSuccess, requiredParam, injected);
-                for (int i = 0; i < n; i++) {
-                    // the definition's input names the binding; its type comes from the behavior
-                    Type pt = successType(spec.params().get(i).type());
-                    code.aload(i + 1);
+                for (SpecImplementation.ParameterBinding.AnInput input
+                        : implemented.declaredInputs()) {
+                    // the definition's input names the binding; its type comes from the behavior,
+                    // paired with it where the parameters were divided rather than here
+                    Type pt = successType(input.declared().type());
+                    code.aload(input.at() + 1);
                     int slot = gen.slot(pt);
                     unbox(code, pt, slot);
-                    Hir.Binder binder = implemented.inputs().get(i).binder();
+                    Hir.Binder binder = input.written().binder();
                     gen.bind(binder.binding(), binder.name(), slot, pt);
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -3,6 +3,7 @@ package souther.compiler.inputs;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.NumberAt;
 import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.DeclarationReadings;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
@@ -346,29 +347,44 @@ public final class InputDomain {
      * called, the signature says what they hold, and the implementation says which binding a body's
      * reads of one carry. Paired here rather than by every caller that has some of them.
      *
-     * @param fn the implementation, or null where nothing implements this behavior — an injected
-     *           behavior has positions and no body to read them in
+     * @param arriving which binder each declared input arrives in, or empty where nothing
+     *                 implements this behavior — an injected behavior has positions and no body to
+     *                 read them in
      */
-    public static InputDomain of(Hir.SpecBehavior behavior, Hir.FnDef fn, Sig sig,
+    public static InputDomain of(Hir.SpecBehavior behavior,
+                                 List<SpecImplementation.ParameterBinding.AnInput> arriving, Sig sig,
                                  RuleReadingSource source, ReadingPolicy policy) {
-        return of(behavior, fn, sig, source, policy, InputDemand.NONE);
+        return of(behavior, arriving, sig, source, policy, InputDemand.NONE);
     }
 
     /** The same, closed over the finite paths this behavior's measurement names as well. */
-    public static InputDomain of(Hir.SpecBehavior behavior, Hir.FnDef fn, Sig sig,
+    public static InputDomain of(Hir.SpecBehavior behavior,
+                                 List<SpecImplementation.ParameterBinding.AnInput> arriving, Sig sig,
                                  RuleReadingSource source, ReadingPolicy policy, InputDemand demand) {
-        return of(behavior, fn, sig, source, policy, demand, DeclarationReadings.NONE);
+        return of(behavior, arriving, sig, source, policy, demand, DeclarationReadings.NONE);
     }
 
-    /** The same, asking {@code machines} first. */
-    public static InputDomain of(Hir.SpecBehavior behavior, Hir.FnDef fn, Sig sig,
+    /**
+     * The same, asking {@code machines} first.
+     *
+     * <p>{@code arriving} says which binder each declared input arrives in, where something
+     * implements the behavior. It is asked of {@link SpecImplementation} and not measured off the
+     * front of the implementation's parameter list: a behavior takes the behaviors it depends on
+     * beside its inputs, so the two lists are not the same length and where one stops is that
+     * reading's to say. Empty where nothing implements the behavior, which has the positions all the
+     * same and nothing to read them through.
+     */
+    public static InputDomain of(Hir.SpecBehavior behavior,
+                                 List<SpecImplementation.ParameterBinding.AnInput> arriving, Sig sig,
                                  RuleReadingSource source, ReadingPolicy policy, InputDemand demand,
                                  DeclarationReadings machines) {
+        Map<Integer, BindingId> bindings = new LinkedHashMap<>();
+        for (SpecImplementation.ParameterBinding.AnInput input : arriving) {
+            bindings.put(input.at(), input.written().binder().binding());
+        }
         List<Parameter> parameters = new ArrayList<>();
         for (int i = 0; i < sig.inputTypes().size() && i < behavior.params().size(); i++) {
-            BindingId binding = fn != null && i < fn.params().size()
-                    ? fn.params().get(i).binder().binding() : null;
-            parameters.add(new Parameter(behavior.params().get(i).name(), binding,
+            parameters.add(new Parameter(behavior.params().get(i).name(), bindings.get(i),
                     sig.inputTypes().get(i)));
         }
         return of(parameters, source, policy, demand, machines);
@@ -384,7 +400,7 @@ public final class InputDomain {
      */
     public static InputDomain of(Hir.SpecBehavior behavior, Sig sig, RuleReadingSource source,
                                  ReadingPolicy policy) {
-        return of(behavior, null, sig, source, policy);
+        return of(behavior, List.of(), sig, source, policy);
     }
 
     /** The positions, in the order they were read. */

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -133,6 +133,8 @@ final class CheckedProgramAssembler {
     private static ModuleBoundaries fileWhatIsChecked(
             Map<ValueName.Behavior, BehaviorTarget> targets, ModuleReading module) {
         Map<ValueName.Behavior, BehaviorTarget> declares = new LinkedHashMap<>();
+        Map<String, SpecImplementation.Implemented> implementations =
+                SpecImplementation.implementationsOf(module.bodies());
         for (Hir.BehaviorDef declared : module.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(module.name(), declared.name());
             Sig signature = module.signatures().get(declared.name());
@@ -146,7 +148,7 @@ final class CheckedProgramAssembler {
                         + " compile has no reading of it");
             }
             BehaviorTarget target = new BehaviorTarget(signatureOf(signature),
-                    implementedAs(state, named, declared, module.bodies(), module.checked(),
+                    implementedAs(state, named, declared, implementations, module.checked(),
                             module.compositions()));
             file(targets, named, target);
             declares.put(named, target);
@@ -628,7 +630,7 @@ final class CheckedProgramAssembler {
      */
     private static CheckedImplementation implementedAs(
             BehaviorImplementation state, ValueName.Behavior named, Hir.BehaviorDef declared,
-            Hir.Module lowered, Bodies.Elaborated checked,
+            Map<String, SpecImplementation.Implemented> implementations, Bodies.Elaborated checked,
             Map<ValueName.Behavior, Composition> compositions) {
         String name = declared.name();
         return switch (state) {
@@ -640,7 +642,8 @@ final class CheckedProgramAssembler {
                 Composition composed = compositions.get(named);
                 yield composed != null
                         ? new CheckedImplementation.Composed(composed)
-                        : new CheckedImplementation.Body(inputBindersOf(named, declared, lowered),
+                        : new CheckedImplementation.Body(
+                                inputBindersOf(named, implementations.get(name)),
                                 checked.behaviorBodies().get(name));
             }
         };
@@ -662,17 +665,21 @@ final class CheckedProgramAssembler {
      * would arrive instead as a dependency's binder handed over as an input's.
      */
     private static List<Core.Binder> inputBindersOf(ValueName.Behavior named,
-                                                    Hir.BehaviorDef declared, Hir.Module lowered) {
-        SpecImplementation.Implemented implemented =
-                declared instanceof Hir.SpecBehavior spec
-                        ? SpecImplementation.implementedBy(lowered, spec)
-                        : null;
+                                                    SpecImplementation.Implemented implemented) {
         if (implemented == null) {
             // This behavior was taken as implemented here and by a body of its own, and the module
             // has no definition to read one from. Nothing here can put that right, and letting it
             // through would hand an output a body whose reads resolve to nothing it was given.
             throw new IllegalStateException("`" + named.module() + "." + named.name()
                     + "` was taken as having a body and has no definition to read it from");
+        }
+        if (!implemented.hasCompleteShape()) {
+            // What this assembler takes, said here rather than by the reading that divided the
+            // parameters: an editor reads a definition whose parameters do not line up and answers
+            // what it can about it, and a checked program holds none.
+            throw new IllegalStateException("`" + named.module() + "." + named.name()
+                    + "` was taken as checked and its implementation writes parameters the"
+                    + " declaration does not account for");
         }
         List<Core.Binder> binders = new ArrayList<>();
         for (Hir.FnParam input : implemented.inputs()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -23,6 +23,7 @@ import souther.compiler.check.RuleRef;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.CheckSurface;
 import souther.compiler.check.Sig;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -710,14 +711,17 @@ public final class Adequacy {
                     // the lowering leaves them alone. A behavior nothing implements has positions
                     // all the same.
                     Answer<Hir.FnDef> fn = db.ask(new Bodies.SettledFn(name, spec.name()));
-                    out.put(spec.name(), InputDomain.of(spec, fn.present() ? fn.value() : null,
+                    SpecImplementation.Implemented implemented = fn.present()
+                            ? SpecImplementation.align(spec, fn.value()) : null;
+                    out.put(spec.name(), InputDomain.of(spec,
+                            implemented == null ? List.of() : implemented.declaredInputs(),
                             sig, reading.value(), db.ask(new Front.Reading()).value(),
                             // What this behavior's body reads, so the reading is closed over the
                             // paths its measurement names as well as the ones the enumeration
                             // finds. Asked as the reading is made and never after it: one that
                             // grew a position when somebody looked one up would answer a question
                             // differently depending on what had been asked before it.
-                            demandOf(db, name, spec, fn.present() ? fn.value() : null,
+                            demandOf(db, name, spec, implemented,
                                     scope.value(), statedOf(stated, spec)),
                             db.readings()));
                 }
@@ -740,24 +744,28 @@ public final class Adequacy {
      * it.
      */
     private static souther.compiler.inputs.InputDemand demandOf(
-            Db db, String module, Hir.SpecBehavior spec, Hir.FnDef fn, Symbols symbols,
+            Db db, String module, Hir.SpecBehavior spec,
+            SpecImplementation.Implemented implemented, Symbols symbols,
             souther.compiler.check.StatedContract stated) {
-        return statedIn(stated, symbols, bodyIn(db, module, spec, fn, symbols));
+        return statedIn(stated, symbols, bodyIn(db, module, spec, implemented, symbols));
     }
 
     /** The locations the implementation reads, or none where nothing implements the behavior. */
     private static souther.compiler.inputs.InputDemand bodyIn(
-            Db db, String module, Hir.SpecBehavior spec, Hir.FnDef fn, Symbols symbols) {
-        Bodies.CheckedBody checked = fn == null ? null
+            Db db, String module, Hir.SpecBehavior spec,
+            SpecImplementation.Implemented implemented, Symbols symbols) {
+        Bodies.CheckedBody checked = implemented == null ? null
                 : db.ask(new Bodies.CheckedBehavior(module, spec.name())).value();
         if (checked == null) {
             return souther.compiler.inputs.InputDemand.NONE;
         }
+        // Which declared input each binder stands for, asked of the reading that divides an
+        // implementation's parameters rather than measured off the front of its list.
         Map<souther.compiler.types.BindingId, String> parameters = new LinkedHashMap<>();
-        for (int i = 0; i < fn.params().size() && i < spec.params().size(); i++) {
-            souther.compiler.types.BindingId binding = fn.params().get(i).binder().binding();
+        for (SpecImplementation.ParameterBinding.AnInput input : implemented.declaredInputs()) {
+            souther.compiler.types.BindingId binding = input.written().binder().binding();
             if (binding != null) {
-                parameters.put(binding, spec.params().get(i).name());
+                parameters.put(binding, input.declared().name());
             }
         }
         return souther.compiler.inputs.InputDemand.of(checked.body(),
@@ -940,8 +948,8 @@ public final class Adequacy {
                     continue;
                 }
                 out.put(spec.name(), souther.compiler.check.PathReachability.of(
-                        body, db.ask(new Front.Reading()).value(), spec, fn, plan, read,
-                        reading.value()));
+                        body, db.ask(new Front.Reading()).value(),
+                        SpecImplementation.align(spec, fn), plan, read, reading.value()));
             }
             return Answer.of(Ordered.map(out));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -587,11 +587,10 @@ public final class Bodies {
      *
      * <p>An injected one is reached through the parameter {@code depends on} gave the body, so the
      * name written at the call denotes that parameter and not the behavior. Which parameter stands
-     * for which behavior is {@link SpecChecker#dependencyBindings}, read off the one division of an
-     * implementation's parameters rather than worked out again: which of them the clause fills is
-     * {@link SpecImplementation}'s to say and not a suffix measured here, the parameters are not
-     * paired with the clause by name because two modules may declare a behavior of one name, and the
-     * answer is a binding because a
+     * for which behavior is asked of the division of the implementation's parameters rather than
+     * worked out again: which of them the clause fills is {@link SpecImplementation}'s to say and
+     * not a suffix measured here, the parameters are not paired with the clause by name because two
+     * modules may declare a behavior of one name, and the answer is a binding because a
      * binding in force wins over the declaration it shadows (spec §fn-rules). Neither is a
      * difference a program can show here — a {@code depends on} its body never calls is refused
      * (E1603), so a shadow of that spelling has the parameter beside it — which is why it is asked
@@ -621,8 +620,8 @@ public final class Bodies {
             if (!body.present() || !spec.present()) {
                 return Answer.absent();
             }
-            Map<BindingId, ValueName.Behavior> injected = SpecChecker.dependencyBindings(
-                    SpecImplementation.align(spec.value(), body.value().value()));
+            Map<BindingId, ValueName.Behavior> injected = SpecImplementation
+                    .align(spec.value(), body.value().value()).injectedBindings();
             Set<ValueName.Behavior> reached = new LinkedHashSet<>();
             List<Hir.Expr> todo = new ArrayList<>();
             todo.add(body.value().value().writtenBody());

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -9,6 +9,7 @@ import souther.compiler.check.AnalysisBody;
 import souther.compiler.check.Expansion;
 import souther.compiler.check.BehaviorChecker;
 import souther.compiler.check.SpecChecker;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.CheckSurface;
 import souther.compiler.check.InvariantSettled;
 import souther.compiler.check.BehaviorContract;
@@ -586,9 +587,11 @@ public final class Bodies {
      *
      * <p>An injected one is reached through the parameter {@code depends on} gave the body, so the
      * name written at the call denotes that parameter and not the behavior. Which parameter stands
-     * for which behavior is {@link SpecChecker#dependencyBindings}, asked rather than worked out
-     * again: the clause and the parameter list are read together in order and not paired by name,
-     * because two modules may declare a behavior of one name, and the answer is a binding because a
+     * for which behavior is {@link SpecChecker#dependencyBindings}, read off the one division of an
+     * implementation's parameters rather than worked out again: which of them the clause fills is
+     * {@link SpecImplementation}'s to say and not a suffix measured here, the parameters are not
+     * paired with the clause by name because two modules may declare a behavior of one name, and the
+     * answer is a binding because a
      * binding in force wins over the declaration it shadows (spec §fn-rules). Neither is a
      * difference a program can show here — a {@code depends on} its body never calls is refused
      * (E1603), so a shadow of that spelling has the parameter beside it — which is why it is asked
@@ -618,8 +621,8 @@ public final class Bodies {
             if (!body.present() || !spec.present()) {
                 return Answer.absent();
             }
-            Map<BindingId, ValueName.Behavior> injected =
-                    SpecChecker.dependencyBindings(spec.value(), body.value().value());
+            Map<BindingId, ValueName.Behavior> injected = SpecChecker.dependencyBindings(
+                    SpecImplementation.align(spec.value(), body.value().value()));
             Set<ValueName.Behavior> reached = new LinkedHashSet<>();
             List<Hir.Expr> todo = new ArrayList<>();
             todo.add(body.value().value().writtenBody());
@@ -2076,8 +2079,9 @@ public final class Bodies {
             Hir.FnDef fn = db.ask(new SettledFn(module, spec.name())).value();
             out.put(spec.name(), souther.compiler.claims.Claims.of(
                     souther.compiler.claims.UnreachableClaims.of(body, read, scope.value(), plan),
-                    souther.compiler.check.PathReachability.of(
-                            body, policy, spec, fn, plan, read, reading.value())));
+                    souther.compiler.check.PathReachability.of(body, policy,
+                            fn == null ? null : SpecImplementation.align(spec, fn),
+                            plan, read, reading.value())));
         }
         // In the order the module declares them, which is the order a reader meets the diagnostics
         // these carry. `Map.copyOf` keeps the entries and not the order (see `Ordered`), so a

--- a/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
@@ -251,11 +251,15 @@ public final class SemanticSnapshot {
     private static ParameterFact factOf(SpecImplementation.ParameterBinding binding, Sig sig,
                                         Answer<Map<ValueName.Behavior, Sig>> reachable) {
         return switch (binding) {
-            case SpecImplementation.ParameterBinding.AnInput input ->
-                    sig == null || input.at() >= sig.inputTypes().size()
-                            ? new ParameterFact.Untyped(input.written())
-                            : new ParameterFact.TypedInput(input.written(),
-                                    sig.inputTypes().get(input.at()));
+            // At the position the signature holds it at, and not tested against the signature's
+            // length first. A signature is built one input per declared parameter, so a position
+            // the division gave is a position the signature has; a test would be an answer checked
+            // against itself, and answering `Untyped` where it failed would put back the silence
+            // this reading exists to remove.
+            case SpecImplementation.ParameterBinding.AnInput input -> sig == null
+                    ? new ParameterFact.Untyped(input.written())
+                    : new ParameterFact.TypedInput(input.written(),
+                            sig.inputTypes().get(input.at()));
             case SpecImplementation.ParameterBinding.AnInjection injected ->
                     injectionFact(injected, reachable);
             // A clause that reaches no declaration names no signature to read, and a parameter the

--- a/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
@@ -8,6 +8,7 @@ import souther.compiler.check.DeclaredTypeEvidence;
 import souther.compiler.check.FieldRead;
 import souther.compiler.check.ResolvedFieldTypes;
 import souther.compiler.check.Sig;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.Region;
@@ -50,6 +51,26 @@ import java.util.Optional;
  * question: a fact this cannot reach is that fact absent, and not the snapshot going away.
  */
 public final class SemanticSnapshot {
+
+    /**
+     * What this module's declarations settle about one parameter a {@code let} wrote.
+     *
+     * <p>Told apart by what a reader may do with it rather than by which kind of position it fills.
+     * Two of these are types a name in a body has, and one of the two is also a type an author may
+     * write where the name is — which is the difference between what is put in a hint and what is
+     * answered when the name is asked about.
+     */
+    private sealed interface ParameterFact {
+
+        /** An input, as the signature says it arrives. */
+        record TypedInput(Hir.FnParam written, Type arrives) implements ParameterFact {}
+
+        /** An injected behavior, as what it takes and answers. */
+        record TypedInjection(Hir.FnParam written, Type takes) implements ParameterFact {}
+
+        /** A parameter this revision settles nothing about. */
+        record Untyped(Hir.FnParam written) implements ParameterFact {}
+    }
 
     private final Db db;
     private final String module;
@@ -168,29 +189,99 @@ public final class SemanticSnapshot {
      * body that will not check does not stop it saying so.
      */
     public List<DeclaredParameter> parametersIn(SourceId source) {
+        List<DeclaredParameter> out = new ArrayList<>();
+        for (ParameterFact fact : parameterFacts()) {
+            // The inputs alone. What the signature says arrives is a type an author may write where
+            // the hint is drawn; a parameter a `depends on` clause fills is a behavior handed to the
+            // implementation, and it has no spelling that goes in that place.
+            if (!(fact instanceof ParameterFact.TypedInput(Hir.FnParam written, Type arrives))) {
+                continue;
+            }
+            Hir.Binder binder = written.binder();
+            // A parameter written nowhere is one a pass introduced; there is no name in the
+            // source for a hint to stand after.
+            if (binder.written().authored() && binder.pos().isIn(source)) {
+                out.add(new DeclaredParameter(binder.written().region(),
+                        new TypeFact(arrives, new Evidence.Declared()), heldToARule(arrives)));
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * What the declarations say about each parameter every {@code let} of this module wrote.
+     *
+     * <p>One classification, read by everything here that is about a parameter. What a hint is drawn
+     * for and what a name in a body is typed by are two uses of one answer, and worked out apart they
+     * were two: the reading that drew hints and the reading that typed bodies each decided for
+     * itself which parameters a signature speaks for, and both decided it by comparing the length of
+     * the {@code let}'s parameter list with the length of the signature. A behavior with a
+     * {@code depends on} clause takes the behaviors it is injected with beside its inputs, so those
+     * two lengths differ for every one of them and both readings left the whole definition out.
+     *
+     * <p>Which parameters the signature speaks for is {@link SpecImplementation}'s to say, and is
+     * asked here rather than worked out from the lengths. What is added is the types: the signature
+     * says what arrives at an input, and an injected parameter is a behavior this module names, whose
+     * signature says what it takes and answers.
+     *
+     * <p>Answered whether or not the definition is one the checker will accept. A parameter the
+     * declaration accounts for nothing for is {@link ParameterFact.Untyped}, which is the same
+     * answer a reader gets for a parameter of a behavior whose signature this revision could not
+     * work out — nothing here says a type, and nothing here says the definition is wrong either.
+     */
+    private List<ParameterFact> parameterFacts() {
         Answer<Hir.Module> resolved = db.ask(new Names.Resolved(module));
         Answer<Map<String, Sig>> signatures = db.ask(new Bodies.Signatures(module));
         if (!resolved.present() || !signatures.present()) {
             return List.of();
         }
-        List<DeclaredParameter> out = new ArrayList<>();
-        for (Hir.FnDef fn : resolved.value().fns()) {
-            Sig sig = signatures.value().get(fn.written().canonical());
-            if (sig == null || sig.inputTypes().size() != fn.params().size()) {
-                continue;
-            }
-            for (int at = 0; at < fn.params().size(); at++) {
-                Hir.Binder binder = fn.params().get(at).binder();
-                Type arrives = sig.inputTypes().get(at);
-                // A parameter written nowhere is one a pass introduced; there is no name in the
-                // source for a hint to stand after.
-                if (binder.written().authored() && binder.pos().isIn(source)) {
-                    out.add(new DeclaredParameter(binder.written().region(),
-                            new TypeFact(arrives, new Evidence.Declared()), heldToARule(arrives)));
-                }
-            }
-        }
-        return List.copyOf(out);
+        Answer<Map<ValueName.Behavior, Sig>> reachable = db.ask(new Bodies.Reachable(module));
+        List<ParameterFact> facts = new ArrayList<>();
+        SpecImplementation.implementationsOf(resolved.value())
+                .forEach((behavior, implemented) -> {
+                    Sig sig = signatures.value().get(behavior);
+                    for (SpecImplementation.ParameterBinding binding : implemented.bindings()) {
+                        facts.add(factOf(binding, sig, reachable));
+                    }
+                });
+        return List.copyOf(facts);
+    }
+
+    /** What one parameter is, given what this module's signatures say. */
+    private static ParameterFact factOf(SpecImplementation.ParameterBinding binding, Sig sig,
+                                        Answer<Map<ValueName.Behavior, Sig>> reachable) {
+        return switch (binding) {
+            case SpecImplementation.ParameterBinding.AnInput input ->
+                    sig == null || input.at() >= sig.inputTypes().size()
+                            ? new ParameterFact.Untyped(input.written())
+                            : new ParameterFact.TypedInput(input.written(),
+                                    sig.inputTypes().get(input.at()));
+            case SpecImplementation.ParameterBinding.AnInjection injected ->
+                    injectionFact(injected, reachable);
+            // A clause that reaches no declaration names no signature to read, and a parameter the
+            // declaration asks for no position for is spoken for by nothing.
+            case SpecImplementation.ParameterBinding.Unanswered unanswered ->
+                    new ParameterFact.Untyped(unanswered.written());
+            case SpecImplementation.ParameterBinding.Extraneous extraneous ->
+                    new ParameterFact.Untyped(extraneous.written());
+        };
+    }
+
+    /**
+     * An injected parameter, typed by the signature of the behavior it is handed.
+     *
+     * <p>What arrives there is that behavior with what it depends on already supplied, so what a
+     * body may do with the name is call it with the inputs the declaration names. Untyped where this
+     * revision has no signature for it, which is the module it is declared in still being read.
+     */
+    private static ParameterFact injectionFact(
+            SpecImplementation.ParameterBinding.AnInjection injected,
+            Answer<Map<ValueName.Behavior, Sig>> reachable) {
+        Sig injects = reachable.present() ? reachable.value().get(injected.behavior()) : null;
+        return injects == null
+                ? new ParameterFact.Untyped(injected.written())
+                : new ParameterFact.TypedInjection(injected.written(),
+                        Type.fn(injects.inputTypes(), injects.outputType()));
     }
 
     /**
@@ -416,30 +507,25 @@ public final class SemanticSnapshot {
      * every other, so a parameter of one behavior cannot be reached by a name in another, and
      * working out which body a position is in would be a scope this does not have to keep.
      *
-     * <p>A behavior whose signature says a different number of things from what its {@code let}
-     * writes is left out. The two disagreeing is a mistake in the module, reported where it is
-     * written, and pairing them off by position anyway would say a parameter arrives as something
-     * the declaration never said it does.
+     * <p>The injected parameters as well as the inputs. A name a body reads is a name whatever it
+     * stands for, and one standing for a behavior the module was handed has a type as much as one
+     * standing for an input does — so a reader asking what {@code dep(x).field} is gets the same
+     * answer here as it would for a call written any other way.
+     *
+     * <p>A parameter nothing here types is left out, which is a fact being absent rather than the
+     * parameter being. What is wrong with a definition the declaration does not account for is
+     * reported where it is written.
      */
     private Map<BindingId, BindingEvidence> parametersOfEveryBehavior() {
-        Answer<Hir.Module> resolved = db.ask(new Names.Resolved(module));
-        Answer<Map<String, Sig>> signatures = db.ask(new Bodies.Signatures(module));
-        if (!resolved.present() || !signatures.present()) {
-            return Map.of();
-        }
         Map<BindingId, BindingEvidence> declared = new LinkedHashMap<>();
-        for (Hir.FnDef fn : resolved.value().fns()) {
-            Sig sig = signatures.value().get(fn.written().canonical());
-            if (sig == null) {
-                continue;
-            }
-            List<Type> arrives = sig.inputTypes();
-            if (arrives.size() != fn.params().size()) {
-                continue;
-            }
-            for (int at = 0; at < arrives.size(); at++) {
-                declared.put(fn.params().get(at).binder().id(),
-                        new BindingEvidence.DeclaredAs(arrives.get(at)));
+        for (ParameterFact fact : parameterFacts()) {
+            switch (fact) {
+                case ParameterFact.TypedInput(Hir.FnParam written, Type arrives) ->
+                        declared.put(written.binder().id(),
+                                new BindingEvidence.DeclaredAs(arrives));
+                case ParameterFact.TypedInjection(Hir.FnParam written, Type takes) ->
+                        declared.put(written.binder().id(), new BindingEvidence.DeclaredAs(takes));
+                case ParameterFact.Untyped _ -> { }
             }
         }
         return declared;

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryParameterAnImplementationWroteStandsForSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryParameterAnImplementationWroteStandsForSomethingTest.java
@@ -1,0 +1,225 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.ValueName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code let} implementing a behavior writes its inputs and then the behaviors it depends on, in
+ * one list. Where that list stops being inputs is what the behavior declares and nothing about the
+ * parameters themselves, and it is said here — so a reader wanting to know which parameter is which
+ * asks rather than measures the two lists against each other.
+ *
+ * <p>One binding per parameter the author wrote, whatever the declaration asks for. A definition is
+ * read while it is being typed, and a reading that handed back only the parameters that lined up
+ * would be handing back a list whose positions are not the positions in the source. So a parameter
+ * the declaration accounts for nothing for is an arm, and it is a different arm from one standing
+ * where a clause that reaches no declaration would have named a behavior: the first has no place in
+ * the declaration at all, and the second has a place and no name.
+ */
+class EveryParameterAnImplementationWroteStandsForSomethingTest {
+
+    private static final String TWO_OF_EACH = """
+            module example.shape
+
+            data MemberId = String
+            data Found = { id: MemberId }
+            data Missing = { why: String }
+
+            behavior findMember : (id: MemberId) -> Found | Missing
+
+            behavior logLookup : (id: MemberId) -> Found | Missing
+
+            behavior place : (id: MemberId, other: MemberId) -> Found | Missing
+                depends on findMember, logLookup
+
+            let place (id, other, findMember, logLookup) = match findMember(id) with
+                | Found   -> logLookup(other)
+                | Missing -> findMember(other)
+            """;
+
+    /**
+     * The inputs are the parameters the behavior declares inputs for, and the ones a
+     * {@code depends on} clause fills are not among them.
+     *
+     * <p>The whole of what this issue was about. A reading that told them apart by comparing the
+     * length of the signature with the length of the {@code let} found the two differing for every
+     * behavior that depends on anything, and left all four of these parameters unaccounted for.
+     */
+    @Test
+    void theInputsAreTheOnesTheBehaviorDeclaresAndTheInjectedOnesAreNot() {
+        SpecImplementation.Implemented implemented = alignmentOf(TWO_OF_EACH, "place");
+
+        assertEquals(List.of("id", "other"), namesOf(implemented.inputs()),
+                "the behavior declares two inputs, so the first two parameters are them");
+        assertEquals(List.of("id", "other"), declaredNamesOf(implemented),
+                "and each of them stands for the input of that name on the `behavior` line");
+        assertEquals(List.of(0, 1), positionsOf(implemented),
+                "at the position the signature holds its type at");
+        assertEquals(List.of("findMember", "logLookup"), injectedNamesOf(implemented),
+                "the rest are the behaviors the clause names, in the order it names them");
+    }
+
+    /** And the facts about the whole shape say it is one a caller may go on from. */
+    @Test
+    void anImplementationTheDeclarationAccountsForIsCompleteInShape() {
+        SpecImplementation.Implemented implemented = alignmentOf(TWO_OF_EACH, "place");
+
+        assertTrue(implemented.hasExactArity());
+        assertTrue(implemented.hasAnsweredDependencies());
+        assertTrue(implemented.hasCompleteShape());
+    }
+
+    /**
+     * A parameter the declaration asks for no position for is one of these, and says so.
+     *
+     * <p>Written where an author has typed one parameter too many and not yet been told. It is
+     * refused where the definition is checked (E1615); what is asked here is what the parameter is
+     * before anything refuses it, which is what an editor reading the buffer has.
+     */
+    @Test
+    void aParameterThePositionsRunOutBeforeIsExtraneous() {
+        SpecImplementation.Implemented implemented = alignmentOf(TWO_OF_EACH.replace(
+                "let place (id, other, findMember, logLookup)",
+                "let place (id, other, findMember, logLookup, stray)"), "place");
+
+        assertEquals(5, implemented.bindings().size(),
+                "one for each parameter the author wrote, including the one nothing asked for");
+        assertInstanceOf(SpecImplementation.ParameterBinding.Extraneous.class,
+                implemented.bindings().get(4));
+        assertFalse(implemented.hasExactArity());
+        assertTrue(implemented.hasAnsweredDependencies(),
+                "every clause still reaches a declaration; it is the list that is too long");
+        assertFalse(implemented.hasCompleteShape());
+    }
+
+    /**
+     * And a definition too short to fill the positions is divided as far as it goes.
+     *
+     * <p>Not refused here. What a reader does about a definition the declaration is not satisfied by
+     * is its own — the checker reports it, an emitter will not run on it, and an editor answers about
+     * the parameters that did line up. A reading that threw would be deciding that for all three.
+     */
+    @Test
+    void aDefinitionShortOfThePositionsIsDividedAsFarAsItGoes() {
+        SpecImplementation.Implemented implemented = alignmentOf(TWO_OF_EACH.replace(
+                "let place (id, other, findMember, logLookup)", "let place (id, other)"), "place");
+
+        assertEquals(List.of("id", "other"), namesOf(implemented.inputs()));
+        assertEquals(List.of(), injectedNamesOf(implemented),
+                "no parameter was written where the clause's behaviors go");
+        assertFalse(implemented.hasExactArity());
+        assertTrue(implemented.hasAnsweredDependencies(),
+                "the clause reaches its declarations whether or not a parameter was written for it");
+    }
+
+    /**
+     * A clause that reaches no declaration leaves the parameter under it standing for nothing, and
+     * that is not the same answer as the parameter being one nothing asked for.
+     */
+    @Test
+    void aClauseThatReachesNothingLeavesItsParameterUnanswered() {
+        SpecImplementation.Implemented implemented = alignmentOf(
+                TWO_OF_EACH.replace("depends on findMember, logLookup",
+                        "depends on findMember, noSuchBehavior")
+                        .replace("logLookup(other)", "findMember(other)")
+                        .replace("let place (id, other, findMember, logLookup)",
+                                "let place (id, other, findMember, noSuchBehavior)"), "place");
+
+        assertInstanceOf(SpecImplementation.ParameterBinding.Unanswered.class,
+                implemented.bindings().get(3),
+                "the clause names nothing, so nothing names this parameter");
+        assertTrue(implemented.hasExactArity(), "a parameter was written for every position");
+        assertFalse(implemented.hasAnsweredDependencies());
+        assertFalse(implemented.hasCompleteShape());
+    }
+
+    /**
+     * Every behavior a module implements, in one walk of it.
+     *
+     * <p>A behavior with no {@code let} is absent rather than present with nothing: an injected
+     * behavior has no parameters to divide, and a caller handed an empty division for it would have
+     * to decide which of the two it was looking at.
+     */
+    @Test
+    void aModuleIsDividedOnceAndABehaviorWithNoLetIsNotInIt() {
+        Map<String, SpecImplementation.Implemented> implementations =
+                SpecImplementation.implementationsOf(moduleOf(TWO_OF_EACH));
+
+        assertEquals(List.of("place"), List.copyOf(implementations.keySet()),
+                "`findMember` and `logLookup` are Java's to supply and have no `let` here");
+        assertNull(implementations.get("findMember"));
+    }
+
+    private static List<String> namesOf(List<Hir.FnParam> parameters) {
+        List<String> names = new ArrayList<>();
+        for (Hir.FnParam parameter : parameters) {
+            names.add(parameter.name());
+        }
+        return names;
+    }
+
+    /** What the `behavior` line calls each input the implementation's parameters stand for. */
+    private static List<String> declaredNamesOf(SpecImplementation.Implemented implemented) {
+        List<String> names = new ArrayList<>();
+        for (SpecImplementation.ParameterBinding.AnInput input : implemented.declaredInputs()) {
+            names.add(input.declared().name());
+        }
+        return names;
+    }
+
+    private static List<Integer> positionsOf(SpecImplementation.Implemented implemented) {
+        List<Integer> at = new ArrayList<>();
+        for (SpecImplementation.ParameterBinding.AnInput input : implemented.declaredInputs()) {
+            at.add(input.at());
+        }
+        return at;
+    }
+
+    /** The behaviors the injected parameters stand for, named as they are declared. */
+    private static List<String> injectedNamesOf(SpecImplementation.Implemented implemented) {
+        List<String> names = new ArrayList<>();
+        for (SpecImplementation.ParameterBinding binding : implemented.bindings()) {
+            if (binding instanceof SpecImplementation.ParameterBinding.AnInjection injected) {
+                ValueName.Behavior behavior = injected.behavior();
+                names.add(behavior.name());
+            }
+        }
+        return names;
+    }
+
+    private static SpecImplementation.Implemented alignmentOf(String source, String behavior) {
+        SpecImplementation.Implemented implemented =
+                SpecImplementation.implementationsOf(moduleOf(source)).get(behavior);
+        assertNotNull(implemented, "`" + behavior + "` is implemented by a `let` of its name");
+        return implemented;
+    }
+
+    /**
+     * The module as its names resolved, which is before anything refuses what is written in it.
+     *
+     * <p>Where these are asked from. Half of what is asked here is about a definition the check
+     * would refuse, and a model read after the check would have none of them in it.
+     */
+    private static Hir.Module moduleOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Hir.Module resolved = compilation.db().ask(new Names.Resolved(module)).value();
+        assertNotNull(resolved, "the source under test resolves");
+        return resolved;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryParameterAnImplementationWroteStandsForSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryParameterAnImplementationWroteStandsForSomethingTest.java
@@ -1,6 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.types.ValueName;
@@ -15,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -86,15 +89,21 @@ class EveryParameterAnImplementationWroteStandsForSomethingTest {
     /**
      * A parameter the declaration asks for no position for is one of these, and says so.
      *
-     * <p>Written where an author has typed one parameter too many and not yet been told. It is
-     * refused where the definition is checked (E1615); what is asked here is what the parameter is
-     * before anything refuses it, which is what an editor reading the buffer has.
+     * <p>Written where an author has typed one parameter too many and not yet been told. What is
+     * asked here is what the parameter is before anything refuses it, which is what an editor
+     * reading the buffer has — and the refusal is asserted beside it, so which diagnostic answers
+     * for the arity is read off the compiler rather than off a comment.
      */
     @Test
     void aParameterThePositionsRunOutBeforeIsExtraneous() {
-        SpecImplementation.Implemented implemented = alignmentOf(TWO_OF_EACH.replace(
+        String tooMany = TWO_OF_EACH.replace(
                 "let place (id, other, findMember, logLookup)",
-                "let place (id, other, findMember, logLookup, stray)"), "place");
+                "let place (id, other, findMember, logLookup, stray)");
+        SpecImplementation.Implemented implemented = alignmentOf(tooMany, "place");
+
+        assertEquals("E1615",
+                assertThrows(CompileException.class, () -> Compiler.compile(tooMany)).code(),
+                "the arity is what refuses it, at the definition");
 
         assertEquals(5, implemented.bindings().size(),
                 "one for each parameter the author wrote, including the one nothing asked for");

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
@@ -155,7 +155,7 @@ class OneReadingTakesBothRoadsToAPositionTest {
         RuleReadingSource rules = RuleReadings.of(compilation, module);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
-        return InputDomain.of(spec, null, sigs.get(behavior), rules,
+        return InputDomain.of(spec, List.of(), sigs.get(behavior), rules,
                 ReadAs.THE_COMPILATION_DOES, demand);
     }
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AParameterCarriesTheTypeItsSignatureAlreadySaidTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AParameterCarriesTheTypeItsSignatureAlreadySaidTest.java
@@ -111,6 +111,31 @@ class AParameterCarriesTheTypeItsSignatureAlreadySaidTest {
         assertEquals(List.of(": Draft"), labelsOf(hints(broken)));
     }
 
+    /**
+     * And a behavior that is handed what it depends on is hinted like any other.
+     *
+     * <p>Its {@code let} takes those behaviors beside the inputs, so it always writes more
+     * parameters than the signature has input types. Told apart by comparing those two lengths, the
+     * whole definition was left out — including the inputs the signature does declare, which are the
+     * ones a hint exists for.
+     */
+    @Test
+    void aBehaviorThatIsHandedWhatItDependsOnHasItsInputsHinted() {
+        assertEquals(List.of(": Draft"), labelsOf(hints("""
+                module m
+
+                data Draft = { plannedCost: Int }
+
+                behavior price : (request: Draft) -> Int
+
+                behavior submit : (request: Draft) -> Int
+                    depends on price
+
+                let submit (request, price) = price(request)
+                """)),
+                "`request` is what the signature types; `price` is a behavior it was handed");
+    }
+
     @Test
     void onlyWhatTheClientAskedToSee() {
         Range firstLineOnly = new Range(new Position(0, 0), new Position(6, 0));

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AParameterCarriesTheTypeItsSignatureAlreadySaidTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AParameterCarriesTheTypeItsSignatureAlreadySaidTest.java
@@ -121,7 +121,7 @@ class AParameterCarriesTheTypeItsSignatureAlreadySaidTest {
      */
     @Test
     void aBehaviorThatIsHandedWhatItDependsOnHasItsInputsHinted() {
-        assertEquals(List.of(": Draft"), labelsOf(hints("""
+        String injected = """
                 module m
 
                 data Draft = { plannedCost: Int }
@@ -132,8 +132,17 @@ class AParameterCarriesTheTypeItsSignatureAlreadySaidTest {
                     depends on price
 
                 let submit (request, price) = price(request)
-                """)),
+                """;
+        List<InlayHint> hints = hints(injected);
+        String letLine = injected.lines().toList().get(9);
+
+        assertEquals(List.of(": Draft"), labelsOf(hints),
                 "`request` is what the signature types; `price` is a behavior it was handed");
+        // And after the input, not after the parameter that stands beside it. Both are names on
+        // one line, so a division that had them the wrong way round draws the same label.
+        assertEquals(letLine.indexOf("(request") + "(request".length(),
+                hints.getFirst().position().character());
+        assertEquals(9, hints.getFirst().position().line());
     }
 
     @Test

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
@@ -75,6 +75,40 @@ class WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest {
                 "and said by declarations, which is what a reader is entitled to know");
     }
 
+    /**
+     * And a behavior that is handed what it depends on has its parameters spoken for like any
+     * other's.
+     *
+     * <p>Such a {@code let} takes the behaviors it is injected with beside its inputs, so it always
+     * writes more parameters than the signature has input types. Told apart by comparing those two
+     * lengths, none of its parameters was spoken for at all — so an author working inside any
+     * behavior that depends on anything was shown nothing after a {@code .}, while the same line one
+     * behavior up answered.
+     */
+    @Test
+    void aParameterOfABehaviorThatIsHandedWhatItDependsOnIsSpokenForToo() {
+        MemberReceiver receiver = leftOfTheDot("""
+                module m
+
+                import lib as l ( Cost )
+
+                data Draft = { plannedCost: Cost }
+
+                behavior price : (draft: Draft) -> Int
+
+                behavior submit : (request: Draft) -> Int
+                    depends on price
+
+                let submit (request, price) = request.plannedCost.
+                """);
+
+        assertEquals("Cost",
+                assertInstanceOf(Type.Ref.class,
+                        assertInstanceOf(MemberReceiver.Value.class, receiver).type().type())
+                        .name().name(),
+                "the signature says what `request` is whatever else the `let` was handed");
+    }
+
     @Test
     void aReceiverNoDeclarationSpeaksForIsStillAValue() {
         // `submitted()` answers something no declaration read here states, so what is missing is the

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest.java
@@ -109,6 +109,45 @@ class WhatIsLeftOfADotIsSaidByTheSnapshotAndNotGuessedTest {
                 "the signature says what `request` is whatever else the `let` was handed");
     }
 
+    /**
+     * And an injected parameter is a value the declarations type, not one they are silent about.
+     *
+     * <p>The signature above the {@code let} says nothing about it — it is not an input. What it is
+     * is the behavior the {@code depends on} clause names, and that behavior's own signature says
+     * what it takes and answers. So the answer here is a typed value that offers no names after the
+     * {@code .}, which is a different thing to say than that nothing states what it is: a behavior
+     * is not a record, and an author writing a {@code .} on one is writing on something the
+     * declarations do account for.
+     */
+    @Test
+    void anInjectedParameterIsTypedAsTheBehaviorItNames() {
+        Probed probed = probe("""
+                module m
+
+                import lib as l ( Cost )
+
+                data Draft = { plannedCost: Cost }
+
+                behavior price : (draft: Draft) -> Cost
+
+                behavior submit : (request: Draft) -> Cost
+                    depends on price
+
+                let submit (request, price) = price.
+                """);
+
+        Type.FnOf takes = assertInstanceOf(Type.FnOf.class,
+                assertInstanceOf(MemberReceiver.Value.class, probed.receiver()).type().type());
+        assertEquals("Draft",
+                assertInstanceOf(Type.Ref.class, takes.params().getFirst()).name().name(),
+                "what `price` takes");
+        assertEquals("Cost", assertInstanceOf(Type.Ref.class, takes.result()).name().name(),
+                "and what it answers");
+        assertTrue(probed.snapshot().fieldsOf(
+                        ((MemberReceiver.Value) probed.receiver()).type()).isEmpty(),
+                "a behavior carries no field for a `.` to name");
+    }
+
     @Test
     void aReceiverNoDeclarationSpeaksForIsStillAValue() {
         // `submitted()` answers something no declaration read here states, so what is missing is the


### PR DESCRIPTION
Closes #1478.

A `let` implementing a behavior writes the behavior's inputs and then the
behaviors it depends on, in one list. Where the inputs stop is what the behavior
declares, and three readings worked it out for themselves — the emitter's took a
prefix and threw where the list was too short, the checker's walked the suffix
and carried on, and the editor's compared the two lists' lengths and stood down
where they differed.

The third is not a stricter form of the same rule. For a behavior that depends
on anything the lengths always differ, so the whole definition was left out,
including the inputs the signature does declare. That is the reported defect —
no parameter type is drawn on such a behavior — and it is not the only one: the
same guard sits on the reading that types a body's names, so nothing was offered
after a `.` on any of those parameters and nothing was said about one on hover,
while the same lines one behavior up answered.

`SpecImplementation.align` is that division and the only place that knows it. It
answers one `ParameterBinding` per parameter the author wrote, whatever the
declaration asks for: an input carries the declaration it stands for, an
injection carries the behavior it is handed, and the two ways a parameter can
stand for nothing stay apart — a `depends on` entry that reaches no declaration
takes a position and settles no name, and a parameter past what the declaration
asks for has no position at all. `implementationsOf` divides a module in one
walk, so a reader looking at each behavior no longer searches the definitions
once per behavior.

Nothing is refused there. Whether a division may be acted on is the reader's:
the checker reports what is wrong with it, the emitter and the assembler each
say they take only a complete one, and the snapshot answers about the parameters
that did line up — which is what an editor reading a buffer mid-edit has.

Every reader that had a division of its own now reads this one: the checker's
arity, its injected-name rule, the scope it types a body in and the bindings it
resolves injected calls through; the input domain, the demand walk and the
reachability reading; and both places that emit.

## Not in this

A guard of the same shape stands in `SemanticSnapshot.calledAt` and in the
analyzer's row-argument labels, comparing a signature's inputs with the
parameters of the behavior it was built from. `SignatureBoundary` makes one
input per declared parameter, so those two lengths are equal by construction and
the guards are answers checked against themselves. That is a different pairing —
a declaration against what was derived from it, rather than against an
implementation — and is filed separately.