### PR TITLE
Give what a reading could not build an owner, and spend it where a verdict leaves

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -240,9 +240,14 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * that both halves are asked along. {@code AdmissibleValues},
      * {@code ConjoinedAdmissibleValues} and {@code PlannedValues} are that walk over what a reading
      * holds, and {@code Apartness} is what the denials between two blocks come to.
-     * {@code Realized} says whether everything asked for was built. {@code StatedByClauses} and
-     * {@code Settlement} put the answers of a choice's branches together, and
-     * {@code StringMachineAnswers} keeps an answer once somebody has looked.
+     * {@code LeftUnbuilt} says what a reading short of a position leaves an answer about it.
+     * {@code StatedByClauses} and {@code Settlement} put the answers of a choice's branches
+     * together, and {@code StringMachineAnswers} keeps an answer once somebody has looked.
+     *
+     * <p>{@code Realized} is not here, and holds what a reading could not build. Which of these
+     * answers that comes to is the question above, and it is asked of a word that answers it once —
+     * so a reading and the answers are two vocabularies, and the value that carries the first
+     * speaks neither of them.
      *
      * <p>What is not here is the list's point. Nothing else in {@code check}, nothing downstream of
      * the compiler, and nothing that reports: a settled answer reaching one of those would be a
@@ -256,8 +261,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/values/AdmissibleValues",
             "souther/compiler/values/Apartness",
             "souther/compiler/values/ConjoinedAdmissibleValues",
+            "souther/compiler/values/LeftUnbuilt",
             "souther/compiler/values/PlannedValues",
-            "souther/compiler/values/Realized",
             "souther/compiler/values/StringMachineAnswers",
             "souther/compiler/values/TextExtents");
 
@@ -276,6 +281,11 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * where a meet begins, which the word decides and the walk carries. What puts a nest here is
      * saying in its own words which answer is the answer: {@code PlannedValues} does, for a position
      * whose plan is already a set and needs no machine.
+     *
+     * <p>{@code LeftUnbuilt} is above and not here, for that reason. What a reading that built
+     * everything leaves an answer is the answer a meet begins from, and it asks the word for it —
+     * naming it there would be this list gaining an entry whose whole content is that the identity
+     * happens to be the positive answer.
      */
     private static final List<String> SAYS_SOMETHING_IS_ADMITTED = List.of(
             "souther/compiler/check/Carrier",
@@ -283,7 +293,6 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/check/StatedByClauses",
             "souther/compiler/values/Apartness",
             "souther/compiler/values/PlannedValues",
-            "souther/compiler/values/Realized",
             "souther/compiler/values/TextExtents");
 
     /**
@@ -391,24 +400,19 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     private record Open(String place, String question) {}
 
-    /** What a settled positive answer is worth beside a position nobody could build. */
-    private static final String WHAT_AN_ANSWER_IS_WORTH = "souther-lang/souther#1498";
-
     /**
-     * And the readings of this word whose meaning nobody has decided yet.
+     * And the readings of this word whose meaning nobody has decided yet, which are none.
      *
-     * <p>One question and no owner for it. {@code admission} reads what a settled positive answer is
-     * worth beside a position nobody could build, which is a rule about what a reading that asked
-     * less than the rules say may publish rather than about which of the three an answer is.
+     * <p>Every reading of one of these answers is an operation the word owns or a switch over all
+     * of them, so an answer added to the three is told what it means to each reader before anything
+     * compiles.
      *
-     * <p>It is a question this word could be given an owner for, and it is not one this compiler has
-     * decided. Naming a reading here says that; it does not say that the reading was left alone.
+     * <p><b>Empty, and what says the walk still works is beside this test.</b> A list nothing is in
+     * is a list a detector that stopped finding anything would also fill, so what holds this one to
+     * meaning something is {@link #COMPARED_IN_THE_FIXTURE}: bodies here comparing every way one
+     * can be written, found by the same walk in the same run.
      */
-    private static final List<Open> COMPARED_IN_PRODUCTION = List.of(
-            new Open("souther/compiler/check/Confinement$Worked#admission"
-                    + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
-                    + "Lsouther/compiler/values/StringMachineAnswers;)"
-                    + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH));
+    private static final List<Open> COMPARED_IN_PRODUCTION = List.of();
 
     /** The operations that make one of these answers out of two. Where a walk starts and where it
      *  stops are questions asked about an operation and answer for none of it, so a place that asks
@@ -428,9 +432,10 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * block of it does, and a reading stands where any alternative does. Each starts where the
      * operation it walks under starts and stops where that operation can no longer be moved, and
      * asks the word for both — a walk that named either would be saying the arithmetic's fact in its
-     * own words, true of these three answers by a coincidence nobody wrote down. The fourth composes
-     * two answers and no more, so there is no place in it to start from or stop at: what two
-     * occurrences of one branch come to is one call.
+     * own words, true of these three answers by a coincidence nobody wrote down. The other two
+     * compose two answers and no more, so there is no place in either to start from or stop at:
+     * what two occurrences of one branch come to is one call, and so is what a reading short of a
+     * position leaves an answer about it.
      *
      * <p><b>Directly, which is the whole of what this holds.</b> What each of these does with the
      * answers it put together is its own, and no walk here follows a call into what it calls. A
@@ -455,6 +460,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/values/ConjoinedAdmissibleValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;"
                     + "Lsouther/compiler/values/AskedOfARelation;)"
+                    + "Lsouther/compiler/values/Emptiness;",
+            "souther/compiler/values/LeftUnbuilt#hold"
+                    + "(Lsouther/compiler/values/Emptiness;)"
                     + "Lsouther/compiler/values/Emptiness;",
             "souther/compiler/values/PlannedValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;)"

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -244,10 +244,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * {@code StatedByClauses} and {@code Settlement} put the answers of a choice's branches
      * together, and {@code StringMachineAnswers} keeps an answer once somebody has looked.
      *
-     * <p>{@code Realized} is not here, and holds what a reading could not build. Which of these
-     * answers that comes to is the question above, and it is asked of a word that answers it once —
-     * so a reading and the answers are two vocabularies, and the value that carries the first
-     * speaks neither of them.
+     * <p>{@code Realized} is not here, and it is what holds a position nobody could build. What
+     * that leaves an answer is {@code LeftUnbuilt}'s and is said there once, so the value carrying
+     * the reading says nothing about the answers at all — which is what leaving this list is.
      *
      * <p>What is not here is the list's point. Nothing else in {@code check}, nothing downstream of
      * the compiler, and nothing that reports: a settled answer reaching one of those would be a

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -125,6 +125,29 @@ sealed interface Confinement<A> {
      */
     record Admission<A>(souther.compiler.values.Emptiness emptiness, EmptyBy by, Refusal<A> site, Shown how) {
 
+        /**
+         * A verdict short of the settled answer that nothing is admitted carries no proof.
+         *
+         * <p>The three words beside the verdict say a lack was shown by something, somewhere, out
+         * of something. With any other verdict they describe a lack nothing was shown, and a
+         * reader that carried one onwards would answer for a refusal no walk reached.
+         *
+         * <p><b>One direction and not both.</b> A verdict that is the settled answer that nothing
+         * is admitted may still name no place: a walk shown a lack about no block in particular
+         * has nothing to name, and {@link #left} is refused for that verdict rather than this. So
+         * what is closed here is that a proof implies the verdict, and not that the verdict
+         * implies a proof.
+         */
+        public Admission {
+            if (!emptiness.isEmpty()
+                    && (by != EmptyBy.NOTHING_SHOWN || !site.isNowhere()
+                            || how != Shown.BY_THE_READINGS)) {
+                throw new IllegalArgumentException(
+                        "a verdict of " + emptiness + " is not one anything showed, and this one"
+                                + " was shown by " + by + " at " + site + " " + how);
+            }
+        }
+
         /** The same, where what was refused is places rather than values several of them share. */
         static <A> Admission<A> at(souther.compiler.values.Emptiness emptiness, EmptyBy by, Set<A> positions, Shown how) {
             Set<Sameness.Block<A>> blocks = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -11,6 +11,7 @@ import souther.compiler.values.ConjoinedAdmissibleValues;
 import souther.compiler.values.Emptiness.SidesShownEmpty;
 import souther.compiler.values.Admits;
 import souther.compiler.values.AskedOfARelation;
+import souther.compiler.values.LeftUnbuilt;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realized;
@@ -64,16 +65,37 @@ import java.util.function.Function;
 sealed interface Confinement<A> {
 
     /**
-     * Whether anything satisfies both readings once {@code outside} has placed the positions, and
-     * what showed it where nothing does.
+     * What the walk over the alternatives left, beside what working the reading out could not
+     * build.
      *
      * <p>The envelope is the question and never a reading of this one. What it holds is what the
      * components beside this can prove about where a position sits, and it is asked here because
      * this is where the alternatives are: a restriction met against what a position admits across
      * all of them is met against a value no alternative stands for, and every one of them has to be
      * asked whole.
+     *
+     * <p><b>Where readings are composed, and not where a verdict is published.</b> A composition
+     * of two of these is short of a position where either of them is, so what a caller putting two
+     * together needs is the two halves still apart — and what a caller asking whether anything
+     * satisfies the pair needs is the verdict with the second half already spent on it
+     * ({@link #admission}). Handed the verdict alone, a composition carries a positive answer
+     * forward that the reading behind it had not settled; handed the halves, nobody outside can
+     * hold one without the other.
      */
-    Admission<A> admission(PositionEnvelope.Restrictions<A> outside, StringMachineAnswers machines);
+    ReadAdmission<A> read(PositionEnvelope.Restrictions<A> outside, StringMachineAnswers machines);
+
+    /**
+     * Whether anything satisfies both readings once {@code outside} has placed the positions, and
+     * what showed it where nothing does.
+     *
+     * <p>What the walk left, held to what the reading could not build — see
+     * {@link ReadAdmission#admission}. This is the answer a reader acts on, and there is no other
+     * way to reach one.
+     */
+    default Admission<A> admission(PositionEnvelope.Restrictions<A> outside,
+                                   StringMachineAnswers machines) {
+        return read(outside, machines).admission();
+    }
 
     /** The same, paying for every machine the asking needs. */
     default Admission<A> admission(PositionEnvelope.Restrictions<A> outside) {
@@ -210,6 +232,50 @@ sealed interface Confinement<A> {
                     Refusal.shownByBoth(one.site, other.site),
                     one.byTheReadings() && other.byTheReadings()
                             ? Shown.BY_THE_READINGS : Shown.ONCE_THE_POSITIONS_ARE_PLACED);
+        }
+    }
+
+    /**
+     * What a walk left, and what the reading it walked could not build, as one value.
+     *
+     * <p><b>Neither half is reachable on its own.</b> The verdict a walk reaches is about the
+     * alternatives it was handed, and a reading short of a position handed it more values than the
+     * rules leave — so the two are one answer, and a reader that could take the first would be
+     * taking a claim the second is the correction to. That was how a conjunction came to carry a
+     * positive answer forward out of a reading nobody had worked out: the verdict was in hand and
+     * the reason to doubt it was not.
+     *
+     * <p>So what leaves here is {@link #admission}, and what a composition of readings takes is the
+     * other half under the eye of whoever composes them. Made only where a reading answers about
+     * itself, which is inside this file.
+     */
+    final class ReadAdmission<A> {
+
+        private final Admission<A> walked;
+        private final LeftUnbuilt leftUnbuilt;
+
+        private ReadAdmission(Admission<A> walked, LeftUnbuilt leftUnbuilt) {
+            this.walked = walked;
+            this.leftUnbuilt = leftUnbuilt;
+        }
+
+        /**
+         * Whether anything satisfies the pair, once what could not be built is spent on the answer.
+         *
+         * <p>What the two halves come to, and the whole of what a reader outside may hold. The
+         * proof travels where the verdict does not move: a lack is shown by something and is where
+         * it is, and neither of those is true of an answer nobody reached — which the verdict
+         * itself refuses to be written with ({@link Admission}), so a verdict that moved is a new
+         * one carrying nothing.
+         */
+        Admission<A> admission() {
+            souther.compiler.values.Emptiness held = leftUnbuilt.hold(walked.emptiness());
+            return held == walked.emptiness() ? walked : Admission.left(held);
+        }
+
+        /** What the reading behind this could not build, for a caller composing readings. */
+        LeftUnbuilt leftUnbuilt() {
+            return leftUnbuilt;
         }
     }
 
@@ -606,15 +672,20 @@ sealed interface Confinement<A> {
         }
 
         @Override
-        public Admission<A> admission(PositionEnvelope.Restrictions<A> outside,
-                                      StringMachineAnswers machines) {
-            return shown != null ? shown : Confinement.admission(ordered, carriers, outside,
-                    // The relation is not asked on this side: what a denial comes to is settled
-                    // against the values its blocks are left, and those are descriptions here. The
-                    // walk says so of each alternative that carries one.
-                    (asked, _) -> values.anyAlternativeAdmits(asked),
-                    (asked, _) -> values.refusedInEveryAlternativeAt(asked),
-                    values.refusedBy(), machines);
+        public ReadAdmission<A> read(PositionEnvelope.Restrictions<A> outside,
+                                     StringMachineAnswers machines) {
+            // Nothing has been built here, so nothing was refused while building: what these
+            // descriptions cannot tell is told by the walk, as the answer nobody has worked out.
+            return new ReadAdmission<>(
+                    shown != null ? shown : Confinement.admission(ordered, carriers, outside,
+                            // The relation is not asked on this side: what a denial comes to is
+                            // settled against the values its blocks are left, and those are
+                            // descriptions here. The walk says so of each alternative that carries
+                            // one.
+                            (asked, _) -> values.anyAlternativeAdmits(asked),
+                            (asked, _) -> values.refusedInEveryAlternativeAt(asked),
+                            values.refusedBy(), machines),
+                    LeftUnbuilt.NOTHING);
         }
 
         /**
@@ -745,20 +816,14 @@ sealed interface Confinement<A> {
         }
 
         @Override
-        public Admission<A> admission(PositionEnvelope.Restrictions<A> outside,
-                                      StringMachineAnswers machines) {
-            if (shown != null) {
-                return shown;
-            }
-            Admission<A> said = Confinement.admission(ordered, carriers, outside,
-                    made.values()::anyAlternativeAdmits,
-                    made.values()::refusedInEveryAlternativeAt,
-                    made.values().refusedBy(), machines);
-            // A position nobody could build is one what stands there is wider than the rules, so a
-            // pair the ranges did not refuse may still hold nothing. Settled empty is settled all
-            // the same: a narrower reading refuses no less.
-            return said.emptiness() == souther.compiler.values.Emptiness.NONEMPTY && !made.unbuilt().isEmpty()
-                    ? Admission.left(souther.compiler.values.Emptiness.UNDECIDED) : said;
+        public ReadAdmission<A> read(PositionEnvelope.Restrictions<A> outside,
+                                     StringMachineAnswers machines) {
+            return new ReadAdmission<>(
+                    shown != null ? shown : Confinement.admission(ordered, carriers, outside,
+                            made.values()::anyAlternativeAdmits,
+                            made.values()::refusedInEveryAlternativeAt,
+                            made.values().refusedBy(), machines),
+                    made.leftUnbuilt());
         }
 
         /** The positions the order leaves no value at, for a reader writing down where. */
@@ -785,24 +850,34 @@ sealed interface Confinement<A> {
         private final Map<A, Carrier> carriers;
         /** What already showed this holds nothing — see {@link Planned#shown}. */
         private final Admission<A> shown;
-
-        Conjoined(ConjoinedAdmissibleValues<A> values, OrderedIntervals<A> ordered,
-                  Map<A, Carrier> carriers) {
-            this(values, ordered, carriers, null);
-        }
+        /**
+         * What the readings taken in here could not build, kept and never interpreted.
+         *
+         * <p>Beside {@code shown} and never folded into it. What showed a conjunction empty is a
+         * proof somebody reached; what a reading could not build is why nobody reached one — so a
+         * conjunction nothing showed empty carries no proof and may still be carrying this, and a
+         * value holding one word for both would have to drop whichever of the two it was not.
+         *
+         * <p>Written at every place one of these is made, rather than defaulted. The three ways one
+         * arrives are a reading taken in, two conjunctions met, and the same conjunction said
+         * again over renamed positions or with a range taken as holding — and the middle of those
+         * is the one a value that filled this in for itself would get wrong.
+         */
+        private final LeftUnbuilt leftUnbuilt;
 
         private Conjoined(ConjoinedAdmissibleValues<A> values, OrderedIntervals<A> ordered,
-                          Map<A, Carrier> carriers, Admission<A> shown) {
+                          Map<A, Carrier> carriers, Admission<A> shown, LeftUnbuilt leftUnbuilt) {
             this.values = values;
             this.ordered = ordered;
             this.carriers = Collections.unmodifiableMap(new LinkedHashMap<>(carriers));
             this.shown = shown;
+            this.leftUnbuilt = leftUnbuilt;
         }
 
-        /** Nothing read, so nothing ruled out. */
+        /** Nothing read, so nothing ruled out and nothing left unbuilt. */
         static <A> Conjoined<A> top() {
             return new Conjoined<>(ConjoinedAdmissibleValues.top(), OrderedIntervals.top(),
-                    Map.of());
+                    Map.of(), null, LeftUnbuilt.NOTHING);
         }
 
         ConjoinedAdmissibleValues<A> values() {
@@ -815,11 +890,13 @@ sealed interface Confinement<A> {
         }
 
         @Override
-        public Admission<A> admission(PositionEnvelope.Restrictions<A> outside,
-                                      StringMachineAnswers machines) {
-            return shown != null ? shown : Confinement.admission(ordered, carriers, outside,
-                    values::anyAlternativeAdmits, values::refusedInEveryAlternativeAt,
-                    values.refusedBy(), machines);
+        public ReadAdmission<A> read(PositionEnvelope.Restrictions<A> outside,
+                                     StringMachineAnswers machines) {
+            return new ReadAdmission<>(
+                    shown != null ? shown : Confinement.admission(ordered, carriers, outside,
+                            values::anyAlternativeAdmits, values::refusedInEveryAlternativeAt,
+                            values.refusedBy(), machines),
+                    leftUnbuilt);
         }
 
         /** The positions the order leaves no value at. */
@@ -842,7 +919,8 @@ sealed interface Confinement<A> {
         Conjoined<A> meet(Conjoined<A> other, Allowance<A> sets) {
             return new Conjoined<>(values.meet(other.values, sets), ordered.meet(other.ordered),
                     Confinement.both(carriers, other.carriers),
-                    eitherShown(admission(), other.admission()));
+                    eitherShown(admission(), other.admission()),
+                    leftUnbuilt.met(other.leftUnbuilt));
         }
 
         /** The same rules about the same positions, under the names {@code naming} gives them. */
@@ -852,14 +930,15 @@ sealed interface Confinement<A> {
             Admission<B> said = shown == null ? null
                     : new Admission<>(shown.emptiness(), shown.by(),
                             shown.site().renamed(naming), shown.how());
-            return new Conjoined<>(values.renamed(naming), ordered.renamed(naming), out, said);
+            return new Conjoined<>(values.renamed(naming), ordered.renamed(naming), out, said,
+                    leftUnbuilt);
         }
 
         /** The same, with {@code bounded} taken as holding of the positions it bounds, on the
          *  orders {@code on} says they are counted by. */
         Conjoined<A> taking(OrderedIntervals<A> bounded, Map<A, Carrier> on) {
             return new Conjoined<>(values, ordered.meet(bounded), Confinement.both(carriers, on),
-                    shown);
+                    shown, leftUnbuilt);
         }
 
         /**
@@ -899,27 +978,33 @@ sealed interface Confinement<A> {
                         + values;
                 return this;
             }
+            // Both halves of what the reading answers, out of one walk of it. What it was shown
+            // empty by is a fact about the rules and travels with them — left behind, a declaration
+            // refused because two of its branches share no value between their sets and their
+            // ranges would be reported as one whose values admit nothing, which is what dropping
+            // the branches left. What it could not build is a fact about the reading and travels
+            // the same way: taken in without it, a conjunction answers that something satisfies it
+            // out of positions nobody worked out.
+            ReadAdmission<A> taken =
+                    read.read(PositionEnvelope.Restrictions.nothingSpokenOf(), machines);
             return new Conjoined<>(
                     ConjoinedAdmissibleValues.of(
                             AdmissibleValues.<A>top().meet(read.values(), sets)),
                     ordered.meet(read.ordered), Confinement.both(carriers, read.carriers()),
-                    // What the reading was already shown empty by, which is a fact about the rules
-                    // and travels with them. Left behind, a declaration refused because two of its
-                    // branches share no value between their sets and their ranges would be reported
-                    // as one whose values admit nothing, which is what dropping the branches left.
-                    eitherShown(admission(machines), read.admission(machines)));
+                    eitherShown(admission(machines), taken.admission()),
+                    leftUnbuilt.met(taken.leftUnbuilt()));
         }
 
         @Override
         public boolean equals(Object other) {
             return other instanceof Conjoined<?> it && values.equals(it.values)
                     && ordered.equals(it.ordered) && carriers.equals(it.carriers)
-                    && Objects.equals(shown, it.shown);
+                    && Objects.equals(shown, it.shown) && leftUnbuilt == it.leftUnbuilt;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(values, ordered, carriers, shown);
+            return Objects.hash(values, ordered, carriers, shown, leftUnbuilt);
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -268,13 +268,13 @@ sealed interface Confinement<A> {
          * itself refuses to be written with ({@link Admission}), so a verdict that moved is a new
          * one carrying nothing.
          */
-        Admission<A> admission() {
+        private Admission<A> admission() {
             souther.compiler.values.Emptiness held = leftUnbuilt.hold(walked.emptiness());
             return held == walked.emptiness() ? walked : Admission.left(held);
         }
 
         /** What the reading behind this could not build, for a caller composing readings. */
-        LeftUnbuilt leftUnbuilt() {
+        private LeftUnbuilt leftUnbuilt() {
             return leftUnbuilt;
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -858,10 +858,12 @@ sealed interface Confinement<A> {
          * conjunction nothing showed empty carries no proof and may still be carrying this, and a
          * value holding one word for both would have to drop whichever of the two it was not.
          *
-         * <p>Written at every place one of these is made, rather than defaulted. The three ways one
-         * arrives are a reading taken in, two conjunctions met, and the same conjunction said
-         * again over renamed positions or with a range taken as holding — and the middle of those
-         * is the one a value that filled this in for itself would get wrong.
+         * <p>Written at every place one of these is made, rather than defaulted. Nothing read
+         * leaves nothing unbuilt; a reading taken in brings its own; two conjunctions met are
+         * short of a position where either is; and the same conjunction said again under other
+         * names, or handed a range to take as holding, asks the readings nothing and so works
+         * nothing out. A value that filled this in for itself would answer the middle two the way
+         * it answers the first.
          */
         private final LeftUnbuilt leftUnbuilt;
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -931,8 +931,9 @@ sealed interface StatedByClauses {
                     new LinkedHashMap<>();
             made.aboutTheAnswer().forEach(each -> answered.merge(each.at(),
                     List.of(each.why()), ReadByClauses::alsoSaying));
-            return new Settlement.Sided(Confinement.Admission.left(souther.compiler.values.Emptiness.UNDECIDED), answered,
-                    made.aboutARule(), made.unbuilt());
+            // The answer the reading gave, and not one written again out of the word. What reaches
+            // here is what nobody settled, which is what that answer already is.
+            return new Settlement.Sided(admitted, answered, made.aboutARule(), made.unbuilt());
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/values/LeftUnbuilt.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/LeftUnbuilt.java
@@ -1,0 +1,63 @@
+package souther.compiler.values;
+
+/**
+ * Whether working a reading out left a position nobody could build.
+ *
+ * <p>What {@link Unbuilt} holds, projected onto the only thing an answer about the reading turns
+ * on. A shortfall is one occurrence — a position, and what was refused there, owed to a rule or to
+ * the answer — and a report is written out of those. What a verdict turns on is none of that: a
+ * position left holding every value is one the walk found no refusal at because nothing asked, and
+ * whether there is such a position is the whole of what the verdict has to know.
+ *
+ * <p><b>Two answers and not a count.</b> A second position nobody could build takes nothing further
+ * off an answer already waiting on the first, so a number here would be a difference no reader
+ * could spend. What is asked is existential.
+ *
+ * <p><b>And this owns the one place where that meets a verdict.</b> A reading short of a position
+ * stands for more values than its rules do, so a settled positive answer about it is about less
+ * than the rules say and is not settled; a settled empty one is settled all the same, since a
+ * narrower reading refuses no less. Both of those are {@link Emptiness#met} against the answer this
+ * embeds into — the identity where nothing was left unbuilt, and the answer nobody has worked out
+ * where something was. Written at a reader instead, the two would be a rule about verdicts kept
+ * somewhere that holds no verdicts, and an answer added to the three would fall through it.
+ */
+public enum LeftUnbuilt {
+
+    /** Every position the reading names was worked out. */
+    NOTHING(Emptiness.identityForMeet()),
+
+    /** At least one of them was not, and stands for every value because of it. */
+    A_POSITION(Emptiness.UNDECIDED);
+
+    private final Emptiness limit;
+
+    LeftUnbuilt(Emptiness limit) {
+        this.limit = limit;
+    }
+
+    /**
+     * What {@code answer} comes to once what the reading could not build is known.
+     *
+     * <p>The embedding and the meet together, so that the answer this becomes is never in anybody's
+     * hand. Handed out on its own it would read as a verdict about the reading, which it is not:
+     * nothing here has looked at what the reading admits.
+     */
+    public Emptiness hold(Emptiness answer) {
+        return answer.met(limit);
+    }
+
+    /**
+     * What two readings asked as one were left with.
+     *
+     * <p>A composition of readings is short of a position where either of them is. Named for the
+     * meet because that is what it is: this embeds into {@link Emptiness#met} on both sides, so
+     * what two of these come to holds the answer that what they come to under the word does, and a
+     * caller may take either route.
+     */
+    public LeftUnbuilt met(LeftUnbuilt other) {
+        return switch (this) {
+            case NOTHING -> other;
+            case A_POSITION -> A_POSITION;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -123,22 +123,20 @@ public final class Realized<A> {
     }
 
     /**
-     * Whether anything satisfies the reading.
+     * Whether working this out left a position nobody could build.
      *
-     * <p>Three answers, because a reading with a position nobody could work out has not been shown
-     * to admit anything or to admit nothing. What stands there is every value, which is true and is
-     * wider than the rules — so the reading may hold something the rules refuse, and reading it as
-     * one that admits something is sound and is not exact.
+     * <p>What a reader asking about the reading is owed beside the reading. The values it comes
+     * back with hold every value at such a position, which is true and is wider than the rules — so
+     * an answer worked out of them alone is sound and is not exact, and what says so is here rather
+     * than at whoever is asking.
      *
-     * <p>Which is why the shortfall travels with it. A caller taking {@link Emptiness#UNDECIDED} for
-     * "it admits something" and dropping what is here has claimed a reading is a branch anybody can
-     * be in, and has kept no record of why nobody knows.
+     * <p>The existential question and not the shortfalls: what a rule or the answer is answerable
+     * for is a report's ({@link #aboutARule}, {@link #aboutTheAnswer}), and what a verdict turns on
+     * is only whether there is such a position. What that comes to for a verdict is
+     * {@link LeftUnbuilt}'s, so nothing here names one of the answers.
      */
-    public Emptiness emptiness() {
-        if (values().isBottom()) {
-            return Emptiness.EMPTY;
-        }
-        return unbuilt().isEmpty() ? Emptiness.NONEMPTY : Emptiness.UNDECIDED;
+    public LeftUnbuilt leftUnbuilt() {
+        return unbuilt().isEmpty() ? LeftUnbuilt.NOTHING : LeftUnbuilt.A_POSITION;
     }
 
     /** Every position whose answer was not built, whichever of the two it is owed to. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -8,13 +8,17 @@ import java.util.Set;
 /**
  * A reading worked out, together with what could not be built while working it out.
  *
- * <p>Three facts settled by one piece of work and handed over together. Which values each position
- * admits is one; whether the reading admits anything at all is the second; and which limit stopped
- * this compiler where it stopped is the third. They are not separable questions — the second and
- * third are only answerable by doing the work the first needed — and a caller given the first alone
- * has to guess the others from what it holds. What it holds is a set widened to every value, and
- * every guess made from that is the wrong one: it reads a position nobody could work out as one the
- * rules left open.
+ * <p>Two facts settled by one piece of work and handed over together. Which values each position
+ * admits is one, and which limit stopped this compiler where it stopped is the other. They are not
+ * separable questions — the second is only answerable by doing the work the first needed — and a
+ * caller given the first alone has to guess it from what it holds. What it holds is a set widened
+ * to every value, and every guess made from that is the wrong one: it reads a position nobody could
+ * work out as one the rules left open.
+ *
+ * <p>Whether anything satisfies the reading is not among them and is not asked here. That is about
+ * the values beside where their orders stop ({@code Confinement}), and what this settles enters it
+ * as {@link LeftUnbuilt} — the reading is one half of the question and answering it here would be
+ * answering for the other half as well.
  *
  * <p><b>The two shortfalls are apart because they are owed to different people.</b> What is about a
  * rule may be filed under that rule and shown to an author as something to change. What is about the

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
@@ -85,4 +85,46 @@ class AReadingShortOfAPositionPublishesNoPositiveAnswerTest {
         assertEquals(souther.compiler.values.Emptiness.UNDECIDED, took.admits(),
                 "a conjunction of one reading answers what that reading answers");
     }
+
+    /**
+     * And to a conjunction met with that one, from either side.
+     *
+     * <p>Two conjunctions are met where a caller holds the readings of two declarations and wants
+     * what they come to, and the one that took the short reading in is the only one carrying the
+     * reason to doubt. Kept on the side it arrived on, which side the caller wrote first would
+     * settle whether the answer is one anybody worked out.
+     */
+    @Test
+    void andToAConjunctionMetWithThatOneFromEitherSide() {
+        Confinement.Conjoined<String> took = Confinement.Conjoined.<String>top()
+                .taking(readWithRoomFor(TOO_LITTLE), AsACompilationAllows.forAdmittedValues());
+        Confinement.Conjoined<String> nothingRead = Confinement.Conjoined.top();
+
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED,
+                took.meet(nothingRead, AsACompilationAllows.forAdmittedValues()).admits());
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED,
+                nothingRead.meet(took, AsACompilationAllows.forAdmittedValues()).admits());
+    }
+
+    /**
+     * And to the same conjunction said again, however it was said again.
+     *
+     * <p>The two ways one of these is made without a reading arriving: the same rules under other
+     * names, and the same rules with a range taken as holding of the positions it bounds. Neither
+     * asks anything of the readings, so neither can have worked out what one of them could not
+     * work out — and a conjunction that answered positively after being renamed would be one whose
+     * answer turned on having been carried across a boundary.
+     */
+    @Test
+    void andToTheSameConjunctionSaidAgain() {
+        Confinement.Conjoined<String> took = Confinement.Conjoined.<String>top()
+                .taking(readWithRoomFor(TOO_LITTLE), AsACompilationAllows.forAdmittedValues());
+
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED,
+                took.renamed(position -> position).admits(),
+                "renaming the positions works nothing out");
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED,
+                took.taking(OrderedIntervals.top(), Map.of()).admits(),
+                "and neither does taking a range as holding of them");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Allowance;
+import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.PlannedValues;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A reading with a position nobody could build says nothing about whether anything satisfies it.
+ *
+ * <p>What stands at such a position is every value, which is true and is wider than the rules. So a
+ * walk that found no refusal there found none because nothing was asked, and the settled positive
+ * answer it came back with is about less than the rules say.
+ *
+ * <p><b>The same rules twice, and only the allowance differs.</b> A reading whose values admit
+ * nothing answers the same however little was built, and one nothing worked out was never going to
+ * answer positively — so a fixture that showed either would show this rule holding where it does
+ * nothing. What is asked here is a reading that does come out positive when there is room to build
+ * it, asked again with room for less.
+ *
+ * <p>And asked wherever the reading is asked. What a reading could not build is a fact about that
+ * reading and not about the question that reached it, so a conjunction that took the reading in
+ * answers under it too — otherwise which answer comes back is settled by how far from the reading
+ * the caller happens to be standing.
+ */
+class AReadingShortOfAPositionPublishesNoPositiveAnswerTest {
+
+    private static final String HERE = "here";
+
+    /** A machine of some hundreds of states, at the one position these readings are about. */
+    private static PlannedValues<String> aPatternWorthBuilding() {
+        PatternRead said = PatternParser.read("a{300}");
+        return PlannedValues.at(HERE, new AdmittedPlan.Pattern(PatternPlan.of(
+                assertInstanceOf(PatternRead.Read.class, said).syntax())));
+    }
+
+    /** Room for a machine of {@code states}, which is what settles whether the pattern is built. */
+    private static Confinement.Worked<String> readWithRoomFor(int states) {
+        return new Confinement.Planned<>(aPatternWorthBuilding(), OrderedIntervals.top(), Map.of())
+                .resolve(Allowance.of(new PatternPlan.Budget(states, states)));
+    }
+
+    /** Room for the pattern, and room for anything else these readings ask for. */
+    private static final int ENOUGH = 50_000;
+
+    /** Room for neither the pattern nor what widening around it costs. */
+    private static final int TOO_LITTLE = 20;
+
+    @Test
+    void theSameRulesComeOutPositiveOnlyWhereEveryPositionWasBuilt() {
+        assertEquals(souther.compiler.values.Emptiness.NONEMPTY,
+                readWithRoomFor(ENOUGH).admits(),
+                "these rules admit something, where there was room to work out what");
+
+        Confinement.Worked<String> shortOfAPosition = readWithRoomFor(TOO_LITTLE);
+
+        assertEquals(Set.of(HERE), shortOfAPosition.made().unbuilt(),
+                "and the same rules leave this position unworked-out at the smaller allowance");
+        assertFalse(shortOfAPosition.made().values().isBottom(),
+                "which is not the values coming out empty: what stands there is every value");
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED, shortOfAPosition.admits(),
+                "so nobody has shown that anything satisfies them");
+    }
+
+    @Test
+    void andSaysTheSameToAConjunctionThatTookTheReadingIn() {
+        Confinement.Worked<String> shortOfAPosition = readWithRoomFor(TOO_LITTLE);
+
+        Confinement.Conjoined<String> took = Confinement.Conjoined.<String>top()
+                .taking(shortOfAPosition, AsACompilationAllows.forAdmittedValues());
+
+        assertEquals(souther.compiler.values.Emptiness.UNDECIDED, took.admits(),
+                "a conjunction of one reading answers what that reading answers");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingShortOfAPositionPublishesNoPositiveAnswerTest.java
@@ -56,7 +56,7 @@ class AReadingShortOfAPositionPublishesNoPositiveAnswerTest {
     /** Room for the pattern, and room for anything else these readings ask for. */
     private static final int ENOUGH = 50_000;
 
-    /** Room for neither the pattern nor what widening around it costs. */
+    /** Not room for it, so the position it is about is left holding every value. */
     private static final int TOO_LITTLE = 20;
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AVerdictNothingShowedEmptyCarriesNoProofTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AVerdictNothingShowedEmptyCarriesNoProofTest.java
@@ -1,0 +1,80 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.values.Refusal;
+import souther.compiler.values.Sameness;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The three words beside a verdict describe a lack, so a verdict short of one carries none of them.
+ *
+ * <p>What emptied the pair, where the lack is, and whether the readings showed it between them are
+ * a proof. Beside a verdict nothing showed empty they describe a refusal no walk reached, and a
+ * reader that took one onwards would answer for it — {@link Confinement.Admission#left} refuses the
+ * other direction, and this closes the value itself so that the canonical constructor cannot be
+ * used to write what the maker refuses.
+ *
+ * <p><b>Both unsettled verdicts and each word on its own.</b> The rule is about a verdict that is
+ * not the settled answer that nothing is admitted, which is two of the three answers; written as a
+ * comparison against one of them it would hold of that one and leave the other free, and the answer
+ * added to the three would arrive free as well. So each word is refused under each of the two.
+ */
+class AVerdictNothingShowedEmptyCarriesNoProofTest {
+
+    /** A place, which is what a verdict nothing showed empty may not name. */
+    private static final Refusal<String> SOMEWHERE =
+            Refusal.atEachOf(Set.of(Sameness.Block.of("here")));
+
+    private static final Refusal<String> NOWHERE = Refusal.nowhere();
+
+    /** The two answers this rule is about: neither of them is a lack anything showed. */
+    private static final Set<souther.compiler.values.Emptiness> NOTHING_SHOWED_THESE_EMPTY =
+            Set.of(souther.compiler.values.Emptiness.NONEMPTY,
+                    souther.compiler.values.Emptiness.UNDECIDED);
+
+    @Test
+    void neitherOfThemMayNameWhatEmptiedThePair() {
+        NOTHING_SHOWED_THESE_EMPTY.forEach(verdict -> assertThrows(
+                IllegalArgumentException.class,
+                () -> new Confinement.Admission<>(verdict, Confinement.EmptyBy.ORDER, NOWHERE,
+                        Confinement.Shown.BY_THE_READINGS),
+                verdict + " was not emptied by the orders, or by anything else"));
+    }
+
+    @Test
+    void neitherOfThemMayNameWhereTheLackIs() {
+        NOTHING_SHOWED_THESE_EMPTY.forEach(verdict -> assertThrows(
+                IllegalArgumentException.class,
+                () -> new Confinement.Admission<>(verdict, Confinement.EmptyBy.NOTHING_SHOWN,
+                        SOMEWHERE, Confinement.Shown.BY_THE_READINGS),
+                verdict + " leaves no position refused, so there is nowhere for it to be"));
+    }
+
+    @Test
+    void andNeitherMaySayWhatShowedIt() {
+        NOTHING_SHOWED_THESE_EMPTY.forEach(verdict -> assertThrows(
+                IllegalArgumentException.class,
+                () -> new Confinement.Admission<>(verdict, Confinement.EmptyBy.NOTHING_SHOWN,
+                        NOWHERE, Confinement.Shown.ONCE_THE_POSITIONS_ARE_PLACED),
+                verdict + " is not something the placed positions showed"));
+    }
+
+    /**
+     * And the settled answer that nothing is admitted may still name no place.
+     *
+     * <p>The direction this does not close, kept as a value that has to go on being writable: a
+     * walk shown a lack about no block in particular has nothing to name, and a rule reading the
+     * implication backwards would refuse the answer such a walk reaches.
+     */
+    @Test
+    void whileALackShownAtNoPlaceIsStillALack() {
+        assertDoesNotThrow(() -> new Confinement.Admission<>(
+                souther.compiler.values.Emptiness.EMPTY, Confinement.EmptyBy.NOTHING_SHOWN,
+                NOWHERE, Confinement.Shown.BY_THE_READINGS));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingLeftUnbuiltHoldsAnAnswerTheSameHoweverItWasComposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingLeftUnbuiltHoldsAnAnswerTheSameHoweverItWasComposedTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * What two readings were left holds an answer where holding it twice does.
+ *
+ * <p>{@link LeftUnbuilt} is put together where readings are, and spent where a verdict is
+ * published. Those are two places, and a caller reaching a verdict has met the readings in whatever
+ * order the composition happened to take — so what the composition comes to has to hold an answer
+ * the way the readings would have held it one at a time, or which answer comes back would follow
+ * how the caller bracketed them.
+ *
+ * <p>Which is the whole of what {@link LeftUnbuilt#met} claims by its name. Written as the word for
+ * holding two things together while meaning something else, it would be a walk's own arithmetic
+ * that agrees with the word today.
+ */
+class WhatAReadingLeftUnbuiltHoldsAnAnswerTheSameHoweverItWasComposedTest {
+
+    private static final List<LeftUnbuilt> BOTH =
+            List.of(LeftUnbuilt.NOTHING, LeftUnbuilt.A_POSITION);
+
+    private static final List<Emptiness> EVERY_ANSWER =
+            List.of(Emptiness.EMPTY, Emptiness.NONEMPTY, Emptiness.UNDECIDED);
+
+    /** Holding an answer under two of these is holding it under what the two come to. */
+    @Test
+    void holdingTwiceIsHoldingUnderWhatTheTwoCameTo() {
+        for (LeftUnbuilt one : BOTH) {
+            for (LeftUnbuilt other : BOTH) {
+                for (Emptiness answer : EVERY_ANSWER) {
+                    assertEquals(one.hold(other.hold(answer)), one.met(other).hold(answer),
+                            one + " and " + other + " holding " + answer);
+                }
+            }
+        }
+    }
+
+    /** A reading that left nothing unbuilt takes nothing off what it is put beside. */
+    @Test
+    void aReadingThatLeftNothingIsWhatTheOtherIs() {
+        for (LeftUnbuilt each : BOTH) {
+            assertSame(each, LeftUnbuilt.NOTHING.met(each));
+            assertSame(each, each.met(LeftUnbuilt.NOTHING));
+        }
+    }
+
+    /** And the same reading met however often, and in whichever order, is the same. */
+    @Test
+    void neitherTheOrderNorHowOftenReachesTheAnswer() {
+        for (LeftUnbuilt one : BOTH) {
+            assertSame(one, one.met(one));
+            for (LeftUnbuilt other : BOTH) {
+                assertSame(one.met(other), other.met(one));
+                for (LeftUnbuilt third : BOTH) {
+                    assertSame(one.met(other).met(third), one.met(other.met(third)));
+                }
+            }
+        }
+    }
+
+    /**
+     * And what each of them does to a verdict.
+     *
+     * <p>The one thing a reader spends this on. A reading short of a position leaves a settled
+     * positive answer unsettled and leaves the other two where they were, which is what meeting
+     * against the answer nobody has worked out comes to — said here as the six cases, so that the
+     * rule is fixed rather than following whatever the embedding is changed to.
+     */
+    @Test
+    void andWhatEachOfThemLeavesAVerdict() {
+        for (Emptiness answer : EVERY_ANSWER) {
+            assertSame(answer, LeftUnbuilt.NOTHING.hold(answer),
+                    "a reading that built everything answers for itself");
+        }
+        assertSame(Emptiness.EMPTY, LeftUnbuilt.A_POSITION.hold(Emptiness.EMPTY),
+                "a narrower reading refuses no less, so settled empty is settled all the same");
+        assertSame(Emptiness.UNDECIDED, LeftUnbuilt.A_POSITION.hold(Emptiness.NONEMPTY),
+                "and a positive answer was about less than the rules say");
+        assertSame(Emptiness.UNDECIDED, LeftUnbuilt.A_POSITION.hold(Emptiness.UNDECIDED));
+    }
+}


### PR DESCRIPTION
A reading with a position nobody could work out stands for every value there,
which is wider than the rules say. So a walk that found no refusal at it found
none because nothing was asked, and the settled positive answer it reached is
about less than the rules. The one place saying so read the answer against a
constant and the shortfalls against a set — a rule about verdicts kept where no
verdict lives, which an answer added to the three would fall through.

It was saying three things at once, and each of them has an owner.

What a reading left unbuilt is a word of its own now, projected off the
shortfalls and answering the existential question a verdict turns on. A
shortfall is one occurrence owed to a rule or to the answer and a report is
written out of those; whether there is such a position is all a verdict needs,
and a second one takes nothing further off an answer already waiting on the
first.

What that leaves an answer is that word's, said as a meet against the answer
nobody has worked out. So a fourth answer is asked what it comes to where the
arithmetic is written, rather than falling through a comparison. And that a
verdict which moved carries no proof is the verdict's own rule, which its
canonical constructor now refuses to be written against — in one direction, since
a lack shown about no block in particular is still a lack.

The rest is where the halves may be apart. A conjunction that took a reading in
kept what showed it empty and dropped what it could not build, and answered that
something satisfies it out of positions nobody had worked out — which nothing
noticed because everything downstream asks only whether it is empty. Both halves
travel as one value now, and it hands out the verdict and nothing else, so
nobody outside can hold the first without the second. The conjunction carries
the other half through every way one of these is made and composes it rather
than reading it.

`Realized` leaves both of the architecture test's nest lists on the way, and says
nothing about the answers any more; the readings of the word that nobody had
decided are none.

Ref souther-lang/souther#1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)