### PR TITLE
Name the observation two connectives share, and let each own what it means

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -91,11 +91,11 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
     /** Which of two alternatives still stand, which is one reading of the classification below and
      *  is published beside the word. */
-    private static final String STANDING = EMPTINESS + "$Alternatives";
+    private static final String STANDING = Word.STANDING.internalName();
 
     /** Which of two answers were shown empty, which is the observation every reader of two of them
      *  at once shares and no connective's reading of it. */
-    private static final String SIDES_SHOWN_EMPTY = EMPTINESS + "$SidesShownEmpty";
+    private static final String SIDES_SHOWN_EMPTY = Word.SIDES_SHOWN_EMPTY.internalName();
 
     /** The two answers that settle something, which is what these rules are about.
      *  {@code UNDECIDED} settles nothing and is named freely. */
@@ -110,23 +110,98 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** What javac writes for a switch over this word: a synthetic table of its constants, read by
      *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
      *  names no constant in the code that does it. */
-    private static final String TAKEN_APART = "$SwitchMap$souther$compiler$values$Emptiness";
+    private static final String TAKEN_APART = Word.ANSWERS.switchTable();
 
     /** The same for a switch over which alternatives stand, which is the other thing a reader may
      *  take apart and is a different question from which of the three an answer is. */
-    private static final String TAKEN_APART_BY_STANDING = TAKEN_APART + "$Alternatives";
+    private static final String TAKEN_APART_BY_STANDING = Word.STANDING.switchTable();
 
     /** And for a switch over which of two answers were shown empty, which is the observation the
      *  connectives share rather than any of their readings of it. */
     private static final String TAKEN_APART_BY_SIDES_SHOWN_EMPTY =
-            TAKEN_APART + "$SidesShownEmpty";
+            Word.SIDES_SHOWN_EMPTY.switchTable();
 
     /** A comparison of one of these against one of its constants, which is a reading of the word
      *  that no owned operation answered and that an answer added to the three would fall through
      *  without anybody deciding. Found by following what the constant becomes
      *  ({@link WhatBecomesOfAValueOnTheStack}), because what compares a value is whatever takes it
      *  off the stack and not whatever is written near it. */
-    private static final String COMPARED = "compared";
+    private static final String COMPARED = Word.ANSWERS.compared();
+
+    /**
+     * The words these rules are about: the answers, and each reading of two of them published beside
+     * them.
+     *
+     * <p><b>One list, because every rule here asks the same three things.</b> Who names a word's
+     * constants, who takes it apart by switching, and who compares one against a constant are asked
+     * of each of these, and each answer is derived from the name rather than written beside the
+     * question. Named at the questions instead, a word added here arrives covered by whichever of
+     * them its author happened to make compile — which is how a reading of two answers came to be
+     * counted where it switched and invisible where it compared.
+     *
+     * <p>What is not a word here is an operation over one. {@code isEmpty} and {@code bothStand} are
+     * readings this vocabulary owns and answer for themselves; a word is something whose constants a
+     * reader could name.
+     */
+    private enum Word {
+
+        /** Whether a position admits anything. */
+        ANSWERS(EMPTINESS),
+
+        /** Which alternatives of a choice anybody can still be in. */
+        STANDING(EMPTINESS + "$Alternatives"),
+
+        /** Which of two answers were shown empty. */
+        SIDES_SHOWN_EMPTY(EMPTINESS + "$SidesShownEmpty");
+
+        private final String internalName;
+
+        Word(String internalName) {
+            this.internalName = internalName;
+        }
+
+        /** The word, as a class is named in a class file. */
+        String internalName() {
+            return internalName;
+        }
+
+        /** What javac calls the synthetic table a switch over this word reads. */
+        String switchTable() {
+            return "$SwitchMap$" + internalName.replace('/', '$');
+        }
+
+        /** What a comparison of one of this word's constants is said as. */
+        String compared() {
+            return "compared:" + internalName;
+        }
+
+        /** Which of these a class file names, where it names one. */
+        static Word of(String internalName) {
+            for (Word word : values()) {
+                if (word.internalName.equals(internalName)) {
+                    return word;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Which readings of {@code word} may compare one of its constants, and where that is being
+     * decided.
+     *
+     * <p>A switch over every word, so that a word added to the vocabulary cannot compile until
+     * somebody has said whether anything may read it that way. The answers carry the readings this
+     * compiler has not decided yet; the two readings of two answers carry none, and that is the whole
+     * of why the classification exists — a connective that compared instead of switching would be
+     * spending a meaning no exhaustive reading had to give it.
+     */
+    private static List<Open> mayCompare(Word word) {
+        return switch (word) {
+            case ANSWERS -> COMPARED_IN_PRODUCTION;
+            case STANDING, SIDES_SHOWN_EMPTY -> List.of();
+        };
+    }
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
@@ -529,11 +604,18 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 "which the walk sees it naming, so its absence above is the detector telling a"
                         + " comparison from the making of an answer and not the walk missing it");
 
-        assertEquals(COMPARED_IN_PRODUCTION.stream().map(Open::place).sorted().toList(),
-                placesSaying(saidInProduction(), use -> use.said().equals(COMPARED)),
-                () -> "a reading that compares is one no owned meaning answered, so what is written"
-                        + " here is the readings whose meaning nobody has decided yet, each with"
-                        + " where it is being decided:\n" + questionsBeingDecided());
+        for (Word word : Word.values()) {
+            assertTrue(saidHere().stream().anyMatch(use -> use.said().equals(word.compared())),
+                    () -> "the bodies beside this test compare a constant of " + word + ", so a"
+                            + " detector that cannot find one there is one that would report none of"
+                            + " them anywhere");
+            assertEquals(mayCompare(word).stream().map(Open::place).sorted().toList(),
+                    placesSaying(saidInProduction(), use -> use.said().equals(word.compared())),
+                    () -> "a reading that compares is one no owned meaning answered, so what is"
+                            + " written here is the readings of " + word + " whose meaning nobody has"
+                            + " decided yet, each with where it is being decided:\n"
+                            + questionsBeingDecided());
+        }
     }
 
     /**
@@ -683,6 +765,17 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
         static boolean itIsEmpty(Emptiness said) {
             return said == Emptiness.EMPTY;
+        }
+
+        /** And a constant of each reading of two answers, which the rule refuses production any of:
+         *  a connective owes something to all four cases and says so by switching, so a comparison
+         *  there is a case left whatever the comparison happened to leave it. */
+        static boolean onlyTheLeftStands(Emptiness.Alternatives standing) {
+            return standing == Emptiness.Alternatives.ONLY_THE_LEFT;
+        }
+
+        static boolean theLeftWasShownEmpty(Emptiness.SidesShownEmpty shown) {
+            return shown == Emptiness.SidesShownEmpty.THE_LEFT;
         }
 
         static boolean emptyIsIt(Emptiness said) {
@@ -905,8 +998,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                                 found.add(new Use(nest, holds, where, spelt, what));
                             }
                         }
-                        if (comparesAConstant(elements, at)) {
-                            found.add(new Use(nest, holds, where, spelt, COMPARED));
+                        String compared = comparesAConstant(elements, at);
+                        if (compared != null) {
+                            found.add(new Use(nest, holds, where, spelt, compared));
                         }
                     }
                 }
@@ -930,18 +1024,17 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     private static List<String> saidBy(CodeElement element, String holds) {
         if (element instanceof FieldInstruction field) {
             String named = field.name().stringValue();
-            if (named.equals(TAKEN_APART) || named.equals(TAKEN_APART_BY_STANDING)
-                    || named.equals(TAKEN_APART_BY_SIDES_SHOWN_EMPTY)) {
+            if (isASwitchTable(named)) {
                 return field.owner().asInternalName().equals(holds) ? List.of() : List.of(named);
             }
-            return field.owner().asInternalName().equals(EMPTINESS)
-                    ? List.of(named) : List.of();
+            // And a constant of any of the words, named. Asked of the words rather than of the
+            // answers alone: a reading of two answers holds constants too, and a walk that knew only
+            // the answers read a nest that names one as a nest that names nothing.
+            return Word.of(field.owner().asInternalName()) != null ? List.of(named) : List.of();
         }
         if (element instanceof InvokeInstruction call) {
             String owner = call.owner().asInternalName();
-            return owner.equals(EMPTINESS) || owner.equals(STANDING)
-                    || owner.equals(SIDES_SHOWN_EMPTY)
-                    ? List.of(call.name().stringValue()) : List.of();
+            return Word.of(owner) != null ? List.of(call.name().stringValue()) : List.of();
         }
         if (element instanceof InvokeDynamicInstruction lambda) {
             List<String> out = new ArrayList<>();
@@ -969,13 +1062,27 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * comparison the constant was written on does not matter: the other operand is worked out
      * between them either way, and what is looked for is the comparison this constant reaches.
      */
-    private static boolean comparesAConstant(List<CodeElement> elements, int at) {
+    private static String comparesAConstant(List<CodeElement> elements, int at) {
         if (!(elements.get(at) instanceof FieldInstruction field)
-                || field.opcode() != Opcode.GETSTATIC
-                || !field.owner().asInternalName().equals(EMPTINESS)) {
-            return false;
+                || field.opcode() != Opcode.GETSTATIC) {
+            return null;
         }
-        return WhatBecomesOfAValueOnTheStack.isTakenByAReferenceComparison(elements, at);
+        Word word = Word.of(field.owner().asInternalName());
+        if (word == null) {
+            return null;
+        }
+        return WhatBecomesOfAValueOnTheStack.isTakenByAReferenceComparison(elements, at)
+                ? word.compared() : null;
+    }
+
+    /** Whether {@code named} is the table a switch over one of the words reads. */
+    private static boolean isASwitchTable(String named) {
+        for (Word word : Word.values()) {
+            if (named.equals(word.switchTable())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** What a descriptor names, as a class is named in a class file. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -89,9 +89,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
     private static final String EMPTINESS = "souther/compiler/values/Emptiness";
 
-    /** Which of two alternatives still stand, which is the one reading of this word that is about
-     *  two answers at once and is published beside them. */
+    /** Which of two alternatives still stand, which is one reading of the classification below and
+     *  is published beside the word. */
     private static final String STANDING = EMPTINESS + "$Alternatives";
+
+    /** Which of two answers were shown empty, which is the observation every reader of two of them
+     *  at once shares and no connective's reading of it. */
+    private static final String SIDES_SHOWN_EMPTY = EMPTINESS + "$SidesShownEmpty";
 
     /** The two answers that settle something, which is what these rules are about.
      *  {@code UNDECIDED} settles nothing and is named freely. */
@@ -101,7 +105,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      *  these holds a settled answer without naming one, which is why calling them counts as saying
      *  it. */
     private static final Set<String> OBSERVES_OR_COMPOSES =
-            Set.of("isEmpty", "isDecided", "met", "joined", "of", "bothStand");
+            Set.of("isEmpty", "isDecided", "met", "joined", "of", "from", "bothStand");
 
     /** What javac writes for a switch over this word: a synthetic table of its constants, read by
      *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
@@ -111,6 +115,11 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** The same for a switch over which alternatives stand, which is the other thing a reader may
      *  take apart and is a different question from which of the three an answer is. */
     private static final String TAKEN_APART_BY_STANDING = TAKEN_APART + "$Alternatives";
+
+    /** And for a switch over which of two answers were shown empty, which is the observation the
+     *  connectives share rather than any of their readings of it. */
+    private static final String TAKEN_APART_BY_SIDES_SHOWN_EMPTY =
+            TAKEN_APART + "$SidesShownEmpty";
 
     /** A comparison of one of these against one of its constants, which is a reading of the word
      *  that no owned operation answered and that an answer added to the three would fall through
@@ -217,6 +226,26 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     + "Lsouther/compiler/check/Settlement$Sided;)"
                     + "Lsouther/compiler/check/StatedTogether$Said;");
 
+    /**
+     * And the readings of which sides two answers show empty.
+     *
+     * <p>The observation two connectives share, and the whole list of what reads it. A conjunct
+     * shown empty decides the conjunction and its proof is what carries; an alternative shown empty
+     * drops out of a choice and its proof goes with it. So each of these owes something of its own
+     * to all four cases and switches, and a third connective arriving is one that has to be written
+     * down here before it can read the observation at all.
+     *
+     * <p>One of them, because a choice's reading is published beside the word
+     * ({@link Emptiness.Alternatives#from}) and the walk passes over the word's own nest, where the
+     * meanings are worked out. So what this list holds is every reading outside it, and today that
+     * is the conjunction alone.
+     */
+    private static final List<String> TAKES_IT_APART_BY_SIDES_SHOWN_EMPTY = List.of(
+            "souther/compiler/check/Confinement#eitherShown"
+                    + "(Lsouther/compiler/check/Confinement$Admission;"
+                    + "Lsouther/compiler/check/Confinement$Admission;)"
+                    + "Lsouther/compiler/check/Confinement$Admission;");
+
     /** The bodies beside this test that compare, which is what holds the detector to finding one
      *  however it was written. */
     private static final List<String> COMPARED_IN_THE_FIXTURE = List.of(
@@ -255,9 +284,6 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     private record Open(String place, String question) {}
 
-    /** A choice and a conjunction read the same partition of two answers opposite ways round. */
-    private static final String ONE_PARTITION_TWO_READINGS = "souther-lang/souther#1492";
-
     /** What a settled positive answer is worth, beside a position nobody could build and at the top
      *  of what a join can reach. */
     private static final String WHAT_AN_ANSWER_IS_WORTH = "souther-lang/souther#1493";
@@ -265,28 +291,16 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /**
      * And the readings of this word whose meaning nobody has decided yet.
      *
-     * <p>Three questions and no owner for any of them. {@code eitherShown} and {@code alsoSeen}
-     * are the same partition of two answers that {@link Emptiness.Alternatives} is, read the other
-     * way round: an alternative shown empty drops out of a choice, and a conjunct shown empty
-     * decides the conjunction, so the four cases mean opposite things and one word for both would
-     * say that a left alternative and a left conjunct are one thing. {@code admission} reads what a
-     * settled positive answer is worth beside a position nobody could build. The two
-     * {@code anyAlternativeAdmits} read that a joined answer has reached the top of what a choice
-     * can be, which is a fact about the arithmetic and is known here rather than where the
-     * arithmetic is.
+     * <p>One question and no owner for it. {@code admission} reads what a settled positive answer is
+     * worth beside a position nobody could build. The two {@code anyAlternativeAdmits} read that a
+     * joined answer has reached the top of what a choice can be, which is a fact about the
+     * arithmetic and is known here rather than where the arithmetic is.
      *
      * <p>Each of them is a question this word could be given an owner for, and none of them is one
      * this compiler has decided. Naming a reading here says that; it does not say that the reading
      * was left alone.
      */
     private static final List<Open> COMPARED_IN_PRODUCTION = List.of(
-            new Open("souther/compiler/check/Confinement#eitherShown"
-                    + "(Lsouther/compiler/check/Confinement$Admission;"
-                    + "Lsouther/compiler/check/Confinement$Admission;)"
-                    + "Lsouther/compiler/check/Confinement$Admission;", ONE_PARTITION_TWO_READINGS),
-            new Open("souther/compiler/check/Settlement$Sided#alsoSeen"
-                    + "(Lsouther/compiler/check/Settlement$Sided;)"
-                    + "Lsouther/compiler/check/Settlement$Sided;", ONE_PARTITION_TWO_READINGS),
             new Open("souther/compiler/check/Confinement$Worked#admission"
                     + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
@@ -423,6 +437,31 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                         use -> use.said().equals(TAKEN_APART_BY_STANDING)),
                 "what a choice comes to differs by which of its alternatives stand, and a reading"
                         + " that owes each of them something says so by switching");
+    }
+
+    /**
+     * And these read which sides two answers show empty, which is the observation and not a reading.
+     *
+     * <p>The list every connective has to be written into. Which sides were shown empty is one fact
+     * and what it is worth is the connective's — opposite things for a choice and a conjunction — so
+     * a reading arriving here is a connective this compiler has begun answering for, and one that
+     * arrived at the same four some other way would be spending a meaning nobody gave it.
+     */
+    @Test
+    void andTheseReadWhichSidesWereShownEmpty() {
+        assertEquals(2, TakingBySidesShownEmpty.by(Emptiness.SidesShownEmpty.THE_RIGHT),
+                "the fixture answers by switching");
+        assertTrue(saidHere().stream().anyMatch(
+                        use -> use.said().equals(TAKEN_APART_BY_SIDES_SHOWN_EMPTY)),
+                "the body beside this test switches over which sides were shown empty, so a"
+                        + " detector that cannot find it there is one whose green would be about"
+                        + " production having stopped switching and not about the rule");
+
+        assertEquals(TAKES_IT_APART_BY_SIDES_SHOWN_EMPTY,
+                placesSaying(saidInProduction(),
+                        use -> use.said().equals(TAKEN_APART_BY_SIDES_SHOWN_EMPTY)),
+                "what a connective makes of the observation is the connective's, and a reading that"
+                        + " owes each of the four cases something says so by switching");
     }
 
     /**
@@ -589,6 +628,25 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 case ONLY_THE_LEFT -> 1;
                 case ONLY_THE_RIGHT -> 2;
                 case BOTH_STAND -> 3;
+            };
+        }
+    }
+
+    /**
+     * A body that switches over which sides were shown empty, for the detector that finds those.
+     *
+     * <p>Here for the same reason as the one above: the rule names what production switches, and a
+     * rule with nothing beside it goes on passing the day javac writes a switch some other way.
+     */
+    private enum TakingBySidesShownEmpty {
+        ;
+
+        static int by(Emptiness.SidesShownEmpty shown) {
+            return switch (shown) {
+                case NEITHER -> 0;
+                case THE_LEFT -> 1;
+                case THE_RIGHT -> 2;
+                case BOTH -> 3;
             };
         }
     }
@@ -872,7 +930,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     private static List<String> saidBy(CodeElement element, String holds) {
         if (element instanceof FieldInstruction field) {
             String named = field.name().stringValue();
-            if (named.equals(TAKEN_APART) || named.equals(TAKEN_APART_BY_STANDING)) {
+            if (named.equals(TAKEN_APART) || named.equals(TAKEN_APART_BY_STANDING)
+                    || named.equals(TAKEN_APART_BY_SIDES_SHOWN_EMPTY)) {
                 return field.owner().asInternalName().equals(holds) ? List.of() : List.of(named);
             }
             return field.owner().asInternalName().equals(EMPTINESS)
@@ -881,6 +940,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         if (element instanceof InvokeInstruction call) {
             String owner = call.owner().asInternalName();
             return owner.equals(EMPTINESS) || owner.equals(STANDING)
+                    || owner.equals(SIDES_SHOWN_EMPTY)
                     ? List.of(call.name().stringValue()) : List.of();
         }
         if (element instanceof InvokeDynamicInstruction lambda) {

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -89,14 +90,6 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
 
     private static final String EMPTINESS = "souther/compiler/values/Emptiness";
 
-    /** Which of two alternatives still stand, which is one reading of the classification below and
-     *  is published beside the word. */
-    private static final String STANDING = Word.STANDING.internalName();
-
-    /** Which of two answers were shown empty, which is the observation every reader of two of them
-     *  at once shares and no connective's reading of it. */
-    private static final String SIDES_SHOWN_EMPTY = Word.SIDES_SHOWN_EMPTY.internalName();
-
     /** The two answers that settle something, which is what these rules are about.
      *  {@code UNDECIDED} settles nothing and is named freely. */
     private static final Set<String> SETTLED = Set.of("EMPTY", "NONEMPTY");
@@ -105,7 +98,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      *  these holds a settled answer without naming one, which is why calling them counts as saying
      *  it. */
     private static final Set<String> OBSERVES_OR_COMPOSES =
-            Set.of("isEmpty", "isDecided", "met", "joined", "of", "from", "bothStand");
+            Set.of("isEmpty", "isDecided", "met", "joined", "of", "bothStand");
 
     /** What javac writes for a switch over this word: a synthetic table of its constants, read by
      *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
@@ -184,6 +177,37 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             }
             return null;
         }
+    }
+
+    /**
+     * The body beside this test that compares a constant of {@code word}, and what it answered.
+     *
+     * <p>Called and not only read. Every detector here is held to a body that exercises it, and a
+     * body nothing calls is one whose behaviour nothing checked: it could compare the wrong constant,
+     * or hold two references apart some other way, and the walk would go on reporting that it found a
+     * comparison of this word. So the control is asked what it says, both of the ways below.
+     *
+     * <p>A switch over every word, for the same reason {@link #mayCompare} is one: a word added to
+     * the vocabulary cannot compile until something beside this test compares one of its constants,
+     * and a rule with no control is a rule whose green is about the detector and not about production.
+     */
+    private static boolean comparesAConstantOf(Word word) {
+        return switch (word) {
+            case ANSWERS -> Comparing.itIsEmpty(Emptiness.EMPTY);
+            case STANDING -> Comparing.onlyTheLeftStands(Emptiness.Alternatives.ONLY_THE_LEFT);
+            case SIDES_SHOWN_EMPTY ->
+                    Comparing.theLeftWasShownEmpty(Emptiness.SidesShownEmpty.THE_LEFT);
+        };
+    }
+
+    /** The same control handed something the constant is not, which is what says it compares. */
+    private static boolean comparesAConstantOfAgainstAnother(Word word) {
+        return switch (word) {
+            case ANSWERS -> Comparing.itIsEmpty(Emptiness.NONEMPTY);
+            case STANDING -> Comparing.onlyTheLeftStands(Emptiness.Alternatives.BOTH_STAND);
+            case SIDES_SHOWN_EMPTY ->
+                    Comparing.theLeftWasShownEmpty(Emptiness.SidesShownEmpty.NEITHER);
+        };
     }
 
     /**
@@ -605,6 +629,11 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                         + " comparison from the making of an answer and not the walk missing it");
 
         for (Word word : Word.values()) {
+            assertTrue(comparesAConstantOf(word),
+                    () -> "the body beside this test answers for a constant of " + word);
+            assertFalse(comparesAConstantOfAgainstAnother(word),
+                    () -> "and it is a comparison, so a body of " + word + " that only looked like"
+                            + " one would hold the detector to nothing");
             assertTrue(saidHere().stream().anyMatch(use -> use.said().equals(word.compared())),
                     () -> "the bodies beside this test compare a constant of " + word + ", so a"
                             + " detector that cannot find one there is one that would report none of"
@@ -614,7 +643,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     () -> "a reading that compares is one no owned meaning answered, so what is"
                             + " written here is the readings of " + word + " whose meaning nobody has"
                             + " decided yet, each with where it is being decided:\n"
-                            + questionsBeingDecided());
+                            + questionsBeingDecided(word));
         }
     }
 
@@ -639,6 +668,35 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 "which the walk finds as well: the two are one word between them, and a rule that"
                         + " read a reference to one and not the other would be about which of them"
                         + " a caller happened to name");
+
+        assertEquals(Emptiness.SidesShownEmpty.NEITHER,
+                Referring.SORTS.apply(Emptiness.NONEMPTY, Emptiness.UNDECIDED),
+                "and the fixture sorts two answers by handle");
+        assertTrue(saidHere().stream().anyMatch(use -> use.said().equals("of")),
+                "and that as well, which is what says the branch asks the words and not the two of"
+                        + " them somebody wrote into it");
+    }
+
+    /**
+     * And every word of the vocabulary is in the nest the walk's two coarse questions name.
+     *
+     * <p>Two of the walk's questions are about a nest and not about a word: which classes are worth
+     * reading at all ({@code holdsTheWord}), and whose own code works out the meanings and is
+     * therefore passed over ({@code isTheWord}). Both name {@code Emptiness}, which answers for every
+     * word today because each of them is written inside it.
+     *
+     * <p>So the assumption is checked rather than relied on. A word put beside the answers instead of
+     * inside them would be read by neither question — its classes skipped by the first and its
+     * meanings counted as somebody else's by the second — and every list above would go on matching.
+     */
+    @Test
+    void andEveryWordIsWrittenInsideTheNestThoseQuestionsName() {
+        for (Word word : Word.values()) {
+            assertEquals(EMPTINESS, nestOf(word.internalName()),
+                    () -> word + " is not written inside the nest the walk reads and passes over, so"
+                            + " a rule about it would be about whichever of the two questions its"
+                            + " author noticed");
+        }
     }
 
     /**
@@ -751,6 +809,12 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
          *  writes an ask and not about the ask. */
         static final Predicate<Emptiness.Alternatives> STANDS =
                 Emptiness.Alternatives::bothStand;
+
+        /** And the classification the connectives read, for the same reason: a handle names a word
+         *  the same ways a call does, and a branch that knew two of the words would read a reference
+         *  to the third as naming nothing. */
+        static final BiFunction<Emptiness, Emptiness, Emptiness.SidesShownEmpty> SORTS =
+                Emptiness.SidesShownEmpty::of;
     }
 
     /**
@@ -899,9 +963,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** Where each reading that compares is being decided, for whoever the rule above stopped: an
      *  entry added to that list is a question somebody is deciding, and an entry that has gone is
      *  one that was. */
-    private static String questionsBeingDecided() {
+    private static String questionsBeingDecided(Word word) {
         StringBuilder out = new StringBuilder();
-        COMPARED_IN_PRODUCTION.forEach(open ->
+        mayCompare(word).forEach(open ->
                 out.append("  ").append(open.place()).append("  ").append(open.question())
                         .append('\n'));
         return out.toString();
@@ -1040,8 +1104,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             List<String> out = new ArrayList<>();
             for (var argument : lambda.bootstrapArgs()) {
                 if (argument instanceof DirectMethodHandleDesc handle
-                        && (named(handle.owner()).equals(EMPTINESS)
-                                || named(handle.owner()).equals(STANDING))) {
+                        && Word.of(named(handle.owner())) != null) {
                     // Whichever kind of handle it is, what it names is what the code would have
                     // said had it been written out: a field for a constant, a method for the rest.
                     out.add(handle.methodName());

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -8,6 +8,7 @@ import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AskedOfEachBlock;
 import souther.compiler.values.ConjoinedAdmissibleValues;
+import souther.compiler.values.Emptiness.SidesShownEmpty;
 import souther.compiler.values.Admits;
 import souther.compiler.values.AskedOfARelation;
 import souther.compiler.values.StringMachineAnswers;
@@ -484,12 +485,23 @@ sealed interface Confinement<A> {
         return block.members().stream().anyMatch(each -> !outside.at(each).saysNothing());
     }
 
-    /** What showed a conjunction of two readings empty, where either of them was. */
+    /**
+     * What showed a conjunction of two readings empty, where either of them was.
+     *
+     * <p>The conjunction's reading of which sides were shown empty, which runs the other way from a
+     * choice's ({@link souther.compiler.values.Emptiness.Alternatives}): a conjunct shown empty is
+     * what decides the conjunction and its proof is what carries, where an alternative shown empty
+     * is the one that drops. So the same four cases mean the opposite thing, and the observation is
+     * shared while the reading of it is not.
+     */
     static <A> Admission<A> eitherShown(Admission<A> one, Admission<A> other) {
-        if (one.emptiness() != souther.compiler.values.Emptiness.EMPTY) {
-            return other.emptiness() == souther.compiler.values.Emptiness.EMPTY ? other : null;
-        }
-        return other.emptiness() == souther.compiler.values.Emptiness.EMPTY ? Admission.bothShown(one, other) : one;
+        return switch (SidesShownEmpty.of(one.emptiness(), other.emptiness())) {
+            // Nothing showed the pair empty, and there is no proof of a lack that was not shown.
+            case NEITHER -> null;
+            case THE_LEFT -> one;
+            case THE_RIGHT -> other;
+            case BOTH -> Admission.bothShown(one, other);
+        };
     }
 
     /** What each position is ordered on, both tables put together. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -357,12 +357,12 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
             asked.addAll(other.ruleShortfalls());
             // And what showed the branch empty, where both occurrences of it are. Where they were
             // shown by different things, or refused at different positions, neither speaks for the
-            // branch — which is the same rule a choice of two dead branches is under.
+            // branch.
             //
             // Asked of the join and not of the two sides. These are two occurrences of one written
             // branch rather than two alternatives, so there is no side here to be named: a branch
             // anybody can be in anywhere it stands is one nothing showed empty, and a proof survives
-            // only where every occurrence was shown.
+            // only where every occurrence was shown empty.
             souther.compiler.values.Emptiness said = emptiness().joined(other.emptiness());
             Confinement.Admission<FactSubject> both = said.isEmpty()
                     ? Confinement.Admission.bothShown(shown, other.shown)

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Emptiness.SidesShownEmpty;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realized;
 import souther.compiler.values.UnreadReason;
@@ -114,7 +115,8 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
                                   Confinement.Planned<FactSubject> one,
                                   souther.compiler.values.Emptiness there,
                                   Confinement.Planned<FactSubject> other) {
-            if (!souther.compiler.values.Emptiness.Alternatives.of(here, there).bothStand()) {
+            if (!souther.compiler.values.Emptiness.Alternatives
+                    .from(SidesShownEmpty.of(here, there)).bothStand()) {
                 return none();
             }
             return new WidthDependency(Width.ofValues(one.values(), other.values()),
@@ -356,8 +358,13 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
             // And what showed the branch empty, where both occurrences of it are. Where they were
             // shown by different things, or refused at different positions, neither speaks for the
             // branch — which is the same rule a choice of two dead branches is under.
+            //
+            // Asked of the join and not of the two sides. These are two occurrences of one written
+            // branch rather than two alternatives, so there is no side here to be named: a branch
+            // anybody can be in anywhere it stands is one nothing showed empty, and a proof survives
+            // only where every occurrence was shown.
             souther.compiler.values.Emptiness said = emptiness().joined(other.emptiness());
-            Confinement.Admission<FactSubject> both = said == souther.compiler.values.Emptiness.EMPTY
+            Confinement.Admission<FactSubject> both = said.isEmpty()
                     ? Confinement.Admission.bothShown(shown, other.shown)
                     : Confinement.Admission.left(said);
             return new Sided(both, why, java.util.Collections.unmodifiableSet(asked), gaveUp);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -6,6 +6,7 @@ import souther.compiler.types.Type;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
+import souther.compiler.values.Emptiness.SidesShownEmpty;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realizations;
@@ -687,11 +688,11 @@ sealed interface StatedByClauses {
          * refused, so a language asked to decide would answer about a branch and not about the
          * choice.
          *
-         * <p>Which of the alternatives are still standing is read off the two answers
-         * ({@link souther.compiler.values.Emptiness.Alternatives}), and whether the answers about
-         * them are final is asked here beside it ({@link #settledHere}). Two questions and not one
-         * word: a branch nobody has worked out stands, and a choice of two that stand is one this
-         * may still have to keep.
+         * <p>Which of the alternatives are still standing is the choice's reading of which of the two
+         * answers were shown empty ({@link souther.compiler.values.Emptiness.Alternatives#from}), and
+         * whether the answers about them are final is asked here beside it ({@link #settledHere}).
+         * Two questions and not one word: a branch nobody has worked out stands, and a choice of two
+         * that stand is one this may still have to keep.
          *
          * <p>What every alternative leaves empty is what the dead choice leaves empty, and where
          * that is no position, the choice admits nothing with none of them at fault. That is the
@@ -728,8 +729,8 @@ sealed interface StatedByClauses {
                 Confinement.Admission<FactSubject> theirs =
                         there.confinement().admission(machines);
                 souther.compiler.values.Emptiness.Alternatives standing =
-                        souther.compiler.values.Emptiness.Alternatives.of(
-                                mine.emptiness(), theirs.emptiness());
+                        souther.compiler.values.Emptiness.Alternatives.from(
+                                SidesShownEmpty.of(mine.emptiness(), theirs.emptiness()));
                 if (settledHere(standing, mine, theirs)) {
                     decided.put(choice.id(), settled(here, mine, there, theirs));
                     return switch (standing) {
@@ -862,8 +863,8 @@ sealed interface StatedByClauses {
          */
         private StatedTogether.Said decided(StatedTogether.Said one, Settlement.Sided here,
                                             StatedTogether.Said other, Settlement.Sided there) {
-            return switch (souther.compiler.values.Emptiness.Alternatives.of(
-                    here.emptiness(), there.emptiness())) {
+            return switch (souther.compiler.values.Emptiness.Alternatives.from(
+                    SidesShownEmpty.of(here.emptiness(), there.emptiness()))) {
                 // The rule for a choice nobody can take, named rather than arrived at: a join is
                 // what two branches somebody can take come to, and neither of these is one.
                 case NEITHER_STANDS -> new StatedTogether.Said(
@@ -1098,8 +1099,8 @@ sealed interface StatedByClauses {
                     // is answerable for what a branch of a branch it has already lost ever reached.
                     Taken left = one.under(fate.left());
                     Taken right = other.under(fate.right());
-                    if (!souther.compiler.values.Emptiness.Alternatives.of(
-                            fate.left().emptiness(), fate.right().emptiness()).bothStand()) {
+                    if (!souther.compiler.values.Emptiness.Alternatives.from(SidesShownEmpty.of(
+                            fate.left().emptiness(), fate.right().emptiness())).bothStand()) {
                         // What is left of a dead alternative is an account and not an alternative,
                         // so the two are accumulated and not composed as a choice. Which of them
                         // was the dead one is asked here and nowhere below: both sides arrive with

--- a/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
@@ -115,15 +115,16 @@ public enum Emptiness {
      * valuing of them is not: named for which side survives, this would be the choice's reading
      * under a word a conjunction takes backwards, and the four cases are the same four either way.
      *
-     * <p><b>{@link #UNDECIDED} was not shown empty.</b> Nobody has shown that nothing satisfies
-     * such an answer, and a reader that sorted it with {@link #EMPTY} would be acting on not having
-     * looked. That rule is written here and nowhere else — every reader of two answers at once needs
-     * it, and read off the constants at each of them it would be as many rules as there are
-     * readers.
+     * <p><b>Whether one answer was shown empty is {@link #isEmpty()}'s, and this holds which of the
+     * two gave that answer.</b> So {@link #UNDECIDED} is not on the shown-empty side because
+     * {@link #isEmpty()} says it is not — nobody has shown that nothing satisfies such an answer, and
+     * a reader that sorted it with {@link #EMPTY} would be acting on not having looked. Nothing here
+     * decides that a second time, and an answer added to the three is told which side it falls on
+     * there, before anything compiles.
      *
-     * <p>Which side an answer falls on is {@link #isEmpty()}, the answers' own word for the settled
-     * negative, so nothing here decides it a second time and an answer added to the three is told
-     * what it means there before anything compiles.
+     * <p>What this owns is the lifting of that decision to two answers: the sides, kept in the order
+     * they were written. Read off the constants at each reader of a pair, the sides would be as many
+     * rules as there are readers.
      *
      * <p><b>And falling on one side of this is not being one answer.</b> {@link #NONEMPTY} and
      * {@link #UNDECIDED} were both not shown empty, which is the whole of what this says about

--- a/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
@@ -23,7 +23,9 @@ package souther.compiler.values;
  * means to each of these before anything compiles. Written as a comparison against a constant, each
  * of them would hand a fourth answer whichever meaning the comparison happened to leave it, and
  * nobody would have decided that. A reader outside asks one of these operations, and
- * {@link Alternatives} for the one reading that is about two of them at once.
+ * {@link SidesShownEmpty} where the question is about two answers at once: which of the two were
+ * shown empty is the observation, and what a connective does about that is the connective's
+ * ({@link Alternatives} for a choice).
  */
 public enum Emptiness {
 
@@ -105,13 +107,60 @@ public enum Emptiness {
     }
 
     /**
+     * Which of two answers were shown empty, in the order they were written.
+     *
+     * <p>The observation two connectives share, and nothing either of them does with it. A conjunct
+     * shown empty decides the conjunction and carries its proof forward; an alternative shown empty
+     * drops out of a choice and its proof goes with it. So what is held here is the sides, and the
+     * valuing of them is not: named for which side survives, this would be the choice's reading
+     * under a word a conjunction takes backwards, and the four cases are the same four either way.
+     *
+     * <p><b>{@link #UNDECIDED} was not shown empty.</b> Nobody has shown that nothing satisfies
+     * such an answer, and a reader that sorted it with {@link #EMPTY} would be acting on not having
+     * looked. That rule is written here and nowhere else — every reader of two answers at once needs
+     * it, and read off the constants at each of them it would be as many rules as there are
+     * readers.
+     *
+     * <p>Which side an answer falls on is {@link #isEmpty()}, the answers' own word for the settled
+     * negative, so nothing here decides it a second time and an answer added to the three is told
+     * what it means there before anything compiles.
+     *
+     * <p><b>And falling on one side of this is not being one answer.</b> {@link #NONEMPTY} and
+     * {@link #UNDECIDED} were both not shown empty, which is the whole of what this says about
+     * them: whether the question was answered at all is {@link #isDecided()}, and a reader that
+     * took this classification for what the two answers are would call a reading exact that is
+     * waiting on a decision.
+     */
+    public enum SidesShownEmpty {
+
+        /** Neither of them was shown empty. */
+        NEITHER,
+
+        /** The left, and nothing showed the right empty. */
+        THE_LEFT,
+
+        /** The right, and nothing showed the left empty. */
+        THE_RIGHT,
+
+        /** Both of them. */
+        BOTH;
+
+        /** Which of two answers, read in the order they were written, were shown empty. */
+        public static SidesShownEmpty of(Emptiness left, Emptiness right) {
+            if (left.isEmpty()) {
+                return right.isEmpty() ? BOTH : THE_LEFT;
+            }
+            return right.isEmpty() ? THE_RIGHT : NEITHER;
+        }
+    }
+
+    /**
      * Which alternatives of a choice anybody can still be in.
      *
-     * <p>A branch stands unless something showed it empty, so {@link #UNDECIDED} stands: nobody
-     * has shown that nothing satisfies it, and a walk that dropped it would be dropping a branch on
-     * the strength of not having looked. That rule is written here and nowhere else — it is the one
-     * thing every reader of a choice needs before it can do anything, and read off the constants at
-     * each of them it would be as many rules as there are readers.
+     * <p>One reading of {@link SidesShownEmpty}, which is where a branch standing unless something
+     * showed it empty is settled. What is added here is the choice's own valuing of that
+     * observation, and it runs the other way from the observation's sides — a side shown empty is
+     * the side that drops.
      *
      * <p><b>A reading of two answers, and not a settlement of a choice.</b> What this says is which
      * of the alternatives are still candidates. What a choice then leaves, which branch the caller
@@ -141,14 +190,20 @@ public enum Emptiness {
         /** Both are alternatives somebody may still be in. */
         BOTH_STAND;
 
-        /** Which of two alternatives, read in the order they were written, still stand. */
-        public static Alternatives of(Emptiness left, Emptiness right) {
-            boolean here = stands(left);
-            boolean there = stands(right);
-            if (here) {
-                return there ? BOTH_STAND : ONLY_THE_LEFT;
-            }
-            return there ? ONLY_THE_RIGHT : NEITHER_STANDS;
+        /**
+         * Which alternatives stand, read off which sides were shown empty.
+         *
+         * <p>An exchange, and the one place it is written: the side that was shown empty is the side
+         * that drops, so what stands is the other one. Carried across as the same word, the
+         * observation's left would name the alternative a choice has lost.
+         */
+        public static Alternatives from(SidesShownEmpty shown) {
+            return switch (shown) {
+                case NEITHER -> BOTH_STAND;
+                case THE_LEFT -> ONLY_THE_RIGHT;
+                case THE_RIGHT -> ONLY_THE_LEFT;
+                case BOTH -> NEITHER_STANDS;
+            };
         }
 
         /**
@@ -163,20 +218,6 @@ public enum Emptiness {
             return switch (this) {
                 case NEITHER_STANDS, ONLY_THE_LEFT, ONLY_THE_RIGHT -> false;
                 case BOTH_STAND -> true;
-            };
-        }
-
-        /**
-         * Whether anybody may still be in an alternative this is the answer about.
-         *
-         * <p>Not published. What a settled answer means to an alternative is this classification's,
-         * and a name for it beside the answers themselves would say that "empty" and "nobody can be
-         * in it" are one thing wherever an {@code Emptiness} is read. They are one thing here.
-         */
-        private static boolean stands(Emptiness said) {
-            return switch (said) {
-                case EMPTY -> false;
-                case NONEMPTY, UNDECIDED -> true;
             };
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest.java
@@ -61,7 +61,9 @@ class AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest {
         }
 
         Branch or(Branch other) {
-            if (souther.compiler.values.Emptiness.Alternatives.of(said(), other.said())
+            if (souther.compiler.values.Emptiness.Alternatives.from(
+                            souther.compiler.values.Emptiness.SidesShownEmpty.of(
+                                    said(), other.said()))
                     .bothStand()) {
                 return new Branch(adoption.either(Opening.nothing(), other.adoption), false);
             }

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -86,8 +86,8 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
     private record Branch(Confinement.Planned<String> reading, boolean dead) {
 
         Branch or(Branch other) {
-            return switch (souther.compiler.values.Emptiness.Alternatives.of(said(),
-                    other.said())) {
+            return switch (souther.compiler.values.Emptiness.Alternatives.from(
+                    souther.compiler.values.Emptiness.SidesShownEmpty.of(said(), other.said()))) {
                 // What showed the choice dead is what showed both of its branches dead, which is
                 // where the holder of both languages takes it from as well.
                 case NEITHER_STANDS -> new Branch(reading.bothDead(other.reading,

--- a/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static souther.compiler.values.Emptiness.EMPTY;
 import static souther.compiler.values.Emptiness.NONEMPTY;
@@ -18,9 +19,13 @@ import static souther.compiler.values.Emptiness.Alternatives.BOTH_STAND;
 import static souther.compiler.values.Emptiness.Alternatives.NEITHER_STANDS;
 import static souther.compiler.values.Emptiness.Alternatives.ONLY_THE_LEFT;
 import static souther.compiler.values.Emptiness.Alternatives.ONLY_THE_RIGHT;
+import static souther.compiler.values.Emptiness.SidesShownEmpty.BOTH;
+import static souther.compiler.values.Emptiness.SidesShownEmpty.NEITHER;
+import static souther.compiler.values.Emptiness.SidesShownEmpty.THE_LEFT;
+import static souther.compiler.values.Emptiness.SidesShownEmpty.THE_RIGHT;
 
 /**
- * Which alternatives two answers leave standing, written out.
+ * Which sides two answers show empty, and which alternatives a choice reads off that.
  *
  * <p>Every pair, said here rather than worked out, because a reading of this written the way the
  * subject is written would agree with it however either was wrong. What every caller of this shares
@@ -31,41 +36,60 @@ import static souther.compiler.values.Emptiness.Alternatives.ONLY_THE_RIGHT;
  * layer working the classification out for itself and then acting on its own answer; what is here
  * is one statement of what the answer is, held against the one place that gives it.
  *
- * <p><b>{@link Emptiness#UNDECIDED} stands.</b> Nobody has shown that nothing satisfies such a
- * branch, and a reading that dropped it would drop a branch on the strength of not having looked.
- * That is the whole content of the rule, and the rows it decides are the four an answer nobody
- * settled takes part in.
+ * <p><b>{@link Emptiness#UNDECIDED} was not shown empty.</b> Nobody has shown that nothing satisfies
+ * such a branch, and a reading that sorted it with {@link Emptiness#EMPTY} would drop a branch on
+ * the strength of not having looked. That is the whole content of the rule, and the rows it decides
+ * are the four an answer nobody settled takes part in.
+ *
+ * <p><b>And the choice's reading is the classification with its sides exchanged.</b> The side shown
+ * empty is the side that drops, so the four ways two sides can be shown empty and the four ways two
+ * alternatives can fall are the same four read in opposite directions. Written out here, because a
+ * projection that carried the word across would name the alternative a choice has lost — and a
+ * conjunction, which reads the same classification the other way, would then be handed a word for
+ * its surviving conjunct that means the refused one.
  */
 class ABranchStandsUnlessSomethingShowedItEmptyTest {
 
-    /** Two answers and which of the alternatives they leave standing. */
-    private record Row(Emptiness left, Emptiness right, Emptiness.Alternatives standing) {}
+    /** Two answers and which of the sides they show empty. */
+    private record Row(Emptiness left, Emptiness right, Emptiness.SidesShownEmpty shown) {}
 
     private static List<Row> table() {
         return List.of(
-                new Row(EMPTY, EMPTY, NEITHER_STANDS),
-                new Row(EMPTY, NONEMPTY, ONLY_THE_RIGHT),
-                new Row(EMPTY, UNDECIDED, ONLY_THE_RIGHT),
-                new Row(NONEMPTY, EMPTY, ONLY_THE_LEFT),
-                new Row(UNDECIDED, EMPTY, ONLY_THE_LEFT),
-                new Row(NONEMPTY, NONEMPTY, BOTH_STAND),
-                new Row(NONEMPTY, UNDECIDED, BOTH_STAND),
-                new Row(UNDECIDED, NONEMPTY, BOTH_STAND),
-                new Row(UNDECIDED, UNDECIDED, BOTH_STAND));
+                new Row(EMPTY, EMPTY, BOTH),
+                new Row(EMPTY, NONEMPTY, THE_LEFT),
+                new Row(EMPTY, UNDECIDED, THE_LEFT),
+                new Row(NONEMPTY, EMPTY, THE_RIGHT),
+                new Row(UNDECIDED, EMPTY, THE_RIGHT),
+                new Row(NONEMPTY, NONEMPTY, NEITHER),
+                new Row(NONEMPTY, UNDECIDED, NEITHER),
+                new Row(UNDECIDED, NONEMPTY, NEITHER),
+                new Row(UNDECIDED, UNDECIDED, NEITHER));
     }
 
+    /** Which alternatives a choice is left by each way the sides can be shown empty. */
+    private static List<Reading> readings() {
+        return List.of(
+                new Reading(NEITHER, BOTH_STAND),
+                new Reading(THE_LEFT, ONLY_THE_RIGHT),
+                new Reading(THE_RIGHT, ONLY_THE_LEFT),
+                new Reading(BOTH, NEITHER_STANDS));
+    }
+
+    /** One way the sides can be shown empty, and what a choice makes of it. */
+    private record Reading(Emptiness.SidesShownEmpty shown, Emptiness.Alternatives standing) {}
+
     /**
-     * Every pair leaves what the table says, each alternative answered for on its own side.
+     * Every pair shows what the table says, each side answered for on its own.
      *
      * <p>Which is where the sides are told apart, and the only place they are: an answer that named
      * the wrong side of every pair would still be a classification, and every law two of these
      * satisfy it would satisfy as well.
      */
     @Test
-    void everyPairOfAnswersLeavesWhatTheTableSays() {
+    void everyPairOfAnswersShowsWhatTheTableSays() {
         for (Row row : table()) {
-            assertEquals(row.standing(),
-                    Emptiness.Alternatives.of(row.left(), row.right()),
+            assertEquals(row.shown(),
+                    Emptiness.SidesShownEmpty.of(row.left(), row.right()),
                     () -> row.left() + " on the left and " + row.right() + " on the right");
         }
     }
@@ -75,7 +99,7 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
      *
      * <p>Asked of the answers themselves rather than of the rows, so that an answer added to the
      * three is a pair this says nothing about and not a pair nobody noticed. The rows say what each
-     * of them leaves; this says that the rows are asked of all of them.
+     * of them shows; this says that the rows are asked of all of them.
      */
     @Test
     void andTheTableIsAboutEveryPairOfAnswersThereIs() {
@@ -93,18 +117,61 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
     }
 
     /**
-     * And every way the alternatives can fall is one some pair of answers reaches.
+     * And every way the sides can be shown empty is one some pair of answers reaches.
      *
      * <p>A way nothing reaches is one no reader's arm is ever taken, and the readers that switch
      * over these would be answering for a case that cannot happen while the case they are wrong
      * about goes unwritten.
      */
     @Test
-    void andEveryWayTheAlternativesCanFallIsReached() {
-        Set<Emptiness.Alternatives> reached = new LinkedHashSet<>();
-        table().forEach(row -> reached.add(row.standing()));
-        assertEquals(Set.of(Emptiness.Alternatives.values()), reached,
-                "every way two alternatives can fall is one some pair of answers leaves");
+    void andEveryWayTheSidesCanBeShownEmptyIsReached() {
+        Set<Emptiness.SidesShownEmpty> reached = new LinkedHashSet<>();
+        table().forEach(row -> reached.add(row.shown()));
+        assertEquals(Set.of(Emptiness.SidesShownEmpty.values()), reached,
+                "every way two sides can be shown empty is one some pair of answers shows");
+    }
+
+    /**
+     * And falling on one side of the classification is not being one answer.
+     *
+     * <p>The rows above put {@link Emptiness#NONEMPTY} and {@link Emptiness#UNDECIDED} on the same
+     * side of every pair, which is what the classification says about them and the only thing it
+     * says. Read as the whole of what the two answers are, it would call a reading exact that is
+     * waiting on a decision — so the rows are held beside the word that does tell them apart, and
+     * the nine are not the six a reader who took them for one answer would write.
+     */
+    @Test
+    void andFallingOnOneSideOfItIsNotBeingOneAnswer() {
+        for (Emptiness said : List.of(NONEMPTY, UNDECIDED)) {
+            assertEquals(NEITHER, Emptiness.SidesShownEmpty.of(said, said),
+                    () -> said + " was not shown empty");
+        }
+        assertNotEquals(NONEMPTY.isDecided(), UNDECIDED.isDecided(),
+                "and whether anybody has looked tells the two of them apart, which is the question"
+                        + " this classification is not the answer to");
+    }
+
+    /**
+     * And which alternatives stand is that classification with its sides exchanged.
+     *
+     * <p>The direction, written out. A choice loses the side that was shown empty, so the left of
+     * the classification is the alternative the choice no longer has — and the four rows here are
+     * the whole of what a reader gets wrong by carrying the word across rather than exchanging it.
+     */
+    @Test
+    void andWhichAlternativesStandIsThatWithTheSidesExchanged() {
+        for (Reading reading : readings()) {
+            assertEquals(reading.standing(), Emptiness.Alternatives.from(reading.shown()),
+                    () -> "a choice whose sides shown empty are " + reading.shown());
+        }
+        Set<Emptiness.SidesShownEmpty> read = new LinkedHashSet<>();
+        readings().forEach(reading -> read.add(reading.shown()));
+        assertEquals(Set.of(Emptiness.SidesShownEmpty.values()), read,
+                "and a way the sides can be shown empty this says nothing about is one a choice is"
+                        + " left something by without anybody having written down what");
+        assertEquals(Set.of(Emptiness.Alternatives.values()),
+                new LinkedHashSet<>(readings().stream().map(Reading::standing).toList()),
+                "and every way two alternatives can fall is one some classification reads as");
     }
 
     /**
@@ -117,8 +184,9 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
     @Test
     void andWhetherThereIsAChoiceAtAllIsTheSameTable() {
         for (Row row : table()) {
-            assertEquals(row.standing() == BOTH_STAND,
-                    Emptiness.Alternatives.of(row.left(), row.right()).bothStand(),
+            assertEquals(row.shown() == NEITHER,
+                    Emptiness.Alternatives.from(
+                            Emptiness.SidesShownEmpty.of(row.left(), row.right())).bothStand(),
                     () -> "a choice between " + row.left() + " and " + row.right());
         }
         assertTrue(BOTH_STAND.bothStand(), "two standing alternatives are a choice");
@@ -128,21 +196,38 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
     }
 
     /**
-     * And neither alternative is answered for out of what the other one is.
+     * And neither side is answered for out of what the other one is.
      *
      * <p>Read the pair backwards and the answer is the same one with its sides exchanged, which is
-     * what it means for this to be about two alternatives and not about a first and a second. What
-     * it does not say is which side is which: an answer with the two names exchanged everywhere
-     * satisfies this as well, and what says which is which is the table above.
+     * what it means for this to be about two sides and not about a first and a second. What it does
+     * not say is which side is which: an answer with the two names exchanged everywhere satisfies
+     * this as well, and what says which is which is the table above.
      */
     @Test
     void andReadingThePairBackwardsExchangesTheSides() {
         for (Emptiness left : Emptiness.values()) {
             for (Emptiness right : Emptiness.values()) {
-                assertEquals(exchanged(Emptiness.Alternatives.of(left, right)),
-                        Emptiness.Alternatives.of(right, left),
+                assertEquals(exchanged(Emptiness.SidesShownEmpty.of(left, right)),
+                        Emptiness.SidesShownEmpty.of(right, left),
                         () -> left + " and " + right + ", read from either end");
             }
+        }
+    }
+
+    /**
+     * And the choice's reading exchanges the sides with it.
+     *
+     * <p>A law about the projection and not about either end of it: whichever way round a choice's
+     * two alternatives were written, reading them the other way answers with the sides exchanged.
+     * A projection that mapped both of the one-sided classifications onto one alternative would
+     * satisfy the rows above for three of the four and fail this.
+     */
+    @Test
+    void andTheChoicesReadingExchangesTheSidesWithIt() {
+        for (Emptiness.SidesShownEmpty shown : Emptiness.SidesShownEmpty.values()) {
+            assertEquals(exchanged(Emptiness.Alternatives.from(shown)),
+                    Emptiness.Alternatives.from(exchanged(shown)),
+                    () -> shown + ", read from either end");
         }
     }
 
@@ -161,8 +246,31 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
      */
     @Test
     void andItClassifiesTwoAnswersAndActsOnNeither() {
+        assertEquals(List.of("bothStand", "from"),
+                writtenOver(Emptiness.Alternatives.class,
+                        Set.of(Emptiness.Alternatives.class, Emptiness.SidesShownEmpty.class,
+                                boolean.class)),
+                "which alternatives a classification leaves standing and whether that is a choice at"
+                        + " all — an operation beside them would be a second place saying what a"
+                        + " choice comes to");
+        assertEquals(List.of("of"),
+                writtenOver(Emptiness.SidesShownEmpty.class,
+                        Set.of(Emptiness.class, Emptiness.SidesShownEmpty.class)),
+                "and the classification sorts two answers and reads neither connective's meaning"
+                        + " into them: a reading named for what a side is worth is a connective's"
+                        + " and is written where that connective is");
+    }
+
+    /**
+     * What is written over {@code word}, each of them mentioning nothing outside {@code mentions}.
+     *
+     * <p>Asked of the declared methods, so that a reading added to one of these words has to be
+     * written down here — and asked about what each of them mentions, because an operation that is
+     * handed a branch or written over a type of the caller's is one such a word has begun composing.
+     */
+    private static List<String> writtenOver(Class<?> word, Set<Class<?>> mentions) {
         List<String> written = new ArrayList<>();
-        for (Method each : Emptiness.Alternatives.class.getDeclaredMethods()) {
+        for (Method each : word.getDeclaredMethods()) {
             // What an enum is, and not an operation somebody wrote over these.
             if (each.isSynthetic() || each.getName().equals("values")
                     || each.getName().equals("valueOf")) {
@@ -172,19 +280,24 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
             assertEquals(0, each.getTypeParameters().length,
                     () -> each.getName() + " is written over some type of the caller's, which is"
                             + " what an operation that is handed a branch needs");
-            List<Class<?>> mentions = new ArrayList<>(List.of(each.getParameterTypes()));
-            mentions.add(each.getReturnType());
-            for (Class<?> what : mentions) {
-                assertTrue(what == Emptiness.class || what == Emptiness.Alternatives.class
-                                || what == boolean.class,
-                        () -> each.getName() + " mentions " + what.getName() + ", which is neither"
-                                + " an answer nor which alternatives stand nor whether they both do");
+            List<Class<?>> said = new ArrayList<>(List.of(each.getParameterTypes()));
+            said.add(each.getReturnType());
+            for (Class<?> what : said) {
+                assertTrue(mentions.contains(what),
+                        () -> each.getName() + " mentions " + what.getName() + ", which is none of"
+                                + " what " + word.getSimpleName() + " is about");
             }
         }
-        assertEquals(List.of("bothStand", "of", "stands"), written.stream().sorted().toList(),
-                "which alternatives two answers leave standing, whether that is a choice at all,"
-                        + " and the rule they are read by — an operation beside them would be a"
-                        + " second place saying what a choice comes to");
+        return written.stream().sorted().toList();
+    }
+
+    private static Emptiness.SidesShownEmpty exchanged(Emptiness.SidesShownEmpty shown) {
+        return switch (shown) {
+            case NEITHER -> NEITHER;
+            case THE_LEFT -> THE_RIGHT;
+            case THE_RIGHT -> THE_LEFT;
+            case BOTH -> BOTH;
+        };
     }
 
     private static Emptiness.Alternatives exchanged(Emptiness.Alternatives standing) {

--- a/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ABranchStandsUnlessSomethingShowedItEmptyTest.java
@@ -10,7 +10,6 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static souther.compiler.values.Emptiness.EMPTY;
 import static souther.compiler.values.Emptiness.NONEMPTY;
@@ -129,26 +128,6 @@ class ABranchStandsUnlessSomethingShowedItEmptyTest {
         table().forEach(row -> reached.add(row.shown()));
         assertEquals(Set.of(Emptiness.SidesShownEmpty.values()), reached,
                 "every way two sides can be shown empty is one some pair of answers shows");
-    }
-
-    /**
-     * And falling on one side of the classification is not being one answer.
-     *
-     * <p>The rows above put {@link Emptiness#NONEMPTY} and {@link Emptiness#UNDECIDED} on the same
-     * side of every pair, which is what the classification says about them and the only thing it
-     * says. Read as the whole of what the two answers are, it would call a reading exact that is
-     * waiting on a decision — so the rows are held beside the word that does tell them apart, and
-     * the nine are not the six a reader who took them for one answer would write.
-     */
-    @Test
-    void andFallingOnOneSideOfItIsNotBeingOneAnswer() {
-        for (Emptiness said : List.of(NONEMPTY, UNDECIDED)) {
-            assertEquals(NEITHER, Emptiness.SidesShownEmpty.of(said, said),
-                    () -> said + " was not shown empty");
-        }
-        assertNotEquals(NONEMPTY.isDecided(), UNDECIDED.isDecided(),
-                "and whether anybody has looked tells the two of them apart, which is the question"
-                        + " this classification is not the answer to");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
@@ -74,7 +74,8 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
      */
     private PlannedValues<String> either(PlannedValues<String> one, PlannedValues<String> other,
                                          boolean apart) {
-        return switch (Emptiness.Alternatives.of(said(one), said(other))) {
+        return switch (Emptiness.Alternatives.from(
+                Emptiness.SidesShownEmpty.of(said(one), said(other)))) {
             case NEITHER_STANDS -> one.bothDead(other);
             case ONLY_THE_RIGHT -> other;
             case ONLY_THE_LEFT -> one;

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -286,7 +286,8 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * one keeps what either branch could not read.
      */
     private static Answer settled(Rule left, Rule right) {
-        return switch (Emptiness.Alternatives.of(said(left), said(right))) {
+        return switch (Emptiness.Alternatives.from(
+                Emptiness.SidesShownEmpty.of(said(left), said(right)))) {
             case NEITHER_STANDS -> new Answer(
                     left.planned().bothDead(right.planned()),
                     Set.of(), Set.of(), true,


### PR DESCRIPTION
Closes #1492.

Which of two answers were shown empty was held in `Emptiness.Alternatives`, whose
constants name the side a choice keeps. A conjunction means the opposite by the
same partition — a conjunct shown empty is what decides and carries its proof,
where an alternative shown empty is what drops — so it could not borrow the word
and compared against the constants instead. That is a reading an answer added to
the three would be given a meaning by without anybody deciding it, which is what
`Emptiness` exists to refuse.

The observation now has a word of its own, `Emptiness.SidesShownEmpty`. It keeps
the sides and values neither of them; which side an answer falls on is
`isEmpty()`, so nothing decides a second time that an undecided answer was not
shown empty. A choice reads it by exchanging the sides, in one place that says it
is an exchange, and reaching `Alternatives` through `from` alone leaves the
classification and the interpretation of it two steps at every call site. A
conjunction keeps the sides and switches over the same word.

A branch's fate over the occurrences of one written choice turned out to read no
sides at all. Those two are one written branch measured twice rather than two
alternatives, so no side there is anything a reader could act on; what it asks is
whether the join came out empty, and it asks it of the answers' own word.

The architecture rule that says who may read the constants loses the exemptions
this question stood in it as, and gains a list of what reads the observation, so
a connective arriving later has to be written into it. The table that states the
rule moves to the word that owns it, the exchange is stated as its own rows
because the laws hold whichever way the sides are named, and both are held
against mutants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)