### PR TITLE
Ask what a leaf states, and compose a choice of bounds where the branches are

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  * <p>So this answers one question: whether a range can be read for the number the leaf states a
  * line on. A line it could not place leaves that number where it was and says so
- * ({@link Read#leftUnplaced}), because the two are not the same fact — a number no rule spoke of
+ * ({@link Read.LeftOpen}), because the two are not the same fact — a number no rule spoke of
  * runs as far as it ever did, and one a rule stopped somewhere nobody worked out is a line this
  * compiler owes an answer for.
  */

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
-import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.numeric.OrderedInterval;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -15,19 +15,27 @@ import java.util.Map;
  * that number is the one it is a line on.
  *
  * <p><b>Leaves, and not the connectives over them</b>, for the reason {@link OrderedReading} gives.
- * What a conjunction or a choice of these comes to is composed where the branches have their fate
- * ({@link StatedByClauses.Part}), so a choice between two bounds on one length settles to what the
- * two of them leave together and a bound in a branch nobody can be in settles to nothing. Read off
- * the leaves alone, a bound written under a {@code ||} would be a bound every value has to meet.
+ * What a conjunction or a choice of these comes to is composed where both of the readings that
+ * decide a branch's fate are held ({@link Confinement.Planned#either}), so a choice between two
+ * bounds on one length settles to what the two of them leave together and a bound in a branch
+ * nobody can be in settles to nothing. Read off the leaves alone, a bound written under a
+ * {@code ||} would be a bound every value has to meet.
  *
  * <p><b>Only what an operation answers</b> ({@link DerivedNumber}). Where the values at a position
  * stop is the reading of ends' and is settled there; keyed alike, the two would be two mechanisms
  * over one order, and the line a report draws would be whichever of them was asked.
  *
- * <p>What this reading could not follow is not written down here. A line it states and could not
- * place leaves that number where it was, which is what {@link OrderedIntervals#top} says, and the
- * clause is answered for by the reading that says what a leaf states at all ({@link StatedLines}) —
- * a second record of it here would be one more thing to keep in step with that answer.
+ * <p><b>Which number a leaf is about is not decided here.</b> That is what the leaf states, and it
+ * is answered where the arithmetic of the comparison is ({@link StatedLines}) — the same answer the
+ * attribution of an end to a conjunct runs on. Asked again here, off which side is spelled as a
+ * name, a rule whose coordinate is written inside an expression would be a rule this reading is not
+ * about, and the choice above it would come back saying the model draws no line.
+ *
+ * <p>So this answers one question: whether a range can be read for the number the leaf states a
+ * line on. A line it could not place leaves that number where it was and says so
+ * ({@link Read#leftUnplaced}), because the two are not the same fact — a number no rule spoke of
+ * runs as far as it ever did, and one a rule stopped somewhere nobody worked out is a line this
+ * compiler owes an answer for.
  */
 final class BoundaryReading {
 
@@ -37,12 +45,17 @@ final class BoundaryReading {
     /** What each of those numbers is ordered on, under the number itself: a leaf is read for every
      *  clause of every value, so nothing here searches for one. */
     private final Map<DerivedNumber, Carrier> carriers;
+    /** And what the clauses call each of them, for the same reason. */
+    private final Map<DerivedNumber, FactSubject> subjects;
 
     private BoundaryReading(Terms terms, Map<FactSubject, DerivedNumber> byName,
                             Map<DerivedNumber, Carrier> carriers) {
         this.terms = terms;
         this.byName = byName;
         this.carriers = carriers;
+        Map<DerivedNumber, FactSubject> named = new LinkedHashMap<>();
+        byName.forEach((subject, number) -> named.put(number, subject));
+        this.subjects = named;
     }
 
     /**
@@ -67,10 +80,36 @@ final class BoundaryReading {
                         new LinkedHashMap<>(carriers));
     }
 
-    /** Where one leaf leaves the numbers this reading holds, which is everywhere it found none. */
-    OrderedIntervals<DerivedNumber> leaf(Core e, boolean positive, Denotations at) {
-        if (byName.isEmpty() || !(e instanceof Core.Binary bin)) {
-            return OrderedIntervals.top();
+    /**
+     * What one leaf did to the number it states a line on.
+     *
+     * <p>Three answers and not a range beside a flag. A number no rule spoke of and one a rule
+     * stopped somewhere nobody worked out are both absent from a range, and only the second is an
+     * end this compiler owes an answer for — read off the range alone, the two are one.
+     */
+    sealed interface Read {
+
+        /** The leaf states a line on none of the numbers this reading holds. */
+        record NoLineStated() implements Read {}
+
+        /** It stops {@code number} inside {@code range}. */
+        record Bounded(DerivedNumber number, FactSubject subject, OrderedInterval range)
+                implements Read {}
+
+        /** It stops {@code number} somewhere nothing here worked out. */
+        record LeftOpen(DerivedNumber number, FactSubject subject) implements Read {}
+    }
+
+    private static final Read NOTHING_STATED = new Read.NoLineStated();
+
+    /** Where one leaf leaves the number it states a line on, or nothing where it states none. */
+    Read leaf(StatedLines.Statement stated, Core e, boolean positive, Denotations at) {
+        if (!(stated instanceof StatedLines.Statement.OnADerivedNumber said)) {
+            return NOTHING_STATED;
+        }
+        FactSubject subject = subjectOf(said.number());
+        if (subject == null || !(e instanceof Core.Binary bin)) {
+            return NOTHING_STATED;
         }
         OrderedLeaf.Read<DerivedNumber> read = OrderedLeaf.of(bin, positive, at, terms,
                 each -> byName.get(terms.subjectOf(each, at)), carriers::get);
@@ -78,8 +117,21 @@ final class BoundaryReading {
         // Every count stops at the largest whole number whether or not a rule was written, and this
         // reading is read for the line an author drew — taken whole, every rule about a length
         // would put an end at a place no clause of it mentions.
+        //
+        // And the number the leaf was said to state a line on, which is not always one this reading
+        // can find a side for: the arithmetic reaches a coordinate written inside an expression and
+        // the walk over the two sides does not. Such a line is one this reading left open, and
+        // saying so is what keeps a choice offering it from reading as a model that draws none.
         return read.left() instanceof OrderedLeaf.Left.Leaves<DerivedNumber> it
-                ? OrderedIntervals.at(it.number(), it.stated())
-                : OrderedIntervals.top();
+                && it.number().equals(said.number())
+                ? new Read.Bounded(it.number(), subject, it.stated())
+                : new Read.LeftOpen(said.number(), subject);
+    }
+
+    /** What the clauses call {@code number}, which is the name every other reader files it
+     *  under. Kept the other way round beside {@link #byName} rather than searched for: a leaf is
+     *  read for every clause of every value. */
+    private FactSubject subjectOf(DerivedNumber number) {
+        return subjects.get(number);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -97,8 +97,15 @@ final class BoundaryReading {
         record Bounded(DerivedNumber number, FactSubject subject, OrderedInterval range)
                 implements Read {}
 
-        /** It stops {@code number} somewhere nothing here worked out. */
-        record LeftOpen(DerivedNumber number, FactSubject subject) implements Read {}
+        /**
+         * It stops {@code number} somewhere nothing here worked out.
+         *
+         * <p>The line is named ({@link OpenEnd}) because what a choice does to it is about this
+         * line and not about the number: a rule stating two lines on one length may have one of
+         * them settled by an alternative and the other written where no alternative reaches, and
+         * told apart by the number the second would answer for the first.
+         */
+        record LeftOpen(OpenEnd end, FactSubject subject) implements Read {}
     }
 
     private static final Read NOTHING_STATED = new Read.NoLineStated();
@@ -125,7 +132,7 @@ final class BoundaryReading {
         // saying so is what keeps a choice offering it from reading as a model that draws none.
         if (!(read.left() instanceof OrderedLeaf.Left.Leaves<DerivedNumber> it)
                 || !it.number().equals(said.number())) {
-            return new Read.LeftOpen(said.number(), subject);
+            return new Read.LeftOpen(new OpenEnd(said.number()), subject);
         }
         OrderedInterval left = it.stated();
         // And a rule whose ends have crossed states no end of this number. What it says is that

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.OrderedInterval;
 
 import java.util.LinkedHashMap;
@@ -122,10 +123,19 @@ final class BoundaryReading {
         // can find a side for: the arithmetic reaches a coordinate written inside an expression and
         // the walk over the two sides does not. Such a line is one this reading left open, and
         // saying so is what keeps a choice offering it from reading as a model that draws none.
-        return read.left() instanceof OrderedLeaf.Left.Leaves<DerivedNumber> it
-                && it.number().equals(said.number())
-                ? new Read.Bounded(it.number(), subject, it.stated())
-                : new Read.LeftOpen(said.number(), subject);
+        if (!(read.left() instanceof OrderedLeaf.Left.Leaves<DerivedNumber> it)
+                || !it.number().equals(said.number())) {
+            return new Read.LeftOpen(said.number(), subject);
+        }
+        OrderedInterval left = it.stated();
+        // And a rule whose ends have crossed states no end of this number. What it says is that
+        // nothing satisfies it there, which is a fact about whether a value exists — the question
+        // this reading has no half of and the readings that decide it already answer. Put in the
+        // envelope, it would be a line at a place the order does not reach, and every reader of the
+        // envelope would have to know not to draw it.
+        return Endpoint.someValueLiesBetween(left.low(), left.high())
+                ? new Read.Bounded(it.number(), subject, left)
+                : NOTHING_STATED;
     }
 
     /** What the clauses call {@code number}, which is the name every other reader files it

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
-import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.OrderedInterval;
 
 import java.util.LinkedHashMap;
@@ -134,15 +133,12 @@ final class BoundaryReading {
                 || !it.number().equals(said.number())) {
             return new Read.LeftOpen(new OpenEnd(said.number()), subject);
         }
-        OrderedInterval left = it.stated();
-        // And a rule whose ends have crossed states no end of this number. What it says is that
-        // nothing satisfies it there, which is a fact about whether a value exists — the question
-        // this reading has no half of and the readings that decide it already answer. Put in the
-        // envelope, it would be a line at a place the order does not reach, and every reader of the
-        // envelope would have to know not to draw it.
-        return Endpoint.someValueLiesBetween(left.low(), left.high())
-                ? new Read.Bounded(it.number(), subject, left)
-                : NOTHING_STATED;
+        // Whatever the ends came to, crossed ones included. That a rule leaves the number no value
+        // is not that no rule spoke of it: the first takes every value of a choice into the
+        // alternative beside it, and the second leaves that alternative saying nothing about the
+        // number at all. Told apart where they compose ({@link BoundaryState}), and collapsed here
+        // they would arrive there as one.
+        return new Read.Bounded(it.number(), subject, it.stated());
     }
 
     /** What the clauses call {@code number}, which is the name every other reader files it

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryReading.java
@@ -1,0 +1,85 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.numeric.OrderedIntervals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The clauses reaching a value, read for where the numbers its operations answer stop.
+ *
+ * <p>The third reading of one clause tree, beside which values may stand at a position and where
+ * the position's own order stops. A rule about how long the string at a place is says nothing about
+ * which strings stand there and nothing about where they stop: it is a line on a whole number, and
+ * that number is the one it is a line on.
+ *
+ * <p><b>Leaves, and not the connectives over them</b>, for the reason {@link OrderedReading} gives.
+ * What a conjunction or a choice of these comes to is composed where the branches have their fate
+ * ({@link StatedByClauses.Part}), so a choice between two bounds on one length settles to what the
+ * two of them leave together and a bound in a branch nobody can be in settles to nothing. Read off
+ * the leaves alone, a bound written under a {@code ||} would be a bound every value has to meet.
+ *
+ * <p><b>Only what an operation answers</b> ({@link DerivedNumber}). Where the values at a position
+ * stop is the reading of ends' and is settled there; keyed alike, the two would be two mechanisms
+ * over one order, and the line a report draws would be whichever of them was asked.
+ *
+ * <p>What this reading could not follow is not written down here. A line it states and could not
+ * place leaves that number where it was, which is what {@link OrderedIntervals#top} says, and the
+ * clause is answered for by the reading that says what a leaf states at all ({@link StatedLines}) —
+ * a second record of it here would be one more thing to keep in step with that answer.
+ */
+final class BoundaryReading {
+
+    private final Terms terms;
+    /** Which number an expression is, for the numbers an operation answers of this value. */
+    private final Map<FactSubject, DerivedNumber> byName;
+    /** What each of those numbers is ordered on, under the number itself: a leaf is read for every
+     *  clause of every value, so nothing here searches for one. */
+    private final Map<DerivedNumber, Carrier> carriers;
+
+    private BoundaryReading(Terms terms, Map<FactSubject, DerivedNumber> byName,
+                            Map<DerivedNumber, Carrier> carriers) {
+        this.terms = terms;
+        this.byName = byName;
+        this.carriers = carriers;
+    }
+
+    /**
+     * A reading with nothing to read, for a value none of whose places is measured.
+     *
+     * <p>Made once. Most values have no operation answering a number of them, and a leaf of every
+     * clause of every one of them is read through this.
+     */
+    private static final BoundaryReading NOTHING =
+            new BoundaryReading(null, Map.of(), Map.of());
+
+    /**
+     * The reading of the numbers {@code numbers} names, whose orders {@code carriers} gives.
+     *
+     * <p>No environment is held, as the readings beside it hold none: which environment a leaf is
+     * read at is where the leaf stands, and the fold hands that down.
+     */
+    static BoundaryReading of(Terms terms, Map<FactSubject, DerivedNumber> numbers,
+                              Map<DerivedNumber, Carrier> carriers) {
+        return numbers.isEmpty() ? NOTHING
+                : new BoundaryReading(terms, new LinkedHashMap<>(numbers),
+                        new LinkedHashMap<>(carriers));
+    }
+
+    /** Where one leaf leaves the numbers this reading holds, which is everywhere it found none. */
+    OrderedIntervals<DerivedNumber> leaf(Core e, boolean positive, Denotations at) {
+        if (byName.isEmpty() || !(e instanceof Core.Binary bin)) {
+            return OrderedIntervals.top();
+        }
+        OrderedLeaf.Read<DerivedNumber> read = OrderedLeaf.of(bin, positive, at, terms,
+                each -> byName.get(terms.subjectOf(each, at)), carriers::get);
+        // The ends the rule states, held inside the order and with none of the order's own added.
+        // Every count stops at the largest whole number whether or not a rule was written, and this
+        // reading is read for the line an author drew — taken whole, every rule about a length
+        // would put an end at a place no clause of it mentions.
+        return read.left() instanceof OrderedLeaf.Left.Leaves<DerivedNumber> it
+                ? OrderedIntervals.at(it.number(), it.stated())
+                : OrderedIntervals.top();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
@@ -1,0 +1,162 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a reading leaves the numbers a value's operations answer: where each of them stops, and
+ * which of them a rule stopped somewhere nothing worked out.
+ *
+ * <p>Two halves of one reading and never two readings. A number no rule spoke of is absent from
+ * both, one a rule stopped is in the first, and one a rule stopped somewhere this compiler could
+ * not follow is in the second — read off a range alone, the first and the last are the same
+ * absence, and a choice offering the last comes back saying the model draws no line.
+ *
+ * <p><b>Composed here and nowhere else.</b> What a conjunction or a choice of these comes to is one
+ * question, and this is where it is answered — beside the values and the orders, under the fate
+ * those two decide ({@link Confinement.Planned}). A second place putting either half of it together
+ * is a second answer about one written choice, and the two would agree until somebody changed one.
+ *
+ * <p><b>An envelope, and no part of whether a value exists.</b> Two alternatives naming one size
+ * each leave the run between them, and no value has a size in there — so this says where the
+ * outermost ends are and is read where a line is looked for. It is asked nothing about whether
+ * anybody can be in a branch, which is the values' and the orders' between them
+ * ({@link Confinement#admission}): a number is bounded by rules the position's own readings have no
+ * word for, so a branch this refused would be refused by a reading they cannot check.
+ *
+ * <p>Which is why {@link #either} joins nothing at a number either side's rules leave no value at.
+ * That such ends have crossed is a sound proof that nobody is in that branch — and acting on it
+ * here would be this reading deciding a fate, so what it does instead is decline to speak: a
+ * number it says nothing about is one no line is drawn on, which is the answer this may always
+ * give.
+ *
+ * @param known where each number a rule stopped is left, for the numbers some rule stopped
+ * @param open  the numbers a rule stopped somewhere nothing here worked out
+ */
+record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<DerivedNumber> open) {
+
+    /** What a leaf stating a line on none of these numbers leaves them, which is most leaves. */
+    private static final BoundaryState NOTHING = new BoundaryState(Map.of(), Set.of());
+
+    BoundaryState {
+        known = known.isEmpty() ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(known));
+        open = open.isEmpty() ? Set.of()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(open));
+    }
+
+    /** A reading that stopped none of these numbers. */
+    static BoundaryState nothing() {
+        return NOTHING;
+    }
+
+    /** One number stopped inside {@code range}. */
+    static BoundaryState bounded(DerivedNumber number, OrderedInterval range) {
+        return new BoundaryState(Map.of(number, range), Set.of());
+    }
+
+    /** One number stopped somewhere nothing here worked out. */
+    static BoundaryState leftOpen(DerivedNumber number) {
+        return new BoundaryState(Map.of(), Set.of(number));
+    }
+
+    /** Whether some rule of this reading stopped {@code number} anywhere it could follow. */
+    boolean bounds(DerivedNumber number) {
+        return known.containsKey(number);
+    }
+
+    /** Where the rules leave {@code number}, which is everywhere none of them stopped it. */
+    OrderedInterval at(DerivedNumber number) {
+        return known.getOrDefault(number, OrderedInterval.OPEN);
+    }
+
+    /**
+     * Both readings holding at once.
+     *
+     * <p>A number either of them stopped is one the pair stops, at the tighter of what they leave;
+     * a number either left open is one the pair left open, because the end it did not work out may
+     * be the one the values finally stop at.
+     */
+    BoundaryState both(BoundaryState other) {
+        if (other == NOTHING) {
+            return this;
+        }
+        if (this == NOTHING) {
+            return other;
+        }
+        Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>(known);
+        other.known.forEach((number, range) ->
+                out.merge(number, range, OrderedInterval::meet));
+        return new BoundaryState(out, union(open, other.open));
+    }
+
+    /**
+     * Either of them, which is what a choice between two branches somebody can be in leaves.
+     *
+     * <p>A number stopped in one branch and not in the other is left where it was: a value taking
+     * the second owes the first nothing, so the choice stops it nowhere. Where both stopped it, the
+     * choice stops it at whichever of the two reaches further out.
+     *
+     * <p>And a number either side's rules leave no value at is one this says nothing about — see
+     * the note on this type. Nothing is joined there and nothing is claimed.
+     *
+     * <p><b>An end one branch left open is one the choice leaves open unless the branch beside it
+     * stops the number nowhere.</b> That is the one thing a choice can show about it, and it is
+     * shown by the other branch having been read to the end and stopped the number nowhere — so a
+     * branch that stopped it, and a branch that left it open too, both leave the end standing.
+     */
+    BoundaryState either(BoundaryState other) {
+        Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>();
+        known.forEach((number, range) -> {
+            OrderedInterval there = other.known.get(number);
+            if (there != null && holdsAValue(range) && holdsAValue(there)) {
+                out.put(number, range.join(there));
+            }
+        });
+        Set<DerivedNumber> left = new LinkedHashSet<>();
+        open.forEach(number -> {
+            if (other.bounds(number) || other.open.contains(number)) {
+                left.add(number);
+            }
+        });
+        other.open.forEach(number -> {
+            if (bounds(number) || open.contains(number)) {
+                left.add(number);
+            }
+        });
+        return new BoundaryState(out, left);
+    }
+
+    /**
+     * Two branches neither of which anybody can be in.
+     *
+     * <p>Nothing anyone is in is stopped anywhere, and no end of such a branch is one a reader is
+     * owed: what is left of the choice is that nobody is in it, which is said by whoever showed it.
+     */
+    BoundaryState bothDead(BoundaryState other) {
+        return NOTHING;
+    }
+
+    private static boolean holdsAValue(OrderedInterval range) {
+        return Endpoint.someValueLiesBetween(range.low(), range.high());
+    }
+
+    private static Set<DerivedNumber> union(Set<DerivedNumber> these,
+                                            Set<DerivedNumber> those) {
+        if (those.isEmpty()) {
+            return these;
+        }
+        if (these.isEmpty()) {
+            return those;
+        }
+        Set<DerivedNumber> out = new LinkedHashSet<>(these);
+        out.addAll(those);
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
@@ -11,17 +11,34 @@ import java.util.Set;
 
 /**
  * What a reading leaves the numbers a value's operations answer: where each of them stops, and
- * which of them a rule stopped somewhere nothing worked out.
+ * which lines on them a rule stated that nothing here could place.
  *
- * <p>Two halves of one reading and never two readings. A number no rule spoke of is absent from
- * both, one a rule stopped is in the first, and one a rule stopped somewhere this compiler could
- * not follow is in the second — read off a range alone, the first and the last are the same
- * absence, and a choice offering the last comes back saying the model draws no line.
+ * <p>Four things a number can be to this reading, and telling them apart is the whole of it.
  *
- * <p><b>Composed here and nowhere else.</b> What a conjunction or a choice of these comes to is one
- * question, and this is where it is answered — beside the values and the orders, under the fate
- * those two decide ({@link Confinement.Planned}). A second place putting either half of it together
- * is a second answer about one written choice, and the two would agree until somebody changed one.
+ * <ul>
+ *   <li><b>Unsaid</b> — no rule of this reading spoke of it, so it runs as far as it ever did. It
+ *       is absent from both halves below.
+ *   <li><b>Known</b> — some rule stopped it, and this is where.
+ *   <li><b>Nothing left</b> — the rules stopped it past themselves, so no value of them is at it.
+ *       A known range whose ends have crossed.
+ *   <li><b>Open</b> — some rule stopped it somewhere nothing here worked out.
+ * </ul>
+ *
+ * <p>A number can be known and open at once: a conjunction of a bound this reading placed and one
+ * it could not is both, and each half is wanted by a different reader.
+ *
+ * <p><b>One algebra, folded over the two trees this reading is folded over.</b> What the rules of a
+ * whole declaration leave a number is settled over the tree the values are derived from, where a
+ * conjunction has been distributed into the branches beside it ({@link Confinement.Planned}); what
+ * a choice is answerable for is settled over the tree the author wrote, where an alternative is
+ * what stands between the brackets ({@link StatedByClauses.Part}). They are two questions and the
+ * same operations answer both — a second set of operations would be a second answer, which is what
+ * this type exists to stop.
+ *
+ * <p>Asked of the derived tree, what a choice left open would be read off branches holding
+ * conjuncts written outside the brackets: {@code (A || B) && C} distributes to
+ * {@code (A && C) || (B && C)}, and a line {@code C} leaves open is then in both alternatives — so
+ * the choice would be answerable for a line the author wrote nowhere near it.
  *
  * <p><b>An envelope, and no part of whether a value exists.</b> Two alternatives naming one size
  * each leave the run between them, and no value has a size in there — so this says where the
@@ -30,16 +47,18 @@ import java.util.Set;
  * ({@link Confinement#admission}): a number is bounded by rules the position's own readings have no
  * word for, so a branch this refused would be refused by a reading they cannot check.
  *
- * <p>Which is why {@link #either} joins nothing at a number either side's rules leave no value at.
- * That such ends have crossed is a sound proof that nobody is in that branch — and acting on it
- * here would be this reading deciding a fate, so what it does instead is decline to speak: a
- * number it says nothing about is one no line is drawn on, which is the answer this may always
- * give.
+ * <p><b>Which is why nothing left is not nothing said.</b> That a branch's rules leave a number no
+ * value is this reading's own knowledge, and it may act on it inside itself: a choice with such an
+ * alternative leaves what the alternative beside it leaves, because every value of the choice is in
+ * that one. What it may not do is hand the emptiness to the fates, and it does not — nobody outside
+ * is told, and the branch stands or falls on what the values and the orders say. Read as nothing
+ * said, the same three alternatives came to two answers depending on where the brackets were.
  *
- * @param known where each number a rule stopped is left, for the numbers some rule stopped
- * @param open  the numbers a rule stopped somewhere nothing here worked out
+ * @param known where each number some rule stopped is left, whether or not a value is there
+ * @param open  every line on one of these numbers that nothing here placed, one for each place an
+ *              author wrote one ({@link OpenEnd})
  */
-record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<DerivedNumber> open) {
+record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> open) {
 
     /** What a leaf stating a line on none of these numbers leaves them, which is most leaves. */
     private static final BoundaryState NOTHING = new BoundaryState(Map.of(), Set.of());
@@ -61,27 +80,44 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<DerivedNumbe
         return new BoundaryState(Map.of(number, range), Set.of());
     }
 
-    /** One number stopped somewhere nothing here worked out. */
-    static BoundaryState leftOpen(DerivedNumber number) {
-        return new BoundaryState(Map.of(), Set.of(number));
+    /** One line stated on a number and placed by nothing. */
+    static BoundaryState leftOpen(OpenEnd end) {
+        return new BoundaryState(Map.of(), Set.of(end));
     }
 
-    /** Whether some rule of this reading stopped {@code number} anywhere it could follow. */
-    boolean bounds(DerivedNumber number) {
-        return known.containsKey(number);
-    }
-
-    /** Where the rules leave {@code number}, which is everywhere none of them stopped it. */
+    /**
+     * Where the rules leave {@code number}, which is everywhere none of them stopped it.
+     *
+     * <p>The range as the rules leave it, ends crossed and all. A caller drawing a line reads the
+     * ends; that they have crossed is a fact about the rules and is that caller's to notice.
+     */
     OrderedInterval at(DerivedNumber number) {
         return known.getOrDefault(number, OrderedInterval.OPEN);
+    }
+
+    /** Whether some rule stopped {@code number} anywhere a value of them is. */
+    private boolean holdsDown(DerivedNumber number) {
+        OrderedInterval range = known.get(number);
+        return range != null && holdsAValue(range);
+    }
+
+    /** Whether the rules of this reading leave {@code number} no value at all. */
+    private boolean leavesNothingAt(DerivedNumber number) {
+        OrderedInterval range = known.get(number);
+        return range != null && !holdsAValue(range);
+    }
+
+    /** Whether some line stated on {@code number} here was placed by nothing. */
+    private boolean openAt(DerivedNumber number) {
+        return open.stream().anyMatch(each -> each.number().equals(number));
     }
 
     /**
      * Both readings holding at once.
      *
      * <p>A number either of them stopped is one the pair stops, at the tighter of what they leave;
-     * a number either left open is one the pair left open, because the end it did not work out may
-     * be the one the values finally stop at.
+     * a line either of them left open is one the pair left open, because the end it did not work
+     * out may be the one the values finally stop at.
      */
     BoundaryState both(BoundaryState other) {
         if (other == NOTHING) {
@@ -91,52 +127,91 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<DerivedNumbe
             return other;
         }
         Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>(known);
-        other.known.forEach((number, range) ->
-                out.merge(number, range, OrderedInterval::meet));
-        return new BoundaryState(out, union(open, other.open));
+        other.known.forEach((number, range) -> out.merge(number, range, OrderedInterval::meet));
+        Set<OpenEnd> ends = new LinkedHashSet<>(open);
+        ends.addAll(other.open);
+        return new BoundaryState(out, ends);
     }
 
     /**
      * Either of them, which is what a choice between two branches somebody can be in leaves.
      *
-     * <p>A number stopped in one branch and not in the other is left where it was: a value taking
-     * the second owes the first nothing, so the choice stops it nowhere. Where both stopped it, the
-     * choice stops it at whichever of the two reaches further out.
+     * <p>Asked of one number at a time, over every number either side speaks of.
      *
-     * <p>And a number either side's rules leave no value at is one this says nothing about — see
-     * the note on this type. Nothing is joined there and nothing is claimed.
-     *
-     * <p><b>An end one branch left open is one the choice leaves open unless the branch beside it
-     * stops the number nowhere.</b> That is the one thing a choice can show about it, and it is
-     * shown by the other branch having been read to the end and stopped the number nowhere — so a
-     * branch that stopped it, and a branch that left it open too, both leave the end standing.
+     * <ul>
+     *   <li>Where one branch leaves the number no value, the choice leaves what the other leaves:
+     *       every value of the choice is in that other branch.
+     *   <li>Where one branch says nothing of it, the choice says nothing: a value taking that
+     *       branch stands anywhere on the number, so the choice does too, and no end of it is
+     *       waiting on a reader.
+     *   <li>Where both stopped it, the choice stops it at whichever reaches further out.
+     *   <li>And a line one branch left open is one the choice leaves open, because the branch
+     *       beside it does not put the number at every value — which is the one thing a choice can
+     *       show about such a line.
+     * </ul>
      */
     BoundaryState either(BoundaryState other) {
+        Set<DerivedNumber> spoken = new LinkedHashSet<>(known.keySet());
+        open.forEach(each -> spoken.add(each.number()));
+        other.known.keySet().forEach(spoken::add);
+        other.open.forEach(each -> spoken.add(each.number()));
         Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>();
-        known.forEach((number, range) -> {
-            OrderedInterval there = other.known.get(number);
-            if (there != null && holdsAValue(range) && holdsAValue(there)) {
-                out.put(number, range.join(there));
+        Set<OpenEnd> ends = new LinkedHashSet<>();
+        for (DerivedNumber number : spoken) {
+            if (leavesNothingAt(number)) {
+                other.keep(number, out, ends);
+            } else if (other.leavesNothingAt(number)) {
+                keep(number, out, ends);
+            } else {
+                chosen(number, other, out, ends);
+            }
+        }
+        return new BoundaryState(out, ends);
+    }
+
+    /** What this branch leaves {@code number}, carried out whole because it is what the choice
+     *  leaves: nobody is in the branch beside it. */
+    private void keep(DerivedNumber number, Map<DerivedNumber, OrderedInterval> out,
+                      Set<OpenEnd> ends) {
+        OrderedInterval range = known.get(number);
+        if (range != null) {
+            out.put(number, range);
+        }
+        open.forEach(each -> {
+            if (each.number().equals(number)) {
+                ends.add(each);
             }
         });
-        Set<DerivedNumber> left = new LinkedHashSet<>();
-        open.forEach(number -> {
-            if (other.bounds(number) || other.open.contains(number)) {
-                left.add(number);
-            }
-        });
-        other.open.forEach(number -> {
-            if (bounds(number) || open.contains(number)) {
-                left.add(number);
-            }
-        });
-        return new BoundaryState(out, left);
+    }
+
+    /** What a choice between two branches somebody can be in leaves {@code number}. */
+    private void chosen(DerivedNumber number, BoundaryState other,
+                        Map<DerivedNumber, OrderedInterval> out, Set<OpenEnd> ends) {
+        OrderedInterval here = known.get(number);
+        OrderedInterval there = other.known.get(number);
+        if (here != null && there != null) {
+            out.put(number, here.join(there));
+        }
+        if (other.holdsDown(number) || other.openAt(number)) {
+            open.forEach(each -> {
+                if (each.number().equals(number)) {
+                    ends.add(each);
+                }
+            });
+        }
+        if (holdsDown(number) || openAt(number)) {
+            other.open.forEach(each -> {
+                if (each.number().equals(number)) {
+                    ends.add(each);
+                }
+            });
+        }
     }
 
     /**
      * Two branches neither of which anybody can be in.
      *
-     * <p>Nothing anyone is in is stopped anywhere, and no end of such a branch is one a reader is
+     * <p>Nothing anyone is in is stopped anywhere, and no line of such a branch is one a reader is
      * owed: what is left of the choice is that nobody is in it, which is said by whoever showed it.
      */
     BoundaryState bothDead(BoundaryState other) {
@@ -145,18 +220,5 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<DerivedNumbe
 
     private static boolean holdsAValue(OrderedInterval range) {
         return Endpoint.someValueLiesBetween(range.low(), range.high());
-    }
-
-    private static Set<DerivedNumber> union(Set<DerivedNumber> these,
-                                            Set<DerivedNumber> those) {
-        if (those.isEmpty()) {
-            return these;
-        }
-        if (these.isEmpty()) {
-            return those;
-        }
-        Set<DerivedNumber> out = new LinkedHashSet<>(these);
-        out.addAll(those);
-        return out;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundaryState.java
@@ -18,14 +18,20 @@ import java.util.Set;
  * <ul>
  *   <li><b>Unsaid</b> — no rule of this reading spoke of it, so it runs as far as it ever did. It
  *       is absent from both halves below.
- *   <li><b>Known</b> — some rule stopped it, and this is where.
- *   <li><b>Nothing left</b> — the rules stopped it past themselves, so no value of them is at it.
- *       A known range whose ends have crossed.
- *   <li><b>Open</b> — some rule stopped it somewhere nothing here worked out.
+ *   <li><b>{@link Left.Known}</b> — some rule stopped it, and this is where.
+ *   <li><b>{@link Left.NothingLeft}</b> — the rules stopped it past themselves, so no value of
+ *       them is at it.
+ *   <li><b>Open</b> — some rule stated a line on it that nothing here worked out, once for each
+ *       place an author wrote one ({@link OpenEnd}).
  * </ul>
  *
  * <p>A number can be known and open at once: a conjunction of a bound this reading placed and one
  * it could not is both, and each half is wanted by a different reader.
+ *
+ * <p><b>Nothing left is a state and not a shape a range happens to take.</b> Ends that have crossed
+ * are how such a number arrives, and a reader that had to notice the crossing is a reader that can
+ * forget to — which is what happened while the join and the question a choice asks the branch
+ * beside it disagreed about whether such a number was bounded. What is written down is the answer.
  *
  * <p><b>One algebra, folded over the two trees this reading is folded over.</b> What the rules of a
  * whole declaration leave a number is settled over the tree the values are derived from, where a
@@ -51,33 +57,48 @@ import java.util.Set;
  * value is this reading's own knowledge, and it may act on it inside itself: a choice with such an
  * alternative leaves what the alternative beside it leaves, because every value of the choice is in
  * that one. What it may not do is hand the emptiness to the fates, and it does not — nobody outside
- * is told, and the branch stands or falls on what the values and the orders say. Read as nothing
- * said, the same three alternatives came to two answers depending on where the brackets were.
+ * is told, and the branch stands or falls on what the values and the orders say.
  *
- * @param known where each number some rule stopped is left, whether or not a value is there
- * @param open  every line on one of these numbers that nothing here placed, one for each place an
- *              author wrote one ({@link OpenEnd})
+ * @param byNumber what the rules leave each number some rule of this reading spoke of
+ * @param open     every line on one of these numbers that nothing here placed
  */
-record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> open) {
+record BoundaryState(Map<DerivedNumber, BoundaryState.Left> byNumber, Set<OpenEnd> open) {
+
+    /** What the rules of one reading leave a number they spoke of. */
+    sealed interface Left {
+
+        /** They stop it inside {@code range}, which holds a value. */
+        record Known(OrderedInterval range) implements Left {}
+
+        /** They stop it past themselves, so no value of them is at it. */
+        record NothingLeft() implements Left {}
+    }
+
+    private static final Left NOTHING_LEFT = new Left.NothingLeft();
 
     /** What a leaf stating a line on none of these numbers leaves them, which is most leaves. */
     private static final BoundaryState NOTHING = new BoundaryState(Map.of(), Set.of());
 
     BoundaryState {
-        known = known.isEmpty() ? Map.of()
-                : Collections.unmodifiableMap(new LinkedHashMap<>(known));
+        byNumber = byNumber.isEmpty() ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(byNumber));
         open = open.isEmpty() ? Set.of()
                 : Collections.unmodifiableSet(new LinkedHashSet<>(open));
     }
 
-    /** A reading that stopped none of these numbers. */
+    /** A reading that spoke of none of these numbers. */
     static BoundaryState nothing() {
         return NOTHING;
     }
 
-    /** One number stopped inside {@code range}. */
+    /**
+     * One number the rules stop inside {@code range}.
+     *
+     * <p>Which of the two states that is is decided here, once, off the range — so nothing further
+     * on has to look at the ends to find out.
+     */
     static BoundaryState bounded(DerivedNumber number, OrderedInterval range) {
-        return new BoundaryState(Map.of(number, range), Set.of());
+        return new BoundaryState(Map.of(number, leftBy(range)), Set.of());
     }
 
     /** One line stated on a number and placed by nothing. */
@@ -86,25 +107,30 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
     }
 
     /**
-     * Where the rules leave {@code number}, which is everywhere none of them stopped it.
+     * Where the rules stop {@code number}, or null where they stop it nowhere a value of them is.
      *
-     * <p>The range as the rules leave it, ends crossed and all. A caller drawing a line reads the
-     * ends; that they have crossed is a fact about the rules and is that caller's to notice.
+     * <p>Null for a number nothing spoke of and for one the rules leave no value at, which are the
+     * two a line may not be drawn from: the first has no ends and the second has ends nothing is
+     * between. What has been read in the second case is that the rules contradict there, and that
+     * is said by whoever answers whether a value exists.
      */
-    OrderedInterval at(DerivedNumber number) {
-        return known.getOrDefault(number, OrderedInterval.OPEN);
+    OrderedInterval knownAt(DerivedNumber number) {
+        return byNumber.get(number) instanceof Left.Known it ? it.range() : null;
     }
 
     /** Whether some rule stopped {@code number} anywhere a value of them is. */
     private boolean holdsDown(DerivedNumber number) {
-        OrderedInterval range = known.get(number);
-        return range != null && holdsAValue(range);
+        return byNumber.get(number) instanceof Left.Known;
     }
 
     /** Whether the rules of this reading leave {@code number} no value at all. */
     private boolean leavesNothingAt(DerivedNumber number) {
-        OrderedInterval range = known.get(number);
-        return range != null && !holdsAValue(range);
+        return byNumber.get(number) instanceof Left.NothingLeft;
+    }
+
+    /** Whether this reading spoke of {@code number} at all. */
+    private boolean spokeOf(DerivedNumber number) {
+        return byNumber.containsKey(number) || openAt(number);
     }
 
     /** Whether some line stated on {@code number} here was placed by nothing. */
@@ -115,9 +141,10 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
     /**
      * Both readings holding at once.
      *
-     * <p>A number either of them stopped is one the pair stops, at the tighter of what they leave;
-     * a line either of them left open is one the pair left open, because the end it did not work
-     * out may be the one the values finally stop at.
+     * <p>A number either of them stopped is one the pair stops, at the tighter of what they leave —
+     * and where the tighter of two leaves no value, the pair leaves none. A line either of them
+     * left open is one the pair left open, because the end it did not work out may be the one the
+     * values finally stop at.
      */
     BoundaryState both(BoundaryState other) {
         if (other == NOTHING) {
@@ -126,41 +153,61 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
         if (this == NOTHING) {
             return other;
         }
-        Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>(known);
-        other.known.forEach((number, range) -> out.merge(number, range, OrderedInterval::meet));
+        Map<DerivedNumber, Left> out = new LinkedHashMap<>(byNumber);
+        other.byNumber.forEach((number, left) -> out.merge(number, left, BoundaryState::met));
         Set<OpenEnd> ends = new LinkedHashSet<>(open);
         ends.addAll(other.open);
         return new BoundaryState(out, ends);
     }
 
+    /** What two readings that both stopped one number leave it. */
+    private static Left met(Left here, Left there) {
+        if (here instanceof Left.Known a && there instanceof Left.Known b) {
+            return leftBy(a.range().meet(b.range()));
+        }
+        return NOTHING_LEFT;
+    }
+
     /**
      * Either of them, which is what a choice between two branches somebody can be in leaves.
      *
-     * <p>Asked of one number at a time, over every number either side speaks of.
+     * <p>Asked of one number at a time, over every number either side spoke of.
      *
      * <ul>
      *   <li>Where one branch leaves the number no value, the choice leaves what the other leaves:
-     *       every value of the choice is in that other branch.
+     *       every value of the choice is in that other branch. Where both do, so does the choice,
+     *       and neither branch's lines are lines anybody is owed.
      *   <li>Where one branch says nothing of it, the choice says nothing: a value taking that
-     *       branch stands anywhere on the number, so the choice does too, and no end of it is
+     *       branch stands anywhere on the number, so the choice does too, and no line on it is
      *       waiting on a reader.
      *   <li>Where both stopped it, the choice stops it at whichever reaches further out.
      *   <li>And a line one branch left open is one the choice leaves open, because the branch
      *       beside it does not put the number at every value — which is the one thing a choice can
      *       show about such a line.
      * </ul>
+     *
+     * <p>Every one of those reads the same either way round, which is what a choice is.
      */
     BoundaryState either(BoundaryState other) {
-        Set<DerivedNumber> spoken = new LinkedHashSet<>(known.keySet());
+        Set<DerivedNumber> spoken = new LinkedHashSet<>(byNumber.keySet());
         open.forEach(each -> spoken.add(each.number()));
-        other.known.keySet().forEach(spoken::add);
+        other.byNumber.keySet().forEach(spoken::add);
         other.open.forEach(each -> spoken.add(each.number()));
-        Map<DerivedNumber, OrderedInterval> out = new LinkedHashMap<>();
+        Map<DerivedNumber, Left> out = new LinkedHashMap<>();
         Set<OpenEnd> ends = new LinkedHashSet<>();
         for (DerivedNumber number : spoken) {
-            if (leavesNothingAt(number)) {
+            boolean here = leavesNothingAt(number);
+            boolean there = other.leavesNothingAt(number);
+            if (here && there) {
+                // Neither branch has a value at the number, so the choice has none — and a line
+                // either of them left open is still one nothing placed, since neither puts the
+                // number at every value. Both sides', so that a choice between one reading and
+                // itself is that reading.
+                keep(number, out, ends);
                 other.keep(number, out, ends);
-            } else if (other.leavesNothingAt(number)) {
+            } else if (here) {
+                other.keep(number, out, ends);
+            } else if (there) {
                 keep(number, out, ends);
             } else {
                 chosen(number, other, out, ends);
@@ -171,11 +218,10 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
 
     /** What this branch leaves {@code number}, carried out whole because it is what the choice
      *  leaves: nobody is in the branch beside it. */
-    private void keep(DerivedNumber number, Map<DerivedNumber, OrderedInterval> out,
-                      Set<OpenEnd> ends) {
-        OrderedInterval range = known.get(number);
-        if (range != null) {
-            out.put(number, range);
+    private void keep(DerivedNumber number, Map<DerivedNumber, Left> out, Set<OpenEnd> ends) {
+        Left left = byNumber.get(number);
+        if (left != null) {
+            out.put(number, left);
         }
         open.forEach(each -> {
             if (each.number().equals(number)) {
@@ -186,25 +232,22 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
 
     /** What a choice between two branches somebody can be in leaves {@code number}. */
     private void chosen(DerivedNumber number, BoundaryState other,
-                        Map<DerivedNumber, OrderedInterval> out, Set<OpenEnd> ends) {
-        OrderedInterval here = known.get(number);
-        OrderedInterval there = other.known.get(number);
+                        Map<DerivedNumber, Left> out, Set<OpenEnd> ends) {
+        // A branch that says nothing of the number puts it at every value, so the choice does too
+        // and nothing about it is waiting on a reader.
+        if (!spokeOf(number) || !other.spokeOf(number)) {
+            return;
+        }
+        OrderedInterval here = knownAt(number);
+        OrderedInterval there = other.knownAt(number);
         if (here != null && there != null) {
-            out.put(number, here.join(there));
+            out.put(number, leftBy(here.join(there)));
         }
         if (other.holdsDown(number) || other.openAt(number)) {
-            open.forEach(each -> {
-                if (each.number().equals(number)) {
-                    ends.add(each);
-                }
-            });
+            keep(number, new LinkedHashMap<>(), ends);
         }
         if (holdsDown(number) || openAt(number)) {
-            other.open.forEach(each -> {
-                if (each.number().equals(number)) {
-                    ends.add(each);
-                }
-            });
+            other.keep(number, new LinkedHashMap<>(), ends);
         }
     }
 
@@ -218,7 +261,9 @@ record BoundaryState(Map<DerivedNumber, OrderedInterval> known, Set<OpenEnd> ope
         return NOTHING;
     }
 
-    private static boolean holdsAValue(OrderedInterval range) {
-        return Endpoint.someValueLiesBetween(range.low(), range.high());
+    /** Which of the two a range is, asked once where a range becomes a state. */
+    private static Left leftBy(OrderedInterval range) {
+        return Endpoint.someValueLiesBetween(range.low(), range.high())
+                ? new Left.Known(range) : NOTHING_LEFT;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -530,6 +530,25 @@ sealed interface Confinement<A> {
 
         private final PlannedValues<A> values;
         private final OrderedIntervals<A> ordered;
+        /**
+         * Where the numbers this value's operations answer stop ({@link BoundaryReading}).
+         *
+         * <p>Here because a choice is composed once and here is where it is composed: what the
+         * alternatives leave a length is joined under the same branch decision as what they leave
+         * the values and the orders, and a third place composing it would be a third answer about
+         * one written choice.
+         *
+         * <p><b>And it is not asked whether anybody can be in a branch.</b> That question is the
+         * values' and the orders' ({@link #admission}), and this holds no half of it: a length is
+         * bounded by rules about a number the position's own reading has no word for, so a branch
+         * refused by one of these would be refused by a reading the other two cannot check.
+         *
+         * <p><b>An envelope and never a claim that the rules are said by it.</b> Two branches
+         * naming one size each join to the run between them, and nothing in that run is a size any
+         * value has — so what this holds is where the outermost ends are, which is what a line is
+         * read off, and it is no evidence that the number is exactly represented.
+         */
+        private final OrderedIntervals<DerivedNumber> derived;
         private final Map<A, Carrier> carriers;
         /**
          * What already showed this holds nothing, or null where nothing has.
@@ -543,13 +562,22 @@ sealed interface Confinement<A> {
         private final Admission<A> shown;
 
         Planned(PlannedValues<A> values, OrderedIntervals<A> ordered, Map<A, Carrier> carriers) {
-            this(values, ordered, carriers, null);
+            this(values, ordered, OrderedIntervals.top(), carriers, null);
+        }
+
+        /** The same, for a leaf that also says where a number one of this value's operations
+         *  answers stops. */
+        Planned(PlannedValues<A> values, OrderedIntervals<A> ordered,
+                OrderedIntervals<DerivedNumber> derived, Map<A, Carrier> carriers) {
+            this(values, ordered, derived, carriers, null);
         }
 
         private Planned(PlannedValues<A> values, OrderedIntervals<A> ordered,
+                        OrderedIntervals<DerivedNumber> derived,
                         Map<A, Carrier> carriers, Admission<A> shown) {
             this.values = values;
             this.ordered = ordered;
+            this.derived = derived;
             this.carriers = Collections.unmodifiableMap(new LinkedHashMap<>(carriers));
             this.shown = shown;
         }
@@ -618,6 +646,7 @@ sealed interface Confinement<A> {
          */
         Planned<A> meet(Planned<A> other) {
             return new Planned<>(values.meet(other.values), ordered.meet(other.ordered),
+                    derived.meet(other.derived),
                     Confinement.both(carriers, other.carriers),
                     eitherShown(admission(), other.admission()));
         }
@@ -628,7 +657,11 @@ sealed interface Confinement<A> {
             return new Planned<>(
                     apart ? values.joinLiveApart(other.values) : values.joinLive(other.values),
                     ordered.joinLive(other.ordered),
-                    Confinement.both(carriers, other.carriers));
+                    // A number one branch bounds and the other says nothing about is left where it
+                    // was: a value taking the second owes the first nothing, and the join of a
+                    // range with every value is every value.
+                    derived.joinLive(other.derived),
+                    Confinement.both(carriers, other.carriers), null);
         }
 
         /**
@@ -649,17 +682,29 @@ sealed interface Confinement<A> {
         Planned<A> bothDead(Planned<A> other, Admission<A> shown) {
             return new Planned<>(values.bothDead(other.values),
                     ordered.bothDead(other.ordered),
+                    derived.bothDead(other.derived),
                     Confinement.both(carriers, other.carriers), shown);
         }
 
         /** This, holding what working it out could not build. */
         Planned<A> alsoStanding(souther.compiler.values.Standing<A> standing) {
-            return new Planned<>(values.alsoStanding(standing), ordered, carriers, shown);
+            return new Planned<>(values.alsoStanding(standing), ordered, derived, carriers, shown);
         }
 
         /** The values worked out, under {@code by}, and the same ranges beside them. */
         Worked<A> resolve(Allowance<A> by) {
-            return new Worked<>(values.resolve(by), ordered, carriers, shown);
+            return new Worked<>(values.resolve(by), ordered, derived, carriers, shown);
+        }
+
+        /**
+         * Where the rules leave the numbers this value's operations answer.
+         *
+         * <p>Handed out for a reader looking for where a line falls, and for nothing else. What it
+         * says is where the outermost ends are; that a number takes every value between them is
+         * not something it was ever asked.
+         */
+        OrderedIntervals<DerivedNumber> derived() {
+            return derived;
         }
 
         @Override
@@ -683,12 +728,16 @@ sealed interface Confinement<A> {
 
         private final Realized<A> made;
         private final OrderedIntervals<A> ordered;
+        /** Where the numbers this value's operations answer stop — see {@link Planned#derived}. */
+        private final OrderedIntervals<DerivedNumber> derived;
         private final Map<A, Carrier> carriers;
         /** What already showed this holds nothing — see {@link Planned#shown}. */
         private final Admission<A> shown;
 
-        Worked(Realized<A> made, OrderedIntervals<A> ordered, Map<A, Carrier> carriers,
+        Worked(Realized<A> made, OrderedIntervals<A> ordered,
+               OrderedIntervals<DerivedNumber> derived, Map<A, Carrier> carriers,
                Admission<A> shown) {
+            this.derived = derived;
             this.made = made;
             this.ordered = ordered;
             this.carriers = Collections.unmodifiableMap(new LinkedHashMap<>(carriers));
@@ -703,6 +752,12 @@ sealed interface Confinement<A> {
             return made.values();
         }
 
+        /** Where the rules leave the numbers this value's operations answer — see
+         *  {@link Planned#derived()}. */
+        OrderedIntervals<DerivedNumber> derived() {
+            return derived;
+        }
+
         /**
          * The same answer, unable to speak for {@code these} because a choice offered an
          * alternative nothing could read.
@@ -713,7 +768,7 @@ sealed interface Confinement<A> {
          */
         Worked<A> alsoOpenedAt(Set<A> these) {
             return these.isEmpty() ? this
-                    : new Worked<>(made.alsoOpenedAt(these), ordered, carriers, shown);
+                    : new Worked<>(made.alsoOpenedAt(these), ordered, derived, carriers, shown);
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -531,24 +531,23 @@ sealed interface Confinement<A> {
         private final PlannedValues<A> values;
         private final OrderedIntervals<A> ordered;
         /**
-         * Where the numbers this value's operations answer stop ({@link BoundaryReading}).
+         * What the rules leave the numbers this value's operations answer ({@link BoundaryState}).
          *
          * <p>Here because a choice is composed once and here is where it is composed: what the
-         * alternatives leave a length is joined under the same branch decision as what they leave
-         * the values and the orders, and a third place composing it would be a third answer about
-         * one written choice.
+         * alternatives leave a length is put together under the same branch decision as what they
+         * leave the values and the orders, and a third place composing any of it would be a third
+         * answer about one written choice.
+         *
+         * <p>Whole, and not the ranges alone. Which numbers a rule stopped somewhere nothing
+         * worked out is the other half of what this reading came to, and it composes by the same
+         * connectives: kept somewhere else, the two halves would be put together twice.
          *
          * <p><b>And it is not asked whether anybody can be in a branch.</b> That question is the
          * values' and the orders' ({@link #admission}), and this holds no half of it: a length is
          * bounded by rules about a number the position's own reading has no word for, so a branch
          * refused by one of these would be refused by a reading the other two cannot check.
-         *
-         * <p><b>An envelope and never a claim that the rules are said by it.</b> Two branches
-         * naming one size each join to the run between them, and nothing in that run is a size any
-         * value has — so what this holds is where the outermost ends are, which is what a line is
-         * read off, and it is no evidence that the number is exactly represented.
          */
-        private final OrderedIntervals<DerivedNumber> derived;
+        private final BoundaryState derived;
         private final Map<A, Carrier> carriers;
         /**
          * What already showed this holds nothing, or null where nothing has.
@@ -562,18 +561,18 @@ sealed interface Confinement<A> {
         private final Admission<A> shown;
 
         Planned(PlannedValues<A> values, OrderedIntervals<A> ordered, Map<A, Carrier> carriers) {
-            this(values, ordered, OrderedIntervals.top(), carriers, null);
+            this(values, ordered, BoundaryState.nothing(), carriers, null);
         }
 
         /** The same, for a leaf that also says where a number one of this value's operations
          *  answers stops. */
         Planned(PlannedValues<A> values, OrderedIntervals<A> ordered,
-                OrderedIntervals<DerivedNumber> derived, Map<A, Carrier> carriers) {
+                BoundaryState derived, Map<A, Carrier> carriers) {
             this(values, ordered, derived, carriers, null);
         }
 
         private Planned(PlannedValues<A> values, OrderedIntervals<A> ordered,
-                        OrderedIntervals<DerivedNumber> derived,
+                        BoundaryState derived,
                         Map<A, Carrier> carriers, Admission<A> shown) {
             this.values = values;
             this.ordered = ordered;
@@ -646,7 +645,7 @@ sealed interface Confinement<A> {
          */
         Planned<A> meet(Planned<A> other) {
             return new Planned<>(values.meet(other.values), ordered.meet(other.ordered),
-                    derived.meet(other.derived),
+                    derived.both(other.derived),
                     Confinement.both(carriers, other.carriers),
                     eitherShown(admission(), other.admission()));
         }
@@ -657,10 +656,12 @@ sealed interface Confinement<A> {
             return new Planned<>(
                     apart ? values.joinLiveApart(other.values) : values.joinLive(other.values),
                     ordered.joinLive(other.ordered),
-                    // A number one branch bounds and the other says nothing about is left where it
-                    // was: a value taking the second owes the first nothing, and the join of a
-                    // range with every value is every value.
-                    derived.joinLive(other.derived),
+                    // Which is not the ranges' own join. That one is written for two alternatives
+                    // this reading has been told somebody can be in, and nothing tells this one:
+                    // whether anybody can be in a branch is settled without it, so a branch whose
+                    // lengths have crossed reaches here alive. What such a branch leaves is
+                    // {@link BoundaryState#either}'s to say.
+                    derived.either(other.derived),
                     Confinement.both(carriers, other.carriers), null);
         }
 
@@ -697,13 +698,13 @@ sealed interface Confinement<A> {
         }
 
         /**
-         * Where the rules leave the numbers this value's operations answer.
+         * What the rules leave the numbers this value's operations answer.
          *
          * <p>Handed out for a reader looking for where a line falls, and for nothing else. What it
          * says is where the outermost ends are; that a number takes every value between them is
          * not something it was ever asked.
          */
-        OrderedIntervals<DerivedNumber> derived() {
+        BoundaryState derived() {
             return derived;
         }
 
@@ -729,13 +730,13 @@ sealed interface Confinement<A> {
         private final Realized<A> made;
         private final OrderedIntervals<A> ordered;
         /** Where the numbers this value's operations answer stop — see {@link Planned#derived}. */
-        private final OrderedIntervals<DerivedNumber> derived;
+        private final BoundaryState derived;
         private final Map<A, Carrier> carriers;
         /** What already showed this holds nothing — see {@link Planned#shown}. */
         private final Admission<A> shown;
 
         Worked(Realized<A> made, OrderedIntervals<A> ordered,
-               OrderedIntervals<DerivedNumber> derived, Map<A, Carrier> carriers,
+               BoundaryState derived, Map<A, Carrier> carriers,
                Admission<A> shown) {
             this.derived = derived;
             this.made = made;
@@ -752,9 +753,9 @@ sealed interface Confinement<A> {
             return made.values();
         }
 
-        /** Where the rules leave the numbers this value's operations answer — see
+        /** What the rules leave the numbers this value's operations answer — see
          *  {@link Planned#derived()}. */
-        OrderedIntervals<DerivedNumber> derived() {
+        BoundaryState derived() {
             return derived;
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedNumber.java
@@ -1,0 +1,49 @@
+package souther.compiler.check;
+
+import souther.compiler.types.ValueName;
+
+/**
+ * A number an operation answers of what stands at a place, and never what stands there.
+ *
+ * <p>{@link NumberAt} says which of the numbers at a place a subject is, and both kinds are one type
+ * there because a reader that has to say what two readings of one name came to needs them under one
+ * subject. This is the half an operation answers, and it is its own type because one order has one
+ * owner: where the values at a position stop is the reading of ends' ({@link OrderedReading}), and
+ * how long the string standing there is is another order this reading holds.
+ *
+ * <p><b>The rule is fixed by what can be built and not by a convention.</b> There is no way to make
+ * one of these out of a place's own value — {@link #of} answers with nothing for one — so a reading
+ * keyed by these cannot come to hold a range the ends already own. Left as a {@code NumberAt} under
+ * a comment, a position's own value put in by mistake would join and meet perfectly happily, and
+ * what came out is two mechanisms settling one order and a report answering from whichever ran last.
+ *
+ * @param position where the number is read from
+ * @param operation the operation that answers it, as it resolved. Two spellings reaching one
+ *                  operation are one number, and two operations over one place are two
+ */
+record DerivedNumber(RuleKey position, ValueName operation) {
+
+    DerivedNumber {
+        if (position == null || operation == null) {
+            throw new IllegalArgumentException("a derived number is what some operation answers"
+                    + " of somewhere");
+        }
+    }
+
+    /** The number {@code at} is, or null where it is what stands at the place rather than
+     *  something answered of it. */
+    static DerivedNumber of(NumberAt<RuleKey> at) {
+        return at.of() instanceof NumberAt.OfWhatNumber.OfWhatAnOperationAnswers taken
+                ? new DerivedNumber(at.position(), taken.operation()) : null;
+    }
+
+    /** The same number as the subject every other reader knows it by. */
+    NumberAt<RuleKey> asNumber() {
+        return NumberAt.takenOf(position, operation);
+    }
+
+    @Override
+    public String toString() {
+        return operation + "(" + position + ")";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
@@ -7,19 +7,27 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * The positions whose ends this reading did not work out, and what stands between each of them and
+ * The numbers of one value whose ends nothing worked out, and what stands between each of them and
  * the walk that raises a rule's questions.
  *
- * <p>One question and one answer: of the ends a part of a clause states, which are the ones this
- * reading did not work out. Whether anybody can be in a branch, which positions a choice leaves as
- * wide as they are, and whether the model raises a question anywhere are three other questions with
- * three other owners, and nothing here decides any of them — what is done with their answers is to
- * strike positions off this one.
+ * <p>One question and one answer: of the ends a part of a clause states, which are the ones nothing
+ * worked out. Whether anybody can be in a branch, which positions a choice leaves as wide as they
+ * are, and whether the model raises a question anywhere are three other questions with three other
+ * owners, and nothing here decides any of them — what is done with their answers is to strike
+ * numbers off this one.
  *
- * <p><b>A choice never puts a position in here.</b> {@link #either} keeps only what its alternatives
- * brought to it, so a choice can strike a position off and can add none: it may show that the branch
- * beside an unfollowed one leaves the position at every value, and it has nothing else to say. So a
- * position here was put here by a leaf the reading gave up on, and the choices above it are the
+ * <p><b>The numbers, and not the positions alone.</b> A place carries what stands at it and
+ * whatever its operations answer of that, and a rule can state a line on either — so which of them
+ * is here is whichever the rule was about, and which reader answered for it is settled by the
+ * number ({@link OrderedReading} for the first, {@link BoundaryReading} for the second). Kept as
+ * positions, a rule stopping a length somewhere nobody worked out had to be filed at the position,
+ * where the branch beside it was rightly found to leave the position's own order alone — and the
+ * end went unreported.
+ *
+ * <p><b>A choice never puts a number in here.</b> {@link #either} keeps only what its alternatives
+ * brought to it, so a choice can strike a number off and can add none: it may show that the branch
+ * beside an unfollowed one leaves the number at every value, and it has nothing else to say. So a
+ * number here was put here by a leaf whose reading gave up on it, and the choices above it are the
  * road, not the source.
  *
  * <p><b>The road is what says whether anything else is telling a reader.</b> The walk that turns a
@@ -41,14 +49,13 @@ import java.util.Set;
  * that is a fact about the rule rather than about how it was bracketed, and
  * {@code (a || b) || c} and {@code a || (b || c)} come to the same choices either way round.
  *
- * @param byPosition every position whose end this part left open, each with what stands between it
- *                   and the walk. Empty where the part's ends were all worked out
+ * @param byNumber every number whose end this part left open, under the name its own reading files
+ *                 it by. Empty where the part's ends were all worked out
  */
-record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
+record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byNumber) {
 
     /**
-     * What stands between one end this reading did not work out and the walk that raises a rule's
-     * questions.
+     * What stands between one end nothing worked out and the walk that raises a rule's questions.
      *
      * @param named        the choices to send an author to, empty where none can be named
      * @param underAChoice whether a choice an author wrote stands between. False is what says the
@@ -102,8 +109,8 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
     EndsLeftOpen {
         // As {@link Behind} is copied, and empty for the same reason: a leaf whose ends this
         // reading worked out makes one of these, and that is every leaf of every clause.
-        byPosition = byPosition.isEmpty() ? Map.of()
-                : Collections.unmodifiableMap(new LinkedHashMap<>(byPosition));
+        byNumber = byNumber.isEmpty() ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(byNumber));
     }
 
     /** A part whose ends this reading worked out, and one no reading has a word for at all. */
@@ -112,17 +119,20 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
     }
 
     /**
-     * One leaf, as the reading of ends answered for it.
+     * One leaf, as a reading answered for it.
      *
-     * <p>Handed the positions rather than asked for them: whether this reading followed the rule to
-     * the end is the reading's own answer ({@code OrderedReading.gaveUpAt}) and which positions the
-     * leaf is about is the clause's, and both are in hand where a leaf is read. A leaf it followed
-     * brings nothing here, whatever it found — a rule read from end to end that places no end is
-     * one this reading answered.
+     * <p>Handed the numbers rather than asked for them: whether a reading followed the rule to the
+     * end is that reading's own answer, and which numbers the leaf is about is what it states —
+     * both are in hand where a leaf is read, and neither is anything this type could work out. A
+     * leaf a reading followed brings nothing here, whatever it found: a rule read from end to end
+     * that places no end is one that reading answered.
      */
-    static EndsLeftOpen at(Set<FactSubject> positions) {
+    static EndsLeftOpen at(Set<FactSubject> numbers) {
+        if (numbers.isEmpty()) {
+            return NOTHING;
+        }
         Map<FactSubject, Behind> out = new LinkedHashMap<>();
-        positions.forEach(each -> out.put(each, Behind.aLeaf()));
+        numbers.forEach(each -> out.put(each, Behind.aLeaf()));
         return new EndsLeftOpen(out);
     }
 
@@ -134,14 +144,14 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
      * conjunction leaves the end at a position either of its parts left open still open.
      */
     EndsLeftOpen both(EndsLeftOpen other) {
-        if (other.byPosition.isEmpty()) {
+        if (other.byNumber.isEmpty()) {
             return this;
         }
-        if (byPosition.isEmpty()) {
+        if (byNumber.isEmpty()) {
             return other;
         }
-        Map<FactSubject, Behind> out = new LinkedHashMap<>(byPosition);
-        other.byPosition.forEach((position, behind) -> out.merge(position, behind, Behind::and));
+        Map<FactSubject, Behind> out = new LinkedHashMap<>(byNumber);
+        other.byNumber.forEach((position, behind) -> out.merge(position, behind, Behind::and));
         return new EndsLeftOpen(out);
     }
 
@@ -169,13 +179,13 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
                         Set<FactSubject> myBounds,
                         EndsLeftOpen other, Adoption<FactSubject, ReadingLanguage.Order> theirs,
                         Set<FactSubject> theirBounds) {
-        if (byPosition.isEmpty() && other.byPosition.isEmpty()) {
+        if (byNumber.isEmpty() && other.byNumber.isEmpty()) {
             return NOTHING;
         }
         Map<FactSubject, Behind> out = new LinkedHashMap<>();
-        byPosition.forEach((position, behind) ->
+        byNumber.forEach((position, behind) ->
                 keptUnder(choice, position, behind, other, theirs, theirBounds, out));
-        other.byPosition.forEach((position, behind) ->
+        other.byNumber.forEach((position, behind) ->
                 keptUnder(choice, position, behind, this, mine, myBounds, out));
         return new EndsLeftOpen(out);
     }
@@ -189,11 +199,11 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
      * and are carried with no choice to name.
      */
     EndsLeftOpen underACollapsedChoice() {
-        if (byPosition.isEmpty()) {
+        if (byNumber.isEmpty()) {
             return this;
         }
         Map<FactSubject, Behind> out = new LinkedHashMap<>();
-        byPosition.forEach((position, behind) ->
+        byNumber.forEach((position, behind) ->
                 out.put(position, behind.underACollapsedChoice()));
         return new EndsLeftOpen(out);
     }
@@ -220,7 +230,7 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
         // never among what the ends bounded and a position is never among these, so which of them
         // is asked is settled by the number rather than by a caller picking one.
         if (!theirs.constrains(position) && !theirBounds.contains(position)
-                && !beside.byPosition.containsKey(position)) {
+                && !beside.byNumber.containsKey(position)) {
             return;
         }
         out.merge(position, behind.under(choice), Behind::and);

--- a/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
@@ -16,13 +16,12 @@ import java.util.Set;
  * owners, and nothing here decides any of them — what is done with their answers is to strike
  * numbers off this one.
  *
- * <p><b>The numbers, and not the positions alone.</b> A place carries what stands at it and
- * whatever its operations answer of that, and a rule can state a line on either — so which of them
- * is here is whichever the rule was about, and which reader answered for it is settled by the
- * number ({@link OrderedReading} for the first, {@link BoundaryReading} for the second). Kept as
- * positions, a rule stopping a length somewhere nobody worked out had to be filed at the position,
- * where the branch beside it was rightly found to leave the position's own order alone — and the
- * end went unreported.
+ * <p><b>What stands at a place, and never a number an operation answers of it.</b> Both are numbers
+ * a rule can state a line on, and they are two orders with two readings — so the second is left
+ * open where its own reading settles what the alternatives leave it
+ * ({@link BoundaryState}), and reaches a document by the road this one takes. Carried here as well,
+ * the rule below would be asked whether the branch beside it bounds a length, which is a question
+ * the reading of ends has no word for and would answer no to.
  *
  * <p><b>A choice never puts a number in here.</b> {@link #either} keeps only what its alternatives
  * brought to it, so a choice can strike a number off and can add none: it may show that the branch
@@ -176,17 +175,15 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byNumber) {
      * branches brought, which is what keeps a choice from inventing a rule nobody could read.
      */
     EndsLeftOpen either(ChoiceSite choice, Adoption<FactSubject, ReadingLanguage.Order> mine,
-                        Set<FactSubject> myBounds,
-                        EndsLeftOpen other, Adoption<FactSubject, ReadingLanguage.Order> theirs,
-                        Set<FactSubject> theirBounds) {
+                        EndsLeftOpen other, Adoption<FactSubject, ReadingLanguage.Order> theirs) {
         if (byNumber.isEmpty() && other.byNumber.isEmpty()) {
             return NOTHING;
         }
         Map<FactSubject, Behind> out = new LinkedHashMap<>();
         byNumber.forEach((position, behind) ->
-                keptUnder(choice, position, behind, other, theirs, theirBounds, out));
+                keptUnder(choice, position, behind, other, theirs, out));
         other.byNumber.forEach((position, behind) ->
-                keptUnder(choice, position, behind, this, mine, myBounds, out));
+                keptUnder(choice, position, behind, this, mine, out));
         return new EndsLeftOpen(out);
     }
 
@@ -222,15 +219,8 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byNumber) {
     private static void keptUnder(ChoiceSite choice, FactSubject position, Behind behind,
                                   EndsLeftOpen beside,
                                   Adoption<FactSubject, ReadingLanguage.Order> theirs,
-                                  Set<FactSubject> theirBounds,
                                   Map<FactSubject, Behind> out) {
-        // Whether the branch beside this one holds the number down, asked of whoever answers for
-        // that number. Where the values at a position stop is the reading of ends', and where a
-        // number an operation answers of one stops is the reading that holds those — a count is
-        // never among what the ends bounded and a position is never among these, so which of them
-        // is asked is settled by the number rather than by a caller picking one.
-        if (!theirs.constrains(position) && !theirBounds.contains(position)
-                && !beside.byNumber.containsKey(position)) {
+        if (!theirs.constrains(position) && !beside.byNumber.containsKey(position)) {
             return;
         }
         out.merge(position, behind.under(choice), Behind::and);

--- a/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EndsLeftOpen.java
@@ -166,15 +166,17 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
      * branches brought, which is what keeps a choice from inventing a rule nobody could read.
      */
     EndsLeftOpen either(ChoiceSite choice, Adoption<FactSubject, ReadingLanguage.Order> mine,
-                        EndsLeftOpen other, Adoption<FactSubject, ReadingLanguage.Order> theirs) {
+                        Set<FactSubject> myBounds,
+                        EndsLeftOpen other, Adoption<FactSubject, ReadingLanguage.Order> theirs,
+                        Set<FactSubject> theirBounds) {
         if (byPosition.isEmpty() && other.byPosition.isEmpty()) {
             return NOTHING;
         }
         Map<FactSubject, Behind> out = new LinkedHashMap<>();
         byPosition.forEach((position, behind) ->
-                keptUnder(choice, position, behind, other, theirs, out));
+                keptUnder(choice, position, behind, other, theirs, theirBounds, out));
         other.byPosition.forEach((position, behind) ->
-                keptUnder(choice, position, behind, this, mine, out));
+                keptUnder(choice, position, behind, this, mine, myBounds, out));
         return new EndsLeftOpen(out);
     }
 
@@ -210,8 +212,15 @@ record EndsLeftOpen(Map<FactSubject, EndsLeftOpen.Behind> byPosition) {
     private static void keptUnder(ChoiceSite choice, FactSubject position, Behind behind,
                                   EndsLeftOpen beside,
                                   Adoption<FactSubject, ReadingLanguage.Order> theirs,
+                                  Set<FactSubject> theirBounds,
                                   Map<FactSubject, Behind> out) {
-        if (!theirs.constrains(position) && !beside.byPosition.containsKey(position)) {
+        // Whether the branch beside this one holds the number down, asked of whoever answers for
+        // that number. Where the values at a position stop is the reading of ends', and where a
+        // number an operation answers of one stops is the reading that holds those — a count is
+        // never among what the ends bounded and a position is never among these, so which of them
+        // is asked is settled by the number rather than by a caller picking one.
+        if (!theirs.constrains(position) && !theirBounds.contains(position)
+                && !beside.byPosition.containsKey(position)) {
             return;
         }
         out.merge(position, behind.under(choice), Behind::and);

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1431,7 +1431,7 @@ public final class FieldDomains {
             // Only the ends nothing else reaches. An end left open with no choice between it and
             // the walk that raises a rule's questions is one those questions already leave
             // standing, and a second account of it is one stop said twice.
-            if (!path.equals(namedBy.get(position)) || !behind.underAChoice()) {
+            if (!path.equals(placeOf(position)) || !behind.underAChoice()) {
                 return;
             }
             if (behind.named().isEmpty()) {
@@ -1467,6 +1467,28 @@ public final class FieldDomains {
      */
     public record EndLeftOpen(NumberAt<RuleKey> at, RuleRef.Invariant rule,
                               ChoiceSite byChoice) {}
+
+    /**
+     * Where the number called {@code subject} sits, whichever of a place's numbers it is.
+     *
+     * <p>Both of them, because a rule can state a line on either: {@link #namedBy} holds what a
+     * place is called and the counts are called something else, and a reader asking only the first
+     * finds nothing for a rule about how long a string is. What such a lookup is for is the place
+     * to report at, which is the same place for both — {@link #numberOf} is what tells them apart
+     * once it is found, and it is written expecting both to arrive.
+     */
+    private RuleKey placeOf(FactSubject subject) {
+        RuleKey named = namedBy.get(subject);
+        if (named != null) {
+            return named;
+        }
+        for (Map.Entry<RuleKey, Counted> each : countAt.entrySet()) {
+            if (each.getValue().atom().equals(subject)) {
+                return each.getKey();
+            }
+        }
+        return null;
+    }
 
     /** Which of {@code path}'s numbers {@code position} is, as this reading named them. */
     private NumberAt<RuleKey> numberOf(RuleKey path, FactSubject position) {

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -7,7 +7,6 @@ import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.OrderedInterval;
-import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.Rel;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -79,7 +78,7 @@ public final class FieldDomains {
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(),
                     Set.of(RuleKey.THE_VALUE),
                     Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE, KnownExtents.NONE,
-                    Map.of(), OrderedIntervals.top());
+                    Map.of(), Map.of(), BoundaryState.nothing());
 
     private final Map<RuleKey, NumericDomain.Bounds> byName;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -129,7 +128,10 @@ public final class FieldDomains {
      * {@link #projection} does not, because being inside the envelope is not being a value the
      * rules admit.
      */
-    private final OrderedIntervals<DerivedNumber> derived;
+    private final BoundaryState derived;
+    /** Which choice an author is sent to for a line on one of those numbers that nothing placed —
+     *  see {@link #endsLeftOpenAt}. */
+    private final Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen;
     /** Which readings took each clause in, as each of them said so. */
     private final ReadingEvidence took;
     /** The accounting, worked out once. Every name of a value asks the same question of it. */
@@ -250,8 +252,11 @@ public final class FieldDomains {
                          Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
                          StringFacts stringMachines, KnownExtents known,
                          Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
-                         OrderedIntervals<DerivedNumber> derived) {
+                         Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>>
+                                 boundsLeftOpen,
+                         BoundaryState derived) {
         this.endsLeftOpen = endsLeftOpen;
+        this.boundsLeftOpen = boundsLeftOpen;
         this.derived = derived;
         this.stringMachines = stringMachines;
         this.known = known;
@@ -481,7 +486,7 @@ public final class FieldDomains {
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
                 seeded.readBy(), seeded.spacing(), seeded.stringMachines(), machines.extents(),
-                seeded.endsLeftOpen(), seeded.derived());
+                seeded.endsLeftOpen(), seeded.boundsLeftOpen(), seeded.derived());
     }
 
     /**
@@ -1431,17 +1436,33 @@ public final class FieldDomains {
             // Only the ends nothing else reaches. An end left open with no choice between it and
             // the walk that raises a rule's questions is one those questions already leave
             // standing, and a second account of it is one stop said twice.
-            if (!path.equals(placeOf(position)) || !behind.underAChoice()) {
+            if (!path.equals(namedBy.get(position)) || !behind.underAChoice()) {
                 return;
             }
-            if (behind.named().isEmpty()) {
-                out.add(new EndLeftOpen(numberOf(path, position), rule, null));
+            said(numberOf(path, position), rule, behind, out);
+        }));
+        // And the lines on the numbers this value's operations answer that nothing placed, which
+        // is the other reading's answer arriving by the same road. Where the choice left one open
+        // is that reading's ({@link BoundaryState}); which choice to send an author to is what the
+        // account of the rule kept, and the two are met before either reaches here.
+        boundsLeftOpen.forEach((rule, open) -> open.forEach((number, behind) -> {
+            if (!path.equals(number.position()) || !behind.underAChoice()) {
                 return;
             }
-            behind.named().forEach(each ->
-                    out.add(new EndLeftOpen(numberOf(path, position), rule, each)));
+            said(number.asNumber(), rule, behind, out);
         }));
         return List.copyOf(out);
+    }
+
+    /** One end left open, said once per choice an author can be sent to and once where none can
+     *  be named. */
+    private static void said(NumberAt<RuleKey> at, RuleRef.Invariant rule,
+                             EndsLeftOpen.Behind behind, List<EndLeftOpen> out) {
+        if (behind.named().isEmpty()) {
+            out.add(new EndLeftOpen(at, rule, null));
+            return;
+        }
+        behind.named().forEach(each -> out.add(new EndLeftOpen(at, rule, each)));
     }
 
     /**
@@ -1467,31 +1488,6 @@ public final class FieldDomains {
      */
     public record EndLeftOpen(NumberAt<RuleKey> at, RuleRef.Invariant rule,
                               ChoiceSite byChoice) {}
-
-    /**
-     * Where the number called {@code subject} sits, whichever of a place's numbers it is.
-     *
-     * <p><b>{@link #subjectAt} run backwards</b>, and over the same two kinds it goes forwards
-     * over: what stands at a place, and what an operation answers of it. A rule can state a line on
-     * either, so a lookup that knew only the first finds nothing for a rule about how long a string
-     * is — and {@link #namedBy} is the first alone, because what it is for elsewhere is the subject
-     * a place's own values are filed under.
-     *
-     * <p>Which place, and never which number: those are the same place for both, and
-     * {@link #numberOf} is what tells them apart once it is found.
-     */
-    private RuleKey placeOf(FactSubject subject) {
-        RuleKey named = namedBy.get(subject);
-        if (named != null) {
-            return named;
-        }
-        for (Map.Entry<RuleKey, Counted> each : countAt.entrySet()) {
-            if (each.getValue().atom().equals(subject)) {
-                return each.getKey();
-            }
-        }
-        return null;
-    }
 
     /** Which of {@code path}'s numbers {@code position} is, as this reading named them. */
     private NumberAt<RuleKey> numberOf(RuleKey path, FactSubject position) {
@@ -1920,7 +1916,7 @@ public final class FieldDomains {
         // Nothing to meet where no choice settled a number of this value, which is most of them.
         // Asked all the same, every lookup of every coordinate builds a subject to find nothing
         // under, and this one is asked once per candidate per counterfactual.
-        if (derived.boundedAt().isEmpty()) {
+        if (derived.known().isEmpty()) {
             return held;
         }
         // And what the choices leave it, which the algebra has no way to: it reads a clause as

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1892,6 +1892,12 @@ public final class FieldDomains {
             return null;
         }
         NumericDomain.Bounds held = constraints.numbers().boundsOf(atom);
+        // Nothing to meet where no choice settled a number of this value, which is most of them.
+        // Asked all the same, every lookup of every coordinate builds a subject to find nothing
+        // under, and this one is asked once per candidate per counterfactual.
+        if (derived.boundedAt().isEmpty()) {
+            return held;
+        }
         // And what the choices leave it, which the algebra has no way to: it reads a clause as
         // written and never enters an alternative, so a length bounded in both branches of a
         // choice comes back from it unbounded. Met rather than preferred — the two are readings of

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1916,25 +1916,21 @@ public final class FieldDomains {
         // Nothing to meet where no choice settled a number of this value, which is most of them.
         // Asked all the same, every lookup of every coordinate builds a subject to find nothing
         // under, and this one is asked once per candidate per counterfactual.
-        if (derived.known().isEmpty()) {
+        if (derived.byNumber().isEmpty()) {
             return held;
         }
         // And what the choices leave it, which the algebra has no way to: it reads a clause as
         // written and never enters an alternative, so a length bounded in both branches of a
         // choice comes back from it unbounded. Met rather than preferred — the two are readings of
         // the same rules and each holds what the other cannot.
+        //
+        // And nothing where that reading stops the number nowhere a value of it is: what has been
+        // read there is that the rules contradict, which is said by whoever answers whether a
+        // value exists, and a line off those ends would fall where the order does not reach.
         DerivedNumber number = DerivedNumber.of(new NumberAt<>(path, kind));
-        if (number == null) {
-            return held;
-        }
-        OrderedInterval settled = derived.at(number);
-        // And no line where the rules leave the number no value. What has been read then is that
-        // they contradict at it, which is what a reader of that is told by whoever answers it —
-        // here it is an envelope with no line in it, and a line drawn from its ends would fall
-        // where the order does not reach.
-        return Endpoint.someValueLiesBetween(settled.low(), settled.high())
-                ? held.meet(new NumericDomain.Bounds(settled.low(), settled.high()))
-                : held;
+        OrderedInterval settled = number == null ? null : derived.knownAt(number);
+        return settled == null ? held
+                : held.meet(new NumericDomain.Bounds(settled.low(), settled.high()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -6,6 +6,8 @@ import souther.compiler.core.Core;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.Rel;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -77,7 +79,7 @@ public final class FieldDomains {
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(),
                     Set.of(RuleKey.THE_VALUE),
                     Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE, KnownExtents.NONE,
-                    Map.of());
+                    Map.of(), OrderedIntervals.top());
 
     private final Map<RuleKey, NumericDomain.Bounds> byName;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -113,6 +115,21 @@ public final class FieldDomains {
     private final Map<BoundaryQuestion, BoundaryStanding> standing;
     /** Where a choice of a rule left an end of it open — see {@link #endsLeftOpenAt}. */
     private final Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen;
+    /**
+     * Where the rules leave the numbers this value's operations answer, with every choice settled.
+     *
+     * <p>Beside the interval algebra and not inside it. That one never enters an alternative — what
+     * a construction owes is asked of the clause as written — so a choice between two bounds on a
+     * length leaves it nothing, and where those two branches together stop the length is known only
+     * to the reading that composed them.
+     *
+     * <p><b>Read where a line is looked for and nowhere else.</b> It is an envelope: two branches
+     * naming one size each leave the run between them, and no value has the sizes in between. So
+     * {@link #leftAt} takes it — a line falls at the outermost end either way — and
+     * {@link #projection} does not, because being inside the envelope is not being a value the
+     * rules admit.
+     */
+    private final OrderedIntervals<DerivedNumber> derived;
     /** Which readings took each clause in, as each of them said so. */
     private final ReadingEvidence took;
     /** The accounting, worked out once. Every name of a value asks the same question of it. */
@@ -232,8 +249,10 @@ public final class FieldDomains {
                          Map<RuleRef.Invariant, Map<Core, InvariantChecker.PartRead>> readBy,
                          Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
                          StringFacts stringMachines, KnownExtents known,
-                         Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen) {
+                         Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
+                         OrderedIntervals<DerivedNumber> derived) {
         this.endsLeftOpen = endsLeftOpen;
+        this.derived = derived;
         this.stringMachines = stringMachines;
         this.known = known;
         this.byName = byName;
@@ -462,7 +481,7 @@ public final class FieldDomains {
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
                 seeded.readBy(), seeded.spacing(), seeded.stringMachines(), machines.extents(),
-                seeded.endsLeftOpen());
+                seeded.endsLeftOpen(), seeded.derived());
     }
 
     /**
@@ -1869,7 +1888,27 @@ public final class FieldDomains {
         // `String` is measured two ways — its own order, and the length of it — and answering with
         // the wrong one clamps a line drawn on one axis by the range of the other.
         FactSubject atom = subjectAt(path, kind);
-        return atom == null ? null : constraints.numbers().boundsOf(atom);
+        if (atom == null) {
+            return null;
+        }
+        NumericDomain.Bounds held = constraints.numbers().boundsOf(atom);
+        // And what the choices leave it, which the algebra has no way to: it reads a clause as
+        // written and never enters an alternative, so a length bounded in both branches of a
+        // choice comes back from it unbounded. Met rather than preferred — the two are readings of
+        // the same rules and each holds what the other cannot.
+        DerivedNumber number = DerivedNumber.of(new NumberAt<>(path, kind));
+        if (number == null) {
+            return held;
+        }
+        OrderedInterval settled = derived.at(number);
+        // And nothing where the envelope holds no value. That its ends have crossed says the rules
+        // admit nothing at this number, which is a fact about whether a value exists — the question
+        // this reading is deliberately no part of ({@link Confinement.Planned#derived}) and one the
+        // readings that decide it already answer. Met in, a line would be drawn where the ends
+        // crossed, at a place the order does not reach.
+        return Endpoint.someValueLiesBetween(settled.low(), settled.high())
+                ? held.meet(new NumericDomain.Bounds(settled.low(), settled.high()))
+                : held;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1427,7 +1427,7 @@ public final class FieldDomains {
      */
     public List<EndLeftOpen> endsLeftOpenAt(RuleKey path) {
         List<EndLeftOpen> out = new ArrayList<>();
-        endsLeftOpen.forEach((rule, open) -> open.byPosition().forEach((position, behind) -> {
+        endsLeftOpen.forEach((rule, open) -> open.byNumber().forEach((position, behind) -> {
             // Only the ends nothing else reaches. An end left open with no choice between it and
             // the walk that raises a rule's questions is one those questions already leave
             // standing, and a second account of it is one stop said twice.
@@ -1471,11 +1471,14 @@ public final class FieldDomains {
     /**
      * Where the number called {@code subject} sits, whichever of a place's numbers it is.
      *
-     * <p>Both of them, because a rule can state a line on either: {@link #namedBy} holds what a
-     * place is called and the counts are called something else, and a reader asking only the first
-     * finds nothing for a rule about how long a string is. What such a lookup is for is the place
-     * to report at, which is the same place for both — {@link #numberOf} is what tells them apart
-     * once it is found, and it is written expecting both to arrive.
+     * <p><b>{@link #subjectAt} run backwards</b>, and over the same two kinds it goes forwards
+     * over: what stands at a place, and what an operation answers of it. A rule can state a line on
+     * either, so a lookup that knew only the first finds nothing for a rule about how long a string
+     * is — and {@link #namedBy} is the first alone, because what it is for elsewhere is the subject
+     * a place's own values are filed under.
+     *
+     * <p>Which place, and never which number: those are the same place for both, and
+     * {@link #numberOf} is what tells them apart once it is found.
      */
     private RuleKey placeOf(FactSubject subject) {
         RuleKey named = namedBy.get(subject);
@@ -1929,14 +1932,7 @@ public final class FieldDomains {
             return held;
         }
         OrderedInterval settled = derived.at(number);
-        // And nothing where the envelope holds no value. That its ends have crossed says the rules
-        // admit nothing at this number, which is a fact about whether a value exists — the question
-        // this reading is deliberately no part of ({@link Confinement.Planned#derived}) and one the
-        // readings that decide it already answer. Met in, a line would be drawn where the ends
-        // crossed, at a place the order does not reach.
-        return Endpoint.someValueLiesBetween(settled.low(), settled.high())
-                ? held.meet(new NumericDomain.Bounds(settled.low(), settled.high()))
-                : held;
+        return held.meet(new NumericDomain.Bounds(settled.low(), settled.high()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -131,7 +131,7 @@ public final class FieldDomains {
     private final BoundaryState derived;
     /** Which choice an author is sent to for a line on one of those numbers that nothing placed —
      *  see {@link #endsLeftOpenAt}. */
-    private final Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen;
+    private final Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>> boundsLeftOpen;
     /** Which readings took each clause in, as each of them said so. */
     private final ReadingEvidence took;
     /** The accounting, worked out once. Every name of a value asks the same question of it. */
@@ -252,7 +252,7 @@ public final class FieldDomains {
                          Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
                          StringFacts stringMachines, KnownExtents known,
                          Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
-                         Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>>
+                         Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>>
                                  boundsLeftOpen,
                          BoundaryState derived) {
         this.endsLeftOpen = endsLeftOpen;
@@ -1445,11 +1445,11 @@ public final class FieldDomains {
         // is the other reading's answer arriving by the same road. Where the choice left one open
         // is that reading's ({@link BoundaryState}); which choice to send an author to is what the
         // account of the rule kept, and the two are met before either reaches here.
-        boundsLeftOpen.forEach((rule, open) -> open.forEach((number, behind) -> {
-            if (!path.equals(number.position()) || !behind.underAChoice()) {
+        boundsLeftOpen.forEach((rule, open) -> open.forEach((end, behind) -> {
+            if (!path.equals(end.number().position()) || !behind.underAChoice()) {
                 return;
             }
-            said(number.asNumber(), rule, behind, out);
+            said(end.number().asNumber(), rule, behind, out);
         }));
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1928,7 +1928,13 @@ public final class FieldDomains {
             return held;
         }
         OrderedInterval settled = derived.at(number);
-        return held.meet(new NumericDomain.Bounds(settled.low(), settled.high()));
+        // And no line where the rules leave the number no value. What has been read then is that
+        // they contradict at it, which is what a reader of that is told by whoever answers it —
+        // here it is an envelope with no line in it, and a line drawn from its ends would fall
+        // where the order does not reach.
+        return Endpoint.someValueLiesBetween(settled.low(), settled.high())
+                ? held.meet(new NumericDomain.Bounds(settled.low(), settled.high()))
+                : held;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2068,9 +2068,18 @@ public final class InvariantChecker {
                 return both;
             }
             case ClauseExpr.Leaf it -> {
-                return lineStatedIn(it.of(), it.positive(), at, byName)
-                        instanceof LineStated.On found
-                        ? Set.of(found.number().at()) : Set.of();
+                // The one number the rule is over, which is the same answer the attribution of an
+                // end to a conjunct is put forward on. A rule over several is a line between them
+                // and an end at none, so it puts nothing forward.
+                return switch (lineStatedIn(it.of(), it.positive(), at, byName)) {
+                    case StatedLines.Statement.OnWhatStandsAtAPosition found ->
+                            Set.of(found.number());
+                    case StatedLines.Statement.OnADerivedNumber found ->
+                            Set.of(found.number().asNumber());
+                    case StatedLines.Statement.NoLine _,
+                         StatedLines.Statement.Between _,
+                         StatedLines.Statement.OnANumberNotNamed _ -> Set.of();
+                };
             }
         }
     }
@@ -2107,72 +2116,53 @@ public final class InvariantChecker {
      * arithmetic.
      */
     private StatedLines linesStatedAgainst(Map<FactSubject, Coordinate> byName) {
-        return (leaf, positive, at, named) ->
-                ownValuesALineIsStatedOn(leaf, positive, at, byName, named);
-    }
+        return new StatedLines() {
 
-    /**
-     * Which positions of {@code named} this leaf says the values stop somewhere on.
-     *
-     * <p>The three ways a leaf can state no line, told apart by what this reader has and the ends
-     * have not. A rule that is no comparison says which values may stand somewhere and orders none
-     * of them. A denial of one value rules that value out and leaves every other where it was. And
-     * a comparison whose positions cancel holds of every row there is, which the arithmetic settles
-     * and a reading of the sides cannot — {@code n - n >= 0} names {@code n} twice and stops it
-     * nowhere.
-     *
-     * <p>Then which number the line falls on, which the coordinate the ordered side names says. A
-     * line on a number an operation answers is a line on that order and leaves the position's own
-     * where it was; a line on a number this reading cannot name is one whose position is what
-     * reading further would say, so every position the leaf writes comes back.
-     */
-    private Set<FactSubject> ownValuesALineIsStatedOn(Core leaf, boolean positive, Denotations at,
-                                                      Map<FactSubject, Coordinate> byName,
-                                                      Set<FactSubject> named) {
-        return switch (lineStatedIn(leaf, positive, at, byName)) {
-            case LineStated.None _ -> Set.of();
-            // Which position it is about is what reading further would say, so every position the
-            // leaf writes is one whose end waits on a reader.
-            case LineStated.OnANumberNotNamed _ -> named;
-            case LineStated.On it -> ownValuesAmong(named, it.number(), byName);
+            @Override
+            public StatedLines.Statement of(Core leaf, boolean positive, Denotations at) {
+                return lineStatedIn(leaf, positive, at, byName);
+            }
+
+            @Override
+            public Set<FactSubject> waitingOnAReader(StatedLines.Statement stated,
+                                                     Set<FactSubject> named) {
+                return switch (stated) {
+                    case StatedLines.Statement.NoLine _ -> Set.of();
+                    // A line between several of this value's numbers falls at none of them, so
+                    // nothing about where any one of them stops is waiting on a reader.
+                    case StatedLines.Statement.Between _ -> Set.of();
+                    // Which position it is about is what reading further would say, so every
+                    // position the leaf writes is one whose end waits on a reader.
+                    case StatedLines.Statement.OnANumberNotNamed _ -> named;
+                    case StatedLines.Statement.OnWhatStandsAtAPosition it ->
+                            ownValuesAmong(named, it.number(), byName);
+                    // A line on a number an operation answers leaves the position's own order
+                    // exactly where it was. Whether that line was placed is the reading that holds
+                    // those numbers' answer, and it is filed under the number rather than here.
+                    case StatedLines.Statement.OnADerivedNumber _ -> Set.of();
+                };
+            }
         };
     }
 
-    /** The positions of {@code named} that {@code number} is the value standing at, which is none
-     *  of them where it is a number an operation answers. */
-    private static Set<FactSubject> ownValuesAmong(Set<FactSubject> named, Coordinate number,
+    /** The positions of {@code named} that {@code number} is the value standing at. */
+    private static Set<FactSubject> ownValuesAmong(Set<FactSubject> named,
+                                                   NumberAt<RuleKey> number,
                                                    Map<FactSubject, Coordinate> byName) {
-        if (!(number.at().of() instanceof NumberAt.OfWhatNumber.OfItsOwnValue)) {
-            return Set.of();
-        }
         Set<FactSubject> out = new LinkedHashSet<>();
         for (FactSubject each : named) {
             Coordinate here = byName.get(each);
-            if (here != null && here.at().equals(number.at())) {
+            if (here != null && here.at().equals(number)) {
                 out.add(each);
             }
         }
         return out;
     }
 
-    /** What line one leaf states, and on which of this value's numbers. */
-    private sealed interface LineStated {
-
-        /** It states none: a rule holding of every row, one saying which values may stand
-         *  somewhere without ordering them, a denial of one value, a shape that is no
-         *  comparison. */
-        record None() implements LineStated {}
-
-        /** It stops the values on this number. */
-        record On(Coordinate number) implements LineStated {}
-
-        /** It stops them on a number this reading cannot name — an absolute value, a
-         *  difference. */
-        record OnANumberNotNamed() implements LineStated {}
-    }
-
-    private static final LineStated NO_LINE = new LineStated.None();
-    private static final LineStated ELSEWHERE = new LineStated.OnANumberNotNamed();
+    private static final StatedLines.Statement NO_LINE = new StatedLines.Statement.NoLine();
+    private static final StatedLines.Statement BETWEEN = new StatedLines.Statement.Between();
+    private static final StatedLines.Statement ELSEWHERE =
+            new StatedLines.Statement.OnANumberNotNamed();
 
     /**
      * Which of this value's numbers one leaf says the values stop on.
@@ -2184,10 +2174,13 @@ public final class InvariantChecker {
      * and a reading of the sides cannot — {@code n - n >= 0} names {@code n} twice and stops it
      * nowhere.
      *
-     * <p>Then which number the line falls on, which the coordinate the ordered side names says.
+     * <p>Then which number the line falls on, which is what the canonical form of the comparison
+     * says and is not read off the sides. A rule whose coordinate is written inside an expression —
+     * {@code String.length(s) * 2 >= 4} — is a rule about that coordinate, and a reading that
+     * looked for a name spelled as a whole side would call it a rule about nothing.
      */
-    private LineStated lineStatedIn(Core leaf, boolean positive, Denotations at,
-                                    Map<FactSubject, Coordinate> byName) {
+    private StatedLines.Statement lineStatedIn(Core leaf, boolean positive, Denotations at,
+                                               Map<FactSubject, Coordinate> byName) {
         if (!(leaf instanceof Core.Binary bin)) {
             return NO_LINE;
         }
@@ -2199,30 +2192,41 @@ public final class InvariantChecker {
         if (said instanceof ComparisonClaim.Singled singled && !singled.holdsAtTheValue()) {
             return NO_LINE;
         }
-        Coordinate found = byName.get(nameOf(bin.left(), at));
-        Core bound = bin.right();
-        if (found == null) {
-            found = byName.get(nameOf(bin.right(), at));
-            bound = bin.left();
+        // Whether the rule holds one of this value's positions to another, which is a fact about
+        // the two sides and not about the arithmetic: {@code n >= m + 1} is over two numbers and
+        // holds no position to a position, so the end at each of them is one a reader is still owed.
+        // Asked of the canonical form, the two would be one answer and a bound against something
+        // built from a position would read as a line that falls at neither.
+        if (Relates.twoPositions(bin, e -> {
+            FactSubject named = nameOf(e, at);
+            return named != null && byName.containsKey(named) ? named : null;
+        })) {
+            return BETWEEN;
         }
-        // Asked of the rule as written, which is what the residue is a residue of. Under a denial
-        // the same form states the opposite of what it reads as, and a rule holding of every row
-        // denied is one holding of none — which is not a rule that states no line, so the question
-        // is left where it was.
-        //
-        // And asked only where it can say what the lookup above cannot. A whole side that is a
-        // coordinate stands in the canonical form with a coefficient of one, so a comparison of one
-        // against a side naming no coordinate cuts that coordinate and cannot cancel. Where both
-        // sides reach one they may — {@code n >= n} — and where neither is one the form is the only
-        // thing that tells a rule holding of every row from a rule about a number with no name.
-        // Asked of every comparison, this reads the arithmetic of both sides at every leaf of every
-        // clause, for the shape almost all of them are.
-        if (positive && (found == null || !coordinatesIn(bound, at, byName).isEmpty())
-                && canonicalFormOf(read, at, byName) instanceof CanonicalForm.CutsNothing form
-                && form.holdsOfEveryRow()) {
-            return NO_LINE;
-        }
-        return found == null ? ELSEWHERE : new LineStated.On(found);
+        return switch (canonicalFormOf(read, at, byName)) {
+            // The walk stopped inside a side, so which number the rule stops the values on is what
+            // reading further would say — and every number the leaf writes about is one waiting on
+            // that reading, the numbers an operation answers among them.
+            case CanonicalForm.NotRead _ -> ELSEWHERE;
+            // The positions cancelled. Read as written, which is what the residue is a residue of:
+            // under a denial the same form states the opposite of what it reads as, and a rule
+            // holding of every row denied is one holding of none — which states no line either, and
+            // whether anybody can be in a branch of it is the fates' to say and not this reading's.
+            case CanonicalForm.CutsNothing _ -> NO_LINE;
+            // Over one number, which is the line's. Over several, and holding no position to a
+            // position, the rule stops the values somewhere on one of them and which is what
+            // reading further would say — the same answer as a number with no name at all.
+            case CanonicalForm.Over over -> over.numbers().size() == 1
+                    ? statedOn(over.numbers().iterator().next()) : ELSEWHERE;
+        };
+    }
+
+    /** Which of the two a line on {@code number} is, said by the number itself. */
+    private static StatedLines.Statement statedOn(Coordinate number) {
+        DerivedNumber derived = DerivedNumber.of(number.at());
+        return derived == null
+                ? new StatedLines.Statement.OnWhatStandsAtAPosition(number.at())
+                : new StatedLines.Statement.OnADerivedNumber(derived);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2084,6 +2084,7 @@ public final class InvariantChecker {
                             Set.of(found.number().asNumber());
                     case StatedLines.Statement.NoLine _,
                          StatedLines.Statement.Between _,
+                         StatedLines.Statement.AdmitsNothing _,
                          StatedLines.Statement.OnANumberNotNamed _ -> Set.of();
                 };
             }
@@ -2140,6 +2141,11 @@ public final class InvariantChecker {
                     // Which position it is about is what reading further would say, so every
                     // position the leaf writes is one whose end waits on a reader.
                     case StatedLines.Statement.OnANumberNotNamed _ -> named;
+                    // And a rule no row meets settles nothing for the alternative beside it. What
+                    // the choice comes to is that alternative, whose end is where it was — so the
+                    // positions this rule writes stay waiting, and nothing here strikes them off
+                    // on the strength of a branch nobody is in.
+                    case StatedLines.Statement.AdmitsNothing _ -> named;
                     case StatedLines.Statement.OnWhatStandsAtAPosition it ->
                             ownValuesAmong(named, it.number(), byName);
                     // A line on a number an operation answers leaves the position's own order
@@ -2169,6 +2175,8 @@ public final class InvariantChecker {
     private static final StatedLines.Statement BETWEEN = new StatedLines.Statement.Between();
     private static final StatedLines.Statement ELSEWHERE =
             new StatedLines.Statement.OnANumberNotNamed();
+    private static final StatedLines.Statement ADMITS_NOTHING =
+            new StatedLines.Statement.AdmitsNothing();
 
     /**
      * Which of this value's numbers one leaf says the values stop on.
@@ -2214,11 +2222,11 @@ public final class InvariantChecker {
             // reading further would say — and every number the leaf writes about is one waiting on
             // that reading, the numbers an operation answers among them.
             case CanonicalForm.NotRead _ -> ELSEWHERE;
-            // The positions cancelled. Read as written, which is what the residue is a residue of:
-            // under a denial the same form states the opposite of what it reads as, and a rule
-            // holding of every row denied is one holding of none — which states no line either, and
-            // whether anybody can be in a branch of it is the fates' to say and not this reading's.
-            case CanonicalForm.CutsNothing _ -> NO_LINE;
+            // The positions cancelled, and what is left is a number against a number. Read as
+            // written, which is what the residue is a residue of: under a denial the same form
+            // states the opposite of what it reads as, and both answers are here.
+            case CanonicalForm.CutsNothing form ->
+                    form.holdsOfEveryRow() == positive ? NO_LINE : ADMITS_NOTHING;
             // Over one number, which is the line's. Over several, and holding no position to a
             // position, the rule stops the values somewhere on one of them and which is what
             // reading further would say — the same answer as a number with no name at all.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2199,17 +2199,28 @@ public final class InvariantChecker {
         if (said instanceof ComparisonClaim.Singled singled && !singled.holdsAtTheValue()) {
             return NO_LINE;
         }
+        Coordinate found = byName.get(nameOf(bin.left(), at));
+        Core bound = bin.right();
+        if (found == null) {
+            found = byName.get(nameOf(bin.right(), at));
+            bound = bin.left();
+        }
         // Asked of the rule as written, which is what the residue is a residue of. Under a denial
         // the same form states the opposite of what it reads as, and a rule holding of every row
         // denied is one holding of none — which is not a rule that states no line, so the question
         // is left where it was.
-        if (positive && canonicalFormOf(read, at, byName) instanceof CanonicalForm.CutsNothing form
+        //
+        // And asked only where it can say what the lookup above cannot. A whole side that is a
+        // coordinate stands in the canonical form with a coefficient of one, so a comparison of one
+        // against a side naming no coordinate cuts that coordinate and cannot cancel. Where both
+        // sides reach one they may — {@code n >= n} — and where neither is one the form is the only
+        // thing that tells a rule holding of every row from a rule about a number with no name.
+        // Asked of every comparison, this reads the arithmetic of both sides at every leaf of every
+        // clause, for the shape almost all of them are.
+        if (positive && (found == null || !coordinatesIn(bound, at, byName).isEmpty())
+                && canonicalFormOf(read, at, byName) instanceof CanonicalForm.CutsNothing form
                 && form.holdsOfEveryRow()) {
             return NO_LINE;
-        }
-        Coordinate found = byName.get(nameOf(bin.left(), at));
-        if (found == null) {
-            found = byName.get(nameOf(bin.right(), at));
         }
         return found == null ? ELSEWHERE : new LineStated.On(found);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -975,7 +975,7 @@ public final class InvariantChecker {
             took.stoppedBy(each.from(), one.account().aboutARule());
             // Only the rules with one, so that a reader asking a position what is left open there
             // walks the rules that have something rather than every rule of the declaration.
-            if (!one.account().endsLeftOpen().byPosition().isEmpty()) {
+            if (!one.account().endsLeftOpen().byNumber().isEmpty()) {
                 endsLeftOpen.merge(each.from(), one.account().endsLeftOpen(), EndsLeftOpen::both);
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -13,7 +13,6 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
-import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.core.Evaluated;
@@ -496,7 +495,8 @@ public final class InvariantChecker {
                   Set<RuleKey> notSeparated,
                   StringFacts stringMachines,
                   Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
-                  OrderedIntervals<DerivedNumber> derived) {
+                  Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen,
+                  BoundaryState derived) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
          *  which operation it is a count of. Projected rather than kept beside {@link #held()}: two
@@ -969,6 +969,8 @@ public final class InvariantChecker {
         // dropped, and a walk here would be asking a second time about a shape the settlement has
         // finished with.
         Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen =
+                new LinkedHashMap<>();
         answered.perClause().forEach((each, one) -> {
             narrowedBy.put(each.from(), one);
             one.account().adopted().forEach(position -> took.record(each.from(), position));
@@ -978,6 +980,9 @@ public final class InvariantChecker {
             if (!one.account().endsLeftOpen().byNumber().isEmpty()) {
                 endsLeftOpen.merge(each.from(), one.account().endsLeftOpen(), EndsLeftOpen::both);
             }
+            one.account().boundsLeftOpen().forEach((number, behind) ->
+                    boundsLeftOpen.computeIfAbsent(each.from(), _ -> new LinkedHashMap<>())
+                            .merge(number, behind, EndsLeftOpen.Behind::and));
         });
         answered.perPart().forEach((each, parts) -> {
             Map<Core, ReadByClauses.OfAPart> out = adoptedBy
@@ -1109,6 +1114,7 @@ public final class InvariantChecker {
                 readBy, Map.copyOf(spacing), admitted, unreadAt, notSeparated,
                 c.answers.facts(),
                 Collections.unmodifiableMap(new LinkedHashMap<>(endsLeftOpen)),
+                Collections.unmodifiableMap(new LinkedHashMap<>(boundsLeftOpen)),
                 // Where every rule reaching this value leaves the numbers its operations answer,
                 // taken from the reading with the choices settled. The interval algebra never
                 // enters an alternative, so this is the one answer that says where a choice of two

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -13,6 +13,7 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.core.Evaluated;
@@ -494,7 +495,8 @@ public final class InvariantChecker {
                   Map<RuleKey, List<UnreadReason>> unreadAt,
                   Set<RuleKey> notSeparated,
                   StringFacts stringMachines,
-                  Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen) {
+                  Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
+                  OrderedIntervals<DerivedNumber> derived) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
          *  which operation it is a count of. Projected rather than kept beside {@link #held()}: two
@@ -927,10 +929,14 @@ public final class InvariantChecker {
                 policy.allowanceForAdmittedValues(c.answers.lending());
         Map<RuleRef.Invariant, Map<Core, ReadByClauses.OfAPart>> adoptedBy = new LinkedHashMap<>();
         Map<RuleRef.Invariant, ReadByClauses.OfARule> narrowedBy = new LinkedHashMap<>();
+        // The numbers this value's clauses can be about, read before any of them is. Both the fold
+        // below and the walk that classifies a comparison are given this one table.
+        Map<FactSubject, Coordinate> numbers = c.coordinatesOf(atoms, keys, held, typeAt);
         // One reader for this value's positions, used over however many clauses reach it, and
         // the one that decides the choices in what they came to.
         StatedByClauses.Reading reader = StatedByClauses
-                .readingOf(c.terms, positions, symbols, alternatives, allowed, c.answers);
+                .readingOf(c.terms, positions, symbols, alternatives, allowed, c.answers,
+                        c.linesStatedAgainst(numbers), boundariesOf(c.terms, numbers));
         // What each clause said and what each part of it said, kept as they were read and
         // asked afterwards. Which branch of a choice anybody can take turns on clauses not yet
         // read and on machines nobody has made at this point, and every one of these questions
@@ -1006,7 +1012,7 @@ public final class InvariantChecker {
                         + " alternatives past a counted " + expansion;
         // And which of the clauses place an edge, asked once the positions have names to be
         // recognised by.
-        Reading reading = c.directsIn(written, at, atoms, keys, held, typeAt, took,
+        Reading reading = c.directsIn(written, at, numbers, typeAt, took,
                 new PartsRead(readBy, adoptedBy, narrowedBy), reach.withoutParts());
         ConstraintState<FactSubject> constraints = k.constraints()
                 .takingRead(answered.whole().confinement(), allowed, c.answers);
@@ -1102,7 +1108,12 @@ public final class InvariantChecker {
                 notGathered, unreadOfEveryValue, Set.copyOf(handedOn),
                 readBy, Map.copyOf(spacing), admitted, unreadAt, notSeparated,
                 c.answers.facts(),
-                Collections.unmodifiableMap(new LinkedHashMap<>(endsLeftOpen)));
+                Collections.unmodifiableMap(new LinkedHashMap<>(endsLeftOpen)),
+                // Where every rule reaching this value leaves the numbers its operations answer,
+                // taken from the reading with the choices settled. The interval algebra never
+                // enters an alternative, so this is the one answer that says where a choice of two
+                // bounds on a length stops it.
+                answered.whole().confinement().derived());
     }
 
     /**
@@ -1616,12 +1627,19 @@ public final class InvariantChecker {
                    Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                    Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
-    private Reading directsIn(List<Written> stated, Denotations at,
-                                   Map<RuleKey, FactSubject> atoms, Map<RuleKey, FactSubject> keys,
-                                   Map<RuleKey, FieldDomains.Counted> held,
-                                   Map<RuleKey, Type> typeAt,
-                                   ReadingEvidence took, PartsRead parts,
-                                   PartsLeftOut withoutParts) {
+    /**
+     * The numbers the clauses of one value can be about, each under the name they write for it.
+     *
+     * <p>Made before any clause is read, because two readings want it. The walk that classifies a
+     * comparison asks which number a rule places its end on; the fold that reads the clause tree
+     * asks which of the positions a leaf orders, so that a rule bounding a length is not taken for
+     * one whose end nothing worked out. Built twice, the two would answer about two tables the day
+     * one of them learned a number the other had not.
+     */
+    private Map<FactSubject, Coordinate> coordinatesOf(Map<RuleKey, FactSubject> atoms,
+                                                       Map<RuleKey, FactSubject> keys,
+                                                       Map<RuleKey, FieldDomains.Counted> held,
+                                                       Map<RuleKey, Type> typeAt) {
         Map<FactSubject, Coordinate> byName = new LinkedHashMap<>();
         keys.forEach((path, key) -> {
             Carrier carrier = Carrier.ofValue(typeAt.get(path), symbols);
@@ -1638,6 +1656,14 @@ public final class InvariantChecker {
         held.forEach((path, counted) -> byName.put(counted.atom(),
                 new Coordinate(NumberAt.takenOf(path, counted.by()),
                         Carrier.WHOLE)));
+        return byName;
+    }
+
+    private Reading directsIn(List<Written> stated, Denotations at,
+                                   Map<FactSubject, Coordinate> byName,
+                                   Map<RuleKey, Type> typeAt,
+                                   ReadingEvidence took, PartsRead parts,
+                                   PartsLeftOut withoutParts) {
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
         List<FieldDomains.WithoutAnEnd> withoutAnEnd = new ArrayList<>();
@@ -1836,6 +1862,7 @@ public final class InvariantChecker {
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
         RunsRead runs = runsOf(clause, from, part, byName, parts, out);
         restricting(clause, from, part, byName, parts, noLines, runs);
+        aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
             // the classification to be handed.
@@ -1982,6 +2009,210 @@ public final class InvariantChecker {
         }
     }
 
+
+    /**
+     * A choice written about one of this value's numbers, put forward as a candidate for the end
+     * the rules leave on it.
+     *
+     * <p>No line is drawn here. This walk stops at a choice, so what a choice leaves a number is
+     * not something it has — that is composed where the branches have their fate
+     * ({@link Confinement.Planned#either}) and is what the rules leave. What is written down is
+     * that this part is about that number, which is what the attribution of an end to a conjunct
+     * runs over ({@link FieldDomains#movedEnds}): a part with no end of its own that moves one is
+     * exactly the case that machinery exists for, and a choice is one.
+     *
+     * <p>One per number the leaves under it state a line on, and never a claim that this choice is
+     * why the end is there: whether taking the part away moves the end is the counterfactual's, and
+     * a candidate that moves none is named nowhere. Which is why they are put forward for every
+     * number the leaves name and not for the ones a choice was newly given an answer about — a
+     * candidate costs a counterfactual and claims nothing, and a rule saying which of them may be
+     * one would be a second place deciding what a choice does.
+     */
+    private void aChoiceAboutOneCoordinate(Core clause, PartId<RuleRef.Invariant> part,
+                                           Denotations at, Map<FactSubject, Coordinate> byName,
+                                           List<FieldDomains.AboutOneCoordinate> naming) {
+        if (!(ClauseExpr.of(clause, true) instanceof ClauseExpr.Joined joined)
+                || joined.how() != ConditionJoin.EITHER) {
+            return;
+        }
+        Set<NumberAt<RuleKey>> numbers = numbersALineIsStatedOn(joined, at, byName);
+        numbers.forEach(each -> naming.add(new FieldDomains.AboutOneCoordinate(each, part)));
+    }
+
+    /**
+     * The numbers the leaves under {@code stated} say the values stop somewhere on.
+     *
+     * <p>A walk for what the leaves state and never for what the clause comes to. Which values a
+     * choice leaves is settled where the branches have their fate, and nothing here asks: a leaf
+     * under an {@code &&} and one under a {@code ||} state the same line, and this is that answer
+     * gathered over whatever an author wrote between them.
+     *
+     * <p>A leaf stating a line on a number this reading cannot name brings nothing, as one stating
+     * no line does. What each number here is is a candidate and no more — whether the part is why
+     * an end is there is the counterfactual's answer ({@link FieldDomains#movedEnds}) — so a leaf
+     * with no number to offer has nothing to put forward either way.
+     */
+    private Set<NumberAt<RuleKey>> numbersALineIsStatedOn(ClauseExpr stated, Denotations at,
+                                                          Map<FactSubject, Coordinate> byName) {
+        switch (stated) {
+            case ClauseExpr.Scoped it -> {
+                // A binding is crossed and never a leaf of its own: what the part states is what
+                // its body states, read inside it — so a rule stating its line through a helper
+                // states the line the same rule written out states.
+                return numbersALineIsStatedOn(it.body(), terms.inside(it.binding(), at), byName);
+            }
+            case ClauseExpr.Joined it -> {
+                Set<NumberAt<RuleKey>> both =
+                        new LinkedHashSet<>(numbersALineIsStatedOn(it.left(), at, byName));
+                both.addAll(numbersALineIsStatedOn(it.right(), at, byName));
+                return both;
+            }
+            case ClauseExpr.Leaf it -> {
+                return lineStatedIn(it.of(), it.positive(), at, byName)
+                        instanceof LineStated.On found
+                        ? Set.of(found.number().at()) : Set.of();
+            }
+        }
+    }
+
+    /**
+     * The reading of the numbers this value's operations answer, out of the one table of them.
+     *
+     * <p>Only those: where the values at a position stop is the reading of ends' order and is
+     * settled there, and a number that cannot be made into one of these cannot reach this reading
+     * ({@link DerivedNumber}).
+     */
+    private static BoundaryReading boundariesOf(Terms terms,
+                                                Map<FactSubject, Coordinate> byName) {
+        Map<FactSubject, DerivedNumber> numbers = new LinkedHashMap<>();
+        Map<DerivedNumber, Carrier> carriers = new LinkedHashMap<>();
+        byName.forEach((name, coordinate) -> {
+            DerivedNumber number = DerivedNumber.of(coordinate.at());
+            if (number == null || coordinate.carrier() == null) {
+                return;
+            }
+            numbers.put(name, number);
+            carriers.put(number, coordinate.carrier());
+        });
+        return BoundaryReading.of(terms, numbers, carriers);
+    }
+
+    /**
+     * The classification of one leaf, for the fold that reads the clause tree.
+     *
+     * <p>Bound to the table of numbers rather than made from it again, so that the reading which
+     * says a rule bounds a length is the same one the walk over comparisons uses. What the fold
+     * does with the answer is its own ({@link StatedByClauses.Reading#whole}); what is answered
+     * here is a fact about the clause, which is why it is asked of the reader holding the
+     * arithmetic.
+     */
+    private StatedLines linesStatedAgainst(Map<FactSubject, Coordinate> byName) {
+        return (leaf, positive, at, named) ->
+                ownValuesALineIsStatedOn(leaf, positive, at, byName, named);
+    }
+
+    /**
+     * Which positions of {@code named} this leaf says the values stop somewhere on.
+     *
+     * <p>The three ways a leaf can state no line, told apart by what this reader has and the ends
+     * have not. A rule that is no comparison says which values may stand somewhere and orders none
+     * of them. A denial of one value rules that value out and leaves every other where it was. And
+     * a comparison whose positions cancel holds of every row there is, which the arithmetic settles
+     * and a reading of the sides cannot — {@code n - n >= 0} names {@code n} twice and stops it
+     * nowhere.
+     *
+     * <p>Then which number the line falls on, which the coordinate the ordered side names says. A
+     * line on a number an operation answers is a line on that order and leaves the position's own
+     * where it was; a line on a number this reading cannot name is one whose position is what
+     * reading further would say, so every position the leaf writes comes back.
+     */
+    private Set<FactSubject> ownValuesALineIsStatedOn(Core leaf, boolean positive, Denotations at,
+                                                      Map<FactSubject, Coordinate> byName,
+                                                      Set<FactSubject> named) {
+        return switch (lineStatedIn(leaf, positive, at, byName)) {
+            case LineStated.None _ -> Set.of();
+            // Which position it is about is what reading further would say, so every position the
+            // leaf writes is one whose end waits on a reader.
+            case LineStated.OnANumberNotNamed _ -> named;
+            case LineStated.On it -> ownValuesAmong(named, it.number(), byName);
+        };
+    }
+
+    /** The positions of {@code named} that {@code number} is the value standing at, which is none
+     *  of them where it is a number an operation answers. */
+    private static Set<FactSubject> ownValuesAmong(Set<FactSubject> named, Coordinate number,
+                                                   Map<FactSubject, Coordinate> byName) {
+        if (!(number.at().of() instanceof NumberAt.OfWhatNumber.OfItsOwnValue)) {
+            return Set.of();
+        }
+        Set<FactSubject> out = new LinkedHashSet<>();
+        for (FactSubject each : named) {
+            Coordinate here = byName.get(each);
+            if (here != null && here.at().equals(number.at())) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+
+    /** What line one leaf states, and on which of this value's numbers. */
+    private sealed interface LineStated {
+
+        /** It states none: a rule holding of every row, one saying which values may stand
+         *  somewhere without ordering them, a denial of one value, a shape that is no
+         *  comparison. */
+        record None() implements LineStated {}
+
+        /** It stops the values on this number. */
+        record On(Coordinate number) implements LineStated {}
+
+        /** It stops them on a number this reading cannot name — an absolute value, a
+         *  difference. */
+        record OnANumberNotNamed() implements LineStated {}
+    }
+
+    private static final LineStated NO_LINE = new LineStated.None();
+    private static final LineStated ELSEWHERE = new LineStated.OnANumberNotNamed();
+
+    /**
+     * Which of this value's numbers one leaf says the values stop on.
+     *
+     * <p>The three ways a leaf can state no line, told apart by what this reader has and the ends
+     * have not. A rule that is no comparison says which values may stand somewhere and orders none
+     * of them. A denial of one value rules that value out and leaves every other where it was. And
+     * a comparison whose positions cancel holds of every row there is, which the arithmetic settles
+     * and a reading of the sides cannot — {@code n - n >= 0} names {@code n} twice and stops it
+     * nowhere.
+     *
+     * <p>Then which number the line falls on, which the coordinate the ordered side names says.
+     */
+    private LineStated lineStatedIn(Core leaf, boolean positive, Denotations at,
+                                    Map<FactSubject, Coordinate> byName) {
+        if (!(leaf instanceof Core.Binary bin)) {
+            return NO_LINE;
+        }
+        Comparison read = Comparison.of(bin).orElse(null);
+        if (read == null) {
+            return NO_LINE;
+        }
+        ComparisonClaim said = positive ? read.claim() : read.claim().denied();
+        if (said instanceof ComparisonClaim.Singled singled && !singled.holdsAtTheValue()) {
+            return NO_LINE;
+        }
+        // Asked of the rule as written, which is what the residue is a residue of. Under a denial
+        // the same form states the opposite of what it reads as, and a rule holding of every row
+        // denied is one holding of none — which is not a rule that states no line, so the question
+        // is left where it was.
+        if (positive && canonicalFormOf(read, at, byName) instanceof CanonicalForm.CutsNothing form
+                && form.holdsOfEveryRow()) {
+            return NO_LINE;
+        }
+        Coordinate found = byName.get(nameOf(bin.left(), at));
+        if (found == null) {
+            found = byName.get(nameOf(bin.right(), at));
+        }
+        return found == null ? ELSEWHERE : new LineStated.On(found);
+    }
 
     /**
      * What {@code e} is called where a coordinate is looked up.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -495,7 +495,7 @@ public final class InvariantChecker {
                   Set<RuleKey> notSeparated,
                   StringFacts stringMachines,
                   Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
-                  Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen,
+                  Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>> boundsLeftOpen,
                   BoundaryState derived) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
@@ -969,7 +969,7 @@ public final class InvariantChecker {
         // dropped, and a walk here would be asking a second time about a shape the settlement has
         // finished with.
         Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen = new LinkedHashMap<>();
-        Map<RuleRef.Invariant, Map<DerivedNumber, EndsLeftOpen.Behind>> boundsLeftOpen =
+        Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>> boundsLeftOpen =
                 new LinkedHashMap<>();
         answered.perClause().forEach((each, one) -> {
             narrowedBy.put(each.from(), one);

--- a/souther-compiler/src/main/java/souther/compiler/check/OpenEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OpenEnd.java
@@ -1,0 +1,43 @@
+package souther.compiler.check;
+
+/**
+ * One line a leaf states on a number an operation answers that nothing here could place.
+ *
+ * <p>The occurrence and not the number. A rule can state a line on one length in two places, and
+ * what a choice does to one of them is not what it does to the other: an end an alternative beside
+ * it settles is gone, and an end written outside that choice stands. Told apart by the number
+ * alone, the second would answer for the first — the reading strikes one off, the number is still
+ * open because of the other, and the choice an author is sent to comes back for an end that choice
+ * had already settled.
+ *
+ * <p><b>So this is equal to itself and to nothing else</b>, and it is made where the leaf is read —
+ * once per line an author wrote, as a {@link ChoiceId} is made once per choice. The tree is walked
+ * once and the settled reading is composed over what that walk produced, so two of these are two
+ * places in the source and never one place counted twice.
+ *
+ * <p><b>It reaches no answer this compiler publishes.</b> What goes out is the number and the
+ * choice ({@code FieldDomains.EndLeftOpen}), which compare as values; this is how the two sides of
+ * one reading find each other on the way there, and a published answer holding it would be one that
+ * says nothing of itself.
+ */
+final class OpenEnd {
+
+    private final DerivedNumber number;
+
+    OpenEnd(DerivedNumber number) {
+        if (number == null) {
+            throw new IllegalArgumentException("an end left open is an end of some number");
+        }
+        this.number = number;
+    }
+
+    /** Which number this is an end of. */
+    DerivedNumber number() {
+        return number;
+    }
+
+    @Override
+    public String toString() {
+        return "an unplaced end of " + number;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedLeaf.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedLeaf.java
@@ -1,0 +1,185 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+
+import souther.compiler.numeric.Place;
+
+import java.util.function.Function;
+
+/**
+ * What one comparison leaves the number it names, for a reading that holds an order.
+ *
+ * <p>One procedure and two readings of it. Where the values at a position stop is one order and how
+ * long the string standing there is is another, and each is read by whoever owns it — but what a
+ * comparison does to an order does not change with which order it is: the side naming the number is
+ * found, the claim is turned to match, a denial swaps what it states, and an end is read against the
+ * carrier. Written once per reading, the two would be one algorithm with two accounts, and the
+ * reading that was not kept in step would answer about a comparison this compiler reads.
+ *
+ * <p>Which numbers a reading has is the reading's, and arrives as {@code named} and
+ * {@code carrierOf}. Nothing here decides what a number is, so neither reading can reach the
+ * other's: a caller holding the positions finds no length and a caller holding the lengths finds no
+ * position, and each of them says so with the answer for a leaf it could not follow.
+ */
+final class OrderedLeaf {
+
+    private OrderedLeaf() {}
+
+    /**
+     * What the comparison came to, and whether it holds the number it names against another of the
+     * same reading's.
+     *
+     * @param againstAnother a fact about the two sides and about neither claim. A rule holding one
+     *                       of this reading's numbers to another draws its line between them rather
+     *                       than at either, so nothing about where this one stops waits on a reader
+     *                       — which stays true where the reading has no range for the rule
+     */
+    record Read<K>(Left<K> left, boolean againstAnother) {}
+
+    /** Which of the three a comparison came to. */
+    sealed interface Left<K> {
+
+        /** A rule this reading lost the thread of: a shape it has no word for, a number it cannot
+         *  name, a bound that is no literal of the order. */
+        record NotFollowed<K>() implements Left<K> {}
+
+        /** A rule it followed to the end that stops the values nowhere — what a disequality
+         *  states, which is a set of values and not a range. */
+        record PlacesNoEnd<K>() implements Left<K> {}
+
+        /**
+         * A rule it followed, leaving {@code number} inside {@code range}.
+         *
+         * <p>What the rule states and not what the order holds. A reading that says where a value
+         * may stand wants the two together — what is below the empty string is nothing, and a range
+         * open below would take {@code value < ""} for a rule leaving room underneath — and a
+         * reading looking for the line an author drew wants this one: the largest whole number is
+         * where every count stops whether or not anybody wrote a rule, and a line there is a row
+         * owed at a place no clause put an edge at.
+         *
+         * @param carrier what {@code number} is ordered on, for a reader that wants the order's own
+         *                ends as well
+         */
+        record Leaves<K>(K number, Carrier carrier, OrderedInterval range) implements Left<K> {
+
+            /** The same, held inside what the order itself holds. */
+            OrderedInterval within() {
+                return carrier.extent().meet(range);
+            }
+
+            /**
+             * The ends this rule states, each held no further out than the order reaches, and none
+             * of the order's own added.
+             *
+             * <p>{@link #within} does two things and a reader looking for the line an author drew
+             * wants one of them. A rule naming a size past the last whole number states a line the
+             * order does not reach, and clamping it is what keeps a border off a place no value is
+             * at; a rule bounding a size below states nothing above, and the largest whole number
+             * arriving as its upper end is a line nobody wrote.
+             *
+             * <p>Nothing at all where the two share no value, which is the same answer
+             * {@link #within} gives: a rule whose end lies wholly past the order holds no value of
+             * it, and an end pulled back to the order's would come back holding the values the rule
+             * refuses.
+             */
+            OrderedInterval stated() {
+                OrderedInterval held = within();
+                if (!Endpoint.someValueLiesBetween(held.low(), held.high())) {
+                    return held;
+                }
+                return new OrderedInterval(range.low() == null ? null : held.low(),
+                        range.high() == null ? null : held.high());
+            }
+        }
+    }
+
+    /** A leaf that is no comparison at all, which every reading loses the thread of. */
+    static <K> Read<K> notFollowed() {
+        return new Read<>(new Left.NotFollowed<>(), false);
+    }
+
+    /**
+     * What {@code bin} leaves, read against the numbers {@code named} knows.
+     *
+     * @param positive  whether the comparison stands as written or under a denial. Denied, a
+     *                  comparison is the one that leaves what it leaves out: {@code !(x /= v)}
+     *                  places both ends and {@code !(x == v)} places none, which is what each of
+     *                  them states written directly
+     * @param named     which of this reading's numbers an expression is, or null where it is none
+     * @param carrierOf what that number's values are ordered on
+     */
+    static <K> Read<K> of(Core.Binary bin, boolean positive, Denotations at, Terms terms,
+                          Function<Core, K> named, Function<K, Carrier> carrierOf) {
+        Comparison read = Comparison.of(bin).orElse(null);
+        if (read == null) {
+            // Written with an operator and not a comparison. The same as a rule of another shape.
+            return notFollowed();
+        }
+        // The side bearing the number read as the left one, as `0 <= value` says what `value >= 0`
+        // says.
+        K number = named.apply(bin.left());
+        Core bound = bin.right();
+        ComparisonClaim claim = read.claim();
+        if (number == null) {
+            number = named.apply(bin.right());
+            bound = bin.left();
+            claim = claim.turned();
+        }
+        Carrier carrier = number == null ? null : carrierOf.apply(number);
+        if (carrier == null) {
+            // Neither side is a number this reading has. The rule may still be about one — a
+            // length, an absolute value, a reversal — and what it holds that number to is then
+            // something this reading cannot follow rather than something it found to be nothing.
+            return notFollowed();
+        }
+        // Whether this rule holds the number to another of the same reading's, which is a fact
+        // about the two sides and about neither claim. Written down here, where both sides are in
+        // hand and before either is read for what it leaves: put inside what one claim does with
+        // its side, the same rule written with a different operator is a rule nobody read
+        // ({@code n == m} beside {@code n < m}).
+        boolean against = named.apply(bound) != null;
+        Hir.Expr written = Terms.asWrittenValue(bound, at);
+        ComparisonClaim said = positive ? claim : claim.denied();
+        return new Read<>(switch (said) {
+            case ComparisonClaim.Singled singled -> singled.holdsAtTheValue()
+                    ? onlyTheValue(number, carrier, written)
+                    : new Left.PlacesNoEnd<>();
+            case ComparisonClaim.Cut cut ->
+                    ends(number, carrier, InvariantBound.at(cut, written, carrier));
+        }, against);
+    }
+
+    /** The range of one value, or nothing where the rule meets the number at something this order
+     *  has no literal for. */
+    private static <K> Left<K> onlyTheValue(K number, Carrier carrier, Hir.Expr written) {
+        Place only = written == null ? null : carrier.literalOf(written);
+        return only == null ? new Left.NotFollowed<>()
+                : leaves(number, carrier,
+                        new OrderedInterval(Endpoint.inclusive(only), Endpoint.inclusive(only)));
+    }
+
+    /** What the end an ordering placed leaves the number. */
+    private static <K> Left<K> ends(K number, Carrier carrier, InvariantBound.Read read) {
+        return switch (read) {
+            case InvariantBound.Read.AnEnd it -> leaves(number, carrier, it.bound().lower()
+                    ? new OrderedInterval(it.bound().end(), null)
+                    : new OrderedInterval(null, it.bound().end()));
+            // The rule names an end the order does not reach, so the number holds nothing. Said as
+            // a range of this order with no value in it, which is the same kind of answer two rules
+            // whose ends cross come to.
+            case InvariantBound.Read.PastWhereTheOrderStops _ ->
+                    leaves(number, carrier, carrier.nothing());
+            // A cut on a number this reading has, against something the order has no literal for.
+            // The other reasons NoEnd stands for are answered before this call, so what arrives is
+            // always this one.
+            case InvariantBound.Read.NoEnd _ -> new Left.NotFollowed<>();
+        };
+    }
+
+    private static <K> Left<K> leaves(K number, Carrier carrier, OrderedInterval range) {
+        return new Left.Leaves<>(number, carrier, range);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -1,11 +1,7 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
-import souther.compiler.numeric.Endpoint;
-import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
-import souther.compiler.numeric.Place;
 import souther.compiler.types.Type;
 
 import java.util.Collections;
@@ -156,11 +152,12 @@ final class OrderedReading {
      * The positions of {@code named} whose ends {@code e} leaves unknown here.
      *
      * <p><b>The set and not a word about the leaf, because the set is what a caller wants and this
-     * is what owns it.</b> Which positions a clause names is the clause's own answer and arrives as
-     * {@code named}; which of them have an end at all, and which of those this reading worked out,
-     * are this reading's. Handed the flag instead, a caller made the set out of every position the
-     * clause named — and a position whose values are not ordered, which has no end for anything to
-     * be unknown about, came back as one whose end nobody could work out.
+     * is what owns it.</b> Which positions the clause says the values stop somewhere on is the
+     * clause's own answer and arrives as {@code named}; which of them have an end at all, and which
+     * of those this reading worked out, are this reading's. Handed the flag instead, a caller made
+     * the set out of every position the clause named — and a position whose values are not ordered,
+     * which has no end for anything to be unknown about, came back as one whose end nobody could
+     * work out.
      *
      * <p>Narrower than {@link #gaveUpAt} by the rules this reading followed to the end and has no
      * range for. A comparison holding one position it counts to another states where the values
@@ -174,10 +171,12 @@ final class OrderedReading {
      * it means. Kept as two flags a caller could ask for both and be told a rule was read and not
      * read.
      *
-     * <p><b>Wider than the relation it recognises.</b> A comparison whose subject is a term this
-     * reading cannot name — an absolute value, a difference — leaves its positions here whatever
-     * the arithmetic under it comes to, because this reading cannot see that it cancels. What such
-     * a rule leaves is known elsewhere, and asking that reader is not something this one can do.
+     * <p><b>And narrower than what this reading gave up on, by what it has no arithmetic for.</b> A
+     * comparison whose positions cancel holds of every row, a call restricts which values may stand
+     * somewhere and orders none of them, and a bound on how long a string is stops another number:
+     * each of them is a leaf this reading lost the thread of and none of them leaves a position's
+     * own order waiting on a reader. Which they are is decided where the arithmetic is
+     * ({@link StatedLines}) and arrives in {@code named}.
      */
     Set<FactSubject> endsLeftUnknownAt(Core e, Set<FactSubject> named) {
         if (!gaveUp.contains(e) || relatingTwoPositions.contains(e)) {
@@ -202,101 +201,37 @@ final class OrderedReading {
         return OrderedIntervals.top();
     }
 
-    /** Where one comparison leaves the position it names, or nothing where it names none. */
+    /**
+     * Where one comparison leaves the position it names, or nothing where it names none.
+     *
+     * <p>What the comparison does to an order is read where both readings of one read it
+     * ({@link OrderedLeaf}); what is here is this reading's own bookkeeping about the leaf, which
+     * is what {@link #gaveUpAt} and {@link #endsLeftUnknownAt} answer out of.
+     */
     private OrderedIntervals<FactSubject> comparison(Core.Binary bin, boolean positive,
                                                      Denotations at) {
-        Comparison read = Comparison.of(bin).orElse(null);
-        if (read == null) {
-            // Written with an operator and not a comparison. The same as a rule of another shape.
-            return gaveUp(bin);
-        }
-        // The position-bearing side read as the left one, as `0 <= value` says what `value >= 0`
-        // says.
-        FactSubject position = positionIn(bin.left(), at);
-        Core bound = bin.right();
-        ComparisonClaim claim = read.claim();
-        if (position == null) {
-            position = positionIn(bin.right(), at);
-            bound = bin.left();
-            claim = claim.turned();
-        }
-        Carrier carrier = position == null ? null : carriers.get(position);
-        if (carrier == null) {
-            // Neither side is a position this counts. The rule may still be about one — a length,
-            // an absolute value, a reversal — and what it holds that position to is then something
-            // this reading cannot follow rather than something it found to be nothing.
-            return gaveUp(bin);
-        }
-        Hir.Expr written = Terms.asWrittenValue(bound, at);
-        // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` places
-        // both ends and `!(value == x)` places none, which is the same answer each of them gets
-        // written directly — and neither is a rule this reading failed at.
-        ComparisonClaim said = positive ? claim : claim.denied();
-        // And whether this rule holds the position to another position this counts, which is a fact
-        // about the two sides and about neither claim. Written down here, where both sides are in
-        // hand and before either is read for what it leaves: put inside what one claim does with
-        // its side, the same rule written with a different operator is a rule nobody read
-        // ({@code n == m} beside {@code n < m}).
-        //
-        // Whether this reading then has a range for it is a separate question, and the two are
-        // asked together by whoever wants the end ({@link #leavesTheEndsUnknownAt}). So a rule that
-        // does place an end is here as well where it happens to compare two positions, and says
-        // nothing by being: there is nothing to be unknown about a rule this reading followed.
-        if (positionIn(bound, at) != null) {
+        OrderedLeaf.Read<FactSubject> read = OrderedLeaf.of(bin, positive, at, terms,
+                e -> positionIn(e, at), carriers::get);
+        // Whether this reading then has a range for the rule is a separate question, and the two
+        // are asked together by whoever wants the end ({@link #endsLeftUnknownAt}). So a rule that
+        // does place an end is written down here as well where it happens to compare two positions,
+        // and says nothing by being: there is nothing to be unknown about a rule this reading
+        // followed.
+        if (read.againstAnother()) {
             relatingTwoPositions.add(bin);
         }
-        return switch (said) {
-            // The value the rule is met at, which is a range with one value in it. What a denial
-            // leaves is every other value, and that is a set rather than a range — which is the
-            // whole of what the rule does to a range, so it is one this reading followed.
-            case ComparisonClaim.Singled singled -> singled.holdsAtTheValue()
-                    ? onlyTheValue(bin, position, carrier, written)
-                    : OrderedIntervals.top();
-            case ComparisonClaim.Cut cut -> ends(bin, position, carrier,
-                    InvariantBound.at(cut, written, carrier));
+        return switch (read.left()) {
+            case OrderedLeaf.Left.NotFollowed<FactSubject> _ -> gaveUp(bin);
+            // A rule read from end to end that stops the values nowhere — what a disequality
+            // states. The values it leaves are a set rather than a range, which is the whole of
+            // what it does to a range, so it is one this reading followed.
+            case OrderedLeaf.Left.PlacesNoEnd<FactSubject> _ -> OrderedIntervals.top();
+            // Inside what the order itself holds, which is what makes the carrier's own ends part
+            // of every answer rather than something applied once around the whole reading: a branch
+            // left short of them is a branch whose emptiness nothing can see.
+            case OrderedLeaf.Left.Leaves<FactSubject> it ->
+                    OrderedIntervals.at(it.number(), it.within());
         };
-    }
-
-    /** The range of one value, or nothing where the rule names none this order reads. */
-    private OrderedIntervals<FactSubject> onlyTheValue(Core e, FactSubject position,
-                                                       Carrier carrier, Hir.Expr written) {
-        Place only = written == null ? null : carrier.literalOf(written);
-        // The rule meets the position at something this order has no literal for, so where it
-        // leaves the position is not something this reading found to be nothing.
-        return only == null ? gaveUp(e)
-                : leaves(position, carrier, new OrderedInterval(
-                        Endpoint.inclusive(only), Endpoint.inclusive(only)));
-    }
-
-    /** What the end an ordering placed leaves the position. */
-    private OrderedIntervals<FactSubject> ends(Core e, FactSubject position, Carrier carrier,
-                                               InvariantBound.Read read) {
-        return switch (read) {
-            case InvariantBound.Read.AnEnd it -> leaves(position, carrier, it.bound().lower()
-                    ? new OrderedInterval(it.bound().end(), null)
-                    : new OrderedInterval(null, it.bound().end()));
-            // The rule names an end the order does not reach, so the position holds nothing. Said as
-            // a range of this order with no value in it, which is the same kind of answer two rules
-            // whose ends cross come to.
-            case InvariantBound.Read.PastWhereTheOrderStops _ ->
-                    leaves(position, carrier, carrier.nothing());
-            // A cut on a position this counts, against something the order has no literal for. The
-            // other reasons NoEnd stands for are answered before this call, so what arrives is
-            // always this one.
-            case InvariantBound.Read.NoEnd _ -> gaveUp(e);
-        };
-    }
-
-    /**
-     * What one rule leaves a position, inside what the order itself holds.
-     *
-     * <p>The one place a position is spoken about, which is what makes the order's own ends part of
-     * every answer rather than something applied once at the end. A reader adding a second such
-     * place has to remember the extent; this one cannot forget it.
-     */
-    private static OrderedIntervals<FactSubject> leaves(FactSubject position, Carrier carrier,
-                                                 OrderedInterval range) {
-        return OrderedIntervals.at(position, carrier.extent().meet(range));
     }
 
     /** The position {@code e} is, or null where it is not one this is reading for. */

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -99,12 +99,16 @@ record ReadByClauses(Confinement.Worked<FactSubject> confinement,
      *                     which choice an author is sent to for it ({@link EndsLeftOpen}). Crosses
      *                     unchanged: what a branch is left open by was settled while the branches
      *                     were, and nothing decided since bears on it
+     * @param boundsLeftOpen the same for a line this part states on a number an operation answers
+     *                       that nothing placed, kept only where the rule's own settled reading
+     *                       still leaves it open ({@link BoundaryState})
      */
     record OfAPart(Adoption<FactSubject, ReadingLanguage.Values> byValues,
                    Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                    Set<RuleShortfall> aboutARule,
                    java.util.Map<FactSubject, AdmittedStrings> aboutStrings,
-                   EndsLeftOpen endsLeftOpen) {
+                   EndsLeftOpen endsLeftOpen,
+                   java.util.Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {
 
         /** The positions some reading took the whole of this part in at. */
         java.util.Set<FactSubject> adopted() {

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -108,7 +108,7 @@ record ReadByClauses(Confinement.Worked<FactSubject> confinement,
                    Set<RuleShortfall> aboutARule,
                    java.util.Map<FactSubject, AdmittedStrings> aboutStrings,
                    EndsLeftOpen endsLeftOpen,
-                   java.util.Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {
+                   java.util.Map<OpenEnd, EndsLeftOpen.Behind> boundsLeftOpen) {
 
         /** The positions some reading took the whole of this part in at. */
         java.util.Set<FactSubject> adopted() {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -494,10 +494,11 @@ sealed interface StatedByClauses {
      *  Built per clause, this walk paid for a pair of readers at every clause of every value. */
     static Reading readingOf(Terms terms, Map<FactSubject, Type> byName,
                              Symbols symbols, Alternatives alternatives,
-                             Allowance<FactSubject> allowed, StringMachineAnswers machines) {
+                             Allowance<FactSubject> allowed, StringMachineAnswers machines,
+                             StatedLines lines, BoundaryReading boundaries) {
         return new Reading(AdmissibleReading.of(terms, byName, symbols, allowed),
                 OrderedReading.of(terms, byName, symbols), terms, byName, alternatives,
-                machines);
+                machines, lines, boundaries);
     }
 
 
@@ -524,7 +525,7 @@ sealed interface StatedByClauses {
      */
     record Reading(AdmissibleReading values, OrderedReading ordered, Terms terms,
                    Map<FactSubject, Type> byName, Alternatives alternatives,
-                   StringMachineAnswers machines)
+                   StringMachineAnswers machines, StatedLines lines, BoundaryReading boundaries)
             implements ClauseReading<StatedByClauses, Denotations> {
 
         /** What a binding under a clause is entered as, for a fold over this reading. The one
@@ -555,7 +556,11 @@ sealed interface StatedByClauses {
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
-            return new Said(new Confinement.Planned<>(said, range, ordered.carriers()), new Part(
+            return new Said(new Confinement.Planned<>(said, range,
+                    // And where the leaf leaves the numbers this value's operations answer, which
+                    // is a third order with a reading of its own. Held beside the other two so that
+                    // the connectives compose it once, under the fate the other two decide.
+                    boundaries.leaf(e, positive, at), ordered.carriers()), new Part(
                     // Each language says for itself whether it could account for the leaf, and each
                     // is asked. Read off what a language produced instead, a rule it followed to
                     // the end and found bounds nothing is one it gave up on — which is what every
@@ -572,14 +577,20 @@ sealed interface StatedByClauses {
                     // decided it and written down where it decided. Read off what the leaf leaves
                     // the positions instead, this would be a list of reasons and no clause.
                     held(values.shortfallsAt(e)),
-                    // And which of the positions this leaf names have an end here that is unknown,
-                    // which is the ends' answer and not this walk's. What the clause names is what
-                    // is handed over; which of those have an end at all, and which of them this
-                    // reading worked out, are questions only it can answer — a rule it followed to
-                    // the end leaves none of them, nor does one holding a position it counts to
-                    // another of them, nor is a position whose values are not ordered one it fell
-                    // short at.
-                    EndsLeftOpen.at(ordered.endsLeftUnknownAt(e, mentions))));
+                    // And which of the positions this leaf names have an end here that is unknown.
+                    // Two readings, each asked what only it can say. Which positions the leaf says
+                    // the values stop somewhere on is a fact about the clause and wants the
+                    // arithmetic of its sides ({@link StatedLines}); which of those have an end at
+                    // all, and which of them were worked out, are the ends' own — a rule it
+                    // followed to the end leaves none of them, nor does one holding a position it
+                    // counts to another of them, nor is a position whose values are not ordered one
+                    // it fell short at.
+                    //
+                    // Read off what the ends managed alone, a rule stating no line and a rule
+                    // stating one nobody worked out are one answer, and every leaf of the first
+                    // kind left an end open under a choice.
+                    EndsLeftOpen.at(ordered.endsLeftUnknownAt(e,
+                            lines.ownValuesALineIsStatedOn(e, positive, at, mentions)))));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -163,18 +163,25 @@ sealed interface StatedByClauses {
      *                     ends' own, and not the other half of {@code ruleShortfalls}: that one is
      *                     about which values may stand at a position, and a reading that has a word
      *                     for a range where the other has none is short of nothing here
+     * @param boundedNumbers the numbers an operation answers that this part stopped somewhere. For
+     *                       the one question a choice asks of the branch beside an end it left open
+     *                       — whether that branch holds the number down at all — which is the ends'
+     *                       own answer for a position and this reading's for a number of one. A
+     *                       count is never in what the ends bounded and a position is never here,
+     *                       so which reader answers is settled by the number and not by a caller
      */
     record Part(Adoption<FactSubject, ReadingLanguage.Values> byValues,
                 Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                 Map<FactSubject, StringRestriction> aboutStrings,
                 Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls,
-                EndsLeftOpen endsLeftOpen) {
+                EndsLeftOpen endsLeftOpen,
+                Set<FactSubject> boundedNumbers) {
 
         /** What a clause of no connective, that no reading has a word for, took in. */
         static Part nothing() {
             return new Part(Adoption.nothing(), Adoption.nothing(), Map.of(), Set.of(), Set.of(),
-                    EndsLeftOpen.nothing());
+                    EndsLeftOpen.nothing(), Set.of());
         }
 
         /**
@@ -196,7 +203,22 @@ sealed interface StatedByClauses {
                     StringRestriction.over(aboutStrings, other.aboutStrings(), true),
                     askedIn(asked, other.asked()),
                     shortOf(ruleShortfalls, other.ruleShortfalls()),
-                    endsLeftOpen.both(other.endsLeftOpen()));
+                    endsLeftOpen.both(other.endsLeftOpen()),
+                    // A number either conjunct stopped is one the pair stops, and a dead
+                    // alternative brings none — which is what a branch nobody can be in bounds.
+                    union(boundedNumbers, other.boundedNumbers()));
+        }
+
+        private static Set<FactSubject> union(Set<FactSubject> these, Set<FactSubject> those) {
+            if (those.isEmpty()) {
+                return these;
+            }
+            if (these.isEmpty()) {
+                return those;
+            }
+            Set<FactSubject> out = new LinkedHashSet<>(these);
+            out.addAll(those);
+            return Collections.unmodifiableSet(out);
         }
 
         /**
@@ -218,7 +240,7 @@ sealed interface StatedByClauses {
             // And no end of it is left open. An end nothing derived is what a value of this type
             // may still be at, and no value of this type is in this branch.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
-                    Set.of(), Set.of(), EndsLeftOpen.nothing());
+                    Set.of(), Set.of(), EndsLeftOpen.nothing(), Set.of());
         }
 
         /**
@@ -231,7 +253,7 @@ sealed interface StatedByClauses {
          */
         Part underACollapsedChoice() {
             return new Part(byValues, byOrder, aboutStrings, asked, ruleShortfalls,
-                    endsLeftOpen.underACollapsedChoice());
+                    endsLeftOpen.underACollapsedChoice(), boundedNumbers);
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */
@@ -265,7 +287,19 @@ sealed interface StatedByClauses {
                     // And the ends the choice leaves open, struck down by what each alternative
                     // says it came to and never added to: what a choice can show is that the branch
                     // beside an unfollowed one puts every value of a position on the order.
-                    endsLeftOpen.either(choice, byOrder, other.endsLeftOpen(), other.byOrder()));
+                    endsLeftOpen.either(choice, byOrder, boundedNumbers,
+                            other.endsLeftOpen(), other.byOrder(), other.boundedNumbers()),
+                    // And the numbers the choice stops, which are the ones both alternatives stop:
+                    // a value taking one of them owes the other nothing, so a number only one of
+                    // them holds down is one the choice holds nowhere.
+                    both(boundedNumbers, other.boundedNumbers()));
+        }
+
+        /** The numbers both of these stop. */
+        private static Set<FactSubject> both(Set<FactSubject> these, Set<FactSubject> those) {
+            Set<FactSubject> out = new LinkedHashSet<>(these);
+            out.retainAll(those);
+            return Collections.unmodifiableSet(out);
         }
 
         /**
@@ -556,11 +590,19 @@ sealed interface StatedByClauses {
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
+            // What the leaf states, asked once and read by both of the questions below: which
+            // number a line falls on is a fact about the clause, and the readings are asked what
+            // they made of it rather than asked to work it out again.
+            StatedLines.Statement stated = lines.of(e, positive, at);
+            BoundaryReading.Read bounds = boundaries.leaf(stated, e, positive, at);
             return new Said(new Confinement.Planned<>(said, range,
                     // And where the leaf leaves the numbers this value's operations answer, which
                     // is a third order with a reading of its own. Held beside the other two so that
                     // the connectives compose it once, under the fate the other two decide.
-                    boundaries.leaf(e, positive, at), ordered.carriers()), new Part(
+                    bounds instanceof BoundaryReading.Read.Bounded it
+                            ? OrderedIntervals.at(it.number(), it.range())
+                            : OrderedIntervals.top(),
+                    ordered.carriers()), new Part(
                     // Each language says for itself whether it could account for the leaf, and each
                     // is asked. Read off what a language produced instead, a rule it followed to
                     // the end and found bounds nothing is one it gave up on — which is what every
@@ -589,8 +631,16 @@ sealed interface StatedByClauses {
                     // Read off what the ends managed alone, a rule stating no line and a rule
                     // stating one nobody worked out are one answer, and every leaf of the first
                     // kind left an end open under a choice.
+                    // The positions whose own end this reading did not work out, and beside them
+                    // the numbers an operation answers whose line nothing placed. One question
+                    // asked of two readings, each about the numbers it holds.
                     EndsLeftOpen.at(ordered.endsLeftUnknownAt(e,
-                            lines.ownValuesALineIsStatedOn(e, positive, at, mentions)))));
+                                    lines.waitingOnAReader(stated, mentions)))
+                            .both(EndsLeftOpen.at(
+                                    bounds instanceof BoundaryReading.Read.LeftOpen open
+                                            ? Set.of(open.subject()) : Set.of())),
+                    bounds instanceof BoundaryReading.Read.Bounded placed
+                            ? Set.of(placed.subject()) : Set.of()));
         }
 
         /**
@@ -1248,7 +1298,7 @@ sealed interface StatedByClauses {
                     // build says nothing about which ends this reading worked out, and a position
                     // struck off here would be one the border is told nothing about because a
                     // pattern beside it was unaffordable.
-                    part.endsLeftOpen()));
+                    part.endsLeftOpen(), part.boundedNumbers()));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -163,15 +163,16 @@ sealed interface StatedByClauses {
      *                     ends' own, and not the other half of {@code ruleShortfalls}: that one is
      *                     about which values may stand at a position, and a reading that has a word
      *                     for a range where the other has none is short of nothing here
-     * @param boundsLeftOpen which choice an author is sent to for a line this part states on a
-     *                       number an operation answers and nothing placed.
-     *
-     *                       <p><b>The provenance and nothing else.</b> Whether such an end is still
-     *                       open once the branches are settled is a fact about what the
-     *                       alternatives leave the number, which is the reading's own and is
-     *                       composed once where it is ({@link BoundaryState}). Gated here as well,
-     *                       a choice would be settled twice — the shape the reading of ends is
-     *                       under, one language at a time, is the shape this would take
+     * @param boundary what this part leaves the numbers an operation answers, over the tree its
+     *                 author wrote ({@link BoundaryState}). The same operations the whole
+     *                 declaration's reading is put together by, asked here of the alternatives as
+     *                 they stand between the brackets — which is the only tree a question about a
+     *                 choice may be asked over, since the other one has conjuncts written outside
+     *                 the brackets distributed into the branches
+     * @param boundsLeftOpen which choice an author is sent to for a line this part states on one of
+     *                       those numbers and nothing placed. The provenance alone: whether the end
+     *                       is still open is {@code boundary}'s answer, and the two are met where
+     *                       the account is published
      */
     record Part(Adoption<FactSubject, ReadingLanguage.Values> byValues,
                 Adoption<FactSubject, ReadingLanguage.Order> byOrder,
@@ -179,12 +180,13 @@ sealed interface StatedByClauses {
                 Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls,
                 EndsLeftOpen endsLeftOpen,
-                Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {
+                BoundaryState boundary,
+                Map<OpenEnd, EndsLeftOpen.Behind> boundsLeftOpen) {
 
         /** What a clause of no connective, that no reading has a word for, took in. */
         static Part nothing() {
             return new Part(Adoption.nothing(), Adoption.nothing(), Map.of(), Set.of(), Set.of(),
-                    EndsLeftOpen.nothing(), Map.of());
+                    EndsLeftOpen.nothing(), BoundaryState.nothing(), Map.of());
         }
 
         /**
@@ -207,20 +209,21 @@ sealed interface StatedByClauses {
                     askedIn(asked, other.asked()),
                     shortOf(ruleShortfalls, other.ruleShortfalls()),
                     endsLeftOpen.both(other.endsLeftOpen()),
+                    boundary.both(other.boundary()),
                     reached(boundsLeftOpen, other.boundsLeftOpen()));
         }
 
         /** The same end reached two ways, which is what a conjunction of two parts comes to. */
-        private static Map<DerivedNumber, EndsLeftOpen.Behind> reached(
-                Map<DerivedNumber, EndsLeftOpen.Behind> these,
-                Map<DerivedNumber, EndsLeftOpen.Behind> those) {
+        private static Map<OpenEnd, EndsLeftOpen.Behind> reached(
+                Map<OpenEnd, EndsLeftOpen.Behind> these,
+                Map<OpenEnd, EndsLeftOpen.Behind> those) {
             if (those.isEmpty()) {
                 return these;
             }
             if (these.isEmpty()) {
                 return those;
             }
-            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>(these);
+            Map<OpenEnd, EndsLeftOpen.Behind> out = new LinkedHashMap<>(these);
             those.forEach((number, behind) ->
                     out.merge(number, behind, EndsLeftOpen.Behind::and));
             return Collections.unmodifiableMap(out);
@@ -245,7 +248,7 @@ sealed interface StatedByClauses {
             // And no end of it is left open. An end nothing derived is what a value of this type
             // may still be at, and no value of this type is in this branch.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
-                    Set.of(), Set.of(), EndsLeftOpen.nothing(), Map.of());
+                    Set.of(), Set.of(), EndsLeftOpen.nothing(), BoundaryState.nothing(), Map.of());
         }
 
         /**
@@ -258,15 +261,16 @@ sealed interface StatedByClauses {
          */
         Part underACollapsedChoice() {
             return new Part(byValues, byOrder, aboutStrings, asked, ruleShortfalls,
-                    endsLeftOpen.underACollapsedChoice(), underACollapsedChoice(boundsLeftOpen));
+                    endsLeftOpen.underACollapsedChoice(), boundary,
+                    underACollapsedChoice(boundsLeftOpen));
         }
 
-        private static Map<DerivedNumber, EndsLeftOpen.Behind> underACollapsedChoice(
-                Map<DerivedNumber, EndsLeftOpen.Behind> these) {
+        private static Map<OpenEnd, EndsLeftOpen.Behind> underACollapsedChoice(
+                Map<OpenEnd, EndsLeftOpen.Behind> these) {
             if (these.isEmpty()) {
                 return these;
             }
-            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            Map<OpenEnd, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
             these.forEach((number, behind) -> out.put(number, behind.underACollapsedChoice()));
             return Collections.unmodifiableMap(out);
         }
@@ -303,6 +307,7 @@ sealed interface StatedByClauses {
                     // says it came to and never added to: what a choice can show is that the branch
                     // beside an unfollowed one puts every value of a position on the order.
                     endsLeftOpen.either(choice, byOrder, other.endsLeftOpen(), other.byOrder()),
+                    boundary.either(other.boundary()),
                     // And the choice an author is sent to for a line on a derived number nothing
                     // placed. Nothing is struck off here: which of them the choice still leaves
                     // open is what the alternatives leave that number, and that is settled once,
@@ -311,12 +316,12 @@ sealed interface StatedByClauses {
         }
 
         /** The same ends, with {@code choice} standing between them and the walk. */
-        private static Map<DerivedNumber, EndsLeftOpen.Behind> under(
-                ChoiceSite choice, Map<DerivedNumber, EndsLeftOpen.Behind> these) {
+        private static Map<OpenEnd, EndsLeftOpen.Behind> under(
+                ChoiceSite choice, Map<OpenEnd, EndsLeftOpen.Behind> these) {
             if (these.isEmpty()) {
                 return these;
             }
-            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            Map<OpenEnd, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
             these.forEach((number, behind) -> out.put(number, behind.under(choice)));
             return Collections.unmodifiableMap(out);
         }
@@ -649,12 +654,17 @@ sealed interface StatedByClauses {
                     // kind left an end open under a choice.
                     EndsLeftOpen.at(ordered.endsLeftUnknownAt(e,
                             lines.waitingOnAReader(stated, mentions))),
+                    // What the leaf leaves the derived numbers, over the tree its author wrote.
+                    // The same state the whole declaration's reading is put together from, and the
+                    // same operations — asked here of the alternatives as they stand between the
+                    // brackets, which is the only tree a question about a choice may be asked over.
+                    stateOf(bounds),
                     // And where a line on a number an operation answers was left open, which
                     // choice an author is sent to for it. The provenance and nothing else:
                     // whether such an end is still open once the branches are settled is the
                     // reading's own answer and is met with this where both are in hand.
                     bounds instanceof BoundaryReading.Read.LeftOpen open
-                            ? Map.of(open.number(), EndsLeftOpen.Behind.aLeaf())
+                            ? Map.of(open.end(), EndsLeftOpen.Behind.aLeaf())
                             : Map.of()));
         }
 
@@ -664,7 +674,7 @@ sealed interface StatedByClauses {
                 case BoundaryReading.Read.NoLineStated _ -> BoundaryState.nothing();
                 case BoundaryReading.Read.Bounded it ->
                         BoundaryState.bounded(it.number(), it.range());
-                case BoundaryReading.Read.LeftOpen it -> BoundaryState.leftOpen(it.number());
+                case BoundaryReading.Read.LeftOpen it -> BoundaryState.leftOpen(it.end());
             };
         }
 
@@ -1037,9 +1047,11 @@ sealed interface StatedByClauses {
             // derived numbers it still leaves open are read off the same one: which of them a
             // choice settled is that reading's answer, worked out where the branches were, and
             // met here with the choices an author is sent to.
-            Confinement.Planned<FactSubject> alone = alone(projected, by).confinement();
-            return new Account(narrowedBy(alone.values(), by),
-                    partsOf(took, made, alone.derived().open()), took.opened());
+            // And which of the lines it stated on a derived number the rule still leaves open,
+            // read off the tree the author wrote — where an alternative is what stands between the
+            // brackets, and a conjunct written outside them is not in either branch.
+            return new Account(narrowedBy(alone(projected, by).confinement().values(), by),
+                    partsOf(took, made, took.took().boundary().open()), took.opened());
         }
 
         /**
@@ -1137,23 +1149,30 @@ sealed interface StatedByClauses {
             return out;
         }
 
-        /** The choices written for the ends of {@code stillOpen}, and none for the rest. */
-        private static Map<DerivedNumber, EndsLeftOpen.Behind> stillOpenOf(
-                Map<DerivedNumber, EndsLeftOpen.Behind> written, Set<DerivedNumber> stillOpen) {
+        /**
+         * The choices written for the ends of {@code stillOpen}, and none for the rest.
+         *
+         * <p>End by end and never by the number they are ends of. One rule can state two lines on
+         * one length, and an alternative beside one of them settles that one alone — asked whether
+         * the length is still open, the settled line finds that it is, because of the other, and
+         * comes back with the choice its own alternative had already answered for.
+         */
+        private static Map<OpenEnd, EndsLeftOpen.Behind> stillOpenOf(
+                Map<OpenEnd, EndsLeftOpen.Behind> written, Set<OpenEnd> stillOpen) {
             if (written.isEmpty()) {
                 return written;
             }
-            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
-            written.forEach((number, behind) -> {
-                if (stillOpen.contains(number)) {
-                    out.put(number, behind);
+            Map<OpenEnd, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            written.forEach((end, behind) -> {
+                if (stillOpen.contains(end)) {
+                    out.put(end, behind);
                 }
             });
             return out;
         }
 
         private Map<Core, PartAccount> partsOf(Taken took, Settlement made,
-                                               Set<DerivedNumber> stillOpen) {
+                                               Set<OpenEnd> stillOpen) {
             Set<FactSubject> unbuilt = made.made().unbuilt();
             // And what could not be built is given up on here too. What a leaf said it adopted was
             // said before any machine was made, so a position whose answer the whole reading did
@@ -1348,7 +1367,7 @@ sealed interface StatedByClauses {
                     // build says nothing about which ends this reading worked out, and a position
                     // struck off here would be one the border is told nothing about because a
                     // pattern beside it was unaffordable.
-                    part.endsLeftOpen(), part.boundsLeftOpen()));
+                    part.endsLeftOpen(), part.boundary(), part.boundsLeftOpen()));
         }
 
         /**
@@ -1724,7 +1743,7 @@ sealed interface StatedByClauses {
                        Set<RuleShortfall> aboutARule,
                        Map<FactSubject, StringRestriction> aboutStrings,
                        EndsLeftOpen endsLeftOpen,
-                       Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {}
+                       Map<OpenEnd, EndsLeftOpen.Behind> boundsLeftOpen) {}
 
     /** How much the allowance has spent in all, for holding an account to spending nothing — see
      *  {@code InvariantChecker.spentBy}. */

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -163,12 +163,15 @@ sealed interface StatedByClauses {
      *                     ends' own, and not the other half of {@code ruleShortfalls}: that one is
      *                     about which values may stand at a position, and a reading that has a word
      *                     for a range where the other has none is short of nothing here
-     * @param boundedNumbers the numbers an operation answers that this part stopped somewhere. For
-     *                       the one question a choice asks of the branch beside an end it left open
-     *                       — whether that branch holds the number down at all — which is the ends'
-     *                       own answer for a position and this reading's for a number of one. A
-     *                       count is never in what the ends bounded and a position is never here,
-     *                       so which reader answers is settled by the number and not by a caller
+     * @param boundsLeftOpen which choice an author is sent to for a line this part states on a
+     *                       number an operation answers and nothing placed.
+     *
+     *                       <p><b>The provenance and nothing else.</b> Whether such an end is still
+     *                       open once the branches are settled is a fact about what the
+     *                       alternatives leave the number, which is the reading's own and is
+     *                       composed once where it is ({@link BoundaryState}). Gated here as well,
+     *                       a choice would be settled twice — the shape the reading of ends is
+     *                       under, one language at a time, is the shape this would take
      */
     record Part(Adoption<FactSubject, ReadingLanguage.Values> byValues,
                 Adoption<FactSubject, ReadingLanguage.Order> byOrder,
@@ -176,12 +179,12 @@ sealed interface StatedByClauses {
                 Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls,
                 EndsLeftOpen endsLeftOpen,
-                Set<FactSubject> boundedNumbers) {
+                Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {
 
         /** What a clause of no connective, that no reading has a word for, took in. */
         static Part nothing() {
             return new Part(Adoption.nothing(), Adoption.nothing(), Map.of(), Set.of(), Set.of(),
-                    EndsLeftOpen.nothing(), Set.of());
+                    EndsLeftOpen.nothing(), Map.of());
         }
 
         /**
@@ -204,21 +207,23 @@ sealed interface StatedByClauses {
                     askedIn(asked, other.asked()),
                     shortOf(ruleShortfalls, other.ruleShortfalls()),
                     endsLeftOpen.both(other.endsLeftOpen()),
-                    // A number either conjunct stopped is one the pair stops, and a dead
-                    // alternative brings none — which is what a branch nobody can be in bounds.
-                    union(boundedNumbers, other.boundedNumbers()));
+                    reached(boundsLeftOpen, other.boundsLeftOpen()));
         }
 
-        private static Set<FactSubject> union(Set<FactSubject> these, Set<FactSubject> those) {
+        /** The same end reached two ways, which is what a conjunction of two parts comes to. */
+        private static Map<DerivedNumber, EndsLeftOpen.Behind> reached(
+                Map<DerivedNumber, EndsLeftOpen.Behind> these,
+                Map<DerivedNumber, EndsLeftOpen.Behind> those) {
             if (those.isEmpty()) {
                 return these;
             }
             if (these.isEmpty()) {
                 return those;
             }
-            Set<FactSubject> out = new LinkedHashSet<>(these);
-            out.addAll(those);
-            return Collections.unmodifiableSet(out);
+            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>(these);
+            those.forEach((number, behind) ->
+                    out.merge(number, behind, EndsLeftOpen.Behind::and));
+            return Collections.unmodifiableMap(out);
         }
 
         /**
@@ -240,7 +245,7 @@ sealed interface StatedByClauses {
             // And no end of it is left open. An end nothing derived is what a value of this type
             // may still be at, and no value of this type is in this branch.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
-                    Set.of(), Set.of(), EndsLeftOpen.nothing(), Set.of());
+                    Set.of(), Set.of(), EndsLeftOpen.nothing(), Map.of());
         }
 
         /**
@@ -253,7 +258,17 @@ sealed interface StatedByClauses {
          */
         Part underACollapsedChoice() {
             return new Part(byValues, byOrder, aboutStrings, asked, ruleShortfalls,
-                    endsLeftOpen.underACollapsedChoice(), boundedNumbers);
+                    endsLeftOpen.underACollapsedChoice(), underACollapsedChoice(boundsLeftOpen));
+        }
+
+        private static Map<DerivedNumber, EndsLeftOpen.Behind> underACollapsedChoice(
+                Map<DerivedNumber, EndsLeftOpen.Behind> these) {
+            if (these.isEmpty()) {
+                return these;
+            }
+            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            these.forEach((number, behind) -> out.put(number, behind.underACollapsedChoice()));
+            return Collections.unmodifiableMap(out);
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */
@@ -287,19 +302,23 @@ sealed interface StatedByClauses {
                     // And the ends the choice leaves open, struck down by what each alternative
                     // says it came to and never added to: what a choice can show is that the branch
                     // beside an unfollowed one puts every value of a position on the order.
-                    endsLeftOpen.either(choice, byOrder, boundedNumbers,
-                            other.endsLeftOpen(), other.byOrder(), other.boundedNumbers()),
-                    // And the numbers the choice stops, which are the ones both alternatives stop:
-                    // a value taking one of them owes the other nothing, so a number only one of
-                    // them holds down is one the choice holds nowhere.
-                    both(boundedNumbers, other.boundedNumbers()));
+                    endsLeftOpen.either(choice, byOrder, other.endsLeftOpen(), other.byOrder()),
+                    // And the choice an author is sent to for a line on a derived number nothing
+                    // placed. Nothing is struck off here: which of them the choice still leaves
+                    // open is what the alternatives leave that number, and that is settled once,
+                    // where they are ({@link BoundaryState#either}).
+                    under(choice, reached(boundsLeftOpen, other.boundsLeftOpen())));
         }
 
-        /** The numbers both of these stop. */
-        private static Set<FactSubject> both(Set<FactSubject> these, Set<FactSubject> those) {
-            Set<FactSubject> out = new LinkedHashSet<>(these);
-            out.retainAll(those);
-            return Collections.unmodifiableSet(out);
+        /** The same ends, with {@code choice} standing between them and the walk. */
+        private static Map<DerivedNumber, EndsLeftOpen.Behind> under(
+                ChoiceSite choice, Map<DerivedNumber, EndsLeftOpen.Behind> these) {
+            if (these.isEmpty()) {
+                return these;
+            }
+            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            these.forEach((number, behind) -> out.put(number, behind.under(choice)));
+            return Collections.unmodifiableMap(out);
         }
 
         /**
@@ -596,13 +615,10 @@ sealed interface StatedByClauses {
             StatedLines.Statement stated = lines.of(e, positive, at);
             BoundaryReading.Read bounds = boundaries.leaf(stated, e, positive, at);
             return new Said(new Confinement.Planned<>(said, range,
-                    // And where the leaf leaves the numbers this value's operations answer, which
-                    // is a third order with a reading of its own. Held beside the other two so that
-                    // the connectives compose it once, under the fate the other two decide.
-                    bounds instanceof BoundaryReading.Read.Bounded it
-                            ? OrderedIntervals.at(it.number(), it.range())
-                            : OrderedIntervals.top(),
-                    ordered.carriers()), new Part(
+                    // And what the leaf leaves the numbers this value's operations answer, which
+                    // is a third reading with a state of its own. Held beside the other two so
+                    // that the connectives compose it once, under the fate the other two decide.
+                    stateOf(bounds), ordered.carriers()), new Part(
                     // Each language says for itself whether it could account for the leaf, and each
                     // is asked. Read off what a language produced instead, a rule it followed to
                     // the end and found bounds nothing is one it gave up on — which is what every
@@ -631,16 +647,25 @@ sealed interface StatedByClauses {
                     // Read off what the ends managed alone, a rule stating no line and a rule
                     // stating one nobody worked out are one answer, and every leaf of the first
                     // kind left an end open under a choice.
-                    // The positions whose own end this reading did not work out, and beside them
-                    // the numbers an operation answers whose line nothing placed. One question
-                    // asked of two readings, each about the numbers it holds.
                     EndsLeftOpen.at(ordered.endsLeftUnknownAt(e,
-                                    lines.waitingOnAReader(stated, mentions)))
-                            .both(EndsLeftOpen.at(
-                                    bounds instanceof BoundaryReading.Read.LeftOpen open
-                                            ? Set.of(open.subject()) : Set.of())),
-                    bounds instanceof BoundaryReading.Read.Bounded placed
-                            ? Set.of(placed.subject()) : Set.of()));
+                            lines.waitingOnAReader(stated, mentions))),
+                    // And where a line on a number an operation answers was left open, which
+                    // choice an author is sent to for it. The provenance and nothing else:
+                    // whether such an end is still open once the branches are settled is the
+                    // reading's own answer and is met with this where both are in hand.
+                    bounds instanceof BoundaryReading.Read.LeftOpen open
+                            ? Map.of(open.number(), EndsLeftOpen.Behind.aLeaf())
+                            : Map.of()));
+        }
+
+        /** What one leaf's reading of the derived numbers comes to, as the state that composes. */
+        private static BoundaryState stateOf(BoundaryReading.Read read) {
+            return switch (read) {
+                case BoundaryReading.Read.NoLineStated _ -> BoundaryState.nothing();
+                case BoundaryReading.Read.Bounded it ->
+                        BoundaryState.bounded(it.number(), it.range());
+                case BoundaryReading.Read.LeftOpen it -> BoundaryState.leftOpen(it.number());
+            };
         }
 
         /**
@@ -1008,8 +1033,13 @@ sealed interface StatedByClauses {
         Account accountOf(StatedByClauses rule, StatedTogether projected, Settlement made,
                           Allowance<FactSubject> by) {
             Taken took = accounted(rule, made.outcomes());
-            return new Account(narrowedBy(alone(projected, by).confinement().values(), by),
-                    partsOf(took, made), took.opened());
+            // This rule's own settled reading, which is what an account of it rests on. The
+            // derived numbers it still leaves open are read off the same one: which of them a
+            // choice settled is that reading's answer, worked out where the branches were, and
+            // met here with the choices an author is sent to.
+            Confinement.Planned<FactSubject> alone = alone(projected, by).confinement();
+            return new Account(narrowedBy(alone.values(), by),
+                    partsOf(took, made, alone.derived().open()), took.opened());
         }
 
         /**
@@ -1107,7 +1137,23 @@ sealed interface StatedByClauses {
             return out;
         }
 
-        private Map<Core, PartAccount> partsOf(Taken took, Settlement made) {
+        /** The choices written for the ends of {@code stillOpen}, and none for the rest. */
+        private static Map<DerivedNumber, EndsLeftOpen.Behind> stillOpenOf(
+                Map<DerivedNumber, EndsLeftOpen.Behind> written, Set<DerivedNumber> stillOpen) {
+            if (written.isEmpty()) {
+                return written;
+            }
+            Map<DerivedNumber, EndsLeftOpen.Behind> out = new LinkedHashMap<>();
+            written.forEach((number, behind) -> {
+                if (stillOpen.contains(number)) {
+                    out.put(number, behind);
+                }
+            });
+            return out;
+        }
+
+        private Map<Core, PartAccount> partsOf(Taken took, Settlement made,
+                                               Set<DerivedNumber> stillOpen) {
             Set<FactSubject> unbuilt = made.made().unbuilt();
             // And what could not be built is given up on here too. What a leaf said it adopted was
             // said before any machine was made, so a position whose answer the whole reading did
@@ -1123,7 +1169,11 @@ sealed interface StatedByClauses {
                     // clause that asked for it, and reaches no clause that asked for something else.
                     shortOf(part.ruleShortfalls(),
                             askedFor(made.made().aboutARule(), part.asked())),
-                    part.aboutStrings(), part.endsLeftOpen())));
+                    part.aboutStrings(), part.endsLeftOpen(),
+                    // The choices this part wrote, kept only for the ends its own rule still
+                    // leaves open. The gate is the reading's and ran once; this is where its
+                    // answer and the provenance meet.
+                    stillOpenOf(part.boundsLeftOpen(), stillOpen))));
             return parts;
         }
 
@@ -1298,7 +1348,7 @@ sealed interface StatedByClauses {
                     // build says nothing about which ends this reading worked out, and a position
                     // struck off here would be one the border is told nothing about because a
                     // pattern beside it was unaffordable.
-                    part.endsLeftOpen(), part.boundedNumbers()));
+                    part.endsLeftOpen(), part.boundsLeftOpen()));
         }
 
         /**
@@ -1601,7 +1651,8 @@ sealed interface StatedByClauses {
             Map<Core, ReadByClauses.OfAPart> out = new IdentityHashMap<>();
             said.forEach((each, part) -> out.put(each, new ReadByClauses.OfAPart(
                     part.byValues(), part.byOrder(), part.aboutARule(),
-                    admitted(part.aboutStrings(), answers), part.endsLeftOpen())));
+                    admitted(part.aboutStrings(), answers), part.endsLeftOpen(),
+                    part.boundsLeftOpen())));
             return out;
         }
 
@@ -1672,7 +1723,8 @@ sealed interface StatedByClauses {
                        Adoption<FactSubject, ReadingLanguage.Order> byOrder,
                        Set<RuleShortfall> aboutARule,
                        Map<FactSubject, StringRestriction> aboutStrings,
-                       EndsLeftOpen endsLeftOpen) {}
+                       EndsLeftOpen endsLeftOpen,
+                       Map<DerivedNumber, EndsLeftOpen.Behind> boundsLeftOpen) {}
 
     /** How much the allowance has spent in all, for holding an account to spending nothing — see
      *  {@code InvariantChecker.spentBy}. */

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
@@ -5,7 +5,7 @@ import souther.compiler.core.Core;
 import java.util.Set;
 
 /**
- * Which positions a leaf states a line about, on the value standing at the position itself.
+ * What one leaf states, and on which of a value's numbers.
  *
  * <p>What a leaf states is one answer, and it is the same answer wherever the leaf is written. The
  * reading of ends composes the connectives an author wrote and has no arithmetic for the sides of a
@@ -14,31 +14,68 @@ import java.util.Set;
  * one bounding a number an operation answers all read alike there — as rules whose end nobody
  * worked out — and under a choice that is what they were published as.
  *
- * <p>The three of them are told apart here, by the reading that has the arithmetic. What comes back
- * is the positions whose own order the leaf says stops somewhere; the reading of ends is then asked
- * which of those it managed, which is its own answer and stays its own.
+ * <p>They are told apart here, by the reading that has the arithmetic, and told apart the way the
+ * attribution of an end to a conjunct already tells them apart: by the numbers the canonical form
+ * of the comparison is over. Read off which side happens to be spelled as a name, a rule whose
+ * coordinate is written inside an expression — {@code String.length(s) * 2 >= 4} — is a rule about
+ * nothing, and under a choice that comes back as a model that draws no line.
  *
- * <p><b>The position's own value and never a number taken of it.</b> A line on what an operation
- * answers — how long the string at a position is — is a line on another order, and where the values
- * at the position stop is untouched by it. Answered with the position, a bound on a length came out
- * as an end of the string order that nothing worked out, and a choice between two such bounds as a
- * border this compiler could not measure.
+ * <p><b>What a leaf states, and never what became of it.</b> Whether a range was read for the line
+ * is the reading that holds that order's answer, and this hands its own out so that the two can be
+ * put together where both are in hand ({@link #waitingOnAReader}). Decided here, a leaf would be
+ * classified by what some reader managed with it, which is the confusion the whole type is against.
  */
 interface StatedLines {
 
+    /** What {@code leaf} states, read as written where {@code positive} and denied where it is
+     *  not. */
+    Statement of(Core leaf, boolean positive, Denotations at);
+
     /**
-     * The positions of {@code named} whose own order {@code leaf} says the values stop on.
+     * The positions of {@code named} whose end nothing here worked out.
      *
-     * <p>Empty where the leaf states no line at all: a rule that holds of every row, one that says
-     * which values may stand somewhere without ordering them, a denial of one value. All of
-     * {@code named} where it states one on a number this reading cannot name — an absolute value, a
-     * difference — since which of the positions it is about is then what reading further would say.
+     * <p>Empty where the leaf states no line, and where the line it states runs between several of
+     * the value's numbers and falls at none of them. All of {@code named} where it states one on a
+     * number this reading cannot name, since which of the positions it is about is what reading
+     * further would say.
      *
-     * @param leaf     the clause of no connective, as the author wrote it
-     * @param positive whether it stands as written or under a denial. A denial of a rule stating one
-     *                 end states the other, and a denial of one ruling a value out states that value
-     * @param named    the positions the leaf writes about, which is the clause's own answer
+     * <p>And empty where the line is on a number an operation answers: such a line leaves the
+     * position's own order exactly where it was, and whether it was placed is filed under the
+     * number by the reading that holds it ({@link BoundaryReading}).
      */
-    Set<FactSubject> ownValuesALineIsStatedOn(Core leaf, boolean positive, Denotations at,
-                                              Set<FactSubject> named);
+    Set<FactSubject> waitingOnAReader(Statement stated, Set<FactSubject> named);
+
+    /** Which of a value's numbers a leaf says the values stop on. */
+    sealed interface Statement {
+
+        /** None of them: a rule holding of every row, one saying which values may stand somewhere
+         *  without ordering them, a denial of one value, a shape that is no comparison. */
+        record NoLine() implements Statement {}
+
+        /** The value standing at a position, named so that a caller can say which one. */
+        record OnWhatStandsAtAPosition(NumberAt<RuleKey> number) implements Statement {
+
+            public OnWhatStandsAtAPosition {
+                if (number == null) {
+                    throw new IllegalArgumentException("this one is about some position's value");
+                }
+            }
+        }
+
+        /** A number an operation answers of what stands at a position. */
+        record OnADerivedNumber(DerivedNumber number) implements Statement {
+
+            public OnADerivedNumber {
+                if (number == null) {
+                    throw new IllegalArgumentException("this one is about some derived number");
+                }
+            }
+        }
+
+        /** Several of them, held to each other: the line runs between them and falls at none. */
+        record Between() implements Statement {}
+
+        /** One this reading cannot name — an absolute value, a difference. */
+        record OnANumberNotNamed() implements Statement {}
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
@@ -1,0 +1,44 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+
+import java.util.Set;
+
+/**
+ * Which positions a leaf states a line about, on the value standing at the position itself.
+ *
+ * <p>What a leaf states is one answer, and it is the same answer wherever the leaf is written. The
+ * reading of ends composes the connectives an author wrote and has no arithmetic for the sides of a
+ * comparison: it can say it did not work a line out and cannot say whether there was one to work
+ * out. So a rule holding every row there is, one restricting which values may stand somewhere, and
+ * one bounding a number an operation answers all read alike there — as rules whose end nobody
+ * worked out — and under a choice that is what they were published as.
+ *
+ * <p>The three of them are told apart here, by the reading that has the arithmetic. What comes back
+ * is the positions whose own order the leaf says stops somewhere; the reading of ends is then asked
+ * which of those it managed, which is its own answer and stays its own.
+ *
+ * <p><b>The position's own value and never a number taken of it.</b> A line on what an operation
+ * answers — how long the string at a position is — is a line on another order, and where the values
+ * at the position stop is untouched by it. Answered with the position, a bound on a length came out
+ * as an end of the string order that nothing worked out, and a choice between two such bounds as a
+ * border this compiler could not measure.
+ */
+interface StatedLines {
+
+    /**
+     * The positions of {@code named} whose own order {@code leaf} says the values stop on.
+     *
+     * <p>Empty where the leaf states no line at all: a rule that holds of every row, one that says
+     * which values may stand somewhere without ordering them, a denial of one value. All of
+     * {@code named} where it states one on a number this reading cannot name — an absolute value, a
+     * difference — since which of the positions it is about is then what reading further would say.
+     *
+     * @param leaf     the clause of no connective, as the author wrote it
+     * @param positive whether it stands as written or under a denial. A denial of a rule stating one
+     *                 end states the other, and a denial of one ruling a value out states that value
+     * @param named    the positions the leaf writes about, which is the clause's own answer
+     */
+    Set<FactSubject> ownValuesALineIsStatedOn(Core leaf, boolean positive, Denotations at,
+                                              Set<FactSubject> named);
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedLines.java
@@ -75,6 +75,22 @@ interface StatedLines {
         /** Several of them, held to each other: the line runs between them and falls at none. */
         record Between() implements Statement {}
 
+        /**
+         * None of them, and no row either: the rule's numbers cancel to something no value meets.
+         *
+         * <p>{@code n - n >= 1} is {@code 0 >= 1}. It states no line, as a rule holding of every
+         * row does, and the two are opposite — the first leaves an alternative beside it standing
+         * alone and the second takes every value of the choice into itself. Which of them a branch
+         * is decides whether an end the alternative beside it left open is still open, so they are
+         * not one answer.
+         *
+         * <p>That nobody is in such a branch is not something this reading may act on: whether
+         * anybody is in one is the values' and the orders', and neither of them reads the
+         * arithmetic that shows it. So what is said here is only that the branch settles nothing
+         * for its neighbour.
+         */
+        record AdmitsNothing() implements Statement {}
+
         /** One this reading cannot name — an absolute value, a difference. */
         record OnANumberNotNamed() implements Statement {}
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -365,7 +365,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(),
                         java.util.Set.of(UNREAD), true, java.util.Set.of()),
                 Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
-                java.util.Map.of());
+                BoundaryState.nothing(), java.util.Map.of());
     }
 
     /** And the alternative beside it that both of them read, constraining one position. */
@@ -376,7 +376,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
                         java.util.Set.of(), false, java.util.Set.of()),
                 Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
-                java.util.Map.of());
+                BoundaryState.nothing(), java.util.Map.of());
     }
 
     /** One choice somebody wrote, told from every other by being this one. */
@@ -391,7 +391,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         java.util.Set.of(), false, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
                 EndsLeftOpen.nothing(),
-                java.util.Map.of());
+                BoundaryState.nothing(), java.util.Map.of());
     }
 
     /** And the alternative beside it that nothing could read. */
@@ -402,7 +402,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         true, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
                 EndsLeftOpen.nothing(),
-                java.util.Map.of());
+                BoundaryState.nothing(), java.util.Map.of());
     }
 
     /** And two choices leaving one position open are two things an author can look at. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -364,7 +364,8 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         java.util.Set.of(), false, java.util.Set.of()),
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(),
                         java.util.Set.of(UNREAD), true, java.util.Set.of()),
-                Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing());
+                Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
+                java.util.Set.of());
     }
 
     /** And the alternative beside it that both of them read, constraining one position. */
@@ -374,7 +375,8 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         java.util.Set.of(), false, java.util.Set.of()),
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
                         java.util.Set.of(), false, java.util.Set.of()),
-                Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing());
+                Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
+                java.util.Set.of());
     }
 
     /** One choice somebody wrote, told from every other by being this one. */
@@ -388,7 +390,8 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
                         java.util.Set.of(), false, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
-                EndsLeftOpen.nothing());
+                EndsLeftOpen.nothing(),
+                java.util.Set.of());
     }
 
     /** And the alternative beside it that nothing could read. */
@@ -398,7 +401,8 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
                         true, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
-                EndsLeftOpen.nothing());
+                EndsLeftOpen.nothing(),
+                java.util.Set.of());
     }
 
     /** And two choices leaving one position open are two things an author can look at. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -365,7 +365,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(),
                         java.util.Set.of(UNREAD), true, java.util.Set.of()),
                 Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
-                java.util.Set.of());
+                java.util.Map.of());
     }
 
     /** And the alternative beside it that both of them read, constraining one position. */
@@ -376,7 +376,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(),
                         java.util.Set.of(), false, java.util.Set.of()),
                 Map.of(), java.util.Set.of(), java.util.Set.of(), EndsLeftOpen.nothing(),
-                java.util.Set.of());
+                java.util.Map.of());
     }
 
     /** One choice somebody wrote, told from every other by being this one. */
@@ -391,7 +391,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         java.util.Set.of(), false, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
                 EndsLeftOpen.nothing(),
-                java.util.Set.of());
+                java.util.Map.of());
     }
 
     /** And the alternative beside it that nothing could read. */
@@ -402,7 +402,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                         true, java.util.Set.of()),
                 Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls,
                 EndsLeftOpen.nothing(),
-                java.util.Set.of());
+                java.util.Map.of());
     }
 
     /** And two choices leaving one position open are two things an author can look at. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
@@ -186,6 +186,28 @@ class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
                 "the ends are at three and five, and no set has a size between them");
     }
 
+    /**
+     * And a branch whose rules leave the number no value is one this says nothing about.
+     *
+     * <p>That two of its rules stop the length past each other is a sound proof that nobody is in
+     * that branch — and this reading is no part of deciding a branch's fate, so it declines rather
+     * than acts on it. Which is what it may always do: a number it says nothing about is one no
+     * line is drawn on.
+     *
+     * <p>Handed to the join the ranges are composed by, the branch arrives as one this reading was
+     * told somebody can be in, which is a promise nothing here made.
+     */
+    @Test
+    void andABranchWhoseRulesLeaveTheNumberNoValueIsOneThisSaysNothingAbout() {
+        assertEquals(List.of(NO_LINE, NO_LINE),
+                List.of(borderIn("(String.length(s) >= 5 && String.length(s) <= 3)"
+                                + " || String.length(s) >= 2"),
+                        borderIn("(String.length(s) == 3 && String.length(s) == 5)"
+                                + " || String.length(s) >= 2")),
+                "the rules of one alternative stop the length past each other, and where a choice"
+                        + " of that leaves it is not this reading's to say");
+    }
+
     /** What the document says the line was read as. */
     private static List<String> lineAt(String number, String value) {
         return List.of("· read as check/" + number + ": = " + value,

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
@@ -62,30 +62,38 @@ class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
                         + " least three is one alternative's business alone");
     }
 
-    /** And it does not turn on which of them was written first. */
+    /**
+     * And it does not turn on which of them was written first.
+     *
+     * <p>Both answers are pinned and not merely held against each other. Two readings that agree
+     * are two readings that agree, and a change leaving them both saying the model draws no line
+     * would pass a test asking only that.
+     */
     @Test
     void andNotOnWhichWasWrittenFirst() {
-        assertEquals(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
-                borderIn("String.length(s) >= 3 || String.length(s) >= 2"),
+        assertEquals(List.of(A_LINE_AT_TWO, A_LINE_AT_TWO),
+                List.of(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
+                        borderIn("String.length(s) >= 3 || String.length(s) >= 2")),
                 "a choice is between its alternatives and not between their order");
     }
 
     /** Nor on how the alternatives were bracketed. */
     @Test
     void norOnHowTheyWereBracketed() {
-        assertEquals(
-                borderIn("(String.length(s) >= 2 || String.length(s) >= 3)"
-                        + " || String.length(s) >= 4"),
-                borderIn("String.length(s) >= 2"
-                        + " || (String.length(s) >= 3 || String.length(s) >= 4)"),
+        assertEquals(List.of(A_LINE_AT_TWO, A_LINE_AT_TWO),
+                List.of(borderIn("(String.length(s) >= 2 || String.length(s) >= 3)"
+                                + " || String.length(s) >= 4"),
+                        borderIn("String.length(s) >= 2"
+                                + " || (String.length(s) >= 3 || String.length(s) >= 4)")),
                 "the same three alternatives, and the brackets are not a fact about the rule");
     }
 
     /** And one bound written twice is that bound. */
     @Test
     void andOneBoundWrittenTwiceIsThatBound() {
-        assertEquals(borderIn("String.length(s) >= 2"),
-                borderIn("String.length(s) >= 2 || String.length(s) >= 2"),
+        assertEquals(List.of(A_LINE_AT_TWO, A_LINE_AT_TWO),
+                List.of(borderIn("String.length(s) >= 2"),
+                        borderIn("String.length(s) >= 2 || String.length(s) >= 2")),
                 "the same rule on both sides holds the length where the rule holds it");
     }
 
@@ -130,8 +138,9 @@ class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
      */
     @Test
     void andADenialReachingTheSameNumberIsTheSameRule() {
-        assertEquals(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
-                borderIn("String.length(s) >= 2 || Bool.not(String.length(s) < 3)"),
+        assertEquals(List.of(A_LINE_AT_TWO, A_LINE_AT_TWO),
+                List.of(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
+                        borderIn("String.length(s) >= 2 || Bool.not(String.length(s) < 3)")),
                 "one rule about the length, written two ways");
     }
 
@@ -228,6 +237,29 @@ class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
                         borderIn(crossed + " || (" + crossed + " || " + unplaced + ")")),
                 "no value of the crossed alternatives exists, so every value is in the third —"
                         + " whose line is one nothing placed, whichever way the brackets fall");
+    }
+
+    /**
+     * And a single rule stating an end past the order is such a branch too.
+     *
+     * <p>No string is longer than the largest whole number, so no value is in that alternative and
+     * every value of the choice is in the one beside it — a line at two where that one places one,
+     * and an end nobody worked out where it does not.
+     *
+     * <p>Which is the same fact as the pair above and reaches it another way: there two rules of a
+     * conjunction stopped the length past each other, and here one rule stops it past the order.
+     * Read as a rule that says nothing about the length, the alternative beside it settles nothing
+     * and the choice comes back as a model that draws no line.
+     */
+    @Test
+    void andSoIsOneRuleStatingAnEndPastTheOrder() {
+        assertEquals(List.of(A_LINE_AT_TWO, NOT_MEASURED),
+                List.of(borderIn("String.length(s) > 9223372036854775807"
+                                + " || String.length(s) >= 2"),
+                        borderIn("String.length(s) > 9223372036854775807"
+                                + " || String.length(s) * 2 >= 4")),
+                "nobody is in the first alternative, so the choice is the second — which draws a"
+                        + " line in one and states one nothing placed in the other");
     }
 
     /** What the document says the line was read as. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
@@ -187,25 +187,47 @@ class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
     }
 
     /**
-     * And a branch whose rules leave the number no value is one this says nothing about.
+     * And a branch whose rules leave the number no value leaves the choice what the other leaves.
      *
-     * <p>That two of its rules stop the length past each other is a sound proof that nobody is in
-     * that branch — and this reading is no part of deciding a branch's fate, so it declines rather
-     * than acts on it. Which is what it may always do: a number it says nothing about is one no
-     * line is drawn on.
+     * <p>Every value of the choice is in the branch beside it, so what the choice stops the length
+     * at is what that branch stops it at. Which this reading may say: that the ends of the first
+     * have crossed is its own knowledge, and acting on it inside itself is not deciding a fate —
+     * nobody outside is told, and whether anybody is in the branch stands on what the values and
+     * the orders say.
      *
-     * <p>Handed to the join the ranges are composed by, the branch arrives as one this reading was
-     * told somebody can be in, which is a promise nothing here made.
+     * <p>Handed to the join the position's ranges are composed by, such a branch arrives as one
+     * this reading was told somebody can be in, which is a promise nothing here made.
      */
     @Test
-    void andABranchWhoseRulesLeaveTheNumberNoValueIsOneThisSaysNothingAbout() {
-        assertEquals(List.of(NO_LINE, NO_LINE),
-                List.of(borderIn("(String.length(s) >= 5 && String.length(s) <= 3)"
-                                + " || String.length(s) >= 2"),
-                        borderIn("(String.length(s) == 3 && String.length(s) == 5)"
-                                + " || String.length(s) >= 2")),
-                "the rules of one alternative stop the length past each other, and where a choice"
-                        + " of that leaves it is not this reading's to say");
+    void andABranchWhoseRulesLeaveTheNumberNoValueLeavesTheOtherDrawingIt() {
+        assertEquals(
+                List.of(lineAt("String.length(v.s)", "7"), lineAt("String.length(v.s)", "7")),
+                List.of(readingIn("(String.length(s) >= 5 && String.length(s) <= 3)"
+                                + " || String.length(s) >= 7"),
+                        readingIn("(String.length(s) == 3 && String.length(s) == 5)"
+                                + " || String.length(s) >= 7")),
+                "no value of the first alternative exists, so the line is the second's — and the"
+                        + " ends of the first are not where anything is");
+    }
+
+    /**
+     * And it does not turn on where the brackets were put, whatever the alternatives came to.
+     *
+     * <p>The one thing a choice may never be. A branch whose rules leave the length no value and a
+     * branch that says nothing about the length read alike off a range — both are absent from it —
+     * and the two are opposite answers: the first is one nobody is in, and the second puts every
+     * length on the order. Read as one, these three alternatives come to a line under one
+     * bracketing and to none under the other.
+     */
+    @Test
+    void andNotOnWhereTheBracketsWere() {
+        String crossed = "(String.length(s) >= 5 && String.length(s) <= 3)";
+        String unplaced = "String.length(s) * 2 >= 4";
+        assertEquals(List.of(NOT_MEASURED, NOT_MEASURED),
+                List.of(borderIn("(" + crossed + " || " + crossed + ") || " + unplaced),
+                        borderIn(crossed + " || (" + crossed + " || " + unplaced + ")")),
+                "no value of the crossed alternatives exists, so every value is in the third —"
+                        + " whose line is one nothing placed, whichever way the brackets fall");
     }
 
     /** What the document says the line was read as. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest.java
@@ -1,0 +1,226 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A choice between two bounds on one of a value's numbers stops it where the two of them leave it.
+ *
+ * <p>Every alternative of a choice is a rule some values meet and no value owes the branch beside
+ * it anything, so what the choice holds a number to is what either alternative holds it to. That is
+ * a join, and it is composed once, where the branches have their fate
+ * ({@link Confinement.Planned#either}).
+ *
+ * <p><b>Which numbers, and who owns each.</b> Where the values at a position stop is the reading of
+ * ends' ({@link OrderedReading}); a number an operation answers of that position — how long the
+ * string standing there is — is another order, keyed apart so that no rule can reach both
+ * ({@link DerivedNumber}). Held under one key, the two would be two mechanisms settling one order,
+ * and which line a report drew would be whichever of them ran last.
+ *
+ * <p><b>An envelope, and never a claim that the rules are said by it.</b> Two alternatives naming
+ * one size each leave the run between them, and no value has a size in between — so this is read
+ * where a line is looked for and is no evidence that the number is exactly represented. The pair is
+ * held below.
+ */
+class AChoiceOfBoundsOnOneNumberStopsItWhereBothLeaveItTest {
+
+    private static final String YES_OR_NO = """
+            data Yes
+            data No
+            data Answer = Yes | No
+            """;
+
+    private static final List<String> A_LINE_AT_TWO =
+            List.of("border      borders 1   obligations 0/0");
+    private static final List<String> NO_LINE =
+            List.of("border      not applicable (the rules of this behavior draw no line)");
+    private static final List<String> NOT_MEASURED =
+            List.of("border      not measured (no line was derived at any position)");
+
+    /**
+     * Two ordinary bounds on how long the string is, one under a choice.
+     *
+     * <p>Written alone, or with {@code &&} between them, these are a border this compiler draws.
+     * Under a choice it drew none and said the end was one nothing could work out — which was the
+     * reading of ends answering about a number it does not count, because the walk that classifies
+     * a comparison stops at a choice.
+     */
+    @Test
+    void twoBoundsOnALengthLeaveTheLooserOfThem() {
+        assertEquals(List.of(A_LINE_AT_TWO, lineAt("String.length(v.s)", "2")),
+                List.of(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
+                        readingIn("String.length(s) >= 2 || String.length(s) >= 3")),
+                "a value taking either alternative is at least two characters long, and one at"
+                        + " least three is one alternative's business alone");
+    }
+
+    /** And it does not turn on which of them was written first. */
+    @Test
+    void andNotOnWhichWasWrittenFirst() {
+        assertEquals(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
+                borderIn("String.length(s) >= 3 || String.length(s) >= 2"),
+                "a choice is between its alternatives and not between their order");
+    }
+
+    /** Nor on how the alternatives were bracketed. */
+    @Test
+    void norOnHowTheyWereBracketed() {
+        assertEquals(
+                borderIn("(String.length(s) >= 2 || String.length(s) >= 3)"
+                        + " || String.length(s) >= 4"),
+                borderIn("String.length(s) >= 2"
+                        + " || (String.length(s) >= 3 || String.length(s) >= 4)"),
+                "the same three alternatives, and the brackets are not a fact about the rule");
+    }
+
+    /** And one bound written twice is that bound. */
+    @Test
+    void andOneBoundWrittenTwiceIsThatBound() {
+        assertEquals(borderIn("String.length(s) >= 2"),
+                borderIn("String.length(s) >= 2 || String.length(s) >= 2"),
+                "the same rule on both sides holds the length where the rule holds it");
+    }
+
+    /**
+     * And an alternative that says nothing about the number leaves it where it was.
+     *
+     * <p>The negative control, and the one an implementation reading "both branches bound
+     * something" would fail: a value taking the second alternative is under no obligation about the
+     * length, so the choice draws no line on it however plain the first alternative is.
+     */
+    @Test
+    void andAnAlternativeSayingNothingOfItLeavesItWhereItWas() {
+        assertEquals(NO_LINE, borderIn("String.length(s) >= 2 || n >= 3"),
+                "nothing holds the length down in the second alternative, so the choice holds it"
+                        + " nowhere");
+    }
+
+    /**
+     * And an alternative nobody can be in leaves the one beside it drawing the line.
+     *
+     * <p>No string is both {@code "a"} and {@code "b"}, so no value takes the first alternative and
+     * what is left of the rule is the second. Which branch that is is settled by the readings that
+     * decide whether anybody can be in one, and the bound on the length is composed under their
+     * answer — asked of the lengths, this branch says the length is at least nine and the choice
+     * would come back drawn at two anyway, which is the right line for the wrong reason.
+     */
+    @Test
+    void andABranchNobodyCanBeInLeavesTheOtherDrawingIt() {
+        assertEquals(A_LINE_AT_TWO,
+                borderIn("(s == \"a\" && s == \"b\" && String.length(s) >= 9)"
+                        + " || String.length(s) >= 2"),
+                "the rule is its right half, and that half draws a line at two");
+    }
+
+    /**
+     * And a denial reaching the same number is the same rule.
+     *
+     * <p>{@code not(length < 3)} is {@code length >= 3} and arrives by another road: the claim is
+     * turned where the leaf is read rather than written that way by an author. A reading that had
+     * asked which operator was written would answer about the shape instead of about the rule, and
+     * this choice would come back as one it could not follow.
+     */
+    @Test
+    void andADenialReachingTheSameNumberIsTheSameRule() {
+        assertEquals(borderIn("String.length(s) >= 2 || String.length(s) >= 3"),
+                borderIn("String.length(s) >= 2 || Bool.not(String.length(s) < 3)"),
+                "one rule about the length, written two ways");
+    }
+
+    /**
+     * And a rule stating a line nothing can place is short of it still.
+     *
+     * <p>The control for every answer above. {@code Int.abs(n)} is a number this reading cannot
+     * name, so a rule about it says the values stop somewhere and leaves where unknown — and the
+     * choice offering it is one whose end nothing worked out. Without this, everything here would
+     * hold of an implementation that had come to answer "no line" under any choice at all.
+     */
+    @Test
+    void andARuleStatingALineNothingCanPlaceIsShortOfItStill() {
+        assertEquals(NOT_MEASURED, borderIn("n >= 2 || Int.abs(n) >= 5"),
+                "the alternative states where `v.n` stops and nothing here worked out where");
+    }
+
+    /**
+     * And the envelope is where the ends are, not a claim that everything inside it is a value.
+     *
+     * <p>Two alternatives naming one size each leave the run between them, and a set of four is a
+     * row nobody can write. So both lines are drawn — the sizes are where the model says they are —
+     * and the run between them comes back with nothing standing on it, because every value tried
+     * there was refused. The two are different contracts and this holds them apart: read as a
+     * representation of the sizes, the range would say four is one of them.
+     */
+    @Test
+    void andTheEnvelopeIsWhereTheEndsAreAndNotWhatTheNumberHolds() {
+        assertEquals(List.of("border      borders 2   obligations 0/0",
+                        "· read as check/Set.size(c): = 3",
+                        "· read as check/Set.size(c): in 3 < Set.size(c) <= 5"
+                                + " — nothing composed one: every value tried at"
+                                + " 3 < Set.size(c) <= 5 was refused",
+                        "· read as check/Set.size(c): = 5",
+                        "· read as check/Set.size(c): in 3 <= Set.size(c) < 5"
+                                + " — nothing composed one: every value tried at"
+                                + " 3 <= Set.size(c) < 5 was refused"),
+                linesOfSource("""
+                        module example.rooms
+
+                        data Codes = Set<String>
+                            invariant said = Set.size(value) == 3 || Set.size(value) == 5
+
+                        data Yes
+                        data No
+                        data Answer = Yes | No
+
+                        behavior check : (c: Codes) -> Answer
+                        let check (c) = Yes
+                        """,
+                        each -> each.startsWith("border") || each.startsWith("· read as")),
+                "the ends are at three and five, and no set has a size between them");
+    }
+
+    /** What the document says the line was read as. */
+    private static List<String> lineAt(String number, String value) {
+        return List.of("· read as check/" + number + ": = " + value,
+                "· read as check/" + number + ": in " + value + " < " + number);
+    }
+
+    private static List<String> borderIn(String clause) {
+        return linesOf(clause, each -> each.startsWith("border"));
+    }
+
+    private static List<String> readingIn(String clause) {
+        return linesOf(clause, each -> each.startsWith("· read as"));
+    }
+
+    private static List<String> linesOf(String clause,
+                                        java.util.function.Predicate<String> which) {
+        return linesOfSource("""
+                module demo
+                %s
+                data N = { n: Int, s: String }
+                    invariant r = %s
+
+                behavior check : (v: N) -> Answer
+                let check (v) = Yes
+                """.formatted(YES_OR_NO, clause), which);
+    }
+
+    private static List<String> linesOfSource(String source,
+                                              java.util.function.Predicate<String> which) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity()).lines()
+                .map(String::strip)
+                .filter(which)
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
@@ -266,6 +266,26 @@ class AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest {
     }
 
     /**
+     * And an alternative no row meets settles nothing for the one beside it.
+     *
+     * <p>{@code n - n >= 1} is {@code 0 >= 1}, which no value satisfies — so every value of the
+     * choice is in the alternative beside it, and the end that one leaves unknown is the rule's.
+     *
+     * <p>The counterpart of {@link #andAnAlternativeHoldingOfEveryRowSettlesTheChoice} and its
+     * opposite: one rule takes every value into itself and the other takes none, and both are
+     * comparisons whose positions cancel. Read as one answer — a rule that states no line — the
+     * first settles the choice and the second was made to settle it too, about a model whose line
+     * nobody has worked out.
+     */
+    @Test
+    void andAnAlternativeNoRowMeetsSettlesNothingForTheOneBesideIt() {
+        assertEquals(List.of("border      not measured (no line was derived at any position)"),
+                borderIn("Int.abs(n) >= 5 || n - n >= 1"),
+                "no value is in the second alternative, so what the rule leaves `n` is what the"
+                        + " first leaves it — and nothing worked that out");
+    }
+
+    /**
      * And a rule that cancels against a side this reading names a position in does too.
      *
      * <p>{@code n + 1 >= n} holds every row, and one whole side of it is a position — so the lookup

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
@@ -240,24 +240,29 @@ class AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest {
     }
 
     /**
-     * And one whose subject this reading cannot name leaves it open, which is weaker than the rules
-     * are.
+     * And an alternative holding of every row settles the choice, whatever stands beside it.
      *
-     * <p>{@code n - n >= 0} holds every value, and written alone this compiler says so — the
-     * reading that classifies a comparison reads it to the end and finds it cuts nothing. That
-     * reading does not go into a choice, and the reading of ends cannot see that the arithmetic
-     * cancels: what it has is a subject it cannot name, which is what an absolute value is as well.
+     * <p>{@code n - n >= 0} holds every value there is, so every value takes that alternative and
+     * the branch beside it constrains nobody. What the choice leaves {@code n} is every value, and
+     * the model draws no line — which is an answer and not this compiler falling short.
      *
-     * <p>So this is the conservative answer and not the exact one, and it is written down rather
-     * than left to be found: what would close it is the classification of a comparison being
-     * asked under a choice.
+     * <p>The reading of ends cannot see it. It has no arithmetic for the sides of a comparison, so
+     * what it has is a subject it cannot name — which is what an absolute value is as well, and
+     * those two are not the same rule. They are told apart by the reading that does have the
+     * arithmetic ({@link StatedLines}), and the answer arrives here already made.
+     *
+     * <p>Read off what the ends managed alone, both alternatives are forms nothing followed and
+     * this came back as a border this compiler could not measure — a limit of this compiler sent
+     * out where the model has an answer. The control for that is
+     * {@link #andAnEndNoAlternativeBoundedIsLeftOpen}, where neither alternative was followed and
+     * neither holds of every row.
      */
     @Test
-    void andOneWhoseSubjectItCannotNameIsLeftOpen() {
-        assertEquals(List.of("border      not measured (no line was derived at any position)"),
+    void andAnAlternativeHoldingOfEveryRowSettlesTheChoice() {
+        assertEquals(theModelDrawsNoLine(),
                 borderIn("Int.abs(n) >= 5 || n - n >= 0"),
-                "neither alternative is one the reading of ends can name a position in, so what"
-                        + " the choice leaves `n` is what following them would answer");
+                "one alternative admits every value, so nothing about `n` rests on the form"
+                        + " beside it");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest.java
@@ -266,6 +266,25 @@ class AnEndAChoiceLeftOpenIsNotTheModelDrawingNoLineTest {
     }
 
     /**
+     * And a rule that cancels against a side this reading names a position in does too.
+     *
+     * <p>{@code n + 1 >= n} holds every row, and one whole side of it is a position — so the lookup
+     * that finds which number a rule is about finds one, and the arithmetic is what says the rule
+     * stops it nowhere. Nor is it a rule holding one position to another: what it compares
+     * {@code n} to is a number built from {@code n}, which is not a position, so nothing else here
+     * answers for it.
+     *
+     * <p>Read off the lookup alone, this is a bound on {@code n} whose end nothing worked out, and
+     * the choice comes back as a border this compiler could not measure.
+     */
+    @Test
+    void andSoDoesOneThatCancelsAgainstASideAPositionIsWrittenIn() {
+        assertEquals(theModelDrawsNoLine(), borderIn("Int.abs(n) >= 5 || n + 1 >= n"),
+                "every value is at least one less than itself plus one, so the alternative"
+                        + " stops `n` nowhere");
+    }
+
+    /**
      * And a choice above one that gave a constraint back does not collect it again.
      *
      * <p>The inner choice puts every value of {@code n} on the order: one of its alternatives says

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest.java
@@ -54,23 +54,27 @@ class WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest {
      * <p>Nothing said of it, stopped at one of two places, stopped where no value is, and each of
      * those with a line on it nothing placed — which are the four the type names, crossed with
      * whether a line is waiting.
+     *
+     * <p><b>Made the way a reading makes one.</b> Which state a range becomes is decided where a
+     * range becomes a state, so a stopped-nowhere written out by hand here would be one these laws
+     * hold of and the reading never produces — and the decision itself would go unasked.
      */
     private static List<BoundaryState> states() {
         List<BoundaryState> out = new ArrayList<>();
-        for (Map<DerivedNumber, BoundaryState.Left> left : List.of(
-                Map.<DerivedNumber, BoundaryState.Left>of(),
-                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
-                        new BoundaryState.Left.Known(FROM_TWO)),
-                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
-                        new BoundaryState.Left.Known(FROM_THREE)),
-                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
-                        new BoundaryState.Left.NothingLeft()),
+        for (BoundaryState stopped : List.of(
+                BoundaryState.nothing(),
+                BoundaryState.bounded(LENGTH, FROM_TWO),
+                BoundaryState.bounded(LENGTH, FROM_THREE),
+                BoundaryState.bounded(LENGTH, CROSSED),
                 // A second number beside the first, so that a rule mixing them is here too.
-                Map.<DerivedNumber, BoundaryState.Left>of(SIZE,
-                        new BoundaryState.Left.Known(FROM_TWO)))) {
-            for (Set<OpenEnd> open : List.of(Set.<OpenEnd>of(), Set.of(ONE_LINE),
-                    Set.of(ANOTHER_LINE), Set.of(ONE_LINE, ANOTHER_LINE))) {
-                out.add(new BoundaryState(left, open));
+                BoundaryState.bounded(SIZE, FROM_TWO))) {
+            for (List<OpenEnd> open : List.of(List.<OpenEnd>of(), List.of(ONE_LINE),
+                    List.of(ANOTHER_LINE), List.of(ONE_LINE, ANOTHER_LINE))) {
+                BoundaryState waiting = stopped;
+                for (OpenEnd each : open) {
+                    waiting = waiting.both(BoundaryState.leftOpen(each));
+                }
+                out.add(waiting);
             }
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest.java
@@ -1,0 +1,212 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A choice is between its alternatives and not between their order, and a conjunction is between
+ * its conjuncts — over every state a reading of one of these numbers can be in.
+ *
+ * <p><b>Enumerated and not chosen.</b> What a number is to this reading is one of a handful of
+ * things, and every pair and every triple of them is written out here rather than picked. The cases
+ * that were got wrong were the ones nobody thought to write down: two branches each leaving the
+ * number no value came out as whichever was on the right, and a case like that is not found by
+ * asking whether the cases somebody wrote hold.
+ *
+ * <p>Over the states and not over sources. What a model can be written to produce is a question
+ * about this compiler's other readings; what the laws of this one are is a question about it, and
+ * asking it through a source would leave the answer resting on which states a corpus happens to
+ * reach.
+ */
+class WhatAChoiceOfTwoBoundaryReadingsLeavesIsTheSameEitherWayRoundTest {
+
+    private static final DerivedNumber LENGTH = new DerivedNumber(RuleKey.of("s"),
+            ValueName.Stdlib.operation("String", "length"));
+    private static final DerivedNumber SIZE = new DerivedNumber(RuleKey.of("t"),
+            ValueName.Stdlib.operation("Set", "size"));
+
+    /** Two lines an author wrote, told apart by being the ones they are. */
+    private static final OpenEnd ONE_LINE = new OpenEnd(LENGTH);
+    private static final OpenEnd ANOTHER_LINE = new OpenEnd(LENGTH);
+
+    private static final OrderedInterval FROM_TWO = above(2);
+    private static final OrderedInterval FROM_THREE = above(3);
+    private static final OrderedInterval CROSSED =
+            new OrderedInterval(Endpoint.inclusive(Count.of(5)), Endpoint.inclusive(Count.of(3)));
+
+    /**
+     * Every state a reading of one number can be in.
+     *
+     * <p>Nothing said of it, stopped at one of two places, stopped where no value is, and each of
+     * those with a line on it nothing placed — which are the four the type names, crossed with
+     * whether a line is waiting.
+     */
+    private static List<BoundaryState> states() {
+        List<BoundaryState> out = new ArrayList<>();
+        for (Map<DerivedNumber, BoundaryState.Left> left : List.of(
+                Map.<DerivedNumber, BoundaryState.Left>of(),
+                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
+                        new BoundaryState.Left.Known(FROM_TWO)),
+                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
+                        new BoundaryState.Left.Known(FROM_THREE)),
+                Map.<DerivedNumber, BoundaryState.Left>of(LENGTH,
+                        new BoundaryState.Left.NothingLeft()),
+                // A second number beside the first, so that a rule mixing them is here too.
+                Map.<DerivedNumber, BoundaryState.Left>of(SIZE,
+                        new BoundaryState.Left.Known(FROM_TWO)))) {
+            for (Set<OpenEnd> open : List.of(Set.<OpenEnd>of(), Set.of(ONE_LINE),
+                    Set.of(ANOTHER_LINE), Set.of(ONE_LINE, ANOTHER_LINE))) {
+                out.add(new BoundaryState(left, open));
+            }
+        }
+        return out;
+    }
+
+    @Test
+    void aChoiceOfTwoOfThemIsTheSameEitherWayRound() {
+        assertEquals(List.of(), turnedRound(BoundaryState::either, "||"),
+                "a choice is between its alternatives, and which of them an author wrote first is"
+                        + " not one of them");
+    }
+
+    @Test
+    void andAConjunctionOfTwoOfThemIs() {
+        assertEquals(List.of(), turnedRound(BoundaryState::both, "&&"),
+                "and so is a conjunction");
+    }
+
+    @Test
+    void andAChoiceDoesNotTurnOnHowItWasBracketed() {
+        assertEquals(List.of(), rebracketed(BoundaryState::either, "||"),
+                "the brackets an author put round three alternatives are not a fact about the"
+                        + " rule");
+    }
+
+    @Test
+    void norDoesAConjunction() {
+        assertEquals(List.of(), rebracketed(BoundaryState::both, "&&"), "nor round three"
+                + " conjuncts");
+    }
+
+    @Test
+    void andOneOfThemWrittenTwiceIsItself() {
+        List<String> differing = new ArrayList<>();
+        for (BoundaryState each : states()) {
+            if (!said(each.either(each)).equals(said(each))) {
+                differing.add(said(each) + " || itself = " + said(each.either(each)));
+            }
+            if (!said(each.both(each)).equals(said(each))) {
+                differing.add(said(each) + " && itself = " + said(each.both(each)));
+            }
+        }
+        assertEquals(List.of(), differing,
+                "a choice between one reading and itself is that reading, and so is a conjunction");
+    }
+
+    /**
+     * The pairs {@code join} answers differently when they are written the other way round.
+     *
+     * <p>Only those. Every pair is asked and the ones that agree are what a passing run has to say
+     * nothing about — held as two whole lists instead, a run that found one disagreement printed
+     * every pair there is, and what had gone wrong was somewhere in it.
+     */
+    private static List<String> turnedRound(
+            java.util.function.BinaryOperator<BoundaryState> join, String written) {
+        List<String> differing = new ArrayList<>();
+        for (BoundaryState one : states()) {
+            for (BoundaryState other : states()) {
+                String asked = said(join.apply(one, other));
+                String answered = said(join.apply(other, one));
+                if (!asked.equals(answered)) {
+                    differing.add(said(one) + " " + written + " " + said(other)
+                            + " = " + asked + ", turned round = " + answered);
+                }
+            }
+        }
+        return differing;
+    }
+
+    /** The triples {@code join} answers differently when the brackets move. */
+    private static List<String> rebracketed(
+            java.util.function.BinaryOperator<BoundaryState> join, String written) {
+        List<String> differing = new ArrayList<>();
+        for (BoundaryState one : states()) {
+            for (BoundaryState other : states()) {
+                for (BoundaryState third : states()) {
+                    String left = said(join.apply(join.apply(one, other), third));
+                    String right = said(join.apply(one, join.apply(other, third)));
+                    if (!left.equals(right)) {
+                        differing.add("(" + said(one) + " " + written + " " + said(other) + ") "
+                                + written + " " + said(third) + " = " + left
+                                + ", rebracketed = " + right);
+                    }
+                }
+            }
+        }
+        return differing;
+    }
+
+    /**
+     * And the states this walks over are the ones the type names, all of them.
+     *
+     * <p>Without this the rules above hold of whatever happened to be listed, and a state left out
+     * is one no law was ever asked about — which is how two branches leaving the number no value
+     * came to be answered by whichever was written second.
+     */
+    @Test
+    void andEveryStateOfOneNumberIsWalkedOver() {
+        Set<String> reached = new LinkedHashSet<>();
+        for (BoundaryState each : states()) {
+            reached.add(shapeOf(each, LENGTH));
+        }
+        assertEquals(Set.of("nothing said", "stopped somewhere", "nothing left",
+                        "nothing said, and a line waiting", "stopped somewhere, and a line waiting",
+                        "nothing left, and a line waiting"),
+                reached,
+                "every state the type names is one these laws were asked about");
+    }
+
+    /** Which of the states {@code number} is in, said in the type's own words. */
+    private static String shapeOf(BoundaryState state, DerivedNumber number) {
+        String said = state.knownAt(number) != null ? "stopped somewhere"
+                : state.byNumber().containsKey(number) ? "nothing left" : "nothing said";
+        return state.open().stream().anyMatch(each -> each.number().equals(number))
+                ? said + ", and a line waiting" : said;
+    }
+
+    /** What a state says, spelled so that two of them can be held against each other. */
+    private static String said(BoundaryState state) {
+        Map<String, String> byNumber = new LinkedHashMap<>();
+        state.byNumber().forEach((number, left) -> byNumber.put(number.toString(),
+                left instanceof BoundaryState.Left.Known it ? it.range().toString()
+                        : "nothing left"));
+        List<String> open = new ArrayList<>();
+        state.open().forEach(each -> open.add(each == ONE_LINE ? "one line" : "another line"));
+        return new java.util.TreeMap<>(byNumber) + " with " + open.stream().sorted().toList();
+    }
+
+    private static OrderedInterval above(int value) {
+        return new OrderedInterval(Endpoint.inclusive(Count.of(value)), null);
+    }
+
+    /** And the two lines are two, so a law that lost one of them is not passing by having one. */
+    @Test
+    void andTheTwoLinesAreTwo() {
+        assertTrue(ONE_LINE != ANOTHER_LINE && !ONE_LINE.equals(ANOTHER_LINE),
+                "each line an author wrote is the one it is");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest.java
@@ -1,0 +1,148 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which number a leaf states a line on does not turn on how the leaf is spelled.
+ *
+ * <p>What a leaf states is one question with one answer: which numbers the comparison is over is
+ * what its canonical form says, and whether one of this value's positions is held to another is
+ * what the two whole sides say. Both are what the attribution of an end to a conjunct already runs
+ * on. A second reading of the same question is a second answer, and the narrower of the two then
+ * decides wherever it happens to be asked.
+ *
+ * <p><b>So this is a contract between readers rather than a list of shapes.</b> Each spelling below
+ * is one rule about how long a string is, written under a choice beside another rule about the same
+ * length. Whatever the choice comes to, it is about that length — and a spelling that came back
+ * about nothing would be one a second reader classified for itself.
+ *
+ * <p>Which is what {@code String.length(s) * 2 >= 4} was: the arithmetic reaches the length and a
+ * walk over the two sides does not, so under a choice the rule was one this compiler said nothing
+ * about and the border came back as a model that draws no line.
+ *
+ * <p>Not that the answers agree, because they do not and should not. One spelling is a bound this
+ * compiler places and another is one it does not, so a choice offering the first draws a line and
+ * one offering the second leaves an end nobody worked out. What may not differ is what the answer
+ * is about.
+ */
+class WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest {
+
+    private static final String YES_OR_NO = """
+            data Yes
+            data No
+            data Answer = Yes | No
+            """;
+
+    /** One rule about how long the string at {@code s} is, written five ways. */
+    private static final List<String> ABOUT_THE_LENGTH = List.of(
+            "String.length(s) >= 2",
+            "2 <= String.length(s)",
+            "Bool.not(String.length(s) < 2)",
+            "String.length(s) * 2 >= 4",
+            "String.length(s) + 1 >= 3");
+
+    @Test
+    void everySpellingOfOneRuleIsAboutTheNumberItIsAbout() {
+        List<String> about = new ArrayList<>();
+        for (String spelling : ABOUT_THE_LENGTH) {
+            about.add(spelling + ": " + numberSpokenOf(spelling + " || String.length(s) >= 9"));
+        }
+        assertEquals(ABOUT_THE_LENGTH.stream()
+                        .map(each -> each + ": String.length(v.s)").toList(),
+                about,
+                "each of them holds the length down, so the choice between one of them and another"
+                        + " bound on the length is about the length");
+    }
+
+    /**
+     * And a rule about another number is not pulled into it.
+     *
+     * <p>The control. Without it, a reading that answered {@code String.length(v.s)} to everything
+     * would pass the rule above, and what it would have shown is that the answer does not turn on
+     * the question either.
+     */
+    @Test
+    void andARuleAboutAnotherNumberIsNotPulledIn() {
+        assertEquals("v.n", numberSpokenOf("Int.abs(n) >= 5 || n >= 9"),
+                "the rule is about the number at `n`, and no reading of it reaches the string");
+    }
+
+    /**
+     * And a choice bounds a number only where both of its alternatives do.
+     *
+     * <p>What an inner choice hands the one above it is the numbers it holds down, and a number
+     * only one of its alternatives holds down is not one of them: a value taking the other stands
+     * anywhere on it. So the pair below differ, and they differ at the inner choice alone.
+     *
+     * <p>The first leaves the length wherever it was — a value with {@code n} at three is any
+     * length — so the alternative beside it holds no end open and the model draws no line. The
+     * second holds the length at two whichever inner alternative is taken, so what the third one
+     * says about it is a line nobody worked out.
+     */
+    @Test
+    void andAChoiceBoundsANumberOnlyWhereBothAlternativesDo() {
+        assertEquals(
+                List.of("border      not applicable (the rules of this behavior draw no line)",
+                        "border      not measured (no line was derived at any position)"),
+                List.of(borderIn("(String.length(s) >= 2 || n >= 3)"
+                                + " || String.length(s) * 2 >= 4"),
+                        borderIn("(String.length(s) >= 2 || String.length(s) >= 5)"
+                                + " || String.length(s) * 2 >= 4")),
+                "the inner choice holds the length nowhere in the first and at two in the second");
+    }
+
+    /** What the document says about this behavior's border. */
+    private static String borderIn(String clause) {
+        return linesOf(clause).stream()
+                .filter(each -> each.startsWith("border"))
+                .findFirst().orElse("nothing");
+    }
+
+    /**
+     * What number the document's answer about this behavior is about.
+     *
+     * <p>Whichever sentence carries it: a line the model draws names the number it falls on, and an
+     * end nobody worked out names the number it is an end of. Which of the two came out is what
+     * this deliberately does not read.
+     */
+    private static String numberSpokenOf(String clause) {
+        List<String> lines = linesOf(clause);
+        for (String each : lines) {
+            if (each.startsWith("· read as check/")) {
+                return each.substring("· read as check/".length()).split(":")[0];
+            }
+            if (each.startsWith("· not read:") && each.contains(" about `")) {
+                return each.substring(each.indexOf(" about `") + " about `".length())
+                        .replace("`", "");
+            }
+        }
+        return "nothing: " + lines;
+    }
+
+    private static List<String> linesOf(String clause) {
+        Compilation compilation = Compilation.ofSource("""
+                module demo
+                %s
+                data N = { n: Int, s: String }
+                    invariant r = %s
+
+                behavior check : (v: N) -> Answer
+                let check (v) = Yes
+                """.formatted(YES_OR_NO, clause), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity()).lines()
+                .map(String::strip)
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest.java
@@ -101,6 +101,29 @@ class WhatALeafStatesDoesNotTurnOnWhatIsWrittenBesideItTest {
                 "the inner choice holds the length nowhere in the first and at two in the second");
     }
 
+    /**
+     * And an end a choice settled stays settled, whatever else leaves the same number open.
+     *
+     * <p>Two lines on one length. The first stands under a choice whose other alternative holds the
+     * length nowhere, so what that choice leaves it is every value and the line is answered for.
+     * The second is written outside any choice, where nothing answers for it — so the rule leaves
+     * the length open, and no choice is one an author can be sent to about it.
+     *
+     * <p>Asked whether the length is still open, the first line finds that it is, because of the
+     * second, and comes back naming the choice its own alternative had already settled. So the ends
+     * are struck off one at a time and never by the number they are ends of.
+     */
+    @Test
+    void andAnEndAChoiceSettledStaysSettled() {
+        assertEquals(List.of(),
+                linesOf("(String.length(s) * 2 >= 4 || n >= 3)"
+                        + " && String.length(s) * 3 >= 6").stream()
+                        .filter(each -> each.contains("left open by a choice"))
+                        .toList(),
+                "the line under the choice was answered for by the alternative beside it, and the"
+                        + " one outside reaches no choice at all");
+    }
+
     /** What the document says about this behavior's border. */
     private static String borderIn(String clause) {
         return linesOf(clause).stream()

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
@@ -61,7 +61,13 @@ class WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest {
     void whereThePositionsStopIsHeldByTheConfinementAndByNothingElse() {
         Set<String> apart = new TreeSet<>();
         int found = 0;
+        int derived = 0;
         for (Class<?> each : compiled()) {
+            for (Field field : each.getDeclaredFields()) {
+                if (field.getType() == OrderedIntervals.class && ofADerivedNumber(field)) {
+                    derived++;
+                }
+            }
             if (!holdsWhereThePositionsStop(each)) {
                 continue;
             }
@@ -71,19 +77,43 @@ class WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest {
             }
         }
         assertTrue(found > 0, "found no type holding an order at all — the scan missed the tree");
+        // And the orders this rule is not about are here to be let past. Without one, the reading
+        // of the type argument is a branch nothing takes, and the rule would read as if it told
+        // two kinds of order apart while every order it ever saw was a position's.
+        assertTrue(derived > 0,
+                "found no order of a number an operation answers — the exemption reaches nothing");
         assertEquals(Set.of(), apart,
                 "a type holding where the positions stop beside what they admit is one whose reader"
                         + " can ask each of them whether anything satisfies the rules");
     }
 
-    /** Whether a class holds where a value's positions stop. */
+    /**
+     * Whether a class holds where a value's positions stop.
+     *
+     * <p>The positions, and not every order this compiler holds in the same algebra. A number an
+     * operation answers of a place is another order with an owner of its own
+     * ({@link DerivedNumber}), and there is no set of values beside it for anybody to compose it
+     * with: what a length runs between says nothing about which strings stand anywhere, so a reader
+     * holding one is not a reader that can decide whether a value exists.
+     *
+     * <p>Read off what the field is an order of, which is written in the class file. Asked of the
+     * raw type alone, the population was every order there is, and a reading that has no half of
+     * the question was refused for holding half of it.
+     */
     private static boolean holdsWhereThePositionsStop(Class<?> of) {
         for (Field each : of.getDeclaredFields()) {
-            if (each.getType() == OrderedIntervals.class) {
+            if (each.getType() == OrderedIntervals.class && !ofADerivedNumber(each)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /** Whether a field's order is one of the numbers an operation answers. */
+    private static boolean ofADerivedNumber(Field of) {
+        return of.getGenericType() instanceof java.lang.reflect.ParameterizedType it
+                && it.getActualTypeArguments().length == 1
+                && it.getActualTypeArguments()[0] == DerivedNumber.class;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
@@ -61,13 +61,7 @@ class WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest {
     void whereThePositionsStopIsHeldByTheConfinementAndByNothingElse() {
         Set<String> apart = new TreeSet<>();
         int found = 0;
-        int derived = 0;
         for (Class<?> each : compiled()) {
-            for (Field field : each.getDeclaredFields()) {
-                if (field.getType() == OrderedIntervals.class && ofADerivedNumber(field)) {
-                    derived++;
-                }
-            }
             if (!holdsWhereThePositionsStop(each)) {
                 continue;
             }
@@ -77,43 +71,19 @@ class WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest {
             }
         }
         assertTrue(found > 0, "found no type holding an order at all — the scan missed the tree");
-        // And the orders this rule is not about are here to be let past. Without one, the reading
-        // of the type argument is a branch nothing takes, and the rule would read as if it told
-        // two kinds of order apart while every order it ever saw was a position's.
-        assertTrue(derived > 0,
-                "found no order of a number an operation answers — the exemption reaches nothing");
         assertEquals(Set.of(), apart,
                 "a type holding where the positions stop beside what they admit is one whose reader"
                         + " can ask each of them whether anything satisfies the rules");
     }
 
-    /**
-     * Whether a class holds where a value's positions stop.
-     *
-     * <p>The positions, and not every order this compiler holds in the same algebra. A number an
-     * operation answers of a place is another order with an owner of its own
-     * ({@link DerivedNumber}), and there is no set of values beside it for anybody to compose it
-     * with: what a length runs between says nothing about which strings stand anywhere, so a reader
-     * holding one is not a reader that can decide whether a value exists.
-     *
-     * <p>Read off what the field is an order of, which is written in the class file. Asked of the
-     * raw type alone, the population was every order there is, and a reading that has no half of
-     * the question was refused for holding half of it.
-     */
+    /** Whether a class holds where a value's positions stop. */
     private static boolean holdsWhereThePositionsStop(Class<?> of) {
         for (Field each : of.getDeclaredFields()) {
-            if (each.getType() == OrderedIntervals.class && !ofADerivedNumber(each)) {
+            if (each.getType() == OrderedIntervals.class) {
                 return true;
             }
         }
         return false;
-    }
-
-    /** Whether a field's order is one of the numbers an operation answers. */
-    private static boolean ofADerivedNumber(Field of) {
-        return of.getGenericType() instanceof java.lang.reflect.ParameterizedType it
-                && it.getActualTypeArguments().length == 1
-                && it.getActualTypeArguments()[0] == DerivedNumber.class;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichReadingStoppedDecidesWhatAPositionIsShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichReadingStoppedDecidesWhatAPositionIsShortOfTest.java
@@ -25,9 +25,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>Two readings answer about one position and they are asked different things. What the classes
  * are made of is which values may stand there; where the border falls is where they stop. So a rule
  * the first read from end to end and the second could not follow leaves the classes exactly as the
- * rules leave them, and leaves the line underived — and a verdict that read "a reading stopped
- * here" off a list holding both said this compiler could not work out how the position divides,
- * about a position every rule of which it had divided.
+ * rules leave them — and a verdict that read "a reading stopped here" off a list holding both said
+ * this compiler could not work out how the position divides, about a position every rule of which
+ * it had divided.
+ *
+ * <p><b>And the border is not short of it either, which is a third answer and not the first.</b>
+ * Whether the rule states a line at all is settled by the reading that has the arithmetic of a
+ * comparison ({@code check.StatedLines}): a call restricting which strings may stand somewhere
+ * orders none of them, so there is no end here for anything to be waiting on. That the reading of
+ * ends has no word for the rule is a fact about that reading and is not promoted to an end nobody
+ * worked out.
+ *
+ * <p>Which is not "the values read it, so the ends are answered". The two vocabularies stay apart:
+ * what closes this is that the line's existence was decided, not that another reader managed the
+ * clause. The control below is a rule that does state a line, on a number this compiler cannot
+ * name, and it is short of it still.
  *
  * <p><b>The pair, and not either half.</b> A test that only asked for the border would pass over a
  * partition quietly widened; one that only asked for the partition would pass over a border quietly
@@ -64,12 +76,35 @@ class WhichReadingStoppedDecidesWhatAPositionIsShortOfTest {
                 "every rule about `v.s` was taken in by the reading the classes are made of");
     }
 
-    /** And the border is short of it, which is the reading that did stop. */
+    /**
+     * And the border says the model draws none, because neither alternative states a line.
+     *
+     * <p>A value written out and a pattern each say which strings may stand at {@code v.s} and
+     * neither orders them, so the choice between them places no end — and that the reading of ends
+     * has no word for a pattern says nothing about it.
+     */
     @Test
-    void andTheBorderIsShortOfIt() {
-        assertEquals(List.of("border      not measured (no line was derived at any position)"),
+    void andTheBorderSaysTheModelDrawsNoLine() {
+        assertEquals(List.of("border      not applicable (the rules of this behavior draw no line)"),
                 borderIn(ONLY_THE_ENDS_STOPPED),
-                "the line at `v.s` rests on an alternative this compiler does not follow");
+                "neither alternative states where the values at `v.s` stop");
+    }
+
+    /**
+     * And an alternative that does state one, on a number nothing can name, is short of it still.
+     *
+     * <p>The control for the pair above. {@code Int.abs(n) >= 5} says the values stop somewhere and
+     * this compiler cannot say where, so the end at {@code v.n} is one reading further would
+     * settle. Without this, the rule above would read as "a choice this compiler cannot follow
+     * draws no line", which is the sentence the whole arrangement is against.
+     */
+    @Test
+    void andAnAlternativeThatStatesALineNothingCanPlaceIsShortOfItStill() {
+        assertEquals(List.of("border      not measured (no line was derived at any position)"),
+                borderIn(ONLY_THE_ENDS_STOPPED.replace(
+                        "s == \"a\" || String.matches(\"[A-Z]{2}\", s)",
+                        "n >= 2 || Int.abs(n) >= 5")),
+                "the alternative states where `v.n` stops and nothing worked out where");
     }
 
     private static List<String> undividedIn(String source) {


### PR DESCRIPTION
Closes #1496.

Under a choice, the only reader asked about a leaf was the one with the narrowest vocabulary. The
reading of ends has no arithmetic for the sides of a comparison, so a rule holding of every row, a
call saying which values may stand somewhere, and a bound on how long a string is all read there as
rules whose end it did not work out — and each of them came back as a border this compiler could not
measure.

```souther
data N = { n: Int, s: String }
    invariant r = String.length(s) >= 2 || String.length(s) >= 3
```

is a border drawn where the two alternatives leave the length. `n >= 2 || n - n >= 0` and
`s == "a" || String.matches("[A-Z]{2}", s)` are rules that draw no line, which is what they are
written alone.

## What a leaf states, asked once

A leaf answers what line it states, on which of the value's numbers, and it answers the same
wherever it is written. The reading of ends is then asked which of those it managed, which is its
own question and stays its own — a rule that states no line leaves nothing waiting on a reader,
whatever connective it was written under.

## A line on a number an operation answers

That is another order with an owner of its own. It is keyed apart, and there is no way to make one
of those keys out of a place's own value, so a reading keyed by them cannot come to hold a range the
ends already own.

It is held beside the values and the orders, so the connectives compose it once, under the fate
those two decide. This reading is asked nothing about whether anybody can be in a branch: a length
is bounded by rules about a number the position's own reading has no word for, so a branch refused
by it would be refused by a reading the other two cannot check.

## Where the line lands

Where the rules leave the number, and which conjunct the end is owed to is found by asking what they
leave without it. No line is drawn from a branch — a value taking one alternative owes the other
nothing, and an end placed there is one every value would have to meet.

Nor is the range evidence that the number is said by it. Two alternatives naming one size each leave
the run between them and no value has a size in there, so the ends are drawn where they are and the
run between them comes back with nothing standing on it.

## Answers that changed

`Int.abs(n) >= 5 || n - n >= 0` is a rule that draws no line: the second alternative holds every row,
so every value takes it. The test pinning the old answer said in its own words that what would close
it is the classification of a comparison being asked under a choice.

`s == "a" || String.matches("[A-Z]{2}", s)` draws none either, and the pair holding the partition and
the border in step is rewritten around the narrower sentence: that the reading of ends had no word
for a leaf is not promoted to an end nobody worked out, once whether there is a line at all has been
settled. The control beside it is a rule that does state one, on a number nothing can name, and it
is short of it still.

## A structural check whose population was too coarse

The rule that only the type holding both languages may hold where the positions stop was counting
every order there is. A number an operation answers is not a position and has no set of values
beside it for anybody to compose it with, so what the field is an order of is read off the class
file. A count of the orders the exemption reaches sits beside it, so the branch cannot come to be
one nothing takes.

## Left over

A choice of bounds on a position's own value is still a position the rules are said to divide no
way — #1500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
