### PR TITLE
Ask which alternatives stand, where every reader was working it out

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -50,25 +50,48 @@ import java.util.Set;
  * compared against something worked out in a conditional stands several jumps away from the
  * comparison that takes it.
  *
- * <p>So this follows the value. How far the stack is above where the value sits is worked out
- * instruction by instruction, and the value is gone as soon as that reaches the value's own place.
- * What the value's place is is never needed — only how far above it the stack has come — so nothing
- * here has to know the depth a method's code begins at.
+ * <p><b>An instruction is what it takes and what it leaves, and never the difference.</b> A call
+ * that takes a receiver and returns something leaves the stack the height it found it, and what is
+ * on it is not what was on it. Read as a height, {@code EMPTY.name() == text} is a constant that
+ * came through a call and reached a comparison; read as what took what, the constant is what the
+ * call took, and the comparison is about a string.
+ *
+ * <p>So what is followed is how far above the value the stack has come. Where that is further than
+ * an instruction takes, the value is under everything the instruction is about and comes through
+ * it; where it is not, that instruction is what took the value, and what it did with it is the
+ * answer.
  *
  * <p><b>What it cannot follow it refuses, and never answers.</b> An instruction whose effect this
- * cannot say, a way round that comes back to where the walk has already been, the beginning of an
- * exception handler, and the end of a method with the value still on the stack are each a place the
- * value was lost rather than taken — and every one of them ends the walk with a refusal. Answered,
- * each would come out as "nothing compares it", which is the one thing a rule written on top of
- * this reads as a fact.
+ * cannot say, one that takes the value and puts it back somewhere this does not model, a way round
+ * that comes back to where the walk has already been, the beginning of an exception handler, and
+ * the end of a method with the value still on the stack are each a place the value was lost rather
+ * than taken — and every one of them ends the walk with a refusal. Answered, each would come out as
+ * "nothing compares it", which is the one thing a rule written on top of this reads as a fact.
  *
- * <p>What it does follow is a value carried across the jumps that work something else out, and
- * across a switch, which takes the number it switched on and leaves the value alone. Each way the
- * code may go is remembered with the stack it is reached at, and picked up again where it arrives.
+ * <p>What it does follow is a value carried across the jumps that work something else out, across a
+ * switch, which takes the number it switched on and leaves the value alone, and across a cast,
+ * which leaves what it took. Each way the code may go is remembered with the stack it is reached
+ * at, and picked up again where it arrives.
  */
 final class WhatBecomesOfAValueOnTheStack {
 
     private WhatBecomesOfAValueOnTheStack() {
+    }
+
+    /**
+     * What one instruction takes off the stack and what it leaves there.
+     *
+     * @param takes    how many slots come off
+     * @param leaves   how many go back on
+     * @param carrying whether what goes back on is what came off. A cast is the same value said
+     *                 under another type; a call that returns something is not, however alike the
+     *                 two look to a walk that only counts
+     */
+    private record Effect(int takes, int leaves, boolean carrying) {
+
+        static Effect of(int takes, int leaves) {
+            return new Effect(takes, leaves, false);
+        }
     }
 
     /**
@@ -82,14 +105,13 @@ final class WhatBecomesOfAValueOnTheStack {
      */
     static boolean isTakenByAReferenceComparison(List<CodeElement> elements, int at) {
         Set<Label> caught = new HashSet<>();
-        elements.forEach(each -> {
+        Map<Label, Integer> placed = new HashMap<>();
+        for (int where = 0; where < elements.size(); where++) {
+            CodeElement each = elements.get(where);
             if (each instanceof ExceptionCatch handler) {
                 caught.add(handler.handler());
             }
-        });
-        Map<Label, Integer> placed = new HashMap<>();
-        for (int where = 0; where < elements.size(); where++) {
-            if (elements.get(where) instanceof LabelTarget target) {
+            if (each instanceof LabelTarget target) {
                 placed.put(target.label(), where);
             }
         }
@@ -127,12 +149,28 @@ final class WhatBecomesOfAValueOnTheStack {
                 // it jumps to. What it does to a stack is not what this value's stack is doing.
                 continue;
             }
-            if (instruction instanceof BranchInstruction branch
-                    && isAReferenceComparison(branch.opcode())) {
-                // Both operands are what the stack holds above the value and the one below them, so
-                // the value is one of the two exactly where the stack has come no further than two
-                // above it.
-                return now <= 2;
+            Effect effect = effectOf(instruction);
+            if (now <= effect.takes()) {
+                // This instruction is what takes the value, so what it is is the answer.
+                if (instruction instanceof BranchInstruction branch
+                        && isAReferenceComparison(branch.opcode())) {
+                    return true;
+                }
+                if (instruction instanceof StackInstruction && effect.leaves() > 0) {
+                    // What a rearrangement leaves is the same values somewhere else, and which
+                    // slot this one went to is not something this says. Answered, the answer would
+                    // be about whatever ends up where the value was.
+                    throw new IllegalStateException(
+                            "a value was taken by a rearrangement of the stack");
+                }
+                if (effect.carrying()) {
+                    // The same value under another name, so it goes on being followed as the one
+                    // thing this instruction left.
+                    now = 1;
+                    reached = !ends(instruction);
+                    continue;
+                }
+                return false;
             }
             for (Label target : whereItMayGo(instruction)) {
                 Integer to = placed.get(target);
@@ -142,15 +180,10 @@ final class WhatBecomesOfAValueOnTheStack {
                     // answering about the way it happened to take.
                     throw new IllegalStateException("a value was followed into a jump that returns");
                 }
-                above.merge(target, now + effectOf(instruction),
+                above.merge(target, now - effect.takes() + effect.leaves(),
                         WhatBecomesOfAValueOnTheStack::agreeing);
             }
-            now += effectOf(instruction);
-            if (now <= 0) {
-                // Something other than a comparison of two references took the value, which is an
-                // answer and not a place the walk gave up at.
-                return false;
-            }
+            now += effect.leaves() - effect.takes();
             reached = !ends(instruction);
         }
         // The value is still on the stack and there is no more code, so what took it was on a way
@@ -204,93 +237,102 @@ final class WhatBecomesOfAValueOnTheStack {
                         && (branch.opcode() == Opcode.GOTO || branch.opcode() == Opcode.GOTO_W));
     }
 
-    /** How many slots one instruction leaves on the stack, less what it took. */
-    private static int effectOf(Instruction instruction) {
+    /** What one instruction takes off the stack and what it leaves there. */
+    private static Effect effectOf(Instruction instruction) {
         return switch (instruction) {
-            case LoadInstruction it -> slotsOf(it.typeKind());
-            case ConstantInstruction it -> slotsOf(it.typeKind());
-            case StoreInstruction it -> -slotsOf(it.typeKind());
+            case LoadInstruction it -> Effect.of(0, slotsOf(it.typeKind()));
+            case ConstantInstruction it -> Effect.of(0, slotsOf(it.typeKind()));
+            case StoreInstruction it -> Effect.of(slotsOf(it.typeKind()), 0);
             case FieldInstruction it -> fieldEffect(it);
             case InvokeInstruction it -> calling(it.typeSymbol().parameterList(),
                     it.typeSymbol().returnType(), it.opcode() != Opcode.INVOKESTATIC);
             case InvokeDynamicInstruction it -> calling(it.typeSymbol().parameterList(),
                     it.typeSymbol().returnType(), false);
-            case ArrayLoadInstruction it -> slotsOf(it.typeKind()) - 2;
-            case ArrayStoreInstruction it -> -slotsOf(it.typeKind()) - 2;
+            case ArrayLoadInstruction it -> Effect.of(2, slotsOf(it.typeKind()));
+            case ArrayStoreInstruction it -> Effect.of(2 + slotsOf(it.typeKind()), 0);
             case StackInstruction it -> stackEffect(it.opcode());
             case OperatorInstruction it -> operatorEffect(it.opcode());
-            case ConvertInstruction it -> slotsOf(it.toType()) - slotsOf(it.fromType());
+            case ConvertInstruction it -> Effect.of(slotsOf(it.fromType()), slotsOf(it.toType()));
             case BranchInstruction it -> branchEffect(it.opcode());
-            case TypeCheckInstruction _ -> 0;
-            case NewObjectInstruction _ -> 1;
-            case NewPrimitiveArrayInstruction _ -> 0;
-            case NewReferenceArrayInstruction _ -> 0;
-            case NewMultiArrayInstruction it -> 1 - it.dimensions();
-            case MonitorInstruction _ -> -1;
-            case IncrementInstruction _ -> 0;
-            case NopInstruction _ -> 0;
-            case ThrowInstruction _ -> -1;
-            case ReturnInstruction it -> -slotsOf(it.typeKind());
-            case TableSwitchInstruction _ -> -1;
-            case LookupSwitchInstruction _ -> -1;
+            // A cast leaves what it took, said under another type, so the value goes on being the
+            // value. Asking whether something is of a type takes it and leaves an answer about it.
+            case TypeCheckInstruction it -> it.opcode() == Opcode.CHECKCAST
+                    ? new Effect(1, 1, true) : Effect.of(1, 1);
+            case NewObjectInstruction _ -> Effect.of(0, 1);
+            case NewPrimitiveArrayInstruction _ -> Effect.of(1, 1);
+            case NewReferenceArrayInstruction _ -> Effect.of(1, 1);
+            case NewMultiArrayInstruction it -> Effect.of(it.dimensions(), 1);
+            case MonitorInstruction _ -> Effect.of(1, 0);
+            case IncrementInstruction _ -> Effect.of(0, 0);
+            case NopInstruction _ -> Effect.of(0, 0);
+            case ThrowInstruction _ -> Effect.of(1, 0);
+            case ReturnInstruction it -> Effect.of(slotsOf(it.typeKind()), 0);
+            case TableSwitchInstruction _ -> Effect.of(1, 0);
+            case LookupSwitchInstruction _ -> Effect.of(1, 0);
             default -> throw new IllegalStateException(
-                    "the walk cannot say what " + instruction.opcode() + " leaves on the stack");
+                    "the walk cannot say what " + instruction.opcode() + " takes off the stack");
         };
     }
 
-    private static int fieldEffect(FieldInstruction field) {
+    private static Effect fieldEffect(FieldInstruction field) {
         int held = slotsOf(TypeKind.from(field.typeSymbol()));
         return switch (field.opcode()) {
-            case GETSTATIC -> held;
-            case PUTSTATIC -> -held;
-            case GETFIELD -> held - 1;
-            case PUTFIELD -> -held - 1;
+            case GETSTATIC -> Effect.of(0, held);
+            case PUTSTATIC -> Effect.of(held, 0);
+            case GETFIELD -> Effect.of(1, held);
+            case PUTFIELD -> Effect.of(1 + held, 0);
             default -> throw new IllegalStateException(
                     "the walk cannot say what " + field.opcode() + " does to a field");
         };
     }
 
-    private static int calling(List<ClassDesc> takes, ClassDesc gives, boolean onAReceiver) {
+    private static Effect calling(List<ClassDesc> takes, ClassDesc gives, boolean onAReceiver) {
         int taken = onAReceiver ? 1 : 0;
         for (ClassDesc each : takes) {
             taken += slotsOf(TypeKind.from(each));
         }
-        return slotsOf(TypeKind.from(gives)) - taken;
+        return Effect.of(taken, slotsOf(TypeKind.from(gives)));
     }
 
-    private static int stackEffect(Opcode opcode) {
+    private static Effect stackEffect(Opcode opcode) {
         return switch (opcode) {
-            case POP -> -1;
-            case POP2 -> -2;
-            case DUP, DUP_X1, DUP_X2 -> 1;
-            case DUP2, DUP2_X1, DUP2_X2 -> 2;
-            case SWAP -> 0;
+            case POP -> Effect.of(1, 0);
+            case POP2 -> Effect.of(2, 0);
+            case DUP -> Effect.of(1, 2);
+            case DUP_X1 -> Effect.of(2, 3);
+            case DUP_X2 -> Effect.of(3, 4);
+            case DUP2 -> Effect.of(2, 4);
+            case DUP2_X1 -> Effect.of(3, 5);
+            case DUP2_X2 -> Effect.of(4, 6);
+            case SWAP -> Effect.of(2, 2);
             default -> throw new IllegalStateException(
                     "the walk cannot say what " + opcode + " does to the stack");
         };
     }
 
-    private static int branchEffect(Opcode opcode) {
+    private static Effect branchEffect(Opcode opcode) {
         return switch (opcode) {
-            case GOTO, GOTO_W -> 0;
-            case IFEQ, IFNE, IFLT, IFGE, IFGT, IFLE, IFNULL, IFNONNULL -> -1;
+            case GOTO, GOTO_W -> Effect.of(0, 0);
+            case IFEQ, IFNE, IFLT, IFGE, IFGT, IFLE, IFNULL, IFNONNULL -> Effect.of(1, 0);
             case IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT, IF_ICMPGE, IF_ICMPGT, IF_ICMPLE,
-                 IF_ACMPEQ, IF_ACMPNE -> -2;
+                 IF_ACMPEQ, IF_ACMPNE -> Effect.of(2, 0);
             default -> throw new IllegalStateException(
                     "the walk cannot say what " + opcode + " does before it jumps");
         };
     }
 
-    private static int operatorEffect(Opcode opcode) {
+    private static Effect operatorEffect(Opcode opcode) {
         return switch (opcode) {
-            case ARRAYLENGTH, INEG, LNEG, FNEG, DNEG -> 0;
+            case ARRAYLENGTH, INEG, FNEG -> Effect.of(1, 1);
+            case LNEG, DNEG -> Effect.of(2, 2);
             case IADD, ISUB, IMUL, IDIV, IREM, IAND, IOR, IXOR,
+                 ISHL, ISHR, IUSHR,
                  FADD, FSUB, FMUL, FDIV, FREM,
-                 ISHL, ISHR, IUSHR, LSHL, LSHR, LUSHR,
-                 FCMPL, FCMPG -> -1;
+                 FCMPL, FCMPG -> Effect.of(2, 1);
+            case LSHL, LSHR, LUSHR -> Effect.of(3, 2);
             case LADD, LSUB, LMUL, LDIV, LREM, LAND, LOR, LXOR,
-                 DADD, DSUB, DMUL, DDIV, DREM -> -2;
-            case LCMP, DCMPL, DCMPG -> -3;
+                 DADD, DSUB, DMUL, DDIV, DREM -> Effect.of(4, 2);
+            case LCMP, DCMPL, DCMPG -> Effect.of(4, 1);
             default -> throw new IllegalStateException(
                     "the walk cannot say what " + opcode + " leaves of its operands");
         };

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -36,6 +36,7 @@ import java.lang.constant.ClassDesc;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -213,21 +214,73 @@ final class WhatBecomesOfAValueOnTheStack {
     /**
      * Whether what is read out of a local this value was put into is compared.
      *
-     * <p>Every reading of the local up to the next writing of it, since after that the name holds
-     * something else. Which is why a writing ends this rather than refusing: what is in the name
-     * from there on is not this value, and the readings before it are all of them there are.
+     * <p><b>A name is not the value, and which value is in it is each way round's own.</b> A name
+     * written on one way through the code still holds what it held on the ways that missed the
+     * writing, so what a place reads out of it is what any way here left there. Read as the last
+     * writing before that place, a name given another value inside a condition would be read as
+     * having it on every way, and a comparison after the condition would be about a value nothing
+     * put there.
+     *
+     * <p>So the ways are followed as they are for a value on the stack, and put together where they
+     * meet: the name holds the value where any way arriving holds it. A way that comes back to
+     * where this has already been is walked again, until no way says anything new — which it
+     * reaches, since a name that holds the value goes on holding it and no round takes that back.
      */
     private static boolean heldIn(List<CodeElement> elements, int from, int slot, int through) {
-        for (int at = from + 1; at < elements.size(); at++) {
-            CodeElement element = elements.get(at);
-            if (element instanceof StoreInstruction put && put.slot() == slot) {
-                return false;
+        Map<Label, Integer> placed = new HashMap<>();
+        for (int where = 0; where < elements.size(); where++) {
+            if (elements.get(where) instanceof LabelTarget target) {
+                placed.put(target.label(), where);
             }
-            if (element instanceof IncrementInstruction added && added.slot() == slot) {
-                return false;
+        }
+        Map<Label, Boolean> arriving = new HashMap<>();
+        Set<Integer> readWhileHeld = new LinkedHashSet<>();
+        boolean anythingNew = true;
+        int rounds = 0;
+        while (anythingNew) {
+            if (++rounds > 16) {
+                throw new IllegalStateException("what a name holds would not settle");
             }
-            if (element instanceof LoadInstruction got && got.slot() == slot
-                    && followedFrom(elements, at, through + 1)) {
+            anythingNew = false;
+            boolean holds = true;
+            boolean reached = true;
+            for (int at = from + 1; at < elements.size(); at++) {
+                CodeElement element = elements.get(at);
+                if (element instanceof LabelTarget target) {
+                    Boolean said = arriving.get(target.label());
+                    if (said != null) {
+                        holds = said || (reached && holds);
+                        reached = true;
+                    }
+                    continue;
+                }
+                if (!(element instanceof Instruction instruction) || !reached) {
+                    continue;
+                }
+                if (holds) {
+                    if (element instanceof StoreInstruction put && put.slot() == slot) {
+                        holds = false;
+                    } else if (element instanceof IncrementInstruction added
+                            && added.slot() == slot) {
+                        holds = false;
+                    } else if (element instanceof LoadInstruction got && got.slot() == slot
+                            && readWhileHeld.add(at)) {
+                        anythingNew = true;
+                    }
+                }
+                for (Label target : whereItMayGo(instruction)) {
+                    Boolean was = arriving.get(target);
+                    boolean now = was != null ? was || holds : holds;
+                    if (was == null || was != now) {
+                        arriving.put(target, now);
+                        anythingNew = true;
+                    }
+                }
+                reached = !ends(instruction);
+            }
+        }
+        for (int at : readWhileHeld) {
+            if (followedFrom(elements, at, through + 1)) {
                 return true;
             }
         }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -1,0 +1,250 @@
+package souther.architecture;
+
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.Instruction;
+import java.lang.classfile.Label;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.TypeKind;
+import java.lang.classfile.instruction.ArrayLoadInstruction;
+import java.lang.classfile.instruction.ArrayStoreInstruction;
+import java.lang.classfile.instruction.BranchInstruction;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.lang.classfile.instruction.ConvertInstruction;
+import java.lang.classfile.instruction.ExceptionCatch;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.IncrementInstruction;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.LabelTarget;
+import java.lang.classfile.instruction.LoadInstruction;
+import java.lang.classfile.instruction.LookupSwitchInstruction;
+import java.lang.classfile.instruction.MonitorInstruction;
+import java.lang.classfile.instruction.NewMultiArrayInstruction;
+import java.lang.classfile.instruction.NewObjectInstruction;
+import java.lang.classfile.instruction.NewPrimitiveArrayInstruction;
+import java.lang.classfile.instruction.NewReferenceArrayInstruction;
+import java.lang.classfile.instruction.NopInstruction;
+import java.lang.classfile.instruction.OperatorInstruction;
+import java.lang.classfile.instruction.ReturnInstruction;
+import java.lang.classfile.instruction.StackInstruction;
+import java.lang.classfile.instruction.StoreInstruction;
+import java.lang.classfile.instruction.TableSwitchInstruction;
+import java.lang.classfile.instruction.ThrowInstruction;
+import java.lang.classfile.instruction.TypeCheckInstruction;
+import java.lang.constant.ClassDesc;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where a value one instruction pushed is used, for a rule about how a value is read.
+ *
+ * <p>A rule that says a constant may not be compared has to say what compares it, and what compares
+ * a value is the instruction that takes it off the stack. Read as the instructions written near it,
+ * the answer would be about where the source put the comparison and not about the comparison: a
+ * constant written where a value is wanted stands beside whatever the method does next, and one
+ * compared against something worked out in a conditional stands several jumps away from the
+ * comparison that takes it.
+ *
+ * <p>So this follows the value. How far the stack is above where the value sits is worked out
+ * instruction by instruction, and the value is gone as soon as that reaches the value's own place.
+ * What the value's place is is never needed — only how far above it the stack has come — so nothing
+ * here has to know the depth a method's code begins at.
+ *
+ * <p><b>Every instruction is answered for.</b> An instruction this cannot say the effect of ends
+ * the walk with a refusal rather than an answer, so a rule written on top of this cannot come to
+ * report that nothing compares a constant because the walk stopped understanding the code.
+ */
+final class WhatBecomesOfAValueOnTheStack {
+
+    private WhatBecomesOfAValueOnTheStack() {
+    }
+
+    /**
+     * Whether the value the instruction at {@code at} pushes is taken by a comparison of two
+     * references.
+     *
+     * <p>Followed forward until something takes the value. Where the code branches, the stack the
+     * branch leaves is remembered against the place it jumps to and picked up again there, which is
+     * what lets a value compared against a conditional's answer be followed past the jumps that
+     * work the answer out.
+     */
+    static boolean isTakenByAReferenceComparison(List<CodeElement> elements, int at) {
+        Set<Label> caught = new HashSet<>();
+        elements.forEach(each -> {
+            if (each instanceof ExceptionCatch handler) {
+                caught.add(handler.handler());
+            }
+        });
+        Map<Label, Integer> above = new HashMap<>();
+        // One, because the value has just been pushed and nothing else is on top of it. What is
+        // followed is this number and never the depth of the stack, so where the method's code
+        // began does not have to be known.
+        int now = 1;
+        boolean reached = true;
+        for (int next = at + 1; next < elements.size(); next++) {
+            CodeElement element = elements.get(next);
+            if (element instanceof LabelTarget target) {
+                if (caught.contains(target.label())) {
+                    // A handler begins with what was thrown and with nothing else, so the stack
+                    // there is not this stack and the value cannot be followed across it.
+                    throw new IllegalStateException(
+                            "a value was followed into the beginning of an exception handler");
+                }
+                Integer said = above.get(target.label());
+                if (said != null) {
+                    if (reached && said != now) {
+                        throw new IllegalStateException(
+                                "two ways to one place leave the stack at two heights");
+                    }
+                    now = said;
+                    reached = true;
+                }
+                continue;
+            }
+            if (!(element instanceof Instruction instruction)) {
+                continue;
+            }
+            if (!reached) {
+                // Code no way reaches from here, which is what stands between a jump and the place
+                // it jumps to. What it does to a stack is not what this value's stack is doing.
+                continue;
+            }
+            if (instruction instanceof BranchInstruction branch) {
+                if (isAReferenceComparison(branch.opcode())) {
+                    // Both operands are what the stack holds above the value and the one below
+                    // them, so the value is one of the two exactly where the stack has come no
+                    // further than two above it.
+                    return now <= 2;
+                }
+                above.merge(branch.target(), now + effectOf(instruction),
+                        WhatBecomesOfAValueOnTheStack::agreeing);
+            }
+            now += effectOf(instruction);
+            if (now <= 0) {
+                return false;
+            }
+            reached = !ends(instruction);
+        }
+        return false;
+    }
+
+    private static int agreeing(int one, int other) {
+        if (one != other) {
+            throw new IllegalStateException("two ways to one place leave the stack at two heights");
+        }
+        return one;
+    }
+
+    private static boolean isAReferenceComparison(Opcode opcode) {
+        return opcode == Opcode.IF_ACMPEQ || opcode == Opcode.IF_ACMPNE;
+    }
+
+    /** Whether nothing carries on to the instruction after this one. */
+    private static boolean ends(Instruction instruction) {
+        return instruction instanceof ReturnInstruction
+                || instruction instanceof ThrowInstruction
+                || instruction instanceof TableSwitchInstruction
+                || instruction instanceof LookupSwitchInstruction
+                || (instruction instanceof BranchInstruction branch
+                        && (branch.opcode() == Opcode.GOTO || branch.opcode() == Opcode.GOTO_W));
+    }
+
+    /** How many slots one instruction leaves on the stack, less what it took. */
+    private static int effectOf(Instruction instruction) {
+        return switch (instruction) {
+            case LoadInstruction it -> slotsOf(it.typeKind());
+            case ConstantInstruction it -> slotsOf(it.typeKind());
+            case StoreInstruction it -> -slotsOf(it.typeKind());
+            case FieldInstruction it -> fieldEffect(it);
+            case InvokeInstruction it -> calling(it.typeSymbol().parameterList(),
+                    it.typeSymbol().returnType(), it.opcode() != Opcode.INVOKESTATIC);
+            case InvokeDynamicInstruction it -> calling(it.typeSymbol().parameterList(),
+                    it.typeSymbol().returnType(), false);
+            case ArrayLoadInstruction it -> slotsOf(it.typeKind()) - 2;
+            case ArrayStoreInstruction it -> -slotsOf(it.typeKind()) - 2;
+            case StackInstruction it -> stackEffect(it.opcode());
+            case OperatorInstruction it -> operatorEffect(it.opcode());
+            case ConvertInstruction it -> slotsOf(it.toType()) - slotsOf(it.fromType());
+            case BranchInstruction it -> branchEffect(it.opcode());
+            case TypeCheckInstruction _ -> 0;
+            case NewObjectInstruction _ -> 1;
+            case NewPrimitiveArrayInstruction _ -> 0;
+            case NewReferenceArrayInstruction _ -> 0;
+            case NewMultiArrayInstruction it -> 1 - it.dimensions();
+            case MonitorInstruction _ -> -1;
+            case IncrementInstruction _ -> 0;
+            case NopInstruction _ -> 0;
+            case ThrowInstruction _ -> -1;
+            case ReturnInstruction it -> -slotsOf(it.typeKind());
+            case TableSwitchInstruction _ -> -1;
+            case LookupSwitchInstruction _ -> -1;
+            default -> throw new IllegalStateException(
+                    "the walk cannot say what " + instruction.opcode() + " leaves on the stack");
+        };
+    }
+
+    private static int fieldEffect(FieldInstruction field) {
+        int held = slotsOf(TypeKind.from(field.typeSymbol()));
+        return switch (field.opcode()) {
+            case GETSTATIC -> held;
+            case PUTSTATIC -> -held;
+            case GETFIELD -> held - 1;
+            case PUTFIELD -> -held - 1;
+            default -> throw new IllegalStateException(
+                    "the walk cannot say what " + field.opcode() + " does to a field");
+        };
+    }
+
+    private static int calling(List<ClassDesc> takes, ClassDesc gives, boolean onAReceiver) {
+        int taken = onAReceiver ? 1 : 0;
+        for (ClassDesc each : takes) {
+            taken += slotsOf(TypeKind.from(each));
+        }
+        return slotsOf(TypeKind.from(gives)) - taken;
+    }
+
+    private static int stackEffect(Opcode opcode) {
+        return switch (opcode) {
+            case POP -> -1;
+            case POP2 -> -2;
+            case DUP, DUP_X1, DUP_X2 -> 1;
+            case DUP2, DUP2_X1, DUP2_X2 -> 2;
+            case SWAP -> 0;
+            default -> throw new IllegalStateException(
+                    "the walk cannot say what " + opcode + " does to the stack");
+        };
+    }
+
+    private static int branchEffect(Opcode opcode) {
+        return switch (opcode) {
+            case GOTO, GOTO_W -> 0;
+            case IFEQ, IFNE, IFLT, IFGE, IFGT, IFLE, IFNULL, IFNONNULL -> -1;
+            case IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT, IF_ICMPGE, IF_ICMPGT, IF_ICMPLE,
+                 IF_ACMPEQ, IF_ACMPNE -> -2;
+            default -> throw new IllegalStateException(
+                    "the walk cannot say what " + opcode + " does before it jumps");
+        };
+    }
+
+    private static int operatorEffect(Opcode opcode) {
+        return switch (opcode) {
+            case ARRAYLENGTH, INEG, LNEG, FNEG, DNEG -> 0;
+            case IADD, ISUB, IMUL, IDIV, IREM, IAND, IOR, IXOR,
+                 FADD, FSUB, FMUL, FDIV, FREM,
+                 ISHL, ISHR, IUSHR, LSHL, LSHR, LUSHR,
+                 FCMPL, FCMPG -> -1;
+            case LADD, LSUB, LMUL, LDIV, LREM, LAND, LOR, LXOR,
+                 DADD, DSUB, DMUL, DDIV, DREM -> -2;
+            case LCMP, DCMPL, DCMPG -> -3;
+            default -> throw new IllegalStateException(
+                    "the walk cannot say what " + opcode + " leaves of its operands");
+        };
+    }
+
+    private static int slotsOf(TypeKind kind) {
+        return kind.slotSize();
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -104,6 +104,21 @@ final class WhatBecomesOfAValueOnTheStack {
      * work the answer out.
      */
     static boolean isTakenByAReferenceComparison(List<CodeElement> elements, int at) {
+        return followedFrom(elements, at, 0);
+    }
+
+    /**
+     * The same, of a value put somewhere and taken out again.
+     *
+     * <p>A value in a local is followed to each place that reads the local before anything writes
+     * it again, and is compared where any of them compares it. Answered without following, a
+     * constant a clause wrote into a name would come out as one nothing compares, which is a rule
+     * that anybody could get round by writing the name.
+     */
+    private static boolean followedFrom(List<CodeElement> elements, int at, int through) {
+        if (through > 4) {
+            throw new IllegalStateException("a value was put away and taken out too many times");
+        }
         Set<Label> caught = new HashSet<>();
         Map<Label, Integer> placed = new HashMap<>();
         for (int where = 0; where < elements.size(); where++) {
@@ -163,6 +178,9 @@ final class WhatBecomesOfAValueOnTheStack {
                     throw new IllegalStateException(
                             "a value was taken by a rearrangement of the stack");
                 }
+                if (instruction instanceof StoreInstruction put) {
+                    return heldIn(elements, next, put.slot(), through);
+                }
                 if (effect.carrying()) {
                     // The same value under another name, so it goes on being followed as the one
                     // thing this instruction left.
@@ -190,6 +208,30 @@ final class WhatBecomesOfAValueOnTheStack {
         // this did not follow. Said as "nothing compares it", that would be the one mistake this
         // whole reading is written to refuse.
         throw new IllegalStateException("a value was followed to the end of a method");
+    }
+
+    /**
+     * Whether what is read out of a local this value was put into is compared.
+     *
+     * <p>Every reading of the local up to the next writing of it, since after that the name holds
+     * something else. Which is why a writing ends this rather than refusing: what is in the name
+     * from there on is not this value, and the readings before it are all of them there are.
+     */
+    private static boolean heldIn(List<CodeElement> elements, int from, int slot, int through) {
+        for (int at = from + 1; at < elements.size(); at++) {
+            CodeElement element = elements.get(at);
+            if (element instanceof StoreInstruction put && put.slot() == slot) {
+                return false;
+            }
+            if (element instanceof IncrementInstruction added && added.slot() == slot) {
+                return false;
+            }
+            if (element instanceof LoadInstruction got && got.slot() == slot
+                    && followedFrom(elements, at, through + 1)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -10,6 +10,7 @@ import java.lang.classfile.instruction.ArrayStoreInstruction;
 import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.classfile.instruction.ConstantInstruction;
 import java.lang.classfile.instruction.ConvertInstruction;
+import java.lang.classfile.instruction.DiscontinuedInstruction;
 import java.lang.classfile.instruction.ExceptionCatch;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.IncrementInstruction;
@@ -221,62 +222,49 @@ final class WhatBecomesOfAValueOnTheStack {
      * having it on every way, and a comparison after the condition would be about a value nothing
      * put there.
      *
-     * <p>So the ways are followed as they are for a value on the stack, and put together where they
-     * meet: the name holds the value where any way arriving holds it. A way that comes back to
-     * where this has already been is walked again, until no way says anything new — which it
-     * reaches, since a name that holds the value goes on holding it and no round takes that back.
+     * <p>So this is over the places in the code and not over what is written after the writing:
+     * the name holds the value at a place where any way of arriving there holds it, and every way
+     * the code may go is one of them — what is written next, wherever it jumps, and wherever what
+     * it throws may be caught. A way that comes back is one of them too, and the places are walked
+     * again until no way says anything new, which they reach because a name holding the value goes
+     * on holding it and no round takes that back.
      */
     private static boolean heldIn(List<CodeElement> elements, int from, int slot, int through) {
-        Map<Label, Integer> placed = new HashMap<>();
-        for (int where = 0; where < elements.size(); where++) {
-            if (elements.get(where) instanceof LabelTarget target) {
-                placed.put(target.label(), where);
-            }
-        }
-        Map<Label, Boolean> arriving = new HashMap<>();
+        Map<Label, Integer> placed = placesOf(elements);
+        boolean[] holds = new boolean[elements.size()];
+        holds[from + 1] = true;
         Set<Integer> readWhileHeld = new LinkedHashSet<>();
         boolean anythingNew = true;
-        int rounds = 0;
         while (anythingNew) {
-            if (++rounds > 16) {
-                throw new IllegalStateException("what a name holds would not settle");
-            }
             anythingNew = false;
-            boolean holds = true;
-            boolean reached = true;
-            for (int at = from + 1; at < elements.size(); at++) {
+            for (int at = 0; at < elements.size(); at++) {
+                if (!holds[at]) {
+                    continue;
+                }
                 CodeElement element = elements.get(at);
-                if (element instanceof LabelTarget target) {
-                    Boolean said = arriving.get(target.label());
-                    if (said != null) {
-                        holds = said || (reached && holds);
-                        reached = true;
-                    }
-                    continue;
-                }
-                if (!(element instanceof Instruction instruction) || !reached) {
-                    continue;
-                }
-                if (holds) {
+                boolean after = true;
+                if (element instanceof Instruction instruction) {
                     if (element instanceof StoreInstruction put && put.slot() == slot) {
-                        holds = false;
+                        after = false;
                     } else if (element instanceof IncrementInstruction added
                             && added.slot() == slot) {
-                        holds = false;
+                        after = false;
                     } else if (element instanceof LoadInstruction got && got.slot() == slot
                             && readWhileHeld.add(at)) {
                         anythingNew = true;
                     }
-                }
-                for (Label target : whereItMayGo(instruction)) {
-                    Boolean was = arriving.get(target);
-                    boolean now = was != null ? was || holds : holds;
-                    if (was == null || was != now) {
-                        arriving.put(target, now);
-                        anythingNew = true;
+                    for (int to : goesTo(elements, placed, at, instruction, after)) {
+                        if (!holds[to]) {
+                            holds[to] = true;
+                            anythingNew = true;
+                        }
                     }
+                } else if (at + 1 < elements.size() && !holds[at + 1]) {
+                    // A label or a line, which nothing carries the value across but the code
+                    // written after it.
+                    holds[at + 1] = true;
+                    anythingNew = true;
                 }
-                reached = !ends(instruction);
             }
         }
         for (int at : readWhileHeld) {
@@ -285,6 +273,63 @@ final class WhatBecomesOfAValueOnTheStack {
             }
         }
         return false;
+    }
+
+    /**
+     * Everywhere the code may be at next, once the instruction at {@code at} has run.
+     *
+     * <p>The whole of it: what is written after it unless nothing carries on to that, wherever it
+     * may jump, and every handler that may catch what it throws. A name holds what it holds however
+     * the code arrived, so an edge left out is a place a name is read at that nothing here reads —
+     * and what a rule on top of this would say of it is that nobody compares the value.
+     *
+     * @param after whether the name still holds the value once this instruction has run, which is
+     *              what is carried to each of them
+     */
+    private static List<Integer> goesTo(List<CodeElement> elements, Map<Label, Integer> placed,
+                                        int at, Instruction instruction, boolean after) {
+        if (!after) {
+            return List.of();
+        }
+        if (instruction instanceof DiscontinuedInstruction) {
+            throw new IllegalStateException(
+                    "a name was followed into a way of jumping this cannot say the ways of");
+        }
+        List<Integer> out = new ArrayList<>();
+        if (!ends(instruction) && at + 1 < elements.size()) {
+            out.add(at + 1);
+        }
+        for (Label target : whereItMayGo(instruction)) {
+            out.add(placeOf(placed, target));
+        }
+        // And wherever what it throws may be caught, since a name is what it was when the throwing
+        // began. Left out, a comparison written in a handler is one nothing reads.
+        for (CodeElement each : elements) {
+            if (each instanceof ExceptionCatch handler
+                    && placeOf(placed, handler.tryStart()) <= at
+                    && at < placeOf(placed, handler.tryEnd())) {
+                out.add(placeOf(placed, handler.handler()));
+            }
+        }
+        return out;
+    }
+
+    private static Map<Label, Integer> placesOf(List<CodeElement> elements) {
+        Map<Label, Integer> placed = new HashMap<>();
+        for (int where = 0; where < elements.size(); where++) {
+            if (elements.get(where) instanceof LabelTarget target) {
+                placed.put(target.label(), where);
+            }
+        }
+        return placed;
+    }
+
+    private static int placeOf(Map<Label, Integer> placed, Label label) {
+        Integer where = placed.get(label);
+        if (where == null) {
+            throw new IllegalStateException("a way leads somewhere this walk never reaches");
+        }
+        return where;
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatBecomesOfAValueOnTheStack.java
@@ -28,10 +28,12 @@ import java.lang.classfile.instruction.OperatorInstruction;
 import java.lang.classfile.instruction.ReturnInstruction;
 import java.lang.classfile.instruction.StackInstruction;
 import java.lang.classfile.instruction.StoreInstruction;
+import java.lang.classfile.instruction.SwitchCase;
 import java.lang.classfile.instruction.TableSwitchInstruction;
 import java.lang.classfile.instruction.ThrowInstruction;
 import java.lang.classfile.instruction.TypeCheckInstruction;
 import java.lang.constant.ClassDesc;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,9 +55,16 @@ import java.util.Set;
  * What the value's place is is never needed — only how far above it the stack has come — so nothing
  * here has to know the depth a method's code begins at.
  *
- * <p><b>Every instruction is answered for.</b> An instruction this cannot say the effect of ends
- * the walk with a refusal rather than an answer, so a rule written on top of this cannot come to
- * report that nothing compares a constant because the walk stopped understanding the code.
+ * <p><b>What it cannot follow it refuses, and never answers.</b> An instruction whose effect this
+ * cannot say, a way round that comes back to where the walk has already been, the beginning of an
+ * exception handler, and the end of a method with the value still on the stack are each a place the
+ * value was lost rather than taken — and every one of them ends the walk with a refusal. Answered,
+ * each would come out as "nothing compares it", which is the one thing a rule written on top of
+ * this reads as a fact.
+ *
+ * <p>What it does follow is a value carried across the jumps that work something else out, and
+ * across a switch, which takes the number it switched on and leaves the value alone. Each way the
+ * code may go is remembered with the stack it is reached at, and picked up again where it arrives.
  */
 final class WhatBecomesOfAValueOnTheStack {
 
@@ -78,6 +87,12 @@ final class WhatBecomesOfAValueOnTheStack {
                 caught.add(handler.handler());
             }
         });
+        Map<Label, Integer> placed = new HashMap<>();
+        for (int where = 0; where < elements.size(); where++) {
+            if (elements.get(where) instanceof LabelTarget target) {
+                placed.put(target.label(), where);
+            }
+        }
         Map<Label, Integer> above = new HashMap<>();
         // One, because the value has just been pushed and nothing else is on top of it. What is
         // followed is this number and never the depth of the stack, so where the method's code
@@ -112,23 +127,60 @@ final class WhatBecomesOfAValueOnTheStack {
                 // it jumps to. What it does to a stack is not what this value's stack is doing.
                 continue;
             }
-            if (instruction instanceof BranchInstruction branch) {
-                if (isAReferenceComparison(branch.opcode())) {
-                    // Both operands are what the stack holds above the value and the one below
-                    // them, so the value is one of the two exactly where the stack has come no
-                    // further than two above it.
-                    return now <= 2;
+            if (instruction instanceof BranchInstruction branch
+                    && isAReferenceComparison(branch.opcode())) {
+                // Both operands are what the stack holds above the value and the one below them, so
+                // the value is one of the two exactly where the stack has come no further than two
+                // above it.
+                return now <= 2;
+            }
+            for (Label target : whereItMayGo(instruction)) {
+                Integer to = placed.get(target);
+                if (to == null || to <= next) {
+                    // A jump backwards, or to somewhere this walk never reaches. What the value
+                    // meets on that way round is not read here, and a walk that carried on would be
+                    // answering about the way it happened to take.
+                    throw new IllegalStateException("a value was followed into a jump that returns");
                 }
-                above.merge(branch.target(), now + effectOf(instruction),
+                above.merge(target, now + effectOf(instruction),
                         WhatBecomesOfAValueOnTheStack::agreeing);
             }
             now += effectOf(instruction);
             if (now <= 0) {
+                // Something other than a comparison of two references took the value, which is an
+                // answer and not a place the walk gave up at.
                 return false;
             }
             reached = !ends(instruction);
         }
-        return false;
+        // The value is still on the stack and there is no more code, so what took it was on a way
+        // this did not follow. Said as "nothing compares it", that would be the one mistake this
+        // whole reading is written to refuse.
+        throw new IllegalStateException("a value was followed to the end of a method");
+    }
+
+    /**
+     * Everywhere the code may carry on to other than the instruction written after this one.
+     *
+     * <p>A switch is one of them and takes nothing but the number it switched on, so a value under
+     * that number is followed across it the same way it is followed across a jump — each way with
+     * the stack the switch leaves.
+     */
+    private static List<Label> whereItMayGo(Instruction instruction) {
+        return switch (instruction) {
+            case BranchInstruction it -> List.of(it.target());
+            case TableSwitchInstruction it -> targetsOf(it.defaultTarget(),
+                    it.cases().stream().map(SwitchCase::target).toList());
+            case LookupSwitchInstruction it -> targetsOf(it.defaultTarget(),
+                    it.cases().stream().map(SwitchCase::target).toList());
+            default -> List.of();
+        };
+    }
+
+    private static List<Label> targetsOf(Label otherwise, List<Label> cases) {
+        List<Label> out = new ArrayList<>(cases);
+        out.add(otherwise);
+        return out;
     }
 
     private static int agreeing(int one, int other) {

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -232,7 +232,10 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsNotEmpty"
                     + "(Lsouther/compiler/values/Emptiness;)Z",
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAway"
-                    + "(Lsouther/compiler/values/Emptiness;)Z");
+                    + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAwayUnlessSomethingElseWas"
+                    + "(Lsouther/compiler/values/Emptiness;"
+                    + "Lsouther/compiler/values/Emptiness;Z)Z");
 
     /**
      * One reading whose meaning nobody has decided yet, and which question it is.
@@ -451,6 +454,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         assertTrue(Comparing.itIsWhatWasPutAway(Emptiness.EMPTY),
                 "and one written into a name and compared out of it is a comparison");
         assertFalse(Comparing.itIsWhatWasPutAway(Emptiness.NONEMPTY));
+        assertTrue(Comparing.itIsWhatWasPutAwayUnlessSomethingElseWas(
+                        Emptiness.EMPTY, Emptiness.NONEMPTY, false),
+                "and one out of a name another way round writes over is a comparison on the way"
+                        + " that did not — and what writes over it is no constant, so this body is"
+                        + " a comparison for this constant or for none");
+        assertTrue(Comparing.itIsWhatWasPutAwayUnlessSomethingElseWas(
+                Emptiness.NONEMPTY, Emptiness.NONEMPTY, true));
         assertTrue(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, true),
                 "and one compared against an answer the code works out first is a comparison too");
         assertFalse(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, false));
@@ -626,6 +636,23 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
          */
         static boolean itIsWhatWasPutAway(Emptiness said) {
             Emptiness nothingAtAll = Emptiness.EMPTY;
+            return said == nothingAtAll;
+        }
+
+        /**
+         * And one written into a name that another way round writes over.
+         *
+         * <p>The second writing is on one way through and not on the other, so what is compared is
+         * this constant wherever the condition was not taken. Read as the writing that stands
+         * nearest before the comparison, the name would be read as holding the other constant on
+         * every way, and this comparison would be one nothing sees.
+         */
+        static boolean itIsWhatWasPutAwayUnlessSomethingElseWas(Emptiness said, Emptiness other,
+                                                                boolean instead) {
+            Emptiness nothingAtAll = Emptiness.EMPTY;
+            if (instead) {
+                nothingAtAll = other;
+            }
             return said == nothingAtAll;
         }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -504,27 +504,39 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return module.resolve("target").resolve("classes");
     }
 
+    /** The two walks, each read once. Every rule here asks the same question of the same class
+     *  files, and nothing writes one while this runs, so a walk per rule is the same answer read
+     *  again — over every class of every module each time. */
+    private static List<Use> inProduction;
+
+    private static List<Use> here;
+
     /** Every saying of the word in the reactor's own compiled classes. */
     private static List<Use> saidInProduction() {
-        List<Path> where = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            where.add(classesOf(module));
+        if (inProduction == null) {
+            List<Path> where = new ArrayList<>();
+            for (Path module : REPOSITORY.modules()) {
+                where.add(classesOf(module));
+            }
+            inProduction = List.copyOf(saidUnder(where));
         }
-        List<Use> found = saidUnder(where);
-        assertFalse(found.isEmpty(), "no saying of the word was read at all");
-        return found;
+        assertFalse(inProduction.isEmpty(), "no saying of the word was read at all");
+        return inProduction;
     }
 
     /** Every saying in the classes compiled beside this test, which is the fixture above. */
     private static List<Use> saidHere() {
-        try {
-            return saidUnder(List.of(Path.of(
-                    WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.class
-                            .getProtectionDomain().getCodeSource().getLocation().toURI())));
-        } catch (URISyntaxException notAPath) {
-            throw new IllegalStateException("this test's own classes are somewhere unreadable",
-                    notAPath);
+        if (here == null) {
+            try {
+                here = List.copyOf(saidUnder(List.of(Path.of(
+                        WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.class
+                                .getProtectionDomain().getCodeSource().getLocation().toURI()))));
+            } catch (URISyntaxException notAPath) {
+                throw new IllegalStateException("this test's own classes are somewhere unreadable",
+                        notAPath);
+            }
         }
+        return here;
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -74,6 +74,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * method reference and a switch are three spellings a scan of source text would have to know about
  * one at a time. Every module's classes, because this module is built last and a check living in
  * the module it is about passes over everything built after it.
+ *
+ * <p><b>Every list here is what a walk found, so every walk is held to a body beside this test.</b>
+ * A list and the walk that fills it are written together and agree by construction: what a walk
+ * stopped reading drops out of the list, and the list is then what the walk can still see rather
+ * than what the repository holds. So each of them is shown finding something written here —
+ * {@link Taking} and {@link TakingByStanding} switch, {@link Referring} asks through a reference,
+ * {@link Comparing} compares every way one can be written — and, where something near it would look
+ * the same to a walk that read less, shown not finding that: {@link Constructing} writes a constant
+ * where a value is wanted, and calls one before comparing what the call gave.
  */
 class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
@@ -240,10 +249,14 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * was left alone.
      */
     private static final List<String> COMPARED_IN_PRODUCTION = List.of(
+            // The same partition of two answers, read one way by a choice and the other by a
+            // conjunction (#1492).
             "souther/compiler/check/Confinement#eitherShown"
                     + "(Lsouther/compiler/check/Confinement$Admission;"
                     + "Lsouther/compiler/check/Confinement$Admission;)"
                     + "Lsouther/compiler/check/Confinement$Admission;",
+            // What a positive answer is worth beside a position nobody could build, and that a
+            // joined answer has reached the top of what a choice can be (#1493).
             "souther/compiler/check/Confinement$Worked#admission"
                     + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
@@ -370,6 +383,14 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     @Test
     void andTheseTakeTheAnswerApartByWhichAlternativesStand() {
+        assertEquals(3, TakingByStanding.by(Emptiness.Alternatives.BOTH_STAND),
+                "the fixture answers by switching");
+        assertTrue(saidHere().stream().anyMatch(
+                        use -> use.said().equals(TAKEN_APART_BY_STANDING)),
+                "the body beside this test switches over which alternatives stand, so a detector"
+                        + " that cannot find it there is one whose green would be about production"
+                        + " having stopped switching and not about the rule");
+
         assertEquals(TAKES_IT_APART_BY_STANDING,
                 placesSaying(saidInProduction(),
                         use -> use.said().equals(TAKEN_APART_BY_STANDING)),
@@ -418,6 +439,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                         + " that finds fewer is one that would let the rest past");
         assertEquals(Emptiness.UNDECIDED, Constructing.whatNobodyHasWorkedOut(),
                 "and the body that writes a constant answers with it");
+        assertTrue(Constructing.whatItIsCalledIs(Emptiness.EMPTY.name().intern()),
+                "and the body that compares what a call made of one answers about that");
         assertTrue(saidHere().stream().anyMatch(use ->
                         use.method().equals("whatNobodyHasWorkedOut")
                                 && use.said().equals("UNDECIDED")),
@@ -444,6 +467,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         assertTrue(saidHere().stream().anyMatch(use -> use.said().equals("isEmpty")),
                 "the fixture beside this test observes a settled answer through a reference, so a"
                         + " walk that cannot find it there is one that would let one past");
+
+        assertTrue(Referring.STANDS.test(Emptiness.Alternatives.BOTH_STAND),
+                "and the fixture asks which alternatives stand by handle");
+        assertTrue(saidHere().stream().anyMatch(use -> use.said().equals("bothStand")),
+                "which the walk finds as well: the two are one word between them, and a rule that"
+                        + " read a reference to one and not the other would be about which of them"
+                        + " a caller happened to name");
     }
 
     /**
@@ -500,6 +530,26 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     /**
+     * A body that switches over which alternatives stand, for the other switch detector.
+     *
+     * <p>The rule about it names what production switches, so the rule alone would go on passing
+     * the day production stopped switching and the day the detector stopped finding one — the same
+     * green, for two reasons a reader could not tell apart.
+     */
+    private enum TakingByStanding {
+        ;
+
+        static int by(Emptiness.Alternatives standing) {
+            return switch (standing) {
+                case NEITHER_STANDS -> 0;
+                case ONLY_THE_LEFT -> 1;
+                case ONLY_THE_RIGHT -> 2;
+                case BOTH_STAND -> 3;
+            };
+        }
+    }
+
+    /**
      * A body that observes a settled answer through a reference to the observation, for the same
      * reason.
      *
@@ -511,6 +561,12 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         ;
 
         static final Predicate<Emptiness> OBSERVES = Emptiness::isEmpty;
+
+        /** And which alternatives stand, which is published beside the word and is read the same
+         *  ways: a rule that found one spelling and not the other would be about how a caller
+         *  writes an ask and not about the ask. */
+        static final Predicate<Emptiness.Alternatives> STANDS =
+                Emptiness.Alternatives::bothStand;
     }
 
     /**
@@ -563,6 +619,18 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
         static Emptiness whatNobodyHasWorkedOut() {
             return Emptiness.UNDECIDED;
+        }
+
+        /**
+         * And one written where a call wants it, whose answer is then compared.
+         *
+         * <p>The call takes the constant and leaves something else, and the comparison after it is
+         * about what the call gave. Read as the height of the stack the two look alike — a call
+         * that takes a receiver and returns a value leaves the stack where it found it — so a walk
+         * that counted would report the constant as compared when what is compared is a string.
+         */
+        static boolean whatItIsCalledIs(String text) {
+            return Emptiness.EMPTY.name() == text;
         }
     }
 
@@ -622,9 +690,10 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /**
      * Every saying of the word under {@code roots}.
      *
-     * <p>The word's own class is passed over: what an enum's constants do among themselves is how
-     * one is written, and read as sayings they would put the word on every list as a namer of
-     * itself.
+     * <p>The word's own class is passed over by the rules about who says it, and by them only:
+     * what an enum's constants do among themselves is how one is written, and read as sayings they
+     * would put the word on every list as a namer of itself. Which reading of one a place is
+     * is asked of it as well — see the comment where that is done.
      */
     private static List<Use> saidUnder(List<Path> roots) {
         List<Use> found = new ArrayList<>();
@@ -703,7 +772,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             List<String> out = new ArrayList<>();
             for (var argument : lambda.bootstrapArgs()) {
                 if (argument instanceof DirectMethodHandleDesc handle
-                        && named(handle.owner()).equals(EMPTINESS)) {
+                        && (named(handle.owner()).equals(EMPTINESS)
+                                || named(handle.owner()).equals(STANDING))) {
                     // Whichever kind of handle it is, what it names is what the code would have
                     // said had it been written out: a field for a constant, a method for the rest.
                     out.add(handle.methodName());

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -12,9 +12,12 @@ import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.LineNumber;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.net.URISyntaxException;
@@ -67,6 +70,10 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
     private static final String EMPTINESS = "souther/compiler/values/Emptiness";
 
+    /** Which of two alternatives still stand, which is the one reading of this word that is about
+     *  two answers at once and is published beside them. */
+    private static final String STANDING = EMPTINESS + "$Alternatives";
+
     /** The two answers that settle something, which is what these rules are about.
      *  {@code UNDECIDED} settles nothing and is named freely. */
     private static final Set<String> SETTLED = Set.of("EMPTY", "NONEMPTY");
@@ -74,12 +81,23 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** The operations that read whether an answer is settled or carry one onwards. A caller of
      *  these holds a settled answer without naming one, which is why calling them counts as saying
      *  it. */
-    private static final Set<String> OBSERVES_OR_COMPOSES = Set.of("isEmpty", "met", "joined");
+    private static final Set<String> OBSERVES_OR_COMPOSES =
+            Set.of("isEmpty", "isDecided", "met", "joined", "of", "bothStand");
 
     /** What javac writes for a switch over this word: a synthetic table of its constants, read by
      *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
      *  names no constant in the code that does it. */
     private static final String TAKEN_APART = "$SwitchMap$souther$compiler$values$Emptiness";
+
+    /** The same for a switch over which alternatives stand, which is the other thing a reader may
+     *  take apart and is a different question from which of the three an answer is. */
+    private static final String TAKEN_APART_BY_STANDING = TAKEN_APART + "$Alternatives";
+
+    /** A comparison of one of these against one of its constants, which is a reading of the word
+     *  that no owned operation answered and that an answer added to the three would fall through
+     *  without anybody deciding. Read as the pair javac writes for one: the constant is pushed, and
+     *  the instruction after it is what compares. */
+    private static final String COMPARED = "compared";
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
@@ -93,7 +111,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * {@code ConjoinedAdmissibleValues} and {@code PlannedValues} are that walk over what a reading
      * holds, and {@code Apartness} is what the denials between two blocks come to.
      * {@code Realized} says whether everything asked for was built. {@code StatedByClauses} and
-     * {@code Settlement} put the answers of a choice's branches together.
+     * {@code Settlement} put the answers of a choice's branches together, and
+     * {@code StringMachineAnswers} keeps an answer once somebody has looked.
      *
      * <p>What is not here is the list's point. Nothing else in {@code check}, nothing downstream of
      * the compiler, and nothing that reports: a settled answer reaching one of those would be a
@@ -109,6 +128,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/values/ConjoinedAdmissibleValues",
             "souther/compiler/values/PlannedValues",
             "souther/compiler/values/Realized",
+            "souther/compiler/values/StringMachineAnswers",
             "souther/compiler/values/TextExtents");
 
     /**
@@ -155,6 +175,52 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     private static final List<String> TAKES_THE_ANSWER_APART = List.of(
             "souther/compiler/check/StatedByClauses#under");
+
+    /**
+     * And the readings that owe something of its own to each way two alternatives can fall.
+     *
+     * <p>What a choice comes to before anything is built, and what one occurrence of it leaves once
+     * its branches were probed. Both leave the branch that stands where one of them does, and both
+     * have a settlement of their own for a choice nobody can take, so neither is composed out of
+     * the other three ways.
+     */
+    private static final List<String> TAKES_IT_APART_BY_STANDING = List.of(
+            "souther/compiler/check/StatedByClauses#chosen",
+            "souther/compiler/check/StatedByClauses#decided");
+
+    /** The bodies beside this test that compare, which is what holds the detector to finding one
+     *  however it was written. */
+    private static final List<String> COMPARED_IN_THE_FIXTURE = List.of(
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest#emptyIsIt",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest"
+                    + "#emptyIsNotIt",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest#itIsEmpty",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest"
+                    + "#itIsNotEmpty");
+
+    /**
+     * And the readings of this word whose meaning nobody has decided yet.
+     *
+     * <p>Three questions and no owner for any of them. {@code eitherShown} and {@code alsoSeen}
+     * are the same partition of two answers that {@link Emptiness.Alternatives} is, read the other
+     * way round: an alternative shown empty drops out of a choice, and a conjunct shown empty
+     * decides the conjunction, so the four cases mean opposite things and one word for both would
+     * say that a left alternative and a left conjunct are one thing. {@code admission} reads what a
+     * settled positive answer is worth beside a position nobody could build. The two
+     * {@code anyAlternativeAdmits} read that a joined answer has reached the top of what a choice
+     * can be, which is a fact about the arithmetic and is known here rather than where the
+     * arithmetic is.
+     *
+     * <p>Each of them is a question this word could be given an owner for, and none of them is one
+     * this compiler has decided. Naming a reading here says that; it does not say that the reading
+     * was left alone.
+     */
+    private static final List<String> COMPARED_IN_PRODUCTION = List.of(
+            "souther/compiler/check/Confinement#admission",
+            "souther/compiler/check/Confinement#eitherShown",
+            "souther/compiler/check/Settlement#alsoSeen",
+            "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits",
+            "souther/compiler/values/PlannedValues#anyAlternativeAdmits");
 
     /** One saying of the word, and whose code holds it. */
     private record Use(String nest, String method, String said) {}
@@ -236,6 +302,64 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 "a reading that owes each of the three answers something different says so by"
                         + " switching, and one that arrived some other way is a reading a fourth"
                         + " answer would be given a meaning by without anybody deciding it");
+    }
+
+    /**
+     * And these take the answer apart by which alternatives of a choice still stand.
+     *
+     * <p>The other thing about this word a reader may switch over, and a different question: which
+     * of the three an answer is, is about one branch, and which alternatives stand is about two.
+     * A reading owed something different for each of the ways two branches can fall has to switch,
+     * and one that arrived at the same four some other way would go on answering the way the
+     * alternatives fell before a fifth was written.
+     */
+    @Test
+    void andTheseTakeTheAnswerApartByWhichAlternativesStand() {
+        assertEquals(TAKES_IT_APART_BY_STANDING,
+                placesSaying(saidInProduction(),
+                        use -> use.said().equals(TAKEN_APART_BY_STANDING)),
+                "what a choice comes to differs by which of its alternatives stand, and a reading"
+                        + " that owes each of them something says so by switching");
+    }
+
+    /**
+     * And nothing outside these compares the word against one of its constants.
+     *
+     * <p>What a settled answer means is the word's own, and every meaning it has an owner for is
+     * asked. A comparison is what is left when nothing was asked: it reads one of the answers by
+     * name and leaves every other answer to whatever the comparison happened to say about it, so
+     * an answer added to the three is given a meaning there without anybody deciding one.
+     *
+     * <p><b>What is left is what has no owner yet, and not what was not got round to.</b> Each of
+     * these is a reading whose meaning is still to be decided — what a conjunction of two readings
+     * is shown empty by, what a positive answer means beside a position nobody could build, and
+     * what it means that a joined answer has reached the top of what a choice can be. Naming a
+     * reading here is saying that it is one of those, and the list is short so that it can be read
+     * as the open questions it is.
+     *
+     * <p>Shown with the same detector run over bodies that compare every way one can be written
+     * ({@link Comparing}), and over one that writes a constant where a value is wanted
+     * ({@link Constructing}) — an answer is made by naming one, and a detector that read every
+     * naming as a reading would refuse the making of an answer.
+     */
+    @Test
+    void andNothingElseComparesTheWordAgainstOneOfItsConstants() {
+        assertEquals(COMPARED_IN_THE_FIXTURE,
+                placesSaying(saidHere(), use -> use.said().equals(COMPARED)),
+                "the bodies beside this test compare it every way it can be written, so a detector"
+                        + " that finds fewer is one that would let the rest past");
+        assertEquals(Emptiness.UNDECIDED, Constructing.whatNobodyHasWorkedOut(),
+                "and the body that writes a constant answers with it");
+        assertTrue(saidHere().stream().anyMatch(use ->
+                        use.method().equals("whatNobodyHasWorkedOut")
+                                && use.said().equals("UNDECIDED")),
+                "which the walk sees it naming, so its absence above is the detector telling a"
+                        + " comparison from the making of an answer and not the walk missing it");
+
+        assertEquals(COMPARED_IN_PRODUCTION,
+                placesSaying(saidInProduction(), use -> use.said().equals(COMPARED)),
+                "a reading that compares is one no owned meaning answered, so what is written here"
+                        + " is the readings whose meaning nobody has decided yet");
     }
 
     /**
@@ -321,6 +445,47 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         static final Predicate<Emptiness> OBSERVES = Emptiness::isEmpty;
     }
 
+    /**
+     * A body that compares the word against one of its constants, written every way it can be.
+     *
+     * <p>Four spellings and one reading. Which operand the constant is written as, and whether the
+     * comparison is for sameness or difference, are the author's and not the rule's — a detector
+     * that found one of them would let the other three past while reporting that there are none.
+     */
+    private enum Comparing {
+        ;
+
+        static boolean itIsEmpty(Emptiness said) {
+            return said == Emptiness.EMPTY;
+        }
+
+        static boolean emptyIsIt(Emptiness said) {
+            return Emptiness.EMPTY == said;
+        }
+
+        static boolean itIsNotEmpty(Emptiness said) {
+            return said != Emptiness.EMPTY;
+        }
+
+        static boolean emptyIsNotIt(Emptiness said) {
+            return Emptiness.EMPTY != said;
+        }
+    }
+
+    /**
+     * And a body that writes a constant where a value is wanted, which is not a comparison.
+     *
+     * <p>The other side of the same rule. An answer is made by naming one, so a detector that read
+     * every naming as a reading would refuse the one thing every maker of an answer has to do.
+     */
+    private enum Constructing {
+        ;
+
+        static Emptiness whatNobodyHasWorkedOut() {
+            return Emptiness.UNDECIDED;
+        }
+    }
+
     /** The nests of the sayings {@code which} keeps, each once and in one order. */
     private static List<String> nestsSaying(List<Use> said, Predicate<Use> which) {
         Set<String> out = new TreeSet<>();
@@ -393,9 +558,15 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                         continue;
                     }
                     String where = method.methodName().stringValue();
-                    for (CodeElement element : code) {
-                        for (String what : saidBy(element, holds)) {
+                    List<CodeElement> elements = new ArrayList<>();
+                    code.forEach(elements::add);
+                    int[] lines = linesOf(elements);
+                    for (int at = 0; at < elements.size(); at++) {
+                        for (String what : saidBy(elements.get(at), holds)) {
                             found.add(new Use(nest, where, what));
+                        }
+                        if (comparesAConstant(elements, lines, at)) {
+                            found.add(new Use(nest, where, COMPARED));
                         }
                     }
                 }
@@ -419,15 +590,15 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     private static List<String> saidBy(CodeElement element, String holds) {
         if (element instanceof FieldInstruction field) {
             String named = field.name().stringValue();
-            if (named.equals(TAKEN_APART)) {
-                return field.owner().asInternalName().equals(holds)
-                        ? List.of() : List.of(TAKEN_APART);
+            if (named.equals(TAKEN_APART) || named.equals(TAKEN_APART_BY_STANDING)) {
+                return field.owner().asInternalName().equals(holds) ? List.of() : List.of(named);
             }
             return field.owner().asInternalName().equals(EMPTINESS)
                     ? List.of(named) : List.of();
         }
         if (element instanceof InvokeInstruction call) {
-            return call.owner().asInternalName().equals(EMPTINESS)
+            String owner = call.owner().asInternalName();
+            return owner.equals(EMPTINESS) || owner.equals(STANDING)
                     ? List.of(call.name().stringValue()) : List.of();
         }
         if (element instanceof InvokeDynamicInstruction lambda) {
@@ -443,6 +614,47 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             return out;
         }
         return List.of();
+    }
+
+    /**
+     * Whether the instruction at {@code at} pushes one of the word's constants to compare it.
+     *
+     * <p>A constant written where a value is wanted is not a reading of the word — an answer is
+     * made by naming one, and that is how one is made. What this is about is a constant pushed so
+     * that something can be told from it, which javac writes as the constant and then a comparison
+     * of two references. So the pair is read and not the constant alone, and which side of the
+     * comparison the constant was written on does not matter: the other operand is worked out
+     * between them either way, and what is looked for is the comparison this constant reaches.
+     */
+    private static boolean comparesAConstant(List<CodeElement> elements, int[] lines, int at) {
+        if (!(elements.get(at) instanceof FieldInstruction field)
+                || field.opcode() != Opcode.GETSTATIC
+                || !field.owner().asInternalName().equals(EMPTINESS)) {
+            return false;
+        }
+        for (int next = at + 1; next < elements.size(); next++) {
+            if (elements.get(next) instanceof BranchInstruction branch) {
+                return (branch.opcode() == Opcode.IF_ACMPEQ
+                        || branch.opcode() == Opcode.IF_ACMPNE)
+                        && lines[next] == lines[at];
+            }
+        }
+        return false;
+    }
+
+    /** Which line of the source each element came from, so that a constant written as a value can
+     *  be told from one pushed to compare: the comparison a constant reaches is written where the
+     *  constant is, and the next comparison in a method that made an answer out of one is not. */
+    private static int[] linesOf(List<CodeElement> elements) {
+        int[] lines = new int[elements.size()];
+        int now = -1;
+        for (int at = 0; at < elements.size(); at++) {
+            if (elements.get(at) instanceof LineNumber said) {
+                now = said.line();
+            }
+            lines[at] = now;
+        }
+        return lines;
     }
 
     /** What a descriptor names, as a class is named in a class file. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -235,6 +235,26 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     + "(Lsouther/compiler/values/Emptiness;)Z");
 
     /**
+     * One reading whose meaning nobody has decided yet, and which question it is.
+     *
+     * <p>The question is carried by the reading and not written beside it. What orders this list is
+     * how the walk's answer sorts, which is nobody's to arrange, so a grouping written between the
+     * entries says an adjacency the order does not give — and says it wrongly the first time an
+     * entry sorts into the middle of another group.
+     *
+     * @param place    the one method, as a permission is written
+     * @param question where the question this reading is is being decided
+     */
+    private record Open(String place, String question) {}
+
+    /** A choice and a conjunction read the same partition of two answers opposite ways round. */
+    private static final String ONE_PARTITION_TWO_READINGS = "souther-lang/souther#1492";
+
+    /** What a settled positive answer is worth, beside a position nobody could build and at the top
+     *  of what a join can reach. */
+    private static final String WHAT_AN_ANSWER_IS_WORTH = "souther-lang/souther#1493";
+
+    /**
      * And the readings of this word whose meaning nobody has decided yet.
      *
      * <p>Three questions and no owner for any of them. {@code eitherShown} and {@code alsoSeen}
@@ -251,29 +271,25 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * this compiler has decided. Naming a reading here says that; it does not say that the reading
      * was left alone.
      */
-    private static final List<String> COMPARED_IN_PRODUCTION = List.of(
-            // The same partition of two answers, read one way by a choice and the other by a
-            // conjunction (#1492).
-            "souther/compiler/check/Confinement#eitherShown"
+    private static final List<Open> COMPARED_IN_PRODUCTION = List.of(
+            new Open("souther/compiler/check/Confinement#eitherShown"
                     + "(Lsouther/compiler/check/Confinement$Admission;"
                     + "Lsouther/compiler/check/Confinement$Admission;)"
-                    + "Lsouther/compiler/check/Confinement$Admission;",
-            // What a positive answer is worth beside a position nobody could build, and that a
-            // joined answer has reached the top of what a choice can be (#1493).
-            "souther/compiler/check/Confinement$Worked#admission"
+                    + "Lsouther/compiler/check/Confinement$Admission;", ONE_PARTITION_TWO_READINGS),
+            new Open("souther/compiler/check/Settlement$Sided#alsoSeen"
+                    + "(Lsouther/compiler/check/Settlement$Sided;)"
+                    + "Lsouther/compiler/check/Settlement$Sided;", ONE_PARTITION_TWO_READINGS),
+            new Open("souther/compiler/check/Confinement$Worked#admission"
                     + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
-                    + "Lsouther/compiler/check/Confinement$Admission;",
-            "souther/compiler/check/Settlement$Sided#alsoSeen"
-                    + "(Lsouther/compiler/check/Settlement$Sided;)"
-                    + "Lsouther/compiler/check/Settlement$Sided;",
-            "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
+                    + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH),
+            new Open("souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;"
                     + "Lsouther/compiler/values/AskedOfARelation;)"
-                    + "Lsouther/compiler/values/Emptiness;",
-            "souther/compiler/values/PlannedValues#anyAlternativeAdmits"
+                    + "Lsouther/compiler/values/Emptiness;", WHAT_AN_ANSWER_IS_WORTH),
+            new Open("souther/compiler/values/PlannedValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;)"
-                    + "Lsouther/compiler/values/Emptiness;");
+                    + "Lsouther/compiler/values/Emptiness;", WHAT_AN_ANSWER_IS_WORTH));
 
     /**
      * One saying of the word, and whose code holds it.
@@ -453,10 +469,11 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 "which the walk sees it naming, so its absence above is the detector telling a"
                         + " comparison from the making of an answer and not the walk missing it");
 
-        assertEquals(COMPARED_IN_PRODUCTION,
+        assertEquals(COMPARED_IN_PRODUCTION.stream().map(Open::place).sorted().toList(),
                 placesSaying(saidInProduction(), use -> use.said().equals(COMPARED)),
-                "a reading that compares is one no owned meaning answered, so what is written here"
-                        + " is the readings whose meaning nobody has decided yet");
+                () -> "a reading that compares is one no owned meaning answered, so what is written"
+                        + " here is the readings whose meaning nobody has decided yet, each with"
+                        + " where it is being decided:\n" + questionsBeingDecided());
     }
 
     /**
@@ -656,6 +673,17 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         Set<String> out = new TreeSet<>();
         said.stream().filter(which).forEach(use -> out.add(use.nest()));
         return new ArrayList<>(out);
+    }
+
+    /** Where each reading that compares is being decided, for whoever the rule above stopped: an
+     *  entry added to that list is a question somebody is deciding, and an entry that has gone is
+     *  one that was. */
+    private static String questionsBeingDecided() {
+        StringBuilder out = new StringBuilder();
+        COMPARED_IN_PRODUCTION.forEach(open ->
+                out.append("  ").append(open.place()).append("  ").append(open.question())
+                        .append('\n'));
+        return out.toString();
     }
 
     /** The one method each of the sayings {@code which} keeps is in, for a rule about readings. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -13,11 +13,9 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
-import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.lang.classfile.instruction.LineNumber;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.net.URISyntaxException;
@@ -58,8 +56,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p><b>What these rules do not say.</b> They fix who may name a settled answer, and not who may
  * act on one: a nest already on a list can grow a second reader of an answer it was already making,
- * and no owner set changes. Nor is {@code x != EMPTY} caught, which is a weaker reading than
- * {@code NONEMPTY} and says less. What is claimed is what a walk over the compiled classes holds.
+ * and no owner set changes. What is claimed is what a walk over the compiled classes holds.
+ *
+ * <p><b>And beside them, which reading of the word each place is.</b> A nest is who may hold a
+ * claim; a reading is one method, so those rules name the class, the method and what it takes and
+ * gives — a permission written as a name would widen to an overload added later, and what they are
+ * written down as is the questions this compiler has not decided. The word's own class is passed
+ * over by the rules about who says it, and by them only: the meanings are worked out there, so a
+ * reading there that no meaning answered is one nobody decided in the one place that decides them.
+ *
+ * <p>What those rules are about is a reference compared against one of the constants, which is what
+ * a repository whose enums are compared with {@code ==} writes. A comparison spelt some other way
+ * is not one of them, and what they hold is that spelling and not every way two of these could be
+ * told apart.
  *
  * <p>Read off those classes, because a call is what the compiler made of it: a lambda body, a
  * method reference and a switch are three spellings a scan of source text would have to know about
@@ -95,8 +104,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
     /** A comparison of one of these against one of its constants, which is a reading of the word
      *  that no owned operation answered and that an answer added to the three would fall through
-     *  without anybody deciding. Read as the pair javac writes for one: the constant is pushed, and
-     *  the instruction after it is what compares. */
+     *  without anybody deciding. Found by following what the constant becomes
+     *  ({@link WhatBecomesOfAValueOnTheStack}), because what compares a value is whatever takes it
+     *  off the stack and not whatever is written near it. */
     private static final String COMPARED = "compared";
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
@@ -174,7 +184,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * an answer added to the three.
      */
     private static final List<String> TAKES_THE_ANSWER_APART = List.of(
-            "souther/compiler/check/StatedByClauses#under");
+            "souther/compiler/check/StatedByClauses$Taken#under"
+                    + "(Lsouther/compiler/check/Settlement$Sided;)"
+                    + "Lsouther/compiler/check/StatedByClauses$Taken;");
 
     /**
      * And the readings that owe something of its own to each way two alternatives can fall.
@@ -185,18 +197,30 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * the other three ways.
      */
     private static final List<String> TAKES_IT_APART_BY_STANDING = List.of(
-            "souther/compiler/check/StatedByClauses#chosen",
-            "souther/compiler/check/StatedByClauses#decided");
+            "souther/compiler/check/StatedByClauses$Reading#chosen"
+                    + "(Lsouther/compiler/check/StatedByClauses$Either;Ljava/util/Map;)"
+                    + "Lsouther/compiler/check/StatedTogether;",
+            "souther/compiler/check/StatedByClauses$Reading#decided"
+                    + "(Lsouther/compiler/check/StatedTogether$Said;"
+                    + "Lsouther/compiler/check/Settlement$Sided;"
+                    + "Lsouther/compiler/check/StatedTogether$Said;"
+                    + "Lsouther/compiler/check/Settlement$Sided;)"
+                    + "Lsouther/compiler/check/StatedTogether$Said;");
 
     /** The bodies beside this test that compare, which is what holds the detector to finding one
      *  however it was written. */
     private static final List<String> COMPARED_IN_THE_FIXTURE = List.of(
-            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest#emptyIsIt",
-            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest"
-                    + "#emptyIsNotIt",
-            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest#itIsEmpty",
-            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest"
-                    + "#itIsNotEmpty");
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#emptyIsIt"
+                    + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#emptyIsNotIt"
+                    + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#emptyIsWhicheverOfThese"
+                    + "(Lsouther/compiler/values/Emptiness;"
+                    + "Lsouther/compiler/values/Emptiness;Z)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsEmpty"
+                    + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsNotEmpty"
+                    + "(Lsouther/compiler/values/Emptiness;)Z");
 
     /**
      * And the readings of this word whose meaning nobody has decided yet.
@@ -216,14 +240,45 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * was left alone.
      */
     private static final List<String> COMPARED_IN_PRODUCTION = List.of(
-            "souther/compiler/check/Confinement#admission",
-            "souther/compiler/check/Confinement#eitherShown",
-            "souther/compiler/check/Settlement#alsoSeen",
-            "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits",
-            "souther/compiler/values/PlannedValues#anyAlternativeAdmits");
+            "souther/compiler/check/Confinement#eitherShown"
+                    + "(Lsouther/compiler/check/Confinement$Admission;"
+                    + "Lsouther/compiler/check/Confinement$Admission;)"
+                    + "Lsouther/compiler/check/Confinement$Admission;",
+            "souther/compiler/check/Confinement$Worked#admission"
+                    + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
+                    + "Lsouther/compiler/values/StringMachineAnswers;)"
+                    + "Lsouther/compiler/check/Confinement$Admission;",
+            "souther/compiler/check/Settlement$Sided#alsoSeen"
+                    + "(Lsouther/compiler/check/Settlement$Sided;)"
+                    + "Lsouther/compiler/check/Settlement$Sided;",
+            "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
+                    + "(Lsouther/compiler/values/AskedOfEachBlock;"
+                    + "Lsouther/compiler/values/AskedOfARelation;)"
+                    + "Lsouther/compiler/values/Emptiness;",
+            "souther/compiler/values/PlannedValues#anyAlternativeAdmits"
+                    + "(Lsouther/compiler/values/AskedOfEachBlock;)"
+                    + "Lsouther/compiler/values/Emptiness;");
 
-    /** One saying of the word, and whose code holds it. */
-    private record Use(String nest, String method, String said) {}
+    /**
+     * One saying of the word, and whose code holds it.
+     *
+     * <p>Both the nest and the class, because the rules above and the rules below are about
+     * different things. Which nest may hold a claim is a claim about a nest: a helper written
+     * beside a reading is that reading's, and the class a lambda's body was put in is not a second
+     * owner of anything. Which reading of the word this is is a claim about one method, and the
+     * class it is declared in is part of naming it.
+     *
+     * @param spelt what the method takes and gives, so that a name is one method and not every
+     *              method wearing it — a permission written as a name would widen to an overload
+     *              added later, and this list is what says which questions are still open
+     */
+    private record Use(String nest, String owner, String method, String spelt, String said) {
+
+        /** The one method this is, said the way a permission is written. */
+        String place() {
+            return owner + "#" + method + spelt;
+        }
+    }
 
     @Test
     void everyNestThatSaysAPositionIsSettledIsWrittenDown() {
@@ -353,6 +408,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         assertFalse(Comparing.emptyIsIt(Emptiness.UNDECIDED));
         assertFalse(Comparing.itIsNotEmpty(Emptiness.EMPTY));
         assertFalse(Comparing.emptyIsNotIt(Emptiness.EMPTY));
+        assertTrue(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, true),
+                "and one compared against an answer the code works out first is a comparison too");
+        assertFalse(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, false));
 
         assertEquals(COMPARED_IN_THE_FIXTURE,
                 placesSaying(saidHere(), use -> use.said().equals(COMPARED)),
@@ -480,6 +538,18 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         static boolean emptyIsNotIt(Emptiness said) {
             return Emptiness.EMPTY != said;
         }
+
+        /**
+         * And one compared against something the code has to work out first.
+         *
+         * <p>The constant is pushed and the comparison that takes it is several jumps away, with
+         * the branches that choose the other side in between. Which is what a walk that reads the
+         * instructions standing near the constant cannot tell from a constant written where a
+         * value is wanted: both have something other than a comparison after them.
+         */
+        static boolean emptyIsWhicheverOfThese(Emptiness one, Emptiness other, boolean take) {
+            return Emptiness.EMPTY == (take ? one : other);
+        }
     }
 
     /**
@@ -503,10 +573,10 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return new ArrayList<>(out);
     }
 
-    /** The same, said of the method as well as the nest, for a rule about readings and not nests. */
+    /** The one method each of the sayings {@code which} keeps is in, for a rule about readings. */
     private static List<String> placesSaying(List<Use> said, Predicate<Use> which) {
         Set<String> out = new TreeSet<>();
-        said.stream().filter(which).forEach(use -> out.add(use.nest() + "#" + use.method()));
+        said.stream().filter(which).forEach(use -> out.add(use.place()));
         return new ArrayList<>(out);
     }
 
@@ -571,24 +641,30 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 ClassModel model = ClassFile.of().parse(bytes);
                 String holds = model.thisClass().asInternalName();
                 String nest = nestOf(holds);
-                if (nest.equals(EMPTINESS)) {
-                    continue;
-                }
+                // The word's own class is passed over by the rules about who says it, and by them
+                // only: what an enum's constants do among themselves is how one is written, and
+                // read as sayings they would put the word on every list as a namer of itself. How
+                // one of the answers is read is another question and is asked of the word too — the
+                // meanings are worked out there, so a comparison there is a meaning nobody decided
+                // in the one place that decides them.
+                boolean isTheWord = nest.equals(EMPTINESS);
                 for (MethodModel method : model.methods()) {
                     CodeModel code = method.code().orElse(null);
                     if (code == null) {
                         continue;
                     }
                     String where = method.methodName().stringValue();
+                    String spelt = method.methodType().stringValue();
                     List<CodeElement> elements = new ArrayList<>();
                     code.forEach(elements::add);
-                    int[] lines = linesOf(elements);
                     for (int at = 0; at < elements.size(); at++) {
-                        for (String what : saidBy(elements.get(at), holds)) {
-                            found.add(new Use(nest, where, what));
+                        if (!isTheWord) {
+                            for (String what : saidBy(elements.get(at), holds)) {
+                                found.add(new Use(nest, holds, where, spelt, what));
+                            }
                         }
-                        if (comparesAConstant(elements, lines, at)) {
-                            found.add(new Use(nest, where, COMPARED));
+                        if (comparesAConstant(elements, at)) {
+                            found.add(new Use(nest, holds, where, spelt, COMPARED));
                         }
                     }
                 }
@@ -648,35 +724,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * comparison the constant was written on does not matter: the other operand is worked out
      * between them either way, and what is looked for is the comparison this constant reaches.
      */
-    private static boolean comparesAConstant(List<CodeElement> elements, int[] lines, int at) {
+    private static boolean comparesAConstant(List<CodeElement> elements, int at) {
         if (!(elements.get(at) instanceof FieldInstruction field)
                 || field.opcode() != Opcode.GETSTATIC
                 || !field.owner().asInternalName().equals(EMPTINESS)) {
             return false;
         }
-        for (int next = at + 1; next < elements.size(); next++) {
-            if (elements.get(next) instanceof BranchInstruction branch) {
-                return (branch.opcode() == Opcode.IF_ACMPEQ
-                        || branch.opcode() == Opcode.IF_ACMPNE)
-                        && lines[next] == lines[at];
-            }
-        }
-        return false;
-    }
-
-    /** Which line of the source each element came from, so that a constant written as a value can
-     *  be told from one pushed to compare: the comparison a constant reaches is written where the
-     *  constant is, and the next comparison in a method that made an answer out of one is not. */
-    private static int[] linesOf(List<CodeElement> elements) {
-        int[] lines = new int[elements.size()];
-        int now = -1;
-        for (int at = 0; at < elements.size(); at++) {
-            if (elements.get(at) instanceof LineNumber said) {
-                now = said.line();
-            }
-            lines[at] = now;
-        }
-        return lines;
+        return WhatBecomesOfAValueOnTheStack.isTakenByAReferenceComparison(elements, at);
     }
 
     /** What a descriptor names, as a class is named in a class file. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -80,9 +80,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * stopped reading drops out of the list, and the list is then what the walk can still see rather
  * than what the repository holds. So each of them is shown finding something written here —
  * {@link Taking} and {@link TakingByStanding} switch, {@link Referring} asks through a reference,
- * {@link Comparing} compares every way one can be written — and, where something near it would look
- * the same to a walk that read less, shown not finding that: {@link Constructing} writes a constant
- * where a value is wanted, and calls one before comparing what the call gave.
+ * {@link Comparing} compares every way one can be written, a name away and a conditional away
+ * included — and, where something near it would look the same to a walk that read less, shown not
+ * finding that: {@link Constructing} writes a constant where a value is wanted, and calls one
+ * before comparing what the call gave.
  */
 class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
@@ -229,6 +230,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsEmpty"
                     + "(Lsouther/compiler/values/Emptiness;)Z",
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsNotEmpty"
+                    + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAway"
                     + "(Lsouther/compiler/values/Emptiness;)Z");
 
     /**
@@ -429,6 +432,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         assertFalse(Comparing.emptyIsIt(Emptiness.UNDECIDED));
         assertFalse(Comparing.itIsNotEmpty(Emptiness.EMPTY));
         assertFalse(Comparing.emptyIsNotIt(Emptiness.EMPTY));
+        assertTrue(Comparing.itIsWhatWasPutAway(Emptiness.EMPTY),
+                "and one written into a name and compared out of it is a comparison");
+        assertFalse(Comparing.itIsWhatWasPutAway(Emptiness.NONEMPTY));
         assertTrue(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, true),
                 "and one compared against an answer the code works out first is a comparison too");
         assertFalse(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, false));
@@ -593,6 +599,17 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
         static boolean emptyIsNotIt(Emptiness said) {
             return Emptiness.EMPTY != said;
+        }
+
+        /**
+         * And one written into a name and compared out of it.
+         *
+         * <p>A constant a clause gave a name to is the same constant, and a rule that read only
+         * what is compared where it was written is one anybody gets round by writing the name.
+         */
+        static boolean itIsWhatWasPutAway(Emptiness said) {
+            Emptiness nothingAtAll = Emptiness.EMPTY;
+            return said == nothingAtAll;
         }
 
         /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -233,9 +233,14 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     + "(Lsouther/compiler/values/Emptiness;)Z",
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAway"
                     + "(Lsouther/compiler/values/Emptiness;)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAwayGoingRound"
+                    + "(Lsouther/compiler/values/Emptiness;"
+                    + "Lsouther/compiler/values/Emptiness;I)Z",
             "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAwayUnlessSomethingElseWas"
                     + "(Lsouther/compiler/values/Emptiness;"
-                    + "Lsouther/compiler/values/Emptiness;Z)Z");
+                    + "Lsouther/compiler/values/Emptiness;Z)Z",
+            "souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest$Comparing#itIsWhatWasPutAwayWhereSomethingWasCaught"
+                    + "(Lsouther/compiler/values/Emptiness;Ljava/lang/RuntimeException;)Z");
 
     /**
      * One reading whose meaning nobody has decided yet, and which question it is.
@@ -461,6 +466,12 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                         + " a comparison for this constant or for none");
         assertTrue(Comparing.itIsWhatWasPutAwayUnlessSomethingElseWas(
                 Emptiness.NONEMPTY, Emptiness.NONEMPTY, true));
+        assertTrue(Comparing.itIsWhatWasPutAwayGoingRound(Emptiness.EMPTY, Emptiness.NONEMPTY, 1),
+                "and one written into a name going round a loop is compared after it");
+        assertFalse(Comparing.itIsWhatWasPutAwayGoingRound(Emptiness.EMPTY, Emptiness.NONEMPTY, 0));
+        assertTrue(Comparing.itIsWhatWasPutAwayWhereSomethingWasCaught(
+                        Emptiness.EMPTY, new IllegalStateException("thrown")),
+                "and one compared where what was thrown is caught is compared there");
         assertTrue(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, true),
                 "and one compared against an answer the code works out first is a comparison too");
         assertFalse(Comparing.emptyIsWhicheverOfThese(Emptiness.EMPTY, Emptiness.NONEMPTY, false));
@@ -654,6 +665,38 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 nothingAtAll = other;
             }
             return said == nothingAtAll;
+        }
+
+        /**
+         * And one written into a name inside a loop and compared after it.
+         *
+         * <p>The way from the writing to the comparison goes backwards first, round the loop and
+         * out of it. Followed only forwards from the writing, that way is not there at all, and the
+         * comparison after the loop is one nothing reads.
+         */
+        static boolean itIsWhatWasPutAwayGoingRound(Emptiness said, Emptiness other, int times) {
+            Emptiness nothingAtAll = other;
+            for (int each = 0; each < times; each++) {
+                nothingAtAll = Emptiness.EMPTY;
+            }
+            return said == nothingAtAll;
+        }
+
+        /**
+         * And one compared where what was thrown is caught.
+         *
+         * <p>A name holds what it held when the throwing began, so the way to the handler is a way
+         * the value travels. Followed only along what carries on, the throw ends the way and the
+         * comparison written in the handler is one nothing reads.
+         */
+        static boolean itIsWhatWasPutAwayWhereSomethingWasCaught(Emptiness said,
+                                                                RuntimeException thrown) {
+            Emptiness nothingAtAll = Emptiness.EMPTY;
+            try {
+                throw thrown;
+            } catch (RuntimeException caught) {
+                return said == nothingAtAll;
+            }
         }
 
         /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -144,6 +144,18 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/check/Confinement",
             "souther/compiler/check/StatedByClauses");
 
+    /**
+     * And the readings that owe each of the three answers something of its own.
+     *
+     * <p>What becomes of a branch of a choice whose fate came back is three things and not two: a
+     * branch nobody can be in leaves an account and not an alternative, a branch nobody settled is
+     * kept saying so, and a branch somebody can be in is itself. Nothing composed out of the two
+     * settled answers says the middle one, so this reading is written as a switch and is told about
+     * an answer added to the three.
+     */
+    private static final List<String> TAKES_THE_ANSWER_APART = List.of(
+            "souther/compiler/check/StatedByClauses#under");
+
     /** One saying of the word, and whose code holds it. */
     private record Use(String nest, String method, String said) {}
 
@@ -195,28 +207,35 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     /**
-     * And nothing takes the answer apart by which of the three it is.
+     * And these take the answer apart by which of the three it is.
      *
-     * <p>A switch over this word says something the three rules above do not watch for: it reads
-     * the answer as a choice between arms rather than asking whether it settles anything. It is
-     * also the one shape whose constants are named in a synthetic class rather than in the code
-     * that switched, so what is asserted is that there is none.
+     * <p>A switch over this word reads the answer as a choice between arms rather than asking
+     * whether it settles anything, and a reading owed a different thing for each of the three has
+     * to. What it buys is the one shape an answer added to the three stops: read by comparisons
+     * against constants, a fourth answer falls into whichever arm the last comparison left it, and
+     * nobody has decided that. So these are written down one method at a time, and what the list is
+     * for is that each entry is a reading somebody chose to owe every answer.
      *
-     * <p>Shown with the same detector run over a body that does switch ({@link Taking}), because an
-     * expectation of none passes just as well when the detector has stopped working — which is what
+     * <p>The nest and the method, since a nest holds readings that are not this one — a name would
+     * be enough to tell two of them apart the day one nest switches in two places, and a descriptor
+     * would be carried the day two methods of one nest share a name.
+     *
+     * <p>Shown with the same detector run over a body that does switch ({@link Taking}), because a
+     * short expectation passes just as well when the detector has stopped working — which is what
      * the day javac writes a switch some other way would look like.
      */
     @Test
-    void andNothingTakesTheAnswerApartByWhichOfTheThreeItIs() {
+    void andTheseTakeTheAnswerApartByWhichOfTheThreeItIs() {
         assertEquals(1, Taking.by(Emptiness.NONEMPTY), "the fixture answers by switching");
         assertTrue(saidHere().stream().anyMatch(use -> use.said().equals(TAKEN_APART)),
                 "the fixture beside this test switches over the word, so a detector that cannot"
                         + " find it there is one that would report none anywhere");
 
-        assertEquals(List.of(),
-                nestsSaying(saidInProduction(), use -> use.said().equals(TAKEN_APART)),
-                "this takes the answer apart by which of the three it is, which the rules above do"
-                        + " not watch: what they read is who names one");
+        assertEquals(TAKES_THE_ANSWER_APART,
+                placesSaying(saidInProduction(), use -> use.said().equals(TAKEN_APART)),
+                "a reading that owes each of the three answers something different says so by"
+                        + " switching, and one that arrived some other way is a reading a fourth"
+                        + " answer would be given a meaning by without anybody deciding it");
     }
 
     /**
@@ -309,6 +328,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return new ArrayList<>(out);
     }
 
+    /** The same, said of the method as well as the nest, for a rule about readings and not nests. */
+    private static List<String> placesSaying(List<Use> said, Predicate<Use> which) {
+        Set<String> out = new TreeSet<>();
+        said.stream().filter(which).forEach(use -> out.add(use.nest() + "#" + use.method()));
+        return new ArrayList<>(out);
+    }
+
     private static Path classesOf(Path module) {
         return module.resolve("target").resolve("classes");
     }
@@ -356,7 +382,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     continue;
                 }
                 ClassModel model = ClassFile.of().parse(bytes);
-                String nest = nestOf(model.thisClass().asInternalName());
+                String holds = model.thisClass().asInternalName();
+                String nest = nestOf(holds);
                 if (nest.equals(EMPTINESS)) {
                     continue;
                 }
@@ -367,7 +394,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     }
                     String where = method.methodName().stringValue();
                     for (CodeElement element : code) {
-                        for (String what : saidBy(element)) {
+                        for (String what : saidBy(element, holds)) {
                             found.add(new Use(nest, where, what));
                         }
                     }
@@ -383,12 +410,18 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * <p>A reference is the call it stands for. {@code Emptiness::isEmpty} puts no call to the word
      * in the code that wrote it — what it names is a handle among a bootstrap's arguments — so a
      * walk over calls alone reads a nest that observes a settled answer as one that says nothing.
+     *
+     * <p>And a switch's table is a saying where it is read and not where it is filled. The
+     * synthetic class javac writes to hold one fills it in its own initializer, which is how a
+     * table is made rather than a reading of the word — counted, every switch would be answered for
+     * twice, once by whoever switched and once by nobody.
      */
-    private static List<String> saidBy(CodeElement element) {
+    private static List<String> saidBy(CodeElement element, String holds) {
         if (element instanceof FieldInstruction field) {
             String named = field.name().stringValue();
             if (named.equals(TAKEN_APART)) {
-                return List.of(TAKEN_APART);
+                return field.owner().asInternalName().equals(holds)
+                        ? List.of() : List.of(TAKEN_APART);
             }
             return field.owner().asInternalName().equals(EMPTINESS)
                     ? List.of(named) : List.of();

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -344,6 +344,16 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     @Test
     void andNothingElseComparesTheWordAgainstOneOfItsConstants() {
+        assertTrue(Comparing.itIsEmpty(Emptiness.EMPTY), "each of the four answers what it says");
+        assertTrue(Comparing.emptyIsIt(Emptiness.EMPTY));
+        assertTrue(Comparing.itIsNotEmpty(Emptiness.NONEMPTY));
+        assertTrue(Comparing.emptyIsNotIt(Emptiness.NONEMPTY));
+        assertFalse(Comparing.itIsEmpty(Emptiness.UNDECIDED), "and each of them is a comparison,"
+                + " so a body that only looked like one would hold the detector to nothing");
+        assertFalse(Comparing.emptyIsIt(Emptiness.UNDECIDED));
+        assertFalse(Comparing.itIsNotEmpty(Emptiness.EMPTY));
+        assertFalse(Comparing.emptyIsNotIt(Emptiness.EMPTY));
+
         assertEquals(COMPARED_IN_THE_FIXTURE,
                 placesSaying(saidHere(), use -> use.said().equals(COMPARED)),
                 "the bodies beside this test compare it every way it can be written, so a detector"

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -96,7 +96,7 @@ sealed interface Confinement<A> {
 
     /** Whether it is settled that nothing does. */
     default boolean holdsNothing() {
-        return admits() == souther.compiler.values.Emptiness.EMPTY;
+        return admits().isEmpty();
     }
 
     /**
@@ -149,7 +149,7 @@ sealed interface Confinement<A> {
          * of it.
          */
         static <A> Admission<A> left(souther.compiler.values.Emptiness emptiness) {
-            if (emptiness == souther.compiler.values.Emptiness.EMPTY) {
+            if (emptiness.isEmpty()) {
                 throw new IllegalArgumentException(
                         "a pair nothing emptied is not a pair shown to admit nothing");
             }
@@ -159,7 +159,7 @@ sealed interface Confinement<A> {
 
         /** Whether it is settled that nothing satisfies what was asked. */
         boolean holdsNothing() {
-            return emptiness == souther.compiler.values.Emptiness.EMPTY;
+            return emptiness.isEmpty();
         }
 
         /** Whether these two readings are the whole of what showed it. */
@@ -302,7 +302,7 @@ sealed interface Confinement<A> {
         // leaves once everything that places its positions has been met with it, and a walk per
         // asking would be an alternative visited twice by two questions that have to agree.
         souther.compiler.values.Emptiness said = admitting.of(placed, relating);
-        if (said != souther.compiler.values.Emptiness.EMPTY) {
+        if (!said.isEmpty()) {
             // And a position with nowhere to be once everything placing it is met, which is a lack
             // the alternatives never hear about: a position no alternative names is not one they
             // are asked about, so where what is required of it does not reach where its own ends
@@ -328,7 +328,7 @@ sealed interface Confinement<A> {
         // pair whose own set and range share no value would be reported against bounds derived
         // somewhere else, which is true and is not what they wrote.
         Shown how = outside.saysNothing()
-                || admitting.of(byTheReadings, byTheReadingsRelating) == souther.compiler.values.Emptiness.EMPTY
+                || admitting.of(byTheReadings, byTheReadingsRelating).isEmpty()
                 ? Shown.BY_THE_READINGS : Shown.ONCE_THE_POSITIONS_ARE_PLACED;
         // The values holding no alternative at all is the values' own answer, and asking anything
         // of the ranges would not have changed it. Told apart here rather than by a second reader
@@ -356,7 +356,7 @@ sealed interface Confinement<A> {
         // reassembling the same three facts — and said to be the readings' whichever asking reached
         // it, since a proof that consults no range is one no placing of a position took part in.
         if (admitting.of((_, _) -> souther.compiler.values.Emptiness.NONEMPTY,
-                relating(carriers, _ -> OrderedInterval.OPEN)) == souther.compiler.values.Emptiness.EMPTY) {
+                relating(carriers, _ -> OrderedInterval.OPEN)).isEmpty()) {
             // With where the reading was refused, where that is nearer than the general answer.
             // Each of those places holds something on its own, so "the values admit nothing" is
             // true of the declaration and says less than what was shown — and which of the two
@@ -591,7 +591,7 @@ sealed interface Confinement<A> {
          */
         souther.compiler.values.Emptiness alreadyEstablished(Allowance<A> by) {
             souther.compiler.values.Emptiness said = admits();
-            if (said != souther.compiler.values.Emptiness.UNDECIDED) {
+            if (said.isDecided()) {
                 return said;
             }
             return values.holdsNothingAsBuilt(by) ? souther.compiler.values.Emptiness.EMPTY : souther.compiler.values.Emptiness.UNDECIDED;

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -114,8 +114,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
                                   Confinement.Planned<FactSubject> one,
                                   souther.compiler.values.Emptiness there,
                                   Confinement.Planned<FactSubject> other) {
-            if (here == souther.compiler.values.Emptiness.EMPTY
-                    || there == souther.compiler.values.Emptiness.EMPTY) {
+            if (!souther.compiler.values.Emptiness.Alternatives.of(here, there).bothStand()) {
                 return none();
             }
             return new WidthDependency(Width.ofValues(one.values(), other.values()),

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -1115,18 +1115,22 @@ sealed interface StatedByClauses {
          * a choice neither branch of which anybody can take from being a case at all. It is this
          * twice and a composition, and the answer cannot turn on the order the alternatives were
          * written in because the composition a dead branch picks treats its two sides alike.
+         *
+         * <p>Each of the three answers is answered for here, which is what an account of a branch
+         * owes: what to do with a branch nobody settled is not what to do with one somebody can be
+         * in, and neither is a reading of the other. So this is where an answer added to the three
+         * is told what becomes of a branch that has it, and no reading below is.
          */
         Taken under(Settlement.Sided fate) {
-            // Asked of what the fate settles and not taken apart by which of the three answers it
-            // is. A branch is one nobody can be in, or one nobody settled, or neither — and the two
-            // questions are asked in that order because the second is about a branch still standing.
-            if (fate.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
-                return inADeadBranch();
-            }
-            if (fate.emptiness() == souther.compiler.values.Emptiness.UNDECIDED) {
-                return holding(fate);
-            }
-            return this;
+            return switch (fate.emptiness()) {
+                // Nobody can be in it, so what is left of it is an account and not an alternative.
+                case EMPTY -> inADeadBranch();
+                // Nobody settled it, and it is kept saying so: kept without, the account would call
+                // a position open where the truth is that nothing looked.
+                case UNDECIDED -> holding(fate);
+                // Somebody can be in it, and there is nothing to say about it that it does not say.
+                case NONEMPTY -> this;
+            };
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -835,7 +835,7 @@ sealed interface StatedByClauses {
          */
         private StatedTogether.Said keptTogether(StatedTogether.Said read,
                                                  Settlement.Sided known) {
-            if (known.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
+            if (known.emptiness().isDecided()) {
                 return read;
             }
             return new StatedTogether.Said(
@@ -858,7 +858,7 @@ sealed interface StatedByClauses {
         private Settlement.Sided probed(StatedTogether.Said read,
                                         Allowance<FactSubject> by) {
             Confinement.Admission<FactSubject> said = read.confinement().admission(machines);
-            if (said.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
+            if (said.emptiness().isDecided()) {
                 return Settlement.Sided.settledAs(said);
             }
             // Worked out, the descriptions become sets and every alternative can be asked where its
@@ -866,7 +866,7 @@ sealed interface StatedByClauses {
             // what a pattern comes to.
             Confinement.Worked<FactSubject> worked = read.confinement().resolve(by);
             Confinement.Admission<FactSubject> admitted = worked.admission(machines);
-            if (admitted.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
+            if (admitted.emptiness().isDecided()) {
                 return Settlement.Sided.settledAs(admitted);
             }
             Realized<FactSubject> made = worked.made();
@@ -949,7 +949,7 @@ sealed interface StatedByClauses {
          */
         private static boolean nobodyIsIn(StatedTogether.Said branch,
                                           Allowance<FactSubject> by) {
-            return branch.confinement().alreadyEstablished(by) == souther.compiler.values.Emptiness.EMPTY;
+            return branch.confinement().alreadyEstablished(by).isEmpty();
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -652,6 +652,12 @@ sealed interface StatedByClauses {
          * refused, so a language asked to decide would answer about a branch and not about the
          * choice.
          *
+         * <p>Which of the alternatives are still standing is read off the two answers
+         * ({@link souther.compiler.values.Emptiness.Alternatives}), and whether the answers about
+         * them are final is asked here beside it ({@link #settledHere}). Two questions and not one
+         * word: a branch nobody has worked out stands, and a choice of two that stand is one this
+         * may still have to keep.
+         *
          * <p>What every alternative leaves empty is what the dead choice leaves empty, and where
          * that is no position, the choice admits nothing with none of them at fault. That is the
          * rule {@link Emptiness.AcrossEveryCase} states for a sum — what proves it has none is the
@@ -686,44 +692,57 @@ sealed interface StatedByClauses {
                 Confinement.Admission<FactSubject> mine = here.confinement().admission(machines);
                 Confinement.Admission<FactSubject> theirs =
                         there.confinement().admission(machines);
-                souther.compiler.values.Emptiness a = mine.emptiness();
-                souther.compiler.values.Emptiness b = theirs.emptiness();
-                // A branch the descriptions already show empty is decided here whichever way the
-                // declaration holds its choices. The answer is definitive — a description empty
-                // before anything is built admits nothing however the other clauses refine it —
-                // and a clause written later can only show more branches impossible, never fewer,
-                // so nothing a deferral waits for can reach a different decision. Deferred anyway,
-                // the dead branch would widen the met-together tree for nothing.
-                //
-                if (a == souther.compiler.values.Emptiness.EMPTY && b == souther.compiler.values.Emptiness.EMPTY) {
+                souther.compiler.values.Emptiness.Alternatives standing =
+                        souther.compiler.values.Emptiness.Alternatives.of(
+                                mine.emptiness(), theirs.emptiness());
+                if (settledHere(standing, mine, theirs)) {
                     decided.put(choice.id(), settled(here, mine, there, theirs));
-                    return new StatedTogether.Said(here.confinement().bothDead(there.confinement(),
-                            Confinement.Admission.bothShown(mine, theirs)));
-                }
-                if (a == souther.compiler.values.Emptiness.EMPTY) {
-                    decided.put(choice.id(), settled(here, mine, there, theirs));
-                    return other;
-                }
-                if (b == souther.compiler.values.Emptiness.EMPTY) {
-                    decided.put(choice.id(), settled(here, mine, there, theirs));
-                    return one;
-                }
-                // Two live branches are another matter: merging them is the one decision a clause
-                // written later can be too late for, since it is the branch structure the later
-                // clause's conjunction would have refined. Held apart, the choice is held open past
-                // the clause and settled by the rules of every clause together; the expansion the
-                // deferral costs was counted over the whole declaration before any clause was
-                // read, which is what admitted the declaration as APART at all.
-                if (alternatives == Alternatives.MERGED
-                        && a == souther.compiler.values.Emptiness.NONEMPTY && b == souther.compiler.values.Emptiness.NONEMPTY) {
-                    decided.put(choice.id(), settled(here, mine, there, theirs));
-                    return new StatedTogether.Said(
-                            either(here.confinement(), there.confinement()));
+                    return switch (standing) {
+                        case NEITHER_STANDS -> new StatedTogether.Said(
+                                here.confinement().bothDead(there.confinement(),
+                                        Confinement.Admission.bothShown(mine, theirs)));
+                        case ONLY_THE_RIGHT -> other;
+                        case ONLY_THE_LEFT -> one;
+                        case BOTH_STAND -> new StatedTogether.Said(
+                                either(here.confinement(), there.confinement()));
+                    };
                 }
             }
             // And where whether a branch can be taken is not settled, the question waits, and the
             // fate comes back from where the machines are made.
             return new StatedTogether.Choice(choice.id(), one, other);
+        }
+
+        /**
+         * Whether the descriptions alone decide this occurrence of a choice.
+         *
+         * <p>Which alternatives stand is one question and whether the answers about them are final
+         * is another, and this is the second — asked of the branches, and of what the whole
+         * declaration was admitted as.
+         *
+         * <p>A branch the descriptions already show empty is decided here whichever way the
+         * declaration holds its choices. The answer is definitive — a description empty before
+         * anything is built admits nothing however the other clauses refine it — and a clause
+         * written later can only show more branches impossible, never fewer, so nothing a deferral
+         * waits for can reach a different decision. Deferred anyway, the dead branch would widen the
+         * met-together tree for nothing.
+         *
+         * <p>Two live branches are another matter: merging them is the one decision a clause written
+         * later can be too late for, since it is the branch structure the later clause's conjunction
+         * would have refined. Held apart, the choice is held open past the clause and settled by the
+         * rules of every clause together; the expansion the deferral costs was counted over the
+         * whole declaration before any clause was read, which is what admitted the declaration as
+         * APART at all. And a branch nobody has worked out stands without being final, so a choice
+         * of two that stand is merged only where both answers came back settled.
+         */
+        private boolean settledHere(souther.compiler.values.Emptiness.Alternatives standing,
+                                    Confinement.Admission<FactSubject> mine,
+                                    Confinement.Admission<FactSubject> theirs) {
+            if (standing.bothStand()) {
+                return alternatives == Alternatives.MERGED
+                        && mine.emptiness().isDecided() && theirs.emptiness().isDecided();
+            }
+            return true;
         }
 
         /** The fate of a choice the descriptions alone decided, for the account to read. */
@@ -808,21 +827,19 @@ sealed interface StatedByClauses {
          */
         private StatedTogether.Said decided(StatedTogether.Said one, Settlement.Sided here,
                                             StatedTogether.Said other, Settlement.Sided there) {
-            if (here.emptiness() == souther.compiler.values.Emptiness.EMPTY && there.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
+            return switch (souther.compiler.values.Emptiness.Alternatives.of(
+                    here.emptiness(), there.emptiness())) {
                 // The rule for a choice nobody can take, named rather than arrived at: a join is
                 // what two branches somebody can take come to, and neither of these is one.
-                return new StatedTogether.Said(one.confinement().bothDead(other.confinement(),
-                        Confinement.Admission.bothShown(here.shown(), there.shown())));
-            }
-            if (here.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
-                return keptTogether(other, there);
-            }
-            if (there.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
-                return keptTogether(one, here);
-            }
-            StatedTogether.Said left = keptTogether(one, here);
-            StatedTogether.Said right = keptTogether(other, there);
-            return new StatedTogether.Said(either(left.confinement(), right.confinement()));
+                case NEITHER_STANDS -> new StatedTogether.Said(
+                        one.confinement().bothDead(other.confinement(),
+                                Confinement.Admission.bothShown(here.shown(), there.shown())));
+                case ONLY_THE_RIGHT -> keptTogether(other, there);
+                case ONLY_THE_LEFT -> keptTogether(one, here);
+                case BOTH_STAND -> new StatedTogether.Said(
+                        either(keptTogether(one, here).confinement(),
+                                keptTogether(other, there).confinement()));
+            };
         }
 
         /**
@@ -1046,8 +1063,8 @@ sealed interface StatedByClauses {
                     // is answerable for what a branch of a branch it has already lost ever reached.
                     Taken left = one.under(fate.left());
                     Taken right = other.under(fate.right());
-                    if (fate.left().emptiness() == souther.compiler.values.Emptiness.EMPTY
-                            || fate.right().emptiness() == souther.compiler.values.Emptiness.EMPTY) {
+                    if (!souther.compiler.values.Emptiness.Alternatives.of(
+                            fate.left().emptiness(), fate.right().emptiness()).bothStand()) {
                         // What is left of a dead alternative is an account and not an alternative,
                         // so the two are accumulated and not composed as a choice. Which of them
                         // was the dead one is asked here and nowhere below: both sides arrive with

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1312,14 +1312,14 @@ public final class AdmissibleValues<A> {
                 Emptiness stands = Emptiness.NONEMPTY;
                 for (Map.Entry<Sameness.Block<A>, ValueSet> each : box.at().entrySet()) {
                     stands = stands.met(asked.of(each.getKey(), each.getValue()));
-                    if (stands == Emptiness.EMPTY) {
+                    if (stands.isEmpty()) {
                         break;
                     }
                 }
                 // And what its denials come to, asked after the blocks and not before. An
                 // alternative already refused at a block is one no relation has to be read for,
                 // and reading it first would spend on every alternative what one question settled.
-                if (stands != Emptiness.EMPTY) {
+                if (!stands.isEmpty()) {
                     stands = stands.met(relating.of(box.apart(), box.product()).emptiness());
                 }
                 any = any.joined(stands);
@@ -1383,7 +1383,7 @@ public final class AdmissibleValues<A> {
         // share, and each of them may be left something on its own — taken apart here, the
         // proof would say a lack is at a place whose own rules are fine with it.
         box.at().forEach((block, set) -> {
-            if (asked.of(block, set) == Emptiness.EMPTY) {
+            if (asked.of(block, set).isEmpty()) {
                 here.add(block);
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -156,7 +156,7 @@ public final class ConjoinedAdmissibleValues<A> {
         Emptiness stands = Emptiness.NONEMPTY;
         for (AdmissibleValues<A> each : factors) {
             stands = stands.met(each.anyAlternativeAdmits(asked, relating));
-            if (stands == Emptiness.EMPTY) {
+            if (stands.isEmpty()) {
                 return stands;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
@@ -17,6 +17,13 @@ package souther.compiler.values;
  * build the machine there and then — and what a branch costs to decide would depend on where the
  * author put the brackets, since what is in hand at that moment is what the walk happened to have
  * reached.
+ *
+ * <p><b>What one of these means is worked out here and asked of here.</b> Every reading of one is
+ * written as a switch over all of them, so an answer added to the three has to be told what it
+ * means to each of these before anything compiles. Written as a comparison against a constant, each
+ * of them would hand a fourth answer whichever meaning the comparison happened to leave it, and
+ * nobody would have decided that. A reader outside asks one of these operations, and
+ * {@link Alternatives} for the one reading that is about two of them at once.
  */
 public enum Emptiness {
 
@@ -31,7 +38,25 @@ public enum Emptiness {
 
     /** Whether this is the settled answer that nothing is admitted. */
     public boolean isEmpty() {
-        return this == EMPTY;
+        return switch (this) {
+            case EMPTY -> true;
+            case NONEMPTY, UNDECIDED -> false;
+        };
+    }
+
+    /**
+     * Whether the question was answered at all, either way.
+     *
+     * <p>The word this enum already has for the third answer, said of the other two. A reader
+     * waiting on a decision is asking this and not which of the settled answers it is: what it does
+     * next turns on whether anybody has looked, and both of the settled answers are somebody having
+     * looked.
+     */
+    public boolean isDecided() {
+        return switch (this) {
+            case EMPTY, NONEMPTY -> true;
+            case UNDECIDED -> false;
+        };
     }
 
     /**
@@ -43,10 +68,18 @@ public enum Emptiness {
      * a different part of the same value.
      */
     public Emptiness met(Emptiness other) {
-        if (this == EMPTY || other == EMPTY) {
-            return EMPTY;
-        }
-        return this == NONEMPTY && other == NONEMPTY ? NONEMPTY : UNDECIDED;
+        return switch (this) {
+            case EMPTY -> EMPTY;
+            case NONEMPTY -> switch (other) {
+                case EMPTY -> EMPTY;
+                case NONEMPTY -> NONEMPTY;
+                case UNDECIDED -> UNDECIDED;
+            };
+            case UNDECIDED -> switch (other) {
+                case EMPTY -> EMPTY;
+                case NONEMPTY, UNDECIDED -> UNDECIDED;
+            };
+        };
     }
 
     /**
@@ -57,9 +90,94 @@ public enum Emptiness {
      * one is — which is not known either.
      */
     public Emptiness joined(Emptiness other) {
-        if (this == NONEMPTY || other == NONEMPTY) {
-            return NONEMPTY;
+        return switch (this) {
+            case NONEMPTY -> NONEMPTY;
+            case EMPTY -> switch (other) {
+                case EMPTY -> EMPTY;
+                case NONEMPTY -> NONEMPTY;
+                case UNDECIDED -> UNDECIDED;
+            };
+            case UNDECIDED -> switch (other) {
+                case NONEMPTY -> NONEMPTY;
+                case EMPTY, UNDECIDED -> UNDECIDED;
+            };
+        };
+    }
+
+    /**
+     * Which alternatives of a choice anybody can still be in.
+     *
+     * <p>A branch stands unless something showed it empty, so {@link #UNDECIDED} stands: nobody
+     * has shown that nothing satisfies it, and a walk that dropped it would be dropping a branch on
+     * the strength of not having looked. That rule is written here and nowhere else — it is the one
+     * thing every reader of a choice needs before it can do anything, and read off the constants at
+     * each of them it would be as many rules as there are readers.
+     *
+     * <p><b>A reading of two answers, and not a settlement of a choice.</b> What this says is which
+     * of the alternatives are still candidates. What a choice then leaves, which branch the caller
+     * takes, whether the values are merged or held apart, whether the question waits — each of
+     * those is the caller's, and each of them differs by what the caller is composing. So there is
+     * no branch here to be handed one, nothing generic to fold with, and no way to ask this which
+     * alternative to take: a choice one alternative of which stands leaves that alternative, which
+     * the caller has in hand, and an operation for saying so would be a second place composing it.
+     *
+     * <p><b>Which alternatives stand and whether the answers are final are two questions.</b> A
+     * branch nobody has worked out stands, so a choice both of whose branches stand may still be
+     * one the answers have not settled — {@link #isDecided()} says that, of one answer at a time.
+     * Held as one word, the two would be a product, and a third question about a choice would
+     * multiply it again.
+     */
+    public enum Alternatives {
+
+        /** Nobody can be in either of them. */
+        NEITHER_STANDS,
+
+        /** The left alternative, and nobody can be in the right. */
+        ONLY_THE_LEFT,
+
+        /** The right alternative, and nobody can be in the left. */
+        ONLY_THE_RIGHT,
+
+        /** Both are alternatives somebody may still be in. */
+        BOTH_STAND;
+
+        /** Which of two alternatives, read in the order they were written, still stand. */
+        public static Alternatives of(Emptiness left, Emptiness right) {
+            boolean here = stands(left);
+            boolean there = stands(right);
+            if (here) {
+                return there ? BOTH_STAND : ONLY_THE_LEFT;
+            }
+            return there ? ONLY_THE_RIGHT : NEITHER_STANDS;
         }
-        return this == EMPTY && other == EMPTY ? EMPTY : UNDECIDED;
+
+        /**
+         * Whether there is a choice here at all.
+         *
+         * <p>What a reader composing two things and not four asks: an occurrence one alternative of
+         * which nobody can be in is no choice there, and the three ways that happens are one answer
+         * to such a reader. Said once, so that an alternative topology added later is told here
+         * whether it is a choice rather than at each of them.
+         */
+        public boolean bothStand() {
+            return switch (this) {
+                case NEITHER_STANDS, ONLY_THE_LEFT, ONLY_THE_RIGHT -> false;
+                case BOTH_STAND -> true;
+            };
+        }
+
+        /**
+         * Whether anybody may still be in an alternative this is the answer about.
+         *
+         * <p>Not published. What a settled answer means to an alternative is this classification's,
+         * and a name for it beside the answers themselves would say that "empty" and "nobody can be
+         * in it" are one thing wherever an {@code Emptiness} is read. They are one thing here.
+         */
+        private static boolean stands(Emptiness said) {
+            return switch (said) {
+                case EMPTY -> false;
+                case NONEMPTY, UNDECIDED -> true;
+            };
+        }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -270,7 +270,7 @@ public sealed interface PlannedValues<A> {
                         for (Map.Entry<Sameness.Block<A>, AdmittedPlan> each
                                 : box.at().entrySet()) {
                             stands = stands.met(askedOf(each.getKey(), each.getValue(), asked));
-                            if (stands == Emptiness.EMPTY) {
+                            if (stands.isEmpty()) {
                                 break;
                             }
                         }
@@ -282,7 +282,7 @@ public sealed interface PlannedValues<A> {
                         // Said of the alternative that holds them and not of the reading, which is
                         // the grain the question is asked at — an alternative beside one carrying a
                         // denial stands on its own rules.
-                        if (stands != Emptiness.EMPTY && !box.apart().isEmpty()) {
+                        if (!stands.isEmpty() && !box.apart().isEmpty()) {
                             stands = box.apart().holdsABlockApartFromItself()
                                     ? Emptiness.EMPTY : Emptiness.UNDECIDED;
                         }
@@ -342,7 +342,7 @@ public sealed interface PlannedValues<A> {
         Set<Sameness.Block<A>> here = new LinkedHashSet<>();
         // The block and not its positions — see {@link AdmissibleValues}.
         box.at().forEach((block, plan) -> {
-            if (askedOf(block, plan, asked) == Emptiness.EMPTY) {
+            if (askedOf(block, plan, asked).isEmpty()) {
                 here.add(block);
             }
         });
@@ -395,7 +395,7 @@ public sealed interface PlannedValues<A> {
      * rather than claiming the opposite.
      */
     default boolean holdsNothingAsBuilt(Allowance<A> by) {
-        if (emptiness() == Emptiness.EMPTY) {
+        if (emptiness().isEmpty()) {
             return true;
         }
         Sameness<A> heldAsOne = sameness();
@@ -483,7 +483,7 @@ public sealed interface PlannedValues<A> {
 
     /** Whether nothing satisfies these rules, so far as that is settled. */
     default boolean isBottom() {
-        return emptiness() == Emptiness.EMPTY;
+        return emptiness().isEmpty();
     }
 
     /** The same blocks as the positions they are made of, which is the coordinate a reading with

--- a/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StringMachineAnswers.java
@@ -157,7 +157,7 @@ public final class StringMachineAnswers {
             return known;
         }
         Emptiness made = TextExtents.inside(language, held, meter);
-        if (made != Emptiness.UNDECIDED) {
+        if (made.isDecided()) {
             MADE.incrementAndGet();
             if (keeps) {
                 inside.put(stretch, made);

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -61,10 +61,18 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
         }
 
         Branch or(Branch other) {
-            if (dead || other.dead) {
-                return new Branch(fated().both(other.fated()), dead && other.dead);
+            if (souther.compiler.values.Emptiness.Alternatives.of(said(), other.said())
+                    .bothStand()) {
+                return new Branch(adoption.either(Opening.nothing(), other.adoption), false);
             }
-            return new Branch(adoption.either(Opening.nothing(), other.adoption), false);
+            return new Branch(fated().both(other.fated()),
+                    said().joined(other.said()).isEmpty());
+        }
+
+        /** This branch's fate, in the words the classification is read in. */
+        private souther.compiler.values.Emptiness said() {
+            return dead ? souther.compiler.values.Emptiness.EMPTY
+                    : souther.compiler.values.Emptiness.NONEMPTY;
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -79,30 +79,35 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
      *
      * <p>Whether a branch admits anything is settled over the values and the order together, so it
      * is carried beside here rather than asked of either. What is under test is what the four cases
-     * leave, not which of them a clause falls into.
+     * leave, not which of them a clause falls into — which is why the case is not worked out here
+     * either, but asked of the one place that says which alternatives a pair of answers leaves
+     * standing.
      */
     private record Branch(Confinement.Planned<String> reading, boolean dead) {
 
         Branch or(Branch other) {
-            if (dead && other.dead) {
+            return switch (souther.compiler.values.Emptiness.Alternatives.of(said(),
+                    other.said())) {
                 // What showed the choice dead is what showed both of its branches dead, which is
                 // where the holder of both languages takes it from as well.
-                return new Branch(reading.bothDead(other.reading,
+                case NEITHER_STANDS -> new Branch(reading.bothDead(other.reading,
                         Confinement.Admission.bothShown(reading.admission(),
                                 other.reading.admission())), true);
-            }
-            // Neither language is asked what a choice with one dead branch leaves: what it leaves
-            // is the standing branch, which the holder has in hand. Composed instead, the choice
-            // would keep only what both sides spoke about — and a side nobody can be in spoke
-            // about positions the other did not, so the whole would come back saying nothing at
-            // all about them.
-            if (dead) {
-                return other;
-            }
-            if (other.dead) {
-                return this;
-            }
-            return new Branch(reading.either(other.reading, false), false);
+                // Neither language is asked what a choice with one dead branch leaves: what it
+                // leaves is the standing branch, which the holder has in hand. Composed instead,
+                // the choice would keep only what both sides spoke about — and a side nobody can be
+                // in spoke about positions the other did not, so the whole would come back saying
+                // nothing at all about them.
+                case ONLY_THE_RIGHT -> other;
+                case ONLY_THE_LEFT -> this;
+                case BOTH_STAND -> new Branch(reading.either(other.reading, false), false);
+            };
+        }
+
+        /** This branch's fate, in the words the classification is read in. */
+        private souther.compiler.values.Emptiness said() {
+            return dead ? souther.compiler.values.Emptiness.EMPTY
+                    : souther.compiler.values.Emptiness.NONEMPTY;
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest.java
@@ -88,6 +88,30 @@ class NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest {
             """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
 
     /**
+     * The first of those with the dead alternative written second instead.
+     *
+     * <p>Which alternative nobody can be in is the author's, and what a choice with one of them
+     * comes to is the branch beside it either way round. Written one way only, the claim would hold
+     * of a reading that keeps a dead second alternative and drops a dead first.
+     */
+    private static final String THE_FORM_IS_IN_A_DEAD_SECOND_ALTERNATIVE = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "C" && y == "Q") || (x == "A" && x == "B" && UNREAD_Y)
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /** And the second of them the same way round. */
+    private static final String ONE_OF_TWO_UNREAD_FORMS_IS_IN_A_DEAD_SECOND_ALTERNATIVE = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (x == "C" && UNREAD_Y) || (x == "A" && x == "B" && UNREAD_Y)
+            """.replace("UNREAD_Y", souther.compiler.ARuleNoReadingTakesIn.about("y"));
+
+    /**
      * One pattern no machine can be made for, written in a dead branch and beside it.
      *
      * <p>A machine is made once for a pattern at a position however many clauses wrote it, so the
@@ -173,6 +197,26 @@ class NothingAWholeDeclarationLeftInADeadBranchReachesAQuestionThatStandsTest {
         assertEquals(2, placesToLookAt(BOTH_UNREAD_FORMS_ARE_IN_BRANCHES_THAT_STAND, "y"),
                 "and with both branches standing both forms are places to go to, which is what"
                         + " makes the count above a fate's doing");
+    }
+
+    /**
+     * And the same whichever of the two alternatives is the one nobody can be in.
+     *
+     * <p>What is above is written with the dead branch first, and every claim of it is about a
+     * choice and not about a side. Held one way round only, a reading that treated a choice as a
+     * choice wherever the second alternative was the dead one would answer the same on all of it —
+     * the branch beside a dead first is composed with nothing either way, and the two ways are told
+     * apart by nothing else here.
+     */
+    @Test
+    void andTheSameWhicheverAlternativeNobodyCanBeIn() {
+        assertEquals(Set.of(),
+                whatARuleIsAnswerableFor(THE_FORM_IS_IN_A_DEAD_SECOND_ALTERNATIVE, "y"),
+                "nothing satisfies the second alternative, so the form written in it is no clause"
+                        + " for an author to go and look at");
+        assertEquals(1,
+                placesToLookAt(ONE_OF_TWO_UNREAD_FORMS_IS_IN_A_DEAD_SECOND_ALTERNATIVE, "y"),
+                "and it is not a second place either, which is the same claim the other way round");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest.java
@@ -173,18 +173,28 @@ class WhatAChoicesWidthRestsOnIsReadOffItsAlternativesTest {
      * this occurrence leaves is the branch beside the dead one, so nothing here rests on an
      * alternative — and read as an answer about the written choice, it would take back what the
      * occurrence beside it found.
+     *
+     * <p>Which of the two is the dead one is the author's, so both ways round are asked. Written one
+     * way only, this would hold of a reading that took a choice with a dead second alternative for a
+     * choice: the branch beside the dead one is the same branch either way, and nothing else here
+     * tells the two apart.
      */
     @Test
     void anOccurrenceOneBranchOfWhichAdmitsNothingRestsOnNeitherAndDoesNotSpeakForTheRest() {
         Settlement.WidthDependency dead = Settlement.WidthDependency.of(
                 souther.compiler.values.Emptiness.EMPTY, branch(isA()),
                 souther.compiler.values.Emptiness.UNDECIDED, branch(unread(Set.of(OTHER))));
+        Settlement.WidthDependency deadOnTheRight = Settlement.WidthDependency.of(
+                souther.compiler.values.Emptiness.UNDECIDED, branch(isA()),
+                souther.compiler.values.Emptiness.EMPTY, branch(unread(Set.of(OTHER))));
         Settlement.WidthDependency live = Settlement.WidthDependency.of(
                 souther.compiler.values.Emptiness.UNDECIDED, branch(isA()),
                 souther.compiler.values.Emptiness.UNDECIDED, branch(unread(Set.of(OTHER))));
 
         assertEquals(Settlement.WidthDependency.none(), dead,
                 "the choice is the branch beside the dead one, and no alternative widened it");
+        assertEquals(Settlement.WidthDependency.none(), deadOnTheRight,
+                "and the same where the dead one is the alternative written second");
         assertEquals(live, dead.alsoSeen(live),
                 "and what the occurrence beside it found is what the written choice is left with");
     }

--- a/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
@@ -2,6 +2,7 @@ package souther.compiler.values;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -143,6 +144,47 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
                         () -> left + " and " + right + ", read from either end");
             }
         }
+    }
+
+    /**
+     * And it classifies two answers and does nothing with the alternatives.
+     *
+     * <p>What a choice comes to, which branch a caller takes, whether the values are merged or held
+     * apart and whether the question waits are each the caller's, and each differs by what the
+     * caller is composing. Written here as well, one of them would be a second place composing a
+     * choice — and the one that must not be written is taking the standing alternative, which is
+     * the operation a choice with one live branch was decided to have none of.
+     *
+     * <p>Held as what this may mention, because that is what an operation over branches needs: a
+     * branch to be handed, or a type variable to be handed one under. Something that mentions
+     * neither cannot be given one, whatever it is called.
+     */
+    @Test
+    void andItClassifiesTwoAnswersAndActsOnNeither() {
+        List<String> written = new ArrayList<>();
+        for (Method each : Emptiness.Alternatives.class.getDeclaredMethods()) {
+            // What an enum is, and not an operation somebody wrote over these.
+            if (each.isSynthetic() || each.getName().equals("values")
+                    || each.getName().equals("valueOf")) {
+                continue;
+            }
+            written.add(each.getName());
+            assertEquals(0, each.getTypeParameters().length,
+                    () -> each.getName() + " is written over some type of the caller's, which is"
+                            + " what an operation that is handed a branch needs");
+            List<Class<?>> mentions = new ArrayList<>(List.of(each.getParameterTypes()));
+            mentions.add(each.getReturnType());
+            for (Class<?> what : mentions) {
+                assertTrue(what == Emptiness.class || what == Emptiness.Alternatives.class
+                                || what == boolean.class,
+                        () -> each.getName() + " mentions " + what.getName() + ", which is neither"
+                                + " an answer nor which alternatives stand nor whether they both do");
+            }
+        }
+        assertEquals(List.of("bothStand", "of", "stands"), written.stream().sorted().toList(),
+                "which alternatives two answers leave standing, whether that is a choice at all,"
+                        + " and the rule they are read by — an operation beside them would be a"
+                        + " second place saying what a choice comes to");
     }
 
     private static Emptiness.Alternatives exchanged(Emptiness.Alternatives standing) {

--- a/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static souther.compiler.values.Emptiness.EMPTY;
+import static souther.compiler.values.Emptiness.NONEMPTY;
+import static souther.compiler.values.Emptiness.UNDECIDED;
+import static souther.compiler.values.Emptiness.Alternatives.BOTH_STAND;
+import static souther.compiler.values.Emptiness.Alternatives.NEITHER_STANDS;
+import static souther.compiler.values.Emptiness.Alternatives.ONLY_THE_LEFT;
+import static souther.compiler.values.Emptiness.Alternatives.ONLY_THE_RIGHT;
+
+/**
+ * Which alternatives two answers leave standing, written out.
+ *
+ * <p>Every pair, said here rather than worked out, because a reading of this written the way the
+ * subject is written would agree with it however either was wrong. What every caller of this shares
+ * is the classification; what is held against it has to come from somewhere else, and the only
+ * somewhere else a table of nine has is the table.
+ *
+ * <p>Which is why writing it out is not the copying this exists to remove. What was copied was each
+ * layer working the classification out for itself and then acting on its own answer; what is here
+ * is one statement of what the answer is, held against the one place that gives it.
+ *
+ * <p><b>{@link Emptiness#UNDECIDED} stands.</b> Nobody has shown that nothing satisfies such a
+ * branch, and a reading that dropped it would drop a branch on the strength of not having looked.
+ * That is the whole content of the rule, and the rows it decides are the four an answer nobody
+ * settled takes part in.
+ */
+class ABranchStandsUnlessSomethingShowedItEmptyTest {
+
+    /** Two answers and which of the alternatives they leave standing. */
+    private record Row(Emptiness left, Emptiness right, Emptiness.Alternatives standing) {}
+
+    private static List<Row> table() {
+        return List.of(
+                new Row(EMPTY, EMPTY, NEITHER_STANDS),
+                new Row(EMPTY, NONEMPTY, ONLY_THE_RIGHT),
+                new Row(EMPTY, UNDECIDED, ONLY_THE_RIGHT),
+                new Row(NONEMPTY, EMPTY, ONLY_THE_LEFT),
+                new Row(UNDECIDED, EMPTY, ONLY_THE_LEFT),
+                new Row(NONEMPTY, NONEMPTY, BOTH_STAND),
+                new Row(NONEMPTY, UNDECIDED, BOTH_STAND),
+                new Row(UNDECIDED, NONEMPTY, BOTH_STAND),
+                new Row(UNDECIDED, UNDECIDED, BOTH_STAND));
+    }
+
+    /**
+     * Every pair leaves what the table says, each alternative answered for on its own side.
+     *
+     * <p>Which is where the sides are told apart, and the only place they are: an answer that named
+     * the wrong side of every pair would still be a classification, and every law two of these
+     * satisfy it would satisfy as well.
+     */
+    @Test
+    void everyPairOfAnswersLeavesWhatTheTableSays() {
+        for (Row row : table()) {
+            assertEquals(row.standing(),
+                    Emptiness.Alternatives.of(row.left(), row.right()),
+                    () -> row.left() + " on the left and " + row.right() + " on the right");
+        }
+    }
+
+    /**
+     * And the table is about every pair of answers there are.
+     *
+     * <p>Asked of the answers themselves rather than of the rows, so that an answer added to the
+     * three is a pair this says nothing about and not a pair nobody noticed. The rows say what each
+     * of them leaves; this says that the rows are asked of all of them.
+     */
+    @Test
+    void andTheTableIsAboutEveryPairOfAnswersThereIs() {
+        List<String> pairs = new ArrayList<>();
+        for (Emptiness left : Emptiness.values()) {
+            for (Emptiness right : Emptiness.values()) {
+                pairs.add(left + "/" + right);
+            }
+        }
+        List<String> written = new ArrayList<>();
+        table().forEach(row -> written.add(row.left() + "/" + row.right()));
+        assertEquals(pairs.stream().sorted().toList(), written.stream().sorted().toList(),
+                "a pair of answers the table says nothing about is one this compiler classifies"
+                        + " without anybody having written down what the classification is");
+    }
+
+    /**
+     * And every way the alternatives can fall is one some pair of answers reaches.
+     *
+     * <p>A way nothing reaches is one no reader's arm is ever taken, and the readers that switch
+     * over these would be answering for a case that cannot happen while the case they are wrong
+     * about goes unwritten.
+     */
+    @Test
+    void andEveryWayTheAlternativesCanFallIsReached() {
+        Set<Emptiness.Alternatives> reached = new LinkedHashSet<>();
+        table().forEach(row -> reached.add(row.standing()));
+        assertEquals(Set.of(Emptiness.Alternatives.values()), reached,
+                "every way two alternatives can fall is one some pair of answers leaves");
+    }
+
+    /**
+     * And whether there is a choice at all is that table and not a second one.
+     *
+     * <p>What a reader composing two things rather than four asks. Read off the rows, so that the
+     * coarse answer cannot come apart from the answer it is coarse about — worked out separately,
+     * the two would be two classifications and the second would be the thing this removes.
+     */
+    @Test
+    void andWhetherThereIsAChoiceAtAllIsTheSameTable() {
+        for (Row row : table()) {
+            assertEquals(row.standing() == BOTH_STAND,
+                    Emptiness.Alternatives.of(row.left(), row.right()).bothStand(),
+                    () -> "a choice between " + row.left() + " and " + row.right());
+        }
+        assertTrue(BOTH_STAND.bothStand(), "two standing alternatives are a choice");
+        assertFalse(NEITHER_STANDS.bothStand(), "and none of the other three is one");
+        assertFalse(ONLY_THE_LEFT.bothStand());
+        assertFalse(ONLY_THE_RIGHT.bothStand());
+    }
+
+    /**
+     * And neither alternative is answered for out of what the other one is.
+     *
+     * <p>Read the pair backwards and the answer is the same one with its sides exchanged, which is
+     * what it means for this to be about two alternatives and not about a first and a second. What
+     * it does not say is which side is which: an answer with the two names exchanged everywhere
+     * satisfies this as well, and what says which is which is the table above.
+     */
+    @Test
+    void andReadingThePairBackwardsExchangesTheSides() {
+        for (Emptiness left : Emptiness.values()) {
+            for (Emptiness right : Emptiness.values()) {
+                assertEquals(exchanged(Emptiness.Alternatives.of(left, right)),
+                        Emptiness.Alternatives.of(right, left),
+                        () -> left + " and " + right + ", read from either end");
+            }
+        }
+    }
+
+    private static Emptiness.Alternatives exchanged(Emptiness.Alternatives standing) {
+        return switch (standing) {
+            case NEITHER_STANDS -> NEITHER_STANDS;
+            case ONLY_THE_LEFT -> ONLY_THE_RIGHT;
+            case ONLY_THE_RIGHT -> ONLY_THE_LEFT;
+            case BOTH_STAND -> BOTH_STAND;
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
@@ -74,20 +74,17 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
      */
     private PlannedValues<String> either(PlannedValues<String> one, PlannedValues<String> other,
                                          boolean apart) {
-        if (dead(one) && dead(other)) {
-            return one.bothDead(other);
-        }
-        if (dead(one)) {
-            return other;
-        }
-        if (dead(other)) {
-            return one;
-        }
-        return apart ? one.joinLiveApart(other) : one.joinLive(other);
+        return switch (Emptiness.Alternatives.of(said(one), said(other))) {
+            case NEITHER_STANDS -> one.bothDead(other);
+            case ONLY_THE_RIGHT -> other;
+            case ONLY_THE_LEFT -> one;
+            case BOTH_STAND -> apart ? one.joinLiveApart(other) : one.joinLive(other);
+        };
     }
 
-    private boolean dead(PlannedValues<String> planned) {
-        return planned.holdsNothingAsBuilt(sets);
+    /** This branch's fate, in the words the classification is read in. */
+    private Emptiness said(PlannedValues<String> planned) {
+        return planned.holdsNothingAsBuilt(sets) ? Emptiness.EMPTY : Emptiness.NONEMPTY;
     }
 
     /** The same, and everything one connective reaches from them. */

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -286,20 +286,26 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * one keeps what either branch could not read.
      */
     private static Answer settled(Rule left, Rule right) {
-        boolean leftStands = !left.planned().holdsNothingAsBuilt(SETS);
-        boolean rightStands = !right.planned().holdsNothingAsBuilt(SETS);
-        if (!leftStands && !rightStands) {
-            return new Answer(
+        return switch (Emptiness.Alternatives.of(said(left), said(right))) {
+            case NEITHER_STANDS -> new Answer(
                     left.planned().bothDead(right.planned()),
                     Set.of(), Set.of(), true,
                     left.holdsSomethingUnread() || right.holdsSomethingUnread());
-        }
-        if (!leftStands) {
-            return standing(right);
-        }
-        if (!rightStands) {
-            return standing(left);
-        }
+            case ONLY_THE_RIGHT -> standing(right);
+            case ONLY_THE_LEFT -> standing(left);
+            case BOTH_STAND -> bothStanding(left, right);
+        };
+    }
+
+    /** A branch's fate, in the words the classification is read in, and asked of this compiler's
+     *  own reading rather than of the models — see {@link #settled}. */
+    private static Emptiness said(Rule branch) {
+        return branch.planned().holdsNothingAsBuilt(SETS) ? Emptiness.EMPTY : Emptiness.NONEMPTY;
+    }
+
+    /** What a choice both branches of which stand comes to, which is the one case the values
+     *  compose. */
+    private static Answer bothStanding(Rule left, Rule right) {
         Set<String> about = new LinkedHashSet<>(left.readAbout());
         about.addAll(right.readAbout());
         Set<String> opened = new LinkedHashSet<>(left.opened());


### PR DESCRIPTION
Closes #1424.

Which of the cases a choice is settled by was read off the two branch answers at
every reader that needed one, and with it the rule that a branch stands unless
something showed it empty. The tests that want a reading a compile would have
produced were not copying the walk; they were doing what it does, for the same
reason — there was nothing to ask.

## What this closes

`Emptiness` owns every reading of its own answers. Which alternatives of a
choice still stand is one of them, and the one that is about two answers at
once, so it is published beside them as `Emptiness.Alternatives`. It classifies
and never acts: what a choice comes to, which branch a caller takes, whether the
values are merged or held apart, and whether the question waits are each the
caller's and each differ by what the caller is composing. So it carries no
branch, folds nothing, and offers no operation for taking one — which is how the
decision that a choice with one standing alternative gets no operation is kept
by the shape of what is published rather than by a sentence about it.

Which alternatives stand and whether the answers about them are final stay two
questions. A branch nobody has worked out stands, so a choice both of whose
branches stand may still be one to keep; said in one word the two would be a
product, and the next question about a choice would multiply it again.

## Where a change stops now

Every reading of one of these answers is a switch over all of them, so an answer
added to the three has to be told what it means before anything compiles — and
it stops in the word's own class and nowhere else, because that is where the
meanings are. A way two alternatives can fall that is added later stops the
readings that owe each way something of its own, and not the ones that ask
whether there is a choice here at all: those are answered once, where the ways
are.

## The rule about this word, turned around

It watched who names a settled answer, which a reading gets round by asking
about the third answer instead — and one was. Asking whether an answer is
decided is asking whether it settles anything, so that counts as saying it, and
the reading doing it is written down with the rest.

What the rule could not watch at all is a comparison against a constant. That
names one of the answers and leaves every other to whatever the comparison
happens to say about it, which is the shape this whole change is about. So the
walk reads a constant and the comparison it reaches together — a constant
written where a value is wanted is how an answer is made and not a reading of
one — and what is left comparing is written down as the open questions it is:
the partition of two answers a conjunction reads, which is the choice's read the
other way round; what a positive answer is worth beside a position nobody could
build; and that a joined answer has reached the top of what a choice can be.
Each of those wants an owner decided, and this decides none of them.

## What the mutations said

Breaking the rule that an answer nobody settled leaves a branch standing, and
breaking which side is which, both go red. The second is caught where the sides
can be told apart, which the two tests holding an equation between two
compositions cannot do — an answer with the sides exchanged satisfies both of
them, and they say so now.

Breaking the reading that says whether there is a choice at all left the account
and the width green for one of the two sides. Every model and every pair holding
that claim was written with the dead alternative first, so what was missing was
the way round and not a claim. Each is asked both ways now, and each goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)