### PR TITLE
Read a declaration for what it says, apart from where it is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CheckedDeclarations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CheckedDeclarations.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.core.ValueShape;
 import souther.compiler.observe.Composed;
 import souther.compiler.types.Type;
@@ -33,27 +32,30 @@ public final class CheckedDeclarations implements souther.compiler.observe.Decla
         ValueShape of(TypeSymbol.AtModule declared);
     }
 
-    private final Symbols symbols;
+    private final PublishedDeclarations published;
     private final Shapes shapes;
 
-    public CheckedDeclarations(Symbols symbols, Shapes shapes) {
-        if (symbols == null || shapes == null) {
+    public CheckedDeclarations(PublishedDeclarations published, Shapes shapes) {
+        if (published == null || shapes == null) {
             throw new IllegalArgumentException("a checked declaration is what a module wrote and"
-                    + " what the check said about it: " + symbols + " " + shapes);
+                    + " what the check said about it: " + published + " " + shapes);
         }
-        this.symbols = symbols;
+        this.published = published;
         this.shapes = shapes;
     }
 
     @Override
     public Composed of(TypeSymbol.AtModule declared) {
-        return switch (symbols.declaredNode(declared)) {
+        // What the declaration says, and not the tree the module that wrote it holds. Which of the
+        // three it is, is the whole of what is read here, and where it was written is not among the
+        // answers — so a declaration moved in its file leaves every row read against it alone.
+        return switch (published.of(declared.key())) {
             // A module wrote this one and this reading cannot see it. Said as what it is: a
             // declaration out of reach is not a declaration with nothing under it.
             case null -> throw new IllegalStateException("`" + declared + "` is declared by a module"
                     + " and this reading cannot reach what it declares");
-            case Hir.Data _ -> new Composed.OfFields(fieldsOf(declared));
-            case Hir.SumData _, Hir.UnitData _ -> Composed.NOTHING;
+            case DeclarationMeaning.Product _ -> new Composed.OfFields(fieldsOf(declared));
+            case DeclarationMeaning.Sum _, DeclarationMeaning.Unit _ -> Composed.NOTHING;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseMeaning.java
@@ -1,0 +1,44 @@
+package souther.compiler.check;
+
+import java.util.Objects;
+
+/**
+ * One clause of a declaration, as what it states rather than as where it is written.
+ *
+ * <p>What it states is a {@link TermMeaning}, which is the reading a term has when where it stands
+ * is not among the questions it answers. Where the clause is written is
+ * {@link ClauseLocations}'s, asked of the declaration by the reader that puts a caret under it.
+ *
+ * <p><b>Two arms, and they are the two {@link TypedClause} has.</b> A clause the discharge reader
+ * has no form for is not a clause that states nothing: from "this reading has no form for it"
+ * follows that its run-time check is the whole of its enforcement, and from "it states nothing"
+ * follows something about the author's model that is not true. Written as one arm and an empty
+ * reading, the second would be published wherever the first happened.
+ *
+ * <p>What a stopped clause carries is which clause it was, and nothing else. What the reading met is
+ * about the run and not about the model, and two runs over one unedited source that met two limits
+ * would answer with two values that never compare equal — which is what an answer a store keeps may
+ * not be. {@link TypedClause.Stopped} is written the same way and for the same reason.
+ */
+public sealed interface ClauseMeaning permits ClauseMeaning.Stated, ClauseMeaning.Stopped {
+
+    /** Which clause of which declaration this is, and what a sentence calls it. */
+    Clause.Ref ref();
+
+    /** It has a form, and this is what it states. */
+    record Stated(Clause.Ref ref, TermMeaning states) implements ClauseMeaning {
+
+        public Stated {
+            Objects.requireNonNull(ref, "a clause that states something is some clause");
+            Objects.requireNonNull(states, "a clause that has a form states what the form says");
+        }
+    }
+
+    /** The reading has no form for it. */
+    record Stopped(Clause.Ref ref) implements ClauseMeaning {
+
+        public Stopped {
+            Objects.requireNonNull(ref, "a clause with no form is still some clause");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.diag.msg.InvariantMessage;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.msg.TypeMessage;
@@ -459,7 +460,7 @@ public final class DataChecker {
      * nothing about, and it still has everything else about it to report.
      */
     static List<CompileException> typesWithNoValue(
-            UninhabitableTypes.WithNoValue counted, Symbols symbols) {
+            UninhabitableTypes.WithNoValue counted, DeclarationLocations written) {
         // A count that found nothing and no count at all are one empty list of sentences and two
         // different facts. Nothing here needs to tell them apart — what would be written is nothing
         // either way — and the difference is kept because the reader that does need it is the one
@@ -480,12 +481,35 @@ public final class DataChecker {
         }
         List<CompileException> found = new ArrayList<>();
         for (UninhabitableTypes.UninhabitableGroup group : groups) {
-            Hir.Def at = symbols.declaredNode(group.reportedAt());
-            found.add(CompileException.of(told(Diagnostic.at(at.pos()), at.name(),
-                    new Emptiness.AtAField.Where.TheValueItself(), false, group.why(),
-                    lacks.get(group.reportedAt()) == 1).build()));
+            // What the declaration is called is what the identity already says, so nothing is
+            // resolved for it. Where it is written is the one thing the identity cannot answer, and
+            // it is asked of the declarations rather than read off a tree fetched for the name.
+            found.add(CompileException.of(told(pointingAt(group.reportedAt(), written),
+                    group.reportedAt().name(), new Emptiness.AtAField.Where.TheValueItself(), false,
+                    group.why(), lacks.get(group.reportedAt()) == 1).build()));
         }
         return found;
+    }
+
+    /**
+     * A report about {@code declared}, begun where {@code written} says it is.
+     *
+     * <p>Both arms, because they are two answers and not an answer and a failure. A declaration this
+     * compilation holds no text for is still a declaration, and what is said about it is said with
+     * where its code came from instead of with a caret — which is the thing {@code DiagnosticPlace}
+     * is two arms for.
+     */
+    private static Diagnostic.Builder pointingAt(TypeSymbol declared, DeclarationLocations written) {
+        if (!(declared instanceof TypeSymbol.AtModule at)) {
+            throw new IllegalStateException("`" + declared + "` was reported as having no value and"
+                    + " no module declares it, so there is nothing this compilation wrote to point"
+                    + " at");
+        }
+        return switch (written.of(at.key())) {
+            case DiagnosticPlace.InSource in -> Diagnostic.at(in.region());
+            case DiagnosticPlace.Unavailable out ->
+                    Diagnostic.atCodeWrittenOutOfSight(out.provenance());
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationCitations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationCitations.java
@@ -1,0 +1,41 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.types.TypeKey;
+
+/**
+ * Where a declaration's code is written, and where this compilation saw it.
+ *
+ * <p>Not {@link DeclarationLocations}, and not a coarser or finer version of it. That one answers
+ * where a report may send a reader, which is a question with two answers: a stretch of text, or a
+ * note about code nobody here holds. This answers what a {@link Citation} answers — which of the
+ * ways a place can come to be this one is — and a reader that carries a place into an account rather
+ * than into a caret means this. A place nobody settled and a place settled in a text this
+ * compilation does not hold are two of the states here and neither of them is a place to point at,
+ * so the other capability cannot express them at all.
+ *
+ * <p>Both are asked of the one address. One declaration is found once, and these are two questions
+ * put to what was found — which is what the two of them being separate capabilities says, and what a
+ * reader looking a declaration up a second time for its place would not.
+ */
+public interface DeclarationCitations {
+
+    /**
+     * Where {@code declaration}'s code is, as a citation.
+     *
+     * @throws NoSuchDeclarationIsCited where nothing declares it. Two of this compiler's answers
+     *     disagreeing: a reader holding the address got it from something that said a declaration is
+     *     there
+     */
+    Citation of(TypeKey declaration);
+
+    /** Raised where a reader asks where a declaration's code is and nothing declares one. */
+    final class NoSuchDeclarationIsCited extends IllegalStateException {
+
+        private static final long serialVersionUID = 1L;
+
+        public NoSuchDeclarationIsCited(TypeKey declaration) {
+            super("`" + declaration + "` was asked where its code is and nothing declares it");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationLocations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationLocations.java
@@ -1,0 +1,44 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.DiagnosticPlace;
+import souther.compiler.types.TypeKey;
+
+/**
+ * Where a declaration is written, for a reader that is about to point at one.
+ *
+ * <p>Beside {@link PublishedDeclarations} and not inside it, for the reason {@link ClauseLocations}
+ * is beside the clauses: they are two facts about one declaration and a reader uses one of them.
+ * Answered together, an edit that moves a declaration and changes nothing it says is an edit that
+ * changes what every module importing it was told.
+ *
+ * <p>One declaration is found once. What is refused is a reader resolving a name to a declaration
+ * for its meaning and resolving it again for its place — the address is settled first, and these are
+ * two questions asked of that one address.
+ *
+ * <p>The answer is a {@link DiagnosticPlace} and not a position, so what a reader does with a
+ * declaration it cannot send anybody to is decided by reading the two arms rather than by reading a
+ * position and classifying it again. {@link DiagnosticPlace.Unavailable} is one of the answers and
+ * not the absence of one: the declaration is there, and what this compilation does not hold is the
+ * text it was written in.
+ */
+public interface DeclarationLocations {
+
+    /**
+     * Where {@code declaration} is written.
+     *
+     * @throws NoSuchDeclarationIsWritten where nothing declares it. Two of this compiler's answers
+     *     disagreeing: a reader holding the address got it from something that said a declaration is
+     *     there
+     */
+    DiagnosticPlace of(TypeKey declaration);
+
+    /** Raised where a reader asks where a declaration is and nothing declares one. */
+    final class NoSuchDeclarationIsWritten extends IllegalStateException {
+
+        private static final long serialVersionUID = 1L;
+
+        public NoSuchDeclarationIsWritten(TypeKey declaration) {
+            super("`" + declaration + "` was asked where it is written and nothing declares it");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -1,0 +1,189 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * What a declaration says, published for a reader in another module.
+ *
+ * <p>A declaration is already a cut at the module boundary: a reader elsewhere asks for the
+ * declaration it names rather than for the module-wide answer it came from. What that cut carried
+ * until now was the authored tree, and every node of one holds where it was written — so a
+ * declaration moved down its file, saying nothing different, arrived at every module that imports it
+ * as a declaration that had changed. Both facts are real and both have readers; a reader across the
+ * boundary reads one of them, and this is that one.
+ *
+ * <p><b>Not a projection of {@link Normalized.Def}.</b> The normalized declaration is the authored
+ * tree after the constructions in its clauses are written as constructions, and it keeps its
+ * positions because the passes below it walk it and report from it. This is a different thing to
+ * say, not a filtered version of that one: what goes in is what a module reading somebody else's
+ * declaration observes, and a component the tree gains later belongs here only if a reader elsewhere
+ * would mean it. Adding one is publishing something, and adding it here silently is what a mirror
+ * would do.
+ *
+ * <p><b>Which kind it is, is what it says.</b> A reader elsewhere asks whether a declaration is a
+ * product, a sum or a unit far more often than it asks anything else, so the kinds are the sum
+ * rather than a tag beside one field list.
+ *
+ * <p>Where the declaration is written is answered beside this and never from it, the way
+ * {@link ClauseLocations} answers where a clause is: they are two facts about one declaration, and a
+ * reader that needs both asks for both under the one address rather than finding the declaration
+ * twice.
+ */
+public sealed interface DeclarationMeaning {
+
+    /** Which declaration this is — the module that wrote it and the name it was written under. */
+    TypeKey declares();
+
+    /**
+     * What {@code declared} says, read through {@code reading}.
+     *
+     * <p>Exhaustive over the kinds a declaration can be, so a kind added to the language arrives
+     * here as a compile error rather than as one silently published under whichever arm happened to
+     * be last. What each arm leaves out is what says where the declaration stands, and an
+     * architecture test walks the components to hold this to it.
+     *
+     * <p>The reading is handed in rather than made here, because which representation a declaration
+     * is read in is the caller's question and not this one's. What this decides is what a reader
+     * elsewhere is told.
+     */
+    static DeclarationMeaning of(Hir.Def declared, Clauses reading) {
+        // The identity the declaration carries, and not one worked out from what it is called. What
+        // says which declaration this is, is the component every kind of one holds; a key built
+        // from the name and the module beside it would be a second account of the same thing.
+        TypeSymbol.AtModule named = declared.declares();
+        return switch (declared) {
+            case Hir.Data data -> new Product(named.key(), data.newtype(),
+                    fieldsOf(data), referencesTo(data.includes()), clausesOf(named, reading));
+            case Hir.SumData sum -> new Sum(named.key(), referencesTo(sum.cases()));
+            case Hir.UnitData _ -> new Unit(named.key());
+        };
+    }
+
+    /**
+     * The fields written on {@code data}, in the order they are written.
+     *
+     * <p>Its own and not the ones it reaches. What a value of a product is made of is the fields it
+     * spreads followed by the fields it writes, and that closure is a question about this
+     * declaration <i>and</i> the ones it names — so it is asked of those meanings together rather
+     * than settled inside one of them. Flattened in here, what this declaration says would change
+     * when a declaration it spreads gained a field, and the two facts the tree keeps apart would be
+     * one.
+     *
+     * <p>The type is read off the field and nothing else: a field's written type denotes what it
+     * denotes wherever the field is read from.
+     */
+    private static List<Field> fieldsOf(Hir.Data data) {
+        List<Field> fields = new ArrayList<>();
+        for (Hir.Field each : data.fields()) {
+            fields.add(new Field(each.name(), TypeOps.fieldType(each)));
+        }
+        return fields;
+    }
+
+    /**
+     * What {@code named} states, clause by clause.
+     *
+     * <p>In the order the declaration writes them, which is the order a clause is addressed by. Both
+     * arms of the reading are carried: a clause this reading has no form for is a clause whose
+     * run-time check stands, which is a different thing to publish than a clause that states
+     * nothing.
+     */
+    private static List<ClauseMeaning> clausesOf(TypeSymbol.AtModule named, Clauses reading) {
+        List<ClauseMeaning> clauses = new ArrayList<>();
+        for (TypeOps.Declared each : reading.of(named).reached()) {
+            Clause.Ref clause = Clause.Ref.of(each);
+            clauses.add(switch (reading.typed(each.asExpanded(), named)) {
+                case TypedClause.Typed typed ->
+                        new ClauseMeaning.Stated(clause, TermMeaning.of(typed.value()));
+                case TypedClause.Stopped _ -> new ClauseMeaning.Stopped(clause);
+            });
+        }
+        return clauses;
+    }
+
+    /** What a list of names in the tree says, which is which declaration each of them reaches. */
+    private static List<DeclarationReference> referencesTo(List<Hir.Name> names) {
+        List<DeclarationReference> references = new ArrayList<>();
+        for (Hir.Name each : names) {
+            references.add(switch (each) {
+                case Hir.Name.Denoting it -> new DeclarationReference.Named(it.type());
+                case Hir.Name.Unanswered it ->
+                        new DeclarationReference.Unanswered(it.name().canonical());
+            });
+        }
+        return references;
+    }
+
+    /**
+     * A product: what a value of it is made of, and what must hold of one.
+     *
+     * @param fields the fields written on it, in the order they are written — its own, not the ones
+     *     it reaches through what it spreads. See {@link Field} for why the order is here at all
+     * @param includes what it spreads, which may name a declaration or name nothing
+     * @param clauses what must hold of a value of it, in the order the author wrote them. The order
+     *     is what a reader elsewhere is entitled to: a clause is addressed by which of the
+     *     declaration's own it is
+     */
+    record Product(TypeKey declares, boolean newtype, List<Field> fields,
+                   List<DeclarationReference> includes,
+                   List<ClauseMeaning> clauses) implements DeclarationMeaning {
+
+        public Product {
+            Objects.requireNonNull(declares, "a declaration is some declaration");
+            fields = List.copyOf(fields);
+            includes = List.copyOf(includes);
+            clauses = List.copyOf(clauses);
+        }
+    }
+
+    /**
+     * One field of a product: what it is called and what type it is.
+     *
+     * <p>A role and a type, and not the field the author wrote. What a value is read through is the
+     * name; how it was spelled and where is the declaring module's business.
+     *
+     * <p><b>In a list, because the order is something the declaration says.</b> A product's fields
+     * are laid out in the order they are reached — what it spreads first, then what it writes — and
+     * that order is the order of the parameters of the entry a value of it is built through. A
+     * module elsewhere builds one by calling that entry, so two declarations whose fields differ
+     * only in order do not say the same thing to it. Carried in a map, they would: what a map
+     * compares is which name goes to which type, and it says nothing about the order the pairs come
+     * back in.
+     */
+    record Field(String role, Type type) {
+
+        public Field {
+            Objects.requireNonNull(role, "a field is called something");
+            Objects.requireNonNull(type, "a field is of some type");
+        }
+    }
+
+    /** A sum: which declarations a value of it may be one of. */
+    record Sum(TypeKey declares, List<DeclarationReference> cases) implements DeclarationMeaning {
+
+        public Sum {
+            Objects.requireNonNull(declares, "a declaration is some declaration");
+            cases = List.copyOf(cases);
+        }
+    }
+
+    /**
+     * A unit: a declaration with nothing in it.
+     *
+     * <p>Which is why it carries only its address. There is one value of it, and what a reader
+     * elsewhere means by it is that this declaration is the one it is.
+     */
+    record Unit(TypeKey declares) implements DeclarationMeaning {
+
+        public Unit {
+            Objects.requireNonNull(declares, "a declaration is some declaration");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -42,16 +42,26 @@ public sealed interface DeclarationMeaning {
     TypeKey declares();
 
     /**
-     * What {@code declared} says, read through {@code reading}.
+     * What {@code declared} says, read as {@code source} reads a module's declarations.
+     *
+     * <p>The way in for a caller outside this package, which is every caller that has a compilation
+     * rather than a reading of one. What a reading is made of stays here: a caller that assembled
+     * one would be choosing which representation a declaration is published in, and that is settled
+     * by which module wrote it and not by who is asking.
+     */
+    public static DeclarationMeaning of(Hir.Def declared, RuleReadingSource source,
+                                        DeclarationReadings machines) {
+        return of(declared, new Clauses(source.symbols(), source.invariants(), source.written(),
+                machines));
+    }
+
+    /**
+     * The same, over a reading already made.
      *
      * <p>Exhaustive over the kinds a declaration can be, so a kind added to the language arrives
      * here as a compile error rather than as one silently published under whichever arm happened to
      * be last. What each arm leaves out is what says where the declaration stands, and an
      * architecture test walks the components to hold this to it.
-     *
-     * <p>The reading is handed in rather than made here, because which representation a declaration
-     * is read in is the caller's question and not this one's. What this decides is what a reader
-     * elsewhere is told.
      */
     static DeclarationMeaning of(Hir.Def declared, Clauses reading) {
         // The identity the declaration carries, and not one worked out from what it is called. What

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -56,6 +56,35 @@ public sealed interface DeclarationMeaning {
     }
 
     /**
+     * What the language itself declares says.
+     *
+     * <p>A second way in, and it is one because there is no reading to make. A reading of a
+     * declaration's clauses is made over the scope of the module that wrote it, and no module of a
+     * compilation writes what the language declares — asked for one, a compilation answers that it
+     * holds no such module, which is true and is not a reason to have nothing to say about the
+     * declaration.
+     *
+     * <p>Nothing is lost by having none. What the library declares is a sum or a unit, and neither
+     * of them says anything a reading answers: a sum names its cases and a unit names itself.
+     *
+     * @throws IllegalStateException where the language declares a product. It would have clauses to
+     *     be read, and the reading they would be read in is the thing there is none of. The library
+     *     declares none today, and one written tomorrow is a fault in this compiler rather than
+     *     something to publish half of
+     */
+    public static DeclarationMeaning ofLanguage(Hir.Def declared) {
+        TypeSymbol.AtModule named = declared.declares();
+        return switch (declared) {
+            case Hir.SumData sum -> new Sum(named.key(), referencesTo(sum.cases()));
+            case Hir.UnitData _ -> new Unit(named.key());
+            case Hir.Data _ -> throw new IllegalStateException(
+                    "the standard library declares the product `" + named.key() + "`, whose clauses"
+                            + " are read in a reading of the module that wrote it, and no module of"
+                            + " a compilation writes what the language declares");
+        };
+    }
+
+    /**
      * The same, over a reading already made.
      *
      * <p>Exhaustive over the kinds a declaration can be, so a kind added to the language arrives
@@ -108,6 +137,12 @@ public sealed interface DeclarationMeaning {
     private static List<ClauseMeaning> clausesOf(TypeSymbol.AtModule named, Clauses reading) {
         List<ClauseMeaning> clauses = new ArrayList<>();
         for (TypeOps.Declared each : reading.of(named).reached()) {
+            if (!each.declaredOn().equals(named)) {
+                // Written on a declaration this one spreads, and that one publishes it. Carried
+                // here as well, what this declaration says would change when another was given a
+                // rule it says nothing about — which is what asking for one is for.
+                continue;
+            }
             Clause.Ref clause = Clause.Ref.of(each);
             clauses.add(switch (reading.typed(each.asExpanded(), named)) {
                 case TypedClause.Typed typed ->
@@ -137,9 +172,10 @@ public sealed interface DeclarationMeaning {
      * @param fields the fields written on it, in the order they are written — its own, not the ones
      *     it reaches through what it spreads. See {@link Field} for why the order is here at all
      * @param includes what it spreads, which may name a declaration or name nothing
-     * @param clauses what must hold of a value of it, in the order the author wrote them. The order
-     *     is what a reader elsewhere is entitled to: a clause is addressed by which of the
-     *     declaration's own it is
+     * @param clauses the clauses written on it, in the order they are written — its own, and not
+     *     the ones it reaches through what it spreads, for the reason {@code fields} is its own. The
+     *     order is what a reader elsewhere is entitled to: a clause is addressed by which of the
+     *     declaration's own it is, so an order is what makes that address mean something
      */
     record Product(TypeKey declares, boolean newtype, List<Field> fields,
                    List<DeclarationReference> includes,

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -13,11 +13,11 @@ import java.util.Objects;
  * What a declaration says, published for a reader in another module.
  *
  * <p>A declaration is already a cut at the module boundary: a reader elsewhere asks for the
- * declaration it names rather than for the module-wide answer it came from. What that cut carried
- * until now was the authored tree, and every node of one holds where it was written — so a
- * declaration moved down its file, saying nothing different, arrived at every module that imports it
- * as a declaration that had changed. Both facts are real and both have readers; a reader across the
- * boundary reads one of them, and this is that one.
+ * declaration it names rather than for the module-wide answer it came from. What it says and where
+ * it is written are two facts about it, both real and each with readers of its own, and a reader
+ * across the boundary means the first. Carried across as the authored tree, the second goes with it
+ * — every node of one holds where it was written, so a declaration moved down its file says nothing
+ * different and arrives as a declaration that changed.
  *
  * <p><b>Not a projection of {@link Normalized.Def}.</b> The normalized declaration is the authored
  * tree after the constructions in its clauses are written as constructions, and it keeps its

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReference.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReference.java
@@ -1,0 +1,56 @@
+package souther.compiler.check;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.util.Objects;
+
+/**
+ * A declaration named by another declaration, as what the naming says rather than as how it was
+ * written.
+ *
+ * <p>What a spread or a case is, once where it was written is somebody else's question. A name in
+ * the tree carries the spelling the author reached it by, which module reached it, and where every
+ * segment of it sits; none of that is what the declaration says about itself, and all of it moves
+ * when a line above the declaration is written.
+ *
+ * <p><b>Two arms, because a name that reaches nothing is a state of the model and not a missing
+ * answer.</b> Name resolution reports what it could not reach and carries on, so a declaration
+ * spreading a name nothing declares is a declaration this compiler has read and has something to say
+ * about. Collapsed into an absence, two declarations spreading two different names that reach
+ * nothing would say the same thing — and what one of them is short of is not what the other is.
+ */
+public sealed interface DeclarationReference {
+
+    /**
+     * It names a declaration, and this is which.
+     *
+     * <p>The identity and not the spelling. Two modules reach one declaration under two spellings
+     * and are naming one thing, which is what an identity says and what a spelling cannot.
+     *
+     * <p>A {@link TypeSymbol} and not a {@link souther.compiler.types.TypeKey}, because a case may
+     * name a declaration no module of this compilation wrote — the language declares some, and
+     * those have no module to be addressed in. Every arm of the identity is a closed set of what
+     * was declared, and none of them holds where anything was written.
+     */
+    record Named(TypeSymbol declaration) implements DeclarationReference {
+
+        public Named {
+            Objects.requireNonNull(declaration, "a reference that names a declaration says which");
+        }
+    }
+
+    /**
+     * It names nothing this compilation declares, and this is the name it was written under.
+     *
+     * <p>The canonical name, which is what a declaration says here: spreading one name that reaches
+     * nothing is not spreading another. Not the spelling — a name and its casing are one name, and
+     * how a name was spelled is where the declaration stands rather than what it says.
+     */
+    record Unanswered(String name) implements DeclarationReference {
+
+        public Unanswered {
+            Objects.requireNonNull(name, "a reference that names nothing was still written as"
+                    + " something");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Citation;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.LinkedHashMap;
@@ -21,10 +22,13 @@ import java.util.Map;
  * so a coordinate that travelled here with a measurement would be one frame of several and nothing
  * would say which. Read from the declaration, there is one frame and it is the author's.
  *
- * <p>Where the declaration is written is read here too, because a report sends a reader to it and
- * a caller that looked it up separately would have a second way of finding one declaration — and a
- * policy of its own for the one that came back empty, which is a null place reaching a reader as a
- * switch over the arms a citation has.
+ * <p>Where the declaration's code is, is read here too, because a report carries it and a caller
+ * that found the declaration a second time to get it would have two ways of finding one — and a
+ * policy of its own for the one that came back empty. That is a rule about how a declaration is
+ * found, and not about what may be asked of it once it has been: the address is settled first, and
+ * what the declaration says and where its code is are two questions put to that one address. What
+ * comes back for a name nothing declares is then one answer and not two, because there was one
+ * lookup.
  *
  * <p>Nothing here is an identity. What tells one authored line from another is the clause and which
  * of its conjuncts drew the end ({@link souther.compiler.partition.AuthoredLine}), and that is what
@@ -59,17 +63,22 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
      * author's. One of these serves every debt of one declaration, so a caller printing a report
      * asks once per declaration rather than once per line.
      */
-    public static DeclaredBorders of(TypeSymbol declaredOn, RuleReadingSource source,
+    public static DeclaredBorders of(TypeSymbol declaredOn, PublishedDeclarations declarations,
+                                     DeclarationCitations citations, RuleReadingSource source,
                                      ReadingPolicy policy) {
-        // Where the declaration is, read here with what it draws. A caller that asked one thing for
-        // the name and another for the place would have two ways of finding one declaration, and a
-        // policy of its own for the one that came back empty.
-        if (!(source.symbols().declaredNode(declaredOn) instanceof souther.compiler.ast.Hir.Data
-                data)) {
+        // One address, and two questions put to it. What kind of declaration this is decides whether
+        // there are lines to read at all; where its code is decides what a report calls the place.
+        // Neither is looked up by the name a second time, which is what would give one declaration
+        // two ways of being found and each of them a policy for coming back empty.
+        if (!(declaredOn instanceof TypeSymbol.AtModule named)) {
             throw new IllegalArgumentException(
                     "there is no declaration of " + declaredOn.name() + " to read");
         }
-        souther.compiler.diag.Citation at = souther.compiler.diag.Citation.of(data.pos());
+        if (!(declarations.of(named.key()) instanceof DeclarationMeaning.Product)) {
+            throw new IllegalArgumentException(
+                    "there is no declaration of " + declaredOn.name() + " to read");
+        }
+        Citation at = citations.of(named.key());
         Map<Key, NumberAt<RuleKey>> forms = new LinkedHashMap<>();
         for (FieldDomains.Placed placed : Rules.of(declaredOn, source, policy).bounds().placed()) {
             // A clause reaching this declaration through a spread is written on another one and is

--- a/souther-compiler/src/main/java/souther/compiler/check/PublishedDeclarations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PublishedDeclarations.java
@@ -1,0 +1,23 @@
+package souther.compiler.check;
+
+import souther.compiler.types.TypeKey;
+
+/**
+ * Where what a declaration says is answered from, for a reader that means only that.
+ *
+ * <p>A capability and not a table, for the reason {@link ClauseLocations} is one: which declarations
+ * a reader asks about is settled by what it reads, so a reader that asks about one depends on that
+ * one and a reader that asks about none depends on nothing. Handed the answers instead, every reader
+ * would depend on every declaration any of them named.
+ *
+ * <p><b>Beside {@link Symbols} and not inside it.</b> A carrier of symbols answers what a
+ * declaration is in the form that carrier reads declarations in, and answering the same question in
+ * two forms is what that interface exists to refuse. This is not that question asked again: where a
+ * declaration is written and what it is made of are things the tree has and this does not, and a
+ * reader holding one of these is holding what a module elsewhere observes.
+ */
+public interface PublishedDeclarations {
+
+    /** What {@code declaration} says, or null where nothing declares it. */
+    DeclarationMeaning of(TypeKey declaration);
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -77,6 +77,7 @@ public final class TypeChecker {
      */
     public static Reported checkModule(Hir.Module module, DerivedSymbols symbols,
                                        UninhabitableTypes.WithNoValue withNoValue,
+                                       DeclarationLocations declaredAt,
                                        ReadingPolicy policy,
                                        Map<String, Sig> sigs,
                                        Set<ValueName.Behavior> importedInjected,
@@ -91,7 +92,7 @@ public final class TypeChecker {
         List<CompileException> errors = new ArrayList<>();
         boolean stopped = false;
         try {
-            checkRecovering(module, symbols, withNoValue, policy, sigs, importedInjected,
+            checkRecovering(module, symbols, withNoValue, declaredAt, policy, sigs, importedInjected,
                     importedUnwritten,
                     lowered, calleeSigs, errors,
                     elaborated, abandoned, reqSigs, recursiveHelperFns, imported, settled, shapes);
@@ -206,6 +207,7 @@ public final class TypeChecker {
      */
     static void checkRecovering(Hir.Module module, DerivedSymbols symbols,
                                         UninhabitableTypes.WithNoValue withNoValue,
+                                        DeclarationLocations declaredAt,
                                        ReadingPolicy policy,
                                         Map<String, Sig> sigs,
                                        Set<ValueName.Behavior> importedInjected,
@@ -340,7 +342,7 @@ public final class TypeChecker {
         if (errors.isEmpty() && everyClauseWasRead(module, settled, shapes)) {
             List<CompileException> said = new ArrayList<>();
             collect(errors, abandoned,
-                    () -> said.addAll(DataChecker.typesWithNoValue(withNoValue, symbols)));
+                    () -> said.addAll(DataChecker.typesWithNoValue(withNoValue, declaredAt)));
             errors.addAll(said);
         }
         Map<String, Hir.FnDef> fns = new HashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -21,6 +21,8 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
+import souther.compiler.check.DeclarationCitations;
+import souther.compiler.check.PublishedDeclarations;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.CheckSurface;
@@ -1789,7 +1791,8 @@ public final class Adequacy {
             }
             resolved.put(debt.point(), new BorderAccount.Answer(debt,
                     debt.id().owedToTheDeclaration().isPresent()
-                            ? axisOf(debt.id(), declarations, ruleReading, policy) : null,
+                            ? axisOf(debt.id(), declarations, Shapes.publishedDeclarations(db),
+                                    Shapes.declarationCitations(db), ruleReading, policy) : null,
                     PointResolver.resolveAt(debt.owed(), List.copyOf(debt.met().keySet()),
                             reading -> readingOf(db, module, scope, debt, debt.at(), reading))));
         }
@@ -4315,7 +4318,8 @@ public final class Adequacy {
                     continue;
                 }
                 out.add(new DeclaredDebt(debt,
-                        axisOf(debt.id(), declarations, reading, policy), owners));
+                        axisOf(debt.id(), declarations, Shapes.publishedDeclarations(db),
+                                Shapes.declarationCitations(db), reading, policy), owners));
             }
             return Answer.of(new DeclaredBoundaries(out, went));
         }
@@ -4337,12 +4341,13 @@ public final class Adequacy {
      */
     private static String axisOf(souther.compiler.partition.BorderObligationId id,
                                  Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
+                                 PublishedDeclarations published, DeclarationCitations citations,
                                  RuleReadingSource reading,
                                  souther.compiler.check.ReadingPolicy policy) {
         TypeSymbol declaredOn = id.owedToTheDeclaration().orElseThrow(
                 () -> new IllegalStateException("what a line with no declaration is on is not"
                         + " something anybody wrote: " + id));
-        String named = declarationRead(read, declaredOn, reading, policy)
+        String named = declarationRead(read, declaredOn, published, citations, reading, policy)
                 // Which line of the declaration this is, asked of the rule. Taken apart
                 // here, a reader would be deciding which rules have a clause and a
                 // conjunct, which is the rule's own answer.
@@ -4356,9 +4361,10 @@ public final class Adequacy {
      *  clauses have ends, and each of them would otherwise read the declaration again. */
     private static souther.compiler.check.DeclaredBorders declarationRead(
             Map<TypeSymbol, souther.compiler.check.DeclaredBorders> kept, TypeSymbol declaredOn,
+            PublishedDeclarations published, DeclarationCitations citations,
             RuleReadingSource reading, souther.compiler.check.ReadingPolicy policy) {
-        return kept.computeIfAbsent(declaredOn,
-                each -> souther.compiler.check.DeclaredBorders.of(each, reading, policy));
+        return kept.computeIfAbsent(declaredOn, each -> souther.compiler.check.DeclaredBorders
+                .of(each, published, citations, reading, policy));
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -2180,7 +2180,8 @@ public final class Bodies {
                     }
                 }
                 reported = TypeChecker.checkModule(lowering.value().settled(), scope.value(),
-                        withNoValue.value(), db.ask(new Front.Reading()).value(),
+                        withNoValue.value(), Shapes.declarationLocations(db),
+                        db.ask(new Front.Reading()).value(),
                         signatures.present() ? signatures.value() : null,
                         injected.value(), unwritten.value(), lowering.value().lowered(),
                         reqSigs.value(), calleeSigs.value(), sigs.value(), published.value(),

--- a/souther-compiler/src/main/java/souther/compiler/query/ExampleExecutions.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ExampleExecutions.java
@@ -7,7 +7,6 @@ import souther.compiler.check.CheckedEnsures;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.DerivedSymbols;
-import souther.compiler.check.Symbols;
 import souther.compiler.core.Contract;
 import souther.compiler.core.ValueShape;
 import souther.compiler.execute.ExampleExecution;
@@ -94,7 +93,7 @@ public final class ExampleExecutions {
         // reaches none by name, which is a module rather than an unanswered question.
         Map<String, Hir.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
         return new ExampleExecution(prepared.value(), scope.value(),
-                checkedFieldTypes(db, scope.value()), sigs.value(),
+                checkedFieldTypes(db), sigs.value(),
                 requirements, values == null ? Map.of() : values, contracts,
                 Output.policyOf(db),
                 withDeclaring ? declaringOf(db, prepared.value()) : Map.of());
@@ -115,8 +114,8 @@ public final class ExampleExecutions {
      * module's shapes say what a value of it is made of. So there is no order in which one module's
      * declarations are tried before another's, and nothing is gathered into a table beforehand.
      */
-    private static FieldTypes checkedFieldTypes(Db db, Symbols symbols) {
-        return FieldTypes.over(new CheckedDeclarations(symbols, declared -> {
+    private static FieldTypes checkedFieldTypes(Db db) {
+        return FieldTypes.over(new CheckedDeclarations(Shapes.publishedDeclarations(db), declared -> {
             Map<TypeSymbol.AtModule, ValueShape> shapes =
                     db.ask(new Shapes.ValueShapes(declared.module())).value();
             return shapes == null ? null : shapes.get(declared);

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.ClauseLocations;
+import souther.compiler.check.DeclarationLocations;
 import souther.compiler.check.DeclarationMeaning;
 import souther.compiler.check.PublishedDeclarations;
 import souther.compiler.check.ExpandedClauseLookup;
@@ -23,6 +24,7 @@ import souther.compiler.check.ResolvedSymbols;
 import souther.compiler.core.ValueShape;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.DiagnosticPlace;
+import souther.compiler.diag.Region;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -801,6 +803,53 @@ public final class Shapes {
             return at instanceof DiagnosticPlace.Unavailable out
                     ? new DiagnosticPlace.Unavailable(out.provenance().asDeclared()) : at;
         }
+    }
+
+    /**
+     * Where one declaration is written.
+     *
+     * <p>Beside {@link MeaningOf} and not inside it, the way {@link ClauseLocation} is beside the
+     * clauses. What a declaration says is what every reading of a module that imports it is built
+     * on; where it is written is what one sentence puts a caret under. Answered together, an edit
+     * that moves a declaration and changes nothing it says is an edit that changes what the model
+     * says, and every module that imports it is worked out again for it.
+     *
+     * <p>Read off the declaration as resolution left it, which is the answer that carries positions
+     * and moves when they do. Asked of the normalized one instead, this would keep the place the
+     * declaration used to be at for as long as what it says stayed the same — which is the stale
+     * report the cut beside it would otherwise have caused.
+     *
+     * <p>The place and not the position: whether a reader can be sent here is settled once, here,
+     * rather than by every reader that holds a position and works it out again.
+     */
+    public record DeclarationLocation(TypeKey named) implements Key<DiagnosticPlace> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<DiagnosticPlace> compute(Db db) {
+            Hir.Def declared = ClausesExpandedFor.declarationOf(db, named);
+            return declared == null ? Answer.absent()
+                    : Answer.of(DiagnosticPlace.of(Region.point(declared.pos())));
+        }
+    }
+
+    /**
+     * Where any declaration is written, for a reader that is about to point at one.
+     *
+     * <p>One of these for the whole compilation, for the reason {@link #expandedClauses} gives:
+     * which declaration is being asked about is the only input there is.
+     */
+    public static DeclarationLocations declarationLocations(Db db) {
+        return declaration -> {
+            Answer<DiagnosticPlace> written = db.ask(new DeclarationLocation(declaration));
+            if (!written.present()) {
+                throw new DeclarationLocations.NoSuchDeclarationIsWritten(declaration);
+            }
+            return written.value();
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -6,7 +6,9 @@ import souther.compiler.check.ClauseLocations;
 import souther.compiler.check.DeclarationCitations;
 import souther.compiler.check.DeclarationLocations;
 import souther.compiler.check.DeclarationMeaning;
+import souther.compiler.check.Normalized;
 import souther.compiler.check.PublishedDeclarations;
+import souther.compiler.stdlib.Stdlib;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.ExpandedClauseResult;
 import souther.compiler.check.ExpandedClauses;
@@ -286,11 +288,11 @@ public final class Shapes {
         /** The declaration {@code named} is, as the settling left it, or null where nothing
          *  declares it. */
         private static Hir.Def normalizedDeclarationOf(Db db, TypeKey named) {
-            Answer<souther.compiler.check.Normalized.Def> mine = db.ask(new NormalizedDef(named));
+            Answer<Normalized.Def> mine = db.ask(new NormalizedDef(named));
             if (mine.present()) {
                 return mine.value().node();
             }
-            Answer<souther.compiler.stdlib.Stdlib> library = db.ask(new Front.Library());
+            Answer<Stdlib> library = db.ask(new Front.Library());
             return library.present() ? library.value().languageDeclaration(named) : null;
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.ClauseLocations;
+import souther.compiler.check.DeclarationMeaning;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.ExpandedClauseResult;
 import souther.compiler.check.ExpandedClauses;
@@ -243,6 +244,49 @@ public final class Shapes {
             }
             souther.compiler.check.Normalized.Def def = defs.value().get(named.name());
             return def == null ? Answer.absent() : Answer.of(def);
+        }
+    }
+
+    /**
+     * What one declaration says, for a reader in another module.
+     *
+     * <p>The cut the module boundary is made at. {@link NormalizedDef} is the declaration as the
+     * passes below the settling walk it, positions and all, because those passes report from it;
+     * this is what the declaration says, and a reader that means only that stops here. An edit that
+     * moves a declaration without changing what it states remakes this and comes out equal, so
+     * nothing that read it is looked at again.
+     *
+     * <p><b>Answered by the module that wrote the declaration.</b> The reading is made over that
+     * module's scope rather than the asking module's, so two modules asking about one declaration
+     * are asking one question — which is what an answer keyed by a declaration has to be, and what
+     * {@code WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest} holds the reading to.
+     *
+     * <p>Absent where nothing declares it. A declaration the language declares is answered for like
+     * any other: it is normal as it stands, having no construction in its clauses left to write out.
+     */
+    public record MeaningOf(TypeKey named) implements Key<DeclarationMeaning> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<DeclarationMeaning> compute(Db db) {
+            Hir.Def declared = normalizedDeclarationOf(db, named);
+            return declared == null ? Answer.absent()
+                    : Answer.of(DeclarationMeaning.of(declared,
+                            db.ruleReadingFor(named.module()), db.readings()));
+        }
+
+        /** The declaration {@code named} is, as the settling left it, or null where nothing
+         *  declares it. */
+        private static Hir.Def normalizedDeclarationOf(Db db, TypeKey named) {
+            Answer<souther.compiler.check.Normalized.Def> mine = db.ask(new NormalizedDef(named));
+            if (mine.present()) {
+                return mine.value().node();
+            }
+            Answer<souther.compiler.stdlib.Stdlib> library = db.ask(new Front.Library());
+            return library.present() ? library.value().languageDeclaration(named) : null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.ClauseLocations;
 import souther.compiler.check.DeclarationMeaning;
+import souther.compiler.check.PublishedDeclarations;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.ExpandedClauseResult;
 import souther.compiler.check.ExpandedClauses;
@@ -800,6 +801,21 @@ public final class Shapes {
             return at instanceof DiagnosticPlace.Unavailable out
                     ? new DiagnosticPlace.Unavailable(out.provenance().asDeclared()) : at;
         }
+    }
+
+    /**
+     * What any declaration says, for a reader in another module.
+     *
+     * <p>One of these for the whole compilation, for the reason {@link #expandedClauses} gives:
+     * which declaration is being asked about is the only input there is. What a reader that takes
+     * one depends on is the declarations it asks about, so a reader asking about none depends on
+     * nothing.
+     */
+    public static PublishedDeclarations publishedDeclarations(Db db) {
+        return declaration -> {
+            Answer<DeclarationMeaning> said = db.ask(new MeaningOf(declaration));
+            return said.present() ? said.value() : null;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.ClauseLocations;
+import souther.compiler.check.DeclarationCitations;
 import souther.compiler.check.DeclarationLocations;
 import souther.compiler.check.DeclarationMeaning;
 import souther.compiler.check.PublishedDeclarations;
@@ -22,6 +23,7 @@ import souther.compiler.check.InvariantChecker;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.ResolvedSymbols;
 import souther.compiler.core.ValueShape;
+import souther.compiler.diag.Citation;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.diag.Region;
@@ -834,6 +836,46 @@ public final class Shapes {
             return declared == null ? Answer.absent()
                     : Answer.of(DiagnosticPlace.of(Region.point(declared.pos())));
         }
+    }
+
+    /**
+     * Where one declaration's code is written, as a citation.
+     *
+     * <p>Beside {@link DeclarationLocation} rather than under it. That one says whether a report may
+     * send a reader here; this says which of the ways a place comes to be this one is, and two of
+     * those — a place nobody settled, and one settled in a text this compilation does not hold —
+     * have no place to point at and so cannot be said there at all. A reader carrying a place into
+     * an account means this one.
+     *
+     * <p>Read off the declaration as resolution left it, for the reason {@link DeclarationLocation}
+     * gives: it is the answer that carries positions and moves when they do.
+     */
+    public record DeclarationCitation(TypeKey named) implements Key<Citation> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<Citation> compute(Db db) {
+            Hir.Def declared = ClausesExpandedFor.declarationOf(db, named);
+            return declared == null ? Answer.absent() : Answer.of(Citation.of(declared.pos()));
+        }
+    }
+
+    /**
+     * Where any declaration's code is, for a reader carrying a place into an account.
+     *
+     * <p>One of these for the whole compilation, for the reason {@link #expandedClauses} gives.
+     */
+    public static DeclarationCitations declarationCitations(Db db) {
+        return declaration -> {
+            Answer<Citation> cited = db.ask(new DeclarationCitation(declaration));
+            if (!cited.present()) {
+                throw new DeclarationCitations.NoSuchDeclarationIsCited(declaration);
+            }
+            return cited.value();
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -279,21 +279,20 @@ public final class Shapes {
 
         @Override
         public Answer<DeclarationMeaning> compute(Db db) {
-            Hir.Def declared = normalizedDeclarationOf(db, named);
-            return declared == null ? Answer.absent()
-                    : Answer.of(DeclarationMeaning.of(declared,
-                            db.ruleReadingFor(named.module()), db.readings()));
-        }
-
-        /** The declaration {@code named} is, as the settling left it, or null where nothing
-         *  declares it. */
-        private static Hir.Def normalizedDeclarationOf(Db db, TypeKey named) {
+            // Which of the two answered decides how the meaning is read, and not only which
+            // declaration came back. A module's own is read in that module's reading of its
+            // declarations; what the language declares is written in no module a compilation holds,
+            // so there is no such reading to make and nothing it would answer.
             Answer<Normalized.Def> mine = db.ask(new NormalizedDef(named));
             if (mine.present()) {
-                return mine.value().node();
+                return Answer.of(DeclarationMeaning.of(mine.value().node(),
+                        db.ruleReadingFor(named.module()), db.readings()));
             }
             Answer<Stdlib> library = db.ask(new Front.Library());
-            return library.present() ? library.value().languageDeclaration(named) : null;
+            Hir.Def declared =
+                    library.present() ? library.value().languageDeclaration(named) : null;
+            return declared == null ? Answer.absent()
+                    : Answer.of(DeclarationMeaning.ofLanguage(declared));
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
@@ -94,7 +94,8 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
     @Test
     void andAProductWithNoSettledShapeIsRefusedRatherThanAnsweredEmpty() {
         FieldTypes nothingSettled =
-                FieldTypes.over(new CheckedDeclarations(symbols, _ -> null));
+                FieldTypes.over(new CheckedDeclarations(
+                        Shapes.publishedDeclarations(compilation.db()), _ -> null));
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> nothingSettled.of(orderOf()));
         assertTrue(refused.getMessage().contains("Order"),

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Front;
+import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
@@ -169,6 +170,8 @@ class ALineIsNamedInTheTermsItWasWrittenInTest {
         String module = compilation.modules().get(0);
         ReadingPolicy policy = compilation.db().ask(new Front.Reading()).value();
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.forms", name));
-        return DeclaredBorders.of(named, RuleReadings.of(compilation, module), policy);
+        return DeclaredBorders.of(named, Shapes.publishedDeclarations(compilation.db()),
+                Shapes.declarationCitations(compilation.db()),
+                RuleReadings.of(compilation, module), policy);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
@@ -1,0 +1,275 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.ast.WrittenName;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.reflect.RecordComponent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What a published declaration says is everything the declaration says, and none of where it stands.
+ *
+ * <p>Two things {@link DeclarationMeaning} has to be, and only one of them is what #1472 was about.
+ * A meaning that read where a declaration stands makes a module that imports it depend on an edit it
+ * cannot see. A meaning that left out something the declaration says makes two declarations that say
+ * different things one dependency, and the store then stops the work of everything that read the one
+ * it kept — which is the worse of the two, and the one a check written only about what a meaning
+ * ignores would never fail on.
+ *
+ * <p><b>The population is the components, as the records declare them.</b> The switch being over a
+ * sealed type says a kind added later arrives as a compile error; it says nothing about a component
+ * added to a kind that is already there. So each component is asked which of the two it is, and a
+ * component that is neither — or that is new and nobody classified — fails here rather than being
+ * quietly left out of what a module elsewhere is told.
+ *
+ * <p><b>A component whose type is a written name is neither.</b> {@link WrittenName} holds what a
+ * name is (its canonical form) beside how and where it was spelled, so a rule that admitted the type
+ * would publish the spelling and one that refused it would drop the name. Those are read through
+ * {@link #SAYS_THROUGH}, and what the producer may call on a {@code WrittenName} is held separately.
+ *
+ * <p>Read off the compiled producer rather than off its text: which accessors it calls is what the
+ * class file says, and reading the source would be answering the same question a second way.
+ */
+class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
+
+    /** What a component of this type says is where the declaration stands, and not what it says. */
+    private static final Set<Class<?>> WHERE_IT_STANDS = Set.of(SourcePos.class, Region.class);
+
+    /** What a component of this type says is both, and is read through one accessor. */
+    private static final Set<Class<?>> BOTH = Set.of(WrittenName.class);
+
+    /**
+     * The one thing a producer may ask a written name.
+     *
+     * <p>A name and its casing are one name, which is what canonical means. Everything else a
+     * written name holds — the spelling the author used, the stretches it was written over, the
+     * place a synthesized one is anchored at — says where the declaration stands.
+     */
+    private static final Set<String> WHAT_A_NAME_MAY_BE_ASKED = Set.of("canonical");
+
+    /**
+     * A component read by an accessor of its own rather than by the one the record generates.
+     *
+     * <p>Each is here because the component is a written name and only its canonical half is
+     * published: {@code Hir.Field.name()} is that field's {@code written().canonical()}, and asking
+     * it is asking the name without asking where it was written.
+     */
+    private static final Map<String, String> SAYS_THROUGH = Map.of("Field.written", "Field.name");
+
+    /**
+     * A component this producer does not read, and what says the same thing instead.
+     *
+     * <p>Written down rather than left out, so that a component going unread for any other reason is
+     * a failure here and not a habit. Two reasons appear, and they are different reasons. One is
+     * that something else publishes it: the clauses go out as {@link ClauseMeaning}, a field's type
+     * as the type it denotes. The other is that a second component of the same record already says
+     * it — a declaration's identity carries the name it was declared under, and a reference's
+     * identity carries which declaration it reaches, so the written name beside either adds only how
+     * that name was spelled and where.
+     */
+    private static final Map<String, String> READ_ELSEWHERE = Map.of(
+            "Data.invariants", "the clause reading, published as ClauseMeaning and audited by"
+                    + " AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest",
+            "Field.type", "TypeOps.fieldType, which answers the type the written type denotes",
+            "Data.written", "declares, the identity minted where this representation was built,"
+                    + " which carries the name the declaration was written under",
+            "SumData.written", "declares, as above",
+            "UnitData.written", "declares, as above",
+            "Denoting.name", "type, which says which declaration the reference reaches. Two modules"
+                    + " reaching one declaration under two spellings name one thing");
+
+    /** The records a published declaration is read off: every kind of one, and the two it holds. */
+    private static List<Class<?>> walked() {
+        List<Class<?>> out = new ArrayList<>(List.of(Hir.Def.class.getPermittedSubclasses()));
+        out.add(Hir.Field.class);
+        out.add(Hir.Name.Denoting.class);
+        out.add(Hir.Name.Unanswered.class);
+        return out;
+    }
+
+    @Test
+    void everythingADeclarationSaysIsRead() throws IOException {
+        Set<String> called = componentsReadByTheProducer();
+        Set<String> unread = new TreeSet<>();
+        for (Class<?> kind : walked()) {
+            for (RecordComponent component : kind.getRecordComponents()) {
+                String named = name(kind, component);
+                if (WHERE_IT_STANDS.contains(component.getType()) || READ_ELSEWHERE.containsKey(named)) {
+                    continue;
+                }
+                if (!called.contains(named) && !called.contains(SAYS_THROUGH.get(named))) {
+                    unread.add(named);
+                }
+            }
+        }
+
+        assertEquals(Set.of(), unread,
+                "a declaration saying this differently is a declaration published the same, and"
+                        + " every module that imported the one the store kept goes on holding it");
+    }
+
+    @Test
+    void andNothingOfWhereItStandsIs() throws IOException {
+        Set<String> called = componentsReadByTheProducer();
+        Set<String> read = new TreeSet<>();
+        for (Class<?> kind : walked()) {
+            for (RecordComponent component : kind.getRecordComponents()) {
+                if (WHERE_IT_STANDS.contains(component.getType())
+                        && called.contains(name(kind, component))) {
+                    read.add(name(kind, component));
+                }
+            }
+        }
+
+        assertEquals(Set.of(), read,
+                "a module importing a declaration published from this is one a blank line written"
+                        + " above the declaration reaches");
+    }
+
+    /**
+     * And of a name that says two things, only what it says is asked.
+     *
+     * <p>The rule above is by component type and this one cannot be: a written name is read, so what
+     * holds the spelling out of the answer is which of its own components the producer asks for.
+     */
+    @Test
+    void andOfANameOnlyWhatItIsCalledIsAsked() throws IOException {
+        Set<String> asked = new TreeSet<>(methodsCalledOn("souther/compiler/ast/WrittenName"));
+        asked.removeAll(WHAT_A_NAME_MAY_BE_ASKED);
+
+        assertEquals(Set.of(), asked,
+                "what a name was spelled as, and where, is where the declaration stands: a meaning"
+                        + " that asked for it moves when the author retypes the same name");
+    }
+
+    /** And the population holds both kinds of component, so neither question is asked of nothing. */
+    @Test
+    void bothKindsOfComponentAreThere() {
+        int says = 0;
+        int stands = 0;
+        for (Class<?> kind : walked()) {
+            for (RecordComponent component : kind.getRecordComponents()) {
+                if (WHERE_IT_STANDS.contains(component.getType())) {
+                    stands++;
+                } else if (!BOTH.contains(component.getType())) {
+                    says++;
+                }
+            }
+        }
+
+        assertFalse(says == 0 || stands == 0,
+                "one of the two kinds of component was not found at all, so one of the questions"
+                        + " above was asked of nothing");
+    }
+
+    private static String name(Class<?> kind, RecordComponent component) {
+        return kind.getSimpleName() + "." + component.getName();
+    }
+
+    /**
+     * Every component of a declaration the producer reads, by the record it is declared on.
+     *
+     * <p>A call made on {@link Hir.Def} is a call on every kind of one: the sealed parent declares
+     * what all of them hold, and which arm it lands in is settled after the call.
+     */
+    private static Set<String> componentsReadByTheProducer() throws IOException {
+        Set<String> read = new LinkedHashSet<>();
+        for (Call call : callsMadeByTheProducer()) {
+            if (!call.owner().startsWith("souther/compiler/ast/Hir")) {
+                continue;
+            }
+            int nested = call.owner().lastIndexOf('$');
+            String on = nested < 0 ? "Hir" : call.owner().substring(nested + 1);
+            if (on.equals("Def")) {
+                for (Class<?> kind : walked()) {
+                    read.add(kind.getSimpleName() + "." + call.name());
+                }
+            } else {
+                read.add(on + "." + call.name());
+            }
+        }
+        return read;
+    }
+
+    /** What the producer asks of {@code owner}, by method name. */
+    private static Set<String> methodsCalledOn(String owner) throws IOException {
+        Set<String> asked = new LinkedHashSet<>();
+        for (Call call : callsMadeByTheProducer()) {
+            if (call.owner().equals(owner)) {
+                asked.add(call.name());
+            }
+        }
+        return asked;
+    }
+
+    /** One call the producer makes. */
+    private record Call(String owner, String name) {}
+
+    /**
+     * Every call the producer makes, following the ones it makes of its own class.
+     *
+     * <p>From {@code of} and no further out: what is being audited is what this producer publishes,
+     * and a call it makes into another class is answered by whatever that class was written to do.
+     * The two it delegates to are named in {@link #READ_ELSEWHERE}.
+     */
+    private static List<Call> callsMadeByTheProducer() throws IOException {
+        ClassModel model = ClassFile.of().parse(Files.readAllBytes(compiledProducer()));
+        List<Call> calls = new ArrayList<>();
+        Set<String> walked = new LinkedHashSet<>();
+        Deque<MethodModel> pending = new ArrayDeque<>();
+        for (MethodModel method : model.methods()) {
+            if (method.methodName().stringValue().equals("of")) {
+                pending.add(method);
+            }
+        }
+        String self = model.thisClass().asInternalName();
+        while (!pending.isEmpty()) {
+            MethodModel method = pending.removeFirst();
+            if (!walked.add(method.methodName().stringValue()
+                    + method.methodType().stringValue())) {
+                continue;
+            }
+            method.code().ifPresent(code -> code.forEach(element -> {
+                if (element instanceof InvokeInstruction call) {
+                    calls.add(new Call(call.owner().asInternalName(), call.name().stringValue()));
+                    if (call.owner().asInternalName().equals(self)) {
+                        for (MethodModel candidate : model.methods()) {
+                            if (candidate.methodName().stringValue().equals(call.name().stringValue())
+                                    && candidate.methodType().stringValue()
+                                            .equals(call.type().stringValue())) {
+                                pending.add(candidate);
+                            }
+                        }
+                    }
+                }
+            }));
+        }
+        return calls;
+    }
+
+    private static Path compiledProducer() {
+        return Path.of("target", "classes", "souther", "compiler", "check",
+                "DeclarationMeaning.class").toAbsolutePath();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
@@ -30,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 /**
  * What a published declaration says is everything the declaration says, and none of where it stands.
  *
- * <p>Two things {@link DeclarationMeaning} has to be, and only one of them is what #1472 was about.
+ * <p>Two things {@link DeclarationMeaning} has to be, and only one of them is the one that is easy
+ * to see.
  * A meaning that read where a declaration stands makes a module that imports it depend on an edit it
  * cannot see. A meaning that left out something the declaration says makes two declarations that say
  * different things one dependency, and the store then stops the work of everything that read the one

--- a/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
@@ -239,8 +239,11 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
         List<Call> calls = new ArrayList<>();
         Set<String> walked = new LinkedHashSet<>();
         Deque<MethodModel> pending = new ArrayDeque<>();
+        // Every way in, and not the one that reads the most. A second entry reading a component the
+        // first does not would be a component published without ever being audited, which is the
+        // hole this walk exists to have none of.
         for (MethodModel method : model.methods()) {
-            if (method.methodName().stringValue().equals("of")) {
+            if (method.methodName().stringValue().startsWith("of")) {
                 pending.add(method);
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
@@ -76,6 +76,19 @@ final class ClauseReadings {
         return new Read(Map.copyOf(stated), List.copyOf(stopped));
     }
 
+    /**
+     * {@code named} as {@code module} publishes it.
+     *
+     * <p>The reading is made the same way {@link #readBy} makes one, so what a test comparing two
+     * meanings is comparing is what a store keyed by the declaration would hold.
+     */
+    static DeclarationMeaning meaningOf(Db db, String module, TypeSymbol.AtModule named) {
+        Symbols symbols = Scopes.derived(db, module).value();
+        return DeclarationMeaning.of(symbols.declaredNode(named),
+                new Clauses(symbols, RuleReadings.declaredBy(db, module),
+                        ClauseLocations.NONE, DeclarationReadings.NONE));
+    }
+
     /** One declaration, the module that wrote it, and a module that reads it without having. */
     record Edge(String asking, String declaring, TypeSymbol.AtModule named) {
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
@@ -1,0 +1,123 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.query.Answer;
+import souther.compiler.query.Db;
+import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What one module's reading of a declaration's clauses states, clause by clause.
+ *
+ * <p>Built for holding two readings of one declaration against each other. The comparison is over
+ * {@link TermMeaning} and not over the term, because what is being asked is whether the two say the
+ * same thing — a term carries where it was written, and two readings of one declaration made in two
+ * modules are made over trees the reader never edited.
+ *
+ * <p>Clause by clause, keyed by {@link Clause.Ref}. Two readings of a declaration reach its clauses
+ * in the order the declaration writes them, but an include brings a clause in under a second name
+ * and a comparison by position would pair the wrong two the first time a declaration spreads
+ * another. The reference is what the declaration answers by, so it pairs what the declaration would
+ * call one clause.
+ *
+ * <p>What stopped is carried beside what stated rather than dropped. A reading in which every clause
+ * stopped agrees with another in which every clause stopped, so a comparison that saw only the
+ * stated ones would come back green over two readings that read nothing.
+ */
+final class ClauseReadings {
+
+    private ClauseReadings() {}
+
+    /**
+     * One reading of one declaration's clauses.
+     *
+     * @param stated what each clause that typed says
+     * @param stopped the clauses this reading has no form for, in the order it reached them
+     */
+    record Read(Map<Clause.Ref, TermMeaning> stated, List<Clause.Ref> stopped) {
+
+        /** How many clauses the reading reached at all — what a control counts. */
+        int reached() {
+            return stated.size() + stopped.size();
+        }
+    }
+
+    /**
+     * {@code named}'s clauses as {@code module} reads them.
+     *
+     * <p>The scope is {@code module}'s and the clauses are the declaring module's: that pairing is
+     * what {@link RuleReadingSource} is, and it is what makes this a question about the reader at
+     * all. Handed one module's scope together with that same module's clauses, every reading would
+     * be of a declaration the reader wrote.
+     */
+    static Read readBy(Db db, String module, TypeSymbol.AtModule named) {
+        Symbols symbols = Scopes.derived(db, module).value();
+        Clauses clauses = new Clauses(symbols, RuleReadings.declaredBy(db, module),
+                ClauseLocations.NONE, DeclarationReadings.NONE);
+        Map<Clause.Ref, TermMeaning> stated = new LinkedHashMap<>();
+        List<Clause.Ref> stopped = new ArrayList<>();
+        for (TypeOps.Declared each : clauses.of(named).reached()) {
+            Clause.Ref clause = Clause.Ref.of(each);
+            switch (clauses.typed(each.asExpanded(), named)) {
+                case TypedClause.Typed typed ->
+                        stated.put(clause, TermMeaning.of(typed.value()));
+                case TypedClause.Stopped _ -> stopped.add(clause);
+            }
+        }
+        return new Read(Map.copyOf(stated), List.copyOf(stopped));
+    }
+
+    /** One declaration, the module that wrote it, and a module that reads it without having. */
+    record Edge(String asking, String declaring, TypeSymbol.AtModule named) {
+
+        @Override
+        public String toString() {
+            return asking + " reads " + named;
+        }
+    }
+
+    /**
+     * Every declaration a module of {@code modules} reaches and did not write.
+     *
+     * <p>Read off what each module's scope reaches rather than off its import lines, so a
+     * declaration reached through another module is here as well. The population is the
+     * compilation's own, so a declaration added to the sources under it is swept without anybody
+     * adding it.
+     *
+     * <p>Whether the declaration writes a clause is not asked. A declaration that spreads another
+     * reaches that one's clauses and writes none of its own, and it is exactly the shape a
+     * comparison by position would pair wrongly — selected on what it writes, it would be the case
+     * left out.
+     */
+    static List<Edge> importsOf(Db db, List<String> modules) {
+        Set<String> compiled = new LinkedHashSet<>(modules);
+        List<Edge> edges = new ArrayList<>();
+        for (String asking : modules) {
+            Answer<Map<String, Hir.Def>> reachable = db.ask(new Names.Reachable(asking));
+            if (!reachable.present()) {
+                continue;
+            }
+            Set<TypeSymbol.AtModule> seen = new LinkedHashSet<>();
+            for (Hir.Def def : reachable.value().values()) {
+                if (!(def instanceof Hir.Data data) || data.declaredBy(asking)
+                        || !compiled.contains(data.declaredIn())) {
+                    continue;
+                }
+                TypeSymbol.AtModule named = TypeSymbols.declared(data.declaredKey());
+                if (seen.add(named)) {
+                    edges.add(new Edge(asking, data.declaredIn(), named));
+                }
+            }
+        }
+        return edges;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest.java
@@ -1,0 +1,66 @@
+package souther.compiler.check;
+
+import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every declaration the corpora import states one thing, whichever module asks.
+ *
+ * <p>The same property as
+ * {@link WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest}, over the models this
+ * repository carries rather than over sources written to ask it. Two runs of one question, and the
+ * sources are the axis: what a written module holds is the shapes somebody chose, and what a corpus
+ * holds is the shapes a model reached on its way to doing something else — a clause spanning a list
+ * of another declaration, a name spelled outside ASCII, an imported behavior a clause reaches
+ * through.
+ *
+ * <p><b>Both halves of a reading are compared, and only one of them is held to anything.</b> Two
+ * readings in which every clause stopped agree over what stated, because neither stated anything, so
+ * the clauses a reading has no form for are compared beside the ones it does and the count below
+ * refuses a sweep in which nothing stated. But no clause of either population stops: what this says
+ * is that a clause <i>with a form</i> has one answer whoever asks, and the arm for a clause without
+ * one is written here and reached by nothing. Holding that arm needs a declaration whose clause the
+ * discharge reader has no form for, and there is none to sweep.
+ */
+@Tag("population")
+class EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest {
+
+    @Test
+    void everyDeclarationACorpusImportsStatesOneThingWhoeverAsks() {
+        int edges = 0;
+        int stated = 0;
+        List<String> stopped = new ArrayList<>();
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            Compilation compilation = corpus.analyse().compilation();
+            compilation.answerEverything();
+            Db db = compilation.db();
+            for (ClauseReadings.Edge edge
+                    : ClauseReadings.importsOf(db, compilation.modules())) {
+                ClauseReadings.Read asking = ClauseReadings.readBy(db, edge.asking(), edge.named());
+                assertEquals(ClauseReadings.readBy(db, edge.declaring(), edge.named()), asking,
+                        "in `" + corpus + "`, `" + edge.named() + "` states one thing where it was"
+                                + " written and another where `" + edge.asking() + "` reads it");
+                edges++;
+                stated += asking.stated().size();
+                asking.stopped().forEach(each -> stopped.add(corpus + " " + each));
+            }
+        }
+        assertTrue(edges > 0,
+                "no module of any corpus reaches a declaration another wrote, so this compared"
+                        + " nothing — the corpora no longer carry an import of a declaration");
+        assertTrue(stated > 0,
+                "the sweep found " + edges + " imported declarations and not one clause of them"
+                        + " reached a form, so every comparison above held of nothing; these"
+                        + " stopped: " + stopped);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p><b>Both halves of a reading are compared, and only one of them is held to anything.</b> Two
  * readings in which every clause stopped agree over what stated, because neither stated anything, so
  * the clauses a reading has no form for are compared beside the ones it does and the count below
- * refuses a sweep in which nothing stated. But no clause of either population stops: what this says
- * is that a clause <i>with a form</i> has one answer whoever asks, and the arm for a clause without
- * one is written here and reached by nothing. Holding that arm needs a declaration whose clause the
- * discharge reader has no form for, and there is none to sweep.
+ * refuses a sweep in which nothing stated. But no clause of a corpus stops, so what this says is
+ * that a clause <i>with a form</i> has one answer whoever asks. The other arm is held beside this,
+ * over a source written to reach it: a corpus is a model somebody wrote to work, and a clause the
+ * discharge reader has no form for is not something to put in one.
  */
 @Tag("population")
 class EveryDeclarationACorpusImportsStatesOneThingWhoeverAsksTest {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest.java
@@ -1,0 +1,264 @@
+package souther.compiler.check;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a declaration's clauses state is the declaring module's answer, whichever module asks.
+ *
+ * <p>The question a boundary has to answer before it can be one. An answer keyed by a declaration is
+ * the declaring module's or it is not an answer about the declaration: asked from two modules and
+ * coming back differently, it would be a value two readers hold under one name, and a store that
+ * kept the first would hand the second somebody else's reading.
+ *
+ * <p>The reading is taken where the clauses become {@code Core} — {@link Clauses#typed} — because
+ * that is the highest rung at which a clause has a form that says what it states and not how it was
+ * written. Below it, {@link Clauses#statedAt} puts a construction's own values where the fields are
+ * read, which is a fact about the use and not about the declaration.
+ *
+ * <p><b>The agreement alone is worth nothing, so three things are held beside it.</b> That the
+ * clauses compared reached a form, so agreement is over something; that a clause given a different
+ * rule reads as a different clause and one merely moved down the file does not; and that a reading
+ * answers for the declaration it was asked about rather than for the spelling. Each is its own
+ * assertion, so a failure says which.
+ *
+ * <p><b>What is held is a clause that has a form.</b> A reading answers a clause it has no form for
+ * with {@link TypedClause.Stopped}, and no clause of these declarations reaches that arm — the
+ * control below pins that, by holding what reached a form to what was reached at all. So nothing
+ * here says two modules agree about a clause neither could type.
+ */
+class WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest {
+
+    /**
+     * What a module declares, in the shapes a clause is written over.
+     *
+     * <p>A newtype whose clause is arithmetic, a product whose clause reads two of its own fields, a
+     * product whose clause reaches a list of another declaration, one whose clause calls a helper
+     * this module defines, and one that spreads two others. The helper is the case a reader-module
+     * dependency would show in: what a clause names is resolved somewhere, and a clause that names
+     * only the language reaches the same answer in any scope by having nothing of the module in it.
+     */
+    private static final String DECLARING = """
+            module demo.base exposing
+                ( Amount, Line, Order, Even, Named, Priced, Item )
+
+            data Amount = Decimal
+                invariant value >= 0.00m
+
+            data Line = { product: String, qty: Int }
+                invariant qty >= 1 && String.length(product) >= 1
+
+            data Order = { lines: List<Line>, total: Amount }
+                invariant List.length(lines) >= 1
+
+            let remainder (n: Int) : Int = Int.floorMod(n, 2)
+
+            data Even = Int
+                invariant remainder(value) == 0
+
+            data Named = { name: String }
+                invariant String.length(name) >= 1
+
+            data Priced = { amount: Int }
+                invariant amount >= 0
+
+            data Item = { ...Named, ...Priced }
+            """;
+
+    /**
+     * A module that imports every one of them and names each in a body.
+     *
+     * <p>Each is written bare somewhere, because an import nothing spells is reported rather than
+     * reached, and what this test needs is a module whose scope has these declarations in it.
+     */
+    private static final String IMPORTING = """
+            module demo.user exposing ( total, count, sound, label, priced )
+
+            import demo.base as Base ( Amount, Line, Order, Even, Item )
+
+            behavior total : (o: Order) -> Amount
+            let total (o) = o.total
+
+            behavior count : (l: Line) -> Int
+            let count (l) = l.qty
+
+            behavior sound : (e: Even) -> Int
+            let sound (e) = e.value
+
+            behavior label : (i: Item) -> String
+            let label (i) = i.name
+
+            behavior priced : (i: Item) -> Int
+            let priced (i) = i.amount
+            """;
+
+    /**
+     * A third module that declares the same spelling and reaches the first one's qualified.
+     *
+     * <p>What tells the comparison beside this from one that answers alike whatever it is asked. Two
+     * modules declaring {@code Amount} is the case {@link Clauses#bindingsOf} names, and a reading
+     * keyed by the declaration has to come back with the rule the declaring module wrote — not the
+     * one the asking module wrote under that spelling, and not one that merged them.
+     */
+    private static final String RIVAL = """
+            module demo.rival exposing ( Amount, theirs, mine )
+
+            data Amount = Decimal
+                invariant value >= 100.00m
+
+            behavior theirs : (a: demo.base.Amount) -> Decimal
+            let theirs (a) = a.value
+
+            behavior mine : (a: Amount) -> Decimal
+            let mine (a) = a.value
+            """;
+
+    /** The two modules of the sources above, in the order a sweep reads them. */
+    private static final List<String> MODULES = List.of("demo.base", "demo.user");
+
+    /**
+     * The declarations {@code demo.user} imports, in the order its scope reaches them.
+     *
+     * <p>Written down rather than counted, because a count says nothing about which. {@code Item}
+     * writes no clause of its own and is here all the same: what it spreads wrote two, and a reading
+     * of {@code Item} reaches both.
+     */
+    private static final List<String> IMPORTED =
+            List.of("Amount", "Line", "Order", "Even", "Item");
+
+    @Test
+    void anImportedDeclarationStatesTheSameThingInBothModules() {
+        Db db = analysed(List.of(DECLARING, IMPORTING));
+        List<ClauseReadings.Edge> edges = ClauseReadings.importsOf(db, MODULES);
+        assertEquals(IMPORTED, edges.stream().map(each -> each.named().name()).toList(),
+                "the sweep is not reaching the declarations these sources were written to import");
+        for (ClauseReadings.Edge edge : edges) {
+            assertEquals(ClauseReadings.readBy(db, edge.declaring(), edge.named()).stated(),
+                    ClauseReadings.readBy(db, edge.asking(), edge.named()).stated(),
+                    "`" + edge.named() + "` states one thing where it was written and another"
+                            + " where `" + edge.asking() + "` reads it");
+        }
+    }
+
+    /**
+     * The control the comparison above is worth nothing without.
+     *
+     * <p>A reading in which nothing typed agrees with another in which nothing typed. So what is
+     * counted is the clauses that reached a form, and it is counted from the importing module —
+     * the side that would come back empty if a clause of somebody else's declaration were the thing
+     * this reader could not type.
+     */
+    @Test
+    void theImportingModuleTypesTheClausesItWasComparedOver() {
+        Db db = analysed(List.of(DECLARING, IMPORTING));
+        int stated = 0;
+        int reached = 0;
+        List<Clause.Ref> stopped = new ArrayList<>();
+        for (ClauseReadings.Edge edge : ClauseReadings.importsOf(db, MODULES)) {
+            ClauseReadings.Read read = ClauseReadings.readBy(db, edge.asking(), edge.named());
+            stated += read.stated().size();
+            reached += read.reached();
+            stopped.addAll(read.stopped());
+        }
+        assertEquals(reached, stated,
+                "the importing module reached " + reached + " clauses of declarations it imports"
+                        + " and has a form for " + stated + " of them; these it could not type: "
+                        + stopped);
+        assertTrue(stated > 0,
+                "no clause of an imported declaration reached a form, so the comparison beside this"
+                        + " one compared nothing");
+    }
+
+    /**
+     * And the control that says the comparison can come back unequal.
+     *
+     * <p>Two edits, and they are the two halves of what a boundary is for. One changes what a clause
+     * states and must be a different reading; the other moves every position under it and states the
+     * same thing, and must be the same reading. A comparison that failed the first would call two
+     * declarations one; a comparison that failed the second is the defect this boundary is built to
+     * end.
+     */
+    @Test
+    void aClauseThatStatesSomethingElseIsANewReadingAndOneMerelyMovedIsNot() {
+        Map<Clause.Ref, TermMeaning> asWritten = amountAsTheImporterReadsIt(DECLARING);
+        Map<Clause.Ref, TermMeaning> stating = amountAsTheImporterReadsIt(
+                DECLARING.replace("invariant value >= 0.00m", "invariant value >= 1.00m"));
+        Map<Clause.Ref, TermMeaning> moved = amountAsTheImporterReadsIt(
+                DECLARING.replace("data Amount = Decimal",
+                        "// a line written above it, which moves every position below\n"
+                                + "data Amount = Decimal"));
+
+        assertTrue(!asWritten.isEmpty(), "`Amount` states a clause, or nothing was compared");
+        assertNotEquals(asWritten, stating,
+                "`Amount` was given a different rule and read as the same one");
+        assertEquals(asWritten, moved,
+                "`Amount` was moved down the file and read as a different declaration");
+    }
+
+    /**
+     * A reading answers for the declaration it was asked about and not for the spelling.
+     *
+     * <p>Which is what says the agreement above is worth something. A {@code readBy} that answered
+     * from the asking module's own declaration of the spelling would agree with itself everywhere,
+     * and every comparison in this class would be green over a reading that never left home. So the
+     * same key is asked of two modules one of which declares that spelling itself, and the two
+     * declarations are asked of the one module that can see both.
+     */
+    @Test
+    void aReadingAnswersForTheDeclarationAskedAboutAndNotForTheSpelling() {
+        Db db = analysed(List.of(DECLARING, IMPORTING, RIVAL));
+        TypeSymbol.AtModule base = TypeSymbols.declared(new TypeKey("demo.base", "Amount"));
+        TypeSymbol.AtModule rival = TypeSymbols.declared(new TypeKey("demo.rival", "Amount"));
+
+        assertEquals(ClauseReadings.readBy(db, "demo.base", base).stated(),
+                ClauseReadings.readBy(db, "demo.rival", base).stated(),
+                "`demo.base.Amount` is read as one thing where it was written and as another"
+                        + " in a module that declares the spelling itself");
+
+        List<TermMeaning> theirs =
+                List.copyOf(ClauseReadings.readBy(db, "demo.rival", base).stated().values());
+        List<TermMeaning> mine =
+                List.copyOf(ClauseReadings.readBy(db, "demo.rival", rival).stated().values());
+        assertTrue(!theirs.isEmpty() && !mine.isEmpty(),
+                "both declarations state a clause, or this compares nothing: " + theirs + mine);
+        assertNotEquals(theirs, mine,
+                "two declarations of one spelling, stating different rules, were read alike");
+    }
+
+    /** `demo.base.Amount` as `demo.user` reads it, over a compilation of {@code declaring}. */
+    private static Map<Clause.Ref, TermMeaning> amountAsTheImporterReadsIt(String declaring) {
+        Db db = analysed(List.of(declaring, IMPORTING));
+        return ClauseReadings.readBy(db, "demo.user",
+                TypeSymbols.declared(new TypeKey("demo.base", "Amount"))).stated();
+    }
+
+    /**
+     * A compilation of {@code sources} with every question of it answered.
+     *
+     * <p>Held to compiling after the questions are asked and not before. What a compilation says is
+     * read off the reports its answers carry, so a store nothing has been asked of is silent about
+     * every source — and a fixture that stopped compiling would go past a check made there.
+     */
+    private static Db analysed(List<String> sources) {
+        Compilation compilation = Compilation.ofSources(sources, ModulePath.EMPTY);
+        compilation.answerEverything();
+        assertEquals(List.of(),
+                compilation.errors().stream().map(each -> each.diagnostic().code()).toList(),
+                "these modules are supposed to compile");
+        return compilation.db();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,10 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * answers for the declaration it was asked about rather than for the spelling. Each is its own
  * assertion, so a failure says which.
  *
- * <p><b>What is held is a clause that has a form.</b> A reading answers a clause it has no form for
- * with {@link TypedClause.Stopped}, and no clause of these declarations reaches that arm — the
- * control below pins that, by holding what reached a form to what was reached at all. So nothing
- * here says two modules agree about a clause neither could type.
+ * <p><b>Both arms are held, over two sources.</b> A reading answers a clause it has no form for with
+ * {@link TypedClause.Stopped}, and nothing that compiles reaches that arm — the control below pins
+ * that for the declarations swept here, by holding what reached a form to what was reached at all.
+ * The arm itself is held over a source this compiler refuses, where a clause names something nothing
+ * declares.
  */
 class WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest {
 
@@ -237,6 +239,64 @@ class WhatADeclarationsClausesStateIsOneAnswerWhicheverModuleAsksTest {
                 "both declarations state a clause, or this compares nothing: " + theirs + mine);
         assertNotEquals(theirs, mine,
                 "two declarations of one spelling, stating different rules, were read alike");
+    }
+
+    /**
+     * A module whose one clause names something nothing declares, and a module that imports it.
+     *
+     * <p>Apart from the sources above because this one does not compile, and that is what it is for:
+     * a clause the discharge reader has no form for is answered with
+     * {@link TypedClause.Stopped}, and nothing that compiles reaches that arm. Name resolution
+     * reports and carries on, so the declaration is still there to be read — which is what makes the
+     * reading askable at all.
+     */
+    private static final String A_CLAUSE_WITH_NO_FORM = """
+            module demo.stopped exposing ( Amount )
+
+            data Amount = Decimal
+                invariant value >= 0.00m && Absent.nothing(value)
+            """;
+
+    /** A module that imports it, so the reading can be taken from a module that did not write it. */
+    private static final String READING_IT = """
+            module demo.reader exposing ( f )
+
+            import demo.stopped as Stopped ( Amount )
+
+            behavior f : (a: Amount) -> Decimal
+            let f (a) = a.value
+            """;
+
+    /**
+     * The other arm: a clause with no form is the same no-form whichever module asks.
+     *
+     * <p>Held because the two arms are two answers and only one of them was reached by anything that
+     * compiles. Two readings that both stopped agree over what they stated by having stated nothing,
+     * so the comparisons above say nothing about this arm however many declarations they sweep.
+     *
+     * <p>What is compared is the whole reading and not the half of it that typed. A clause this
+     * reader has no form for and one the declaring module has no form for are the same clause, named
+     * the same way, and the two lists are held to being the same list.
+     */
+    @Test
+    void aClauseWithNoFormIsTheSameNoFormWhicheverModuleAsks() {
+        Compilation compilation =
+                Compilation.ofSources(List.of(A_CLAUSE_WITH_NO_FORM, READING_IT), ModulePath.EMPTY);
+        compilation.answerEverything();
+        assertFalse(compilation.errors().isEmpty(),
+                "this source is supposed to name something nothing declares");
+
+        Db db = compilation.db();
+        TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("demo.stopped", "Amount"));
+        ClauseReadings.Read declaring = ClauseReadings.readBy(db, "demo.stopped", named);
+        ClauseReadings.Read asking = ClauseReadings.readBy(db, "demo.reader", named);
+
+        assertFalse(declaring.stopped().isEmpty(),
+                "the clause this fixture writes is supposed to have no form, and the declaring"
+                        + " module found one for it: " + declaring);
+        assertEquals(declaring, asking,
+                "`demo.stopped.Amount` reads one way where it was written and another where"
+                        + " `demo.reader` reads it");
     }
 
     /** `demo.base.Amount` as `demo.user` reads it, over a compilation of {@code declaring}. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest.java
@@ -97,6 +97,29 @@ class WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest {
     }
 
     /**
+     * And a rule given to what it spreads is not something it says.
+     *
+     * <p>Which is why its clauses are its own. A value of it must satisfy that rule, and that is a
+     * fact about this declaration together with the one it spreads — worked out from both of them
+     * by whoever needs it. Carried in here instead, what this declaration says would change when
+     * another was given a rule it says nothing about, and every module importing it would be worked
+     * out again for an edit it cannot see.
+     *
+     * <p>The declaration that was given the rule does say something else, which is what keeps the
+     * first half from being met by a meaning that reads nothing.
+     */
+    @Test
+    void andARuleGivenToWhatItSpreadsIsNotSomethingItSays() {
+        String given = requireEdited(DECLARING, "invariant String.length(name) >= 1",
+                "invariant String.length(name) >= 2");
+
+        assertEquals(published("Item", DECLARING), published("Item", given),
+                "`Item` says what it says, and `Named` was the one given a rule");
+        assertNotEquals(published("Named", DECLARING), published("Named", given),
+                "`Named` was given a rule it did not have and says the same thing");
+    }
+
+    /**
      * {@code source} with {@code from} written as {@code to}, where that changed something.
      *
      * <p>Every comparison here rests on the edit having happened. A search string that matches

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.check;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A published declaration says something else when the declaration does, and the same thing when it
+ * only moved.
+ *
+ * <p>What the audit beside this cannot see. Reading every component a declaration says is not the
+ * same as carrying what they say: a producer that gathered the fields into a map would read both of
+ * them and publish an answer two declarations laid out differently share, and every accessor it
+ * called would be accounted for. So the order the parts are in is held here, by editing a
+ * declaration in a way that changes nothing else.
+ *
+ * <p>Each edit below changes one thing. What a reader elsewhere is told has to move with the four
+ * that change what the declaration says, and stay put for the one that changes only where it is.
+ */
+class WhatAPublishedDeclarationSaysMovesWithWhatItSaysTest {
+
+    private static final String DECLARING = """
+            module demo
+
+            data Named = { name: String }
+                invariant String.length(name) >= 1
+
+            data Priced = { amount: Int }
+                invariant amount >= 0
+
+            data Item = { ...Named, ...Priced }
+
+            data Pair = { a: Int, b: Int }
+
+            data Line = { product: String, qty: Int }
+                invariant qty >= 1
+                invariant String.length(product) >= 1
+            """;
+
+    @Test
+    void aDeclarationThatOnlyMovedSaysTheSameThing() {
+        assertEquals(published("Line", DECLARING),
+                published("Line", requireEdited(DECLARING, "data Named",
+                        "// a line written above every declaration below it\ndata Named")),
+                "a line written above a declaration moves every position under it and changes"
+                        + " nothing any of them says");
+    }
+
+    @Test
+    void aProductWhoseFieldsAreLaidOutDifferentlySaysSomethingElse() {
+        assertNotEquals(published("Pair", DECLARING),
+                published("Pair",
+                        requireEdited(DECLARING, "{ a: Int, b: Int }", "{ b: Int, a: Int }")),
+                "the fields are the parameters of the entry a value is built through, in order, so"
+                        + " a module elsewhere builds one of these two differently");
+    }
+
+    @Test
+    void aFieldOfAnotherTypeSaysSomethingElse() {
+        assertNotEquals(published("Pair", DECLARING),
+                published("Pair",
+                        requireEdited(DECLARING, "{ a: Int, b: Int }", "{ a: Int, b: Decimal }")),
+                "what a field is is what a value of the product holds there");
+    }
+
+    @Test
+    void aProductThatSpreadsInAnotherOrderSaysSomethingElse() {
+        assertNotEquals(published("Item", DECLARING),
+                published("Item", requireEdited(DECLARING, "{ ...Named, ...Priced }",
+                        "{ ...Priced, ...Named }")),
+                "what a product spreads is reached in the order it is written, and the fields it"
+                        + " reaches are laid out in that order");
+    }
+
+    @Test
+    void aDeclarationWhoseClausesAreWrittenInAnotherOrderSaysSomethingElse() {
+        // Written with the indent spelled out rather than as a text block: a block strips the indent
+        // its own lines share, and a search string that lost it matches nothing in the source it is
+        // looking through — which is an edit that did not happen and a comparison of one thing with
+        // itself.
+        String asWritten = "    invariant qty >= 1\n"
+                + "    invariant String.length(product) >= 1";
+        String swapped = "    invariant String.length(product) >= 1\n"
+                + "    invariant qty >= 1";
+        assertNotEquals(published("Line", DECLARING),
+                published("Line", requireEdited(DECLARING, asWritten, swapped)),
+                "a clause is addressed by which of the declaration's own it is, so the order they"
+                        + " are written in is what a reader elsewhere names them by");
+    }
+
+    /**
+     * {@code source} with {@code from} written as {@code to}, where that changed something.
+     *
+     * <p>Every comparison here rests on the edit having happened. A search string that matches
+     * nothing leaves the source as it was, and what the assertion then compares is one declaration
+     * with itself — which reads as the producer having carried the difference for an equality, and
+     * as the producer having lost it for an inequality. Neither is what the edit was for.
+     */
+    private static String requireEdited(String source, String from, String to) {
+        String edited = source.replace(from, to);
+        assertNotEquals(source, edited, "this edit matched nothing, so nothing was compared: " + from);
+        return edited;
+    }
+
+    /** What {@code demo} publishes about {@code declared}, over a compilation of {@code source}. */
+    private static DeclarationMeaning published(String declared, String source) {
+        Compilation compilation = Compilation.ofSources(List.of(source), null);
+        compilation.answerEverything();
+        assertEquals(List.of(),
+                compilation.errors().stream().map(each -> each.diagnostic().code()).toList(),
+                "this source is supposed to compile");
+        Db db = compilation.db();
+        return ClauseReadings.meaningOf(db, "demo",
+                TypeSymbols.declared(new TypeKey("demo", declared)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
@@ -179,7 +179,7 @@ class ALimitThatFiredIsNotALimitTheTermReadTest {
         // No module is being read, so nothing here declares a data whose fields could be asked for.
         return ObservedValues.of(live, symbols,
                 new NeutralForm(symbols,
-                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), limits);
+                        FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))), limits);
     }
 
     private static List<Object> longs(int count) {

--- a/souther-compiler/src/test/java/souther/compiler/examples/ObservedValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ObservedValuesTest.java
@@ -35,7 +35,7 @@ class ObservedValuesTest {
         // No module is being read, so nothing here declares a data whose fields could be asked for.
         return ObservedValues.of(live, symbols,
                 new NeutralForm(symbols,
-                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), limits);
+                        FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))), limits);
     }
 
     private static ObservedValue observe(Object live) {

--- a/souther-compiler/src/test/java/souther/compiler/examples/ValueRenderingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ValueRenderingTest.java
@@ -31,7 +31,7 @@ class ValueRenderingTest {
         Symbols symbols = Symbols.none(DefaultStdlib.get());
         // No module is being read, so nothing here declares a data whose fields could be asked for.
         return new ValueRendering(new NeutralForm(symbols,
-                FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))));
+                FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))));
     }
 
     private static String show(ObservedValue v) {

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatALimitAdmitsIsWhatAWalkUnderItKeptTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatALimitAdmitsIsWhatAWalkUnderItKeptTest.java
@@ -146,7 +146,7 @@ class WhatALimitAdmitsIsWhatAWalkUnderItKeptTest {
         // No module is being read, so nothing here declares a data whose fields could be asked for.
         return ObservedValues.of(live, symbols,
                 new NeutralForm(symbols,
-                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), limits);
+                        FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))), limits);
     }
 
     private static String shown(Object live) {

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest.java
@@ -155,15 +155,14 @@ class WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest {
 
     /** No module is being read, so nothing here declares a data whose fields could be asked for. */
     private static ValueTypes declarations() {
-        Symbols symbols = Symbols.none(DefaultStdlib.get());
-        return ValueTypes.over(FieldTypes.over(new CheckedDeclarations(symbols, _ -> null)));
+        return ValueTypes.over(FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null)));
     }
 
     private static ObservedValue observe(Object live) {
         Symbols symbols = Symbols.none(DefaultStdlib.get());
         return ObservedValues.of(live, symbols,
                 new NeutralForm(symbols,
-                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))),
+                        FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))),
                 Limits.DEFAULT);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhicheverBudgetStopsAWalkItStopsItWithOneWordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhicheverBudgetStopsAWalkItStopsItWithOneWordTest.java
@@ -165,7 +165,7 @@ class WhicheverBudgetStopsAWalkItStopsItWithOneWordTest {
         // No module is being read, so nothing here declares a data whose fields could be asked for.
         return ObservedValues.of(live, symbols,
                 new NeutralForm(symbols,
-                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), DEFAULT);
+                        FieldTypes.over(new CheckedDeclarations(_ -> null, _ -> null))), DEFAULT);
     }
 
     private static List<Object> longs(int count) {

--- a/souther-compiler/src/test/java/souther/compiler/query/AMovedDeclarationIsPublishedAsTheSameDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AMovedDeclarationIsPublishedAsTheSameDeclarationTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.query;
+
+import souther.compiler.check.DeclarationMeaning;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A declaration written somewhere else in its file is published as the same declaration.
+ *
+ * <p>What the boundary is for, asked of a store that has been edited rather than of two stores built
+ * from two texts. The comparisons beside {@link souther.compiler.check.DeclarationMeaning} hold the
+ * producer to reading the same things; this holds the answer a store keeps to coming back equal
+ * after the edit that used to make every importer look again.
+ *
+ * <p>Both directions, because an answer that never changes stops work it should not stop. The
+ * declaration is moved and then given a different rule, and the second is what says the first is
+ * about the move.
+ */
+class AMovedDeclarationIsPublishedAsTheSameDeclarationTest {
+
+    private static final String PRICES = """
+            module shop.prices exposing ( Amount )
+
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    /** Imports it, so the workspace is one an edit could cross. */
+    private static final String CART = """
+            module shop.cart exposing ( Total )
+
+            import shop.prices ( Amount )
+
+            data Total = { paid: Amount }
+            """;
+
+    private static final TypeKey AMOUNT = new TypeKey("shop.prices", "Amount");
+
+    @Test
+    void movingADeclarationDownItsFileDoesNotChangeWhatItSays() {
+        Compilation c = started();
+        DeclarationMeaning before = published(c);
+
+        edit(c, PRICES.replace("data Amount",
+                "// a line written above it, which moves every position below\ndata Amount"));
+
+        assertEquals(before, published(c),
+                "a line written above the declaration is an edit no module importing it can see,"
+                        + " and what it says came back different");
+    }
+
+    @Test
+    void andGivingItAnotherRuleDoes() {
+        Compilation c = started();
+        DeclarationMeaning before = published(c);
+
+        edit(c, PRICES.replace("invariant value >= 0", "invariant value >= 1"));
+
+        assertNotEquals(before, published(c),
+                "the declaration was given a rule it did not have and was published as the one it"
+                        + " had before");
+    }
+
+    /** What the store says {@code shop.prices.Amount} says. */
+    private static DeclarationMeaning published(Compilation c) {
+        Answer<DeclarationMeaning> answer = c.db().ask(new Shapes.MeaningOf(AMOUNT));
+        assertTrue(answer.present(), "the store has nothing to say about `" + AMOUNT + "`");
+        return answer.value();
+    }
+
+    /** The same workspace with {@code prices} written into it. */
+    private static void edit(Compilation c, String prices) {
+        assertNotEquals(PRICES, prices, "this edit matched nothing, so nothing was compared");
+        Map<String, String> edited = new LinkedHashMap<>();
+        edited.put("prices.sou", prices);
+        c.update(edited, Set.of());
+        c.answerEverything();
+        assertTrue(c.db().allReports().isEmpty(), "the workspace still compiles after the edit");
+    }
+
+    private static Compilation started() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("prices.sou", PRICES);
+        byId.put("cart.sou", CART);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        c.answerEverything();
+        assertTrue(c.db().allReports().isEmpty(), "the workspace compiles to begin with");
+        return c;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AReportAboutADeclarationFollowsItWhenItMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReportAboutADeclarationFollowsItWhenItMovesTest.java
@@ -1,0 +1,72 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Primary;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A report about a declaration is sent where the declaration is now.
+ *
+ * <p>The half of the boundary that has to keep working. What a declaration says is answered apart
+ * from where it is written so that moving one reaches nobody; a reader that puts a caret under the
+ * declaration still means where it is, and it asks for that separately. Left depending on the
+ * meaning for both, such a reader would go on pointing at the line the declaration used to be on for
+ * as long as it kept saying the same thing — and the report would be wrong in a way no test of what
+ * the compiler says can see, because what it says would not have changed.
+ *
+ * <p>Written now rather than when the cut starts saving work. A check that a caret follows its
+ * declaration passes today whatever the reader depends on, and it is the one that would fail the
+ * day the answer it depends on stops moving.
+ */
+class AReportAboutADeclarationFollowsItWhenItMovesTest {
+
+    /** A product with no value: nothing satisfies both of its rules, so it is refused. */
+    private static final String EMPTY = """
+            module shop.empty exposing ( Impossible )
+
+            data Impossible = Int
+                invariant value >= 1 && value <= 0
+            """;
+
+    @Test
+    void movingTheDeclarationMovesTheCaretUnderIt() {
+        Compilation c = Compilation.ofDocuments(Map.of("empty.sou", EMPTY), Set.of(),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        int before = whereItIsReported(c);
+
+        Map<String, String> edited = new LinkedHashMap<>();
+        edited.put("empty.sou", EMPTY.replace("data Impossible",
+                "// two lines written above it\n// which move it down the file\ndata Impossible"));
+        c.update(edited, Set.of());
+        c.answerEverything();
+
+        assertNotEquals(before, whereItIsReported(c),
+                "the declaration was written two lines further down and the report still points at"
+                        + " the line it used to be on");
+        assertEquals(before + 2, whereItIsReported(c),
+                "the report followed the declaration, but not to where it went");
+    }
+
+    /** The line the one report about this workspace puts its caret on. */
+    private static int whereItIsReported(Compilation c) {
+        List<Located> errors = c.errors();
+        assertEquals(1, errors.size(),
+                "this workspace is supposed to be refused for exactly one thing: " + errors);
+        if (errors.getFirst().diagnostic().primary() instanceof Primary.InSource in) {
+            return in.place().region().start().line();
+        }
+        throw new AssertionError("the report is supposed to point at the declaration, and points "
+                + errors.getFirst().diagnostic().primary() + " instead");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AnIncludeThatDenotesNothingReachesTheNormalizedDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnIncludeThatDenotesNothingReachesTheNormalizedDeclarationTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Normalized;
+import souther.compiler.types.TypeKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name a declaration spreads that denotes nothing is still there when the declaration is
+ * normalized.
+ *
+ * <p>Asked because it decides what an answer about a declaration has to be able to say. A reading
+ * published across a module boundary carries what a declaration includes; if an unresolved name is
+ * gone by the rung that reading is taken at, what it carries is a list of declarations, and if it is
+ * not, then which name went unanswered is part of what the declaration says — two declarations
+ * spreading two different names that denote nothing do not say the same thing.
+ *
+ * <p>The source is one this compiler refuses. That is the state being asked about: name resolution
+ * reports and carries on, and what this holds is what the passes below it are handed.
+ */
+class AnIncludeThatDenotesNothingReachesTheNormalizedDeclarationTest {
+
+    private static final String SPREADING_NOTHING = """
+            module demo
+
+            data Named = { name: String }
+
+            data Item = { ...Named, ...Absent }
+
+            behavior f : (i: Item) -> String
+            let f (i) = i.name
+            """;
+
+    @Test
+    void whatADeclarationSpreadsIsThereWhetherOrNotItDenotes() {
+        Compilation compilation = Compilation.ofSource(SPREADING_NOTHING, "Main");
+        // Asked after the questions are, because what a compilation says is read off the reports its
+        // answers carry: asked of a store nothing has been asked of, every source is silent.
+        compilation.answerEverything();
+        assertFalse(compilation.errors().isEmpty(),
+                "this source is supposed to name something nothing declares");
+
+        Answer<Normalized.Def> normalized =
+                compilation.db().ask(new Shapes.NormalizedDef(new TypeKey("demo", "Item")));
+        assertTrue(normalized.present(),
+                "`Item` has no normalized declaration at all, so nothing below the settling is"
+                        + " answered about a declaration that spreads a name nothing declares");
+
+        assertTrue(normalized.value().node() instanceof Hir.Data,
+                "`Item` is a product and came back as " + normalized.value().node());
+        Hir.Data item = (Hir.Data) normalized.value().node();
+
+        List<String> denoting = new ArrayList<>();
+        List<String> unanswered = new ArrayList<>();
+        for (Hir.Name each : item.includes()) {
+            switch (each) {
+                case Hir.Name.Denoting it -> denoting.add(it.type().name());
+                case Hir.Name.Unanswered it -> unanswered.add(it.name().canonical());
+            }
+        }
+        assertEquals(List.of("Named"), denoting, "what `Item` spreads and reaches");
+        assertEquals(List.of("Absent"), unanswered,
+                "what `Item` spreads and does not reach — and which name it was");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
@@ -59,6 +59,8 @@ class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
         Answer<?> checked = c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn"));
         Answer<?> published = c.db().ask(new Shapes.MeaningOf(
                 new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+        Answer<?> expanded = c.db().ask(new Shapes.ClausesExpandedFor(
+                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
 
         edit(c, "// a line written above the declaration\n" + DECLARING);
 
@@ -68,6 +70,12 @@ class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
         assertEquals(published.value(), c.db().ask(new Shapes.MeaningOf(
                         new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
                 "what the declaration says is the same, and the boundary answer moved");
+        // Which answer carries the move across. The clauses a reading is answered from are the
+        // declaration's own, in the representation its module expanded them into -- an authored
+        // tree, so moving the declaration makes a different one.
+        assertNotEquals(expanded.value(), c.db().ask(new Shapes.ClausesExpandedFor(
+                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                "the clauses came out the same, so this is no longer what carries the move");
         assertNotSame(checked, c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn")),
                 "the importer's checked body no longer moves for a comment written next door —"
                         + " which is the goal, so this line is the one to change");

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
@@ -1,0 +1,118 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an edit that only moves a declaration reaches in the module that imports it.
+ *
+ * <p>The chain #1472 was opened about, written down where it can be watched while the readers are
+ * moved one at a time. A comment line written in the declaring module moves every position under it
+ * and says nothing different; the importer's answers were worked out again for it, through the
+ * declaration answers that carry the authored tree.
+ *
+ * <p><b>Written to be red until it is not.</b> Each answer below is asked before and after the edit
+ * and held to whichever of the two it is today, so moving a reader onto the boundary shows up here
+ * as this test failing rather than as nothing. What it is holding is the measurement, not the goal:
+ * a line saying an answer is remade is a line to change when it stops being remade, and the
+ * comparison beside it — that an edit changing what the declaration says does reach the importer —
+ * is what keeps the goal from being met by an answer that never moves.
+ */
+class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
+
+    private static final String DECLARING = """
+            module shop.prices exposing ( Amount )
+
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    /** Imports it, names it in a signature, and writes a row about it, so the importer measures. */
+    private static final String IMPORTING = """
+            module shop.cart exposing ( Basket, paidOn )
+
+            import shop.prices ( Amount )
+
+            data Basket = { paid: Amount }
+
+            behavior paidOn : (t: Basket) -> Int
+            let paidOn (t) = t.paid.value
+
+            example paidOn
+                | "one" : (Basket { paid = Amount { value = 1 } }) -> 1
+            """;
+
+    @Test
+    void aCommentWrittenInTheDeclaringModuleStillReachesTheImporter() {
+        Compilation c = started();
+        Answer<?> inputs = c.db().ask(new Adequacy.Inputs("shop.cart"));
+        Answer<?> checked = c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn"));
+        Answer<?> published = c.db().ask(new Shapes.MeaningOf(
+                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+
+        edit(c, "// a line written above the declaration\n" + DECLARING);
+
+        // Worked out again and come out the same, which is what stops the work above it. The answer
+        // is a new object either way -- what an edit is absorbed by is the value being equal, not
+        // the store having skipped the question.
+        assertEquals(published.value(), c.db().ask(new Shapes.MeaningOf(
+                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                "what the declaration says is the same, and the boundary answer moved");
+        assertNotSame(checked, c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn")),
+                "the importer's checked body no longer moves for a comment written next door —"
+                        + " which is the goal, so this line is the one to change");
+        assertNotSame(inputs, c.db().ask(new Adequacy.Inputs("shop.cart")),
+                "the importer's inputs no longer move for a comment written next door — which is"
+                        + " the goal, so this line is the one to change");
+    }
+
+    /**
+     * And the edit that changes what the declaration says does reach it.
+     *
+     * <p>Without this the goal above is met by an importer that never looks at the declaration at
+     * all, which is the other way to be wrong about a boundary.
+     */
+    @Test
+    void andAnEditThatChangesWhatItSaysReachesTheImporter() {
+        Compilation c = started();
+        Answer<?> published = c.db().ask(new Shapes.MeaningOf(
+                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+        Answer<?> checked = c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn"));
+
+        edit(c, DECLARING.replace("invariant value >= 0", "invariant value >= 1"));
+
+        assertNotEquals(published.value(), c.db().ask(new Shapes.MeaningOf(
+                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                "the declaration was given a rule it did not have");
+        assertNotSame(checked, c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn")),
+                "a body checked against the declaration was not checked again");
+    }
+
+    private static void edit(Compilation c, String prices) {
+        Map<String, String> edited = new LinkedHashMap<>();
+        edited.put("prices.sou", prices);
+        c.update(edited, Set.of());
+        c.answerEverything();
+    }
+
+    private static Compilation started() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("prices.sou", DECLARING);
+        byId.put("cart.sou", IMPORTING);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        c.answerEverything();
+        assertTrue(c.db().allReports().isEmpty(), "the workspace compiles to begin with: "
+                + c.db().allReports());
+        return c;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeKey;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,10 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * What an edit that only moves a declaration reaches in the module that imports it.
  *
- * <p>The chain #1472 was opened about, written down where it can be watched while the readers are
- * moved one at a time. A comment line written in the declaring module moves every position under it
- * and says nothing different; the importer's answers were worked out again for it, through the
- * declaration answers that carry the authored tree.
+ * <p>Written down where it can be watched while the readers are moved onto the boundary one at a
+ * time. A comment line written in the declaring module moves every position under it and says
+ * nothing different; the importer's answers are worked out again for it, through the declaration
+ * answers that carry the authored tree.
  *
  * <p><b>Written to be red until it is not.</b> Each answer below is asked before and after the edit
  * and held to whichever of the two it is today, so moving a reader onto the boundary shows up here
@@ -52,15 +53,17 @@ class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
                 | "one" : (Basket { paid = Amount { value = 1 } }) -> 1
             """;
 
+    private static final TypeKey AMOUNT = new TypeKey("shop.prices", "Amount");
+
     @Test
     void aCommentWrittenInTheDeclaringModuleStillReachesTheImporter() {
         Compilation c = started();
         Answer<?> inputs = c.db().ask(new Adequacy.Inputs("shop.cart"));
         Answer<?> checked = c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn"));
         Answer<?> published = c.db().ask(new Shapes.MeaningOf(
-                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+                AMOUNT));
         Answer<?> expanded = c.db().ask(new Shapes.ClausesExpandedFor(
-                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+                AMOUNT));
 
         edit(c, "// a line written above the declaration\n" + DECLARING);
 
@@ -68,13 +71,13 @@ class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
         // is a new object either way -- what an edit is absorbed by is the value being equal, not
         // the store having skipped the question.
         assertEquals(published.value(), c.db().ask(new Shapes.MeaningOf(
-                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                        AMOUNT)).value(),
                 "what the declaration says is the same, and the boundary answer moved");
         // Which answer carries the move across. The clauses a reading is answered from are the
         // declaration's own, in the representation its module expanded them into -- an authored
         // tree, so moving the declaration makes a different one.
         assertNotEquals(expanded.value(), c.db().ask(new Shapes.ClausesExpandedFor(
-                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                        AMOUNT)).value(),
                 "the clauses came out the same, so this is no longer what carries the move");
         assertNotSame(checked, c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn")),
                 "the importer's checked body no longer moves for a comment written next door —"
@@ -94,13 +97,13 @@ class WhatCrossesAModuleBoundaryWhenADeclarationOnlyMovesTest {
     void andAnEditThatChangesWhatItSaysReachesTheImporter() {
         Compilation c = started();
         Answer<?> published = c.db().ask(new Shapes.MeaningOf(
-                new souther.compiler.types.TypeKey("shop.prices", "Amount")));
+                AMOUNT));
         Answer<?> checked = c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn"));
 
         edit(c, DECLARING.replace("invariant value >= 0", "invariant value >= 1"));
 
         assertNotEquals(published.value(), c.db().ask(new Shapes.MeaningOf(
-                        new souther.compiler.types.TypeKey("shop.prices", "Amount"))).value(),
+                        AMOUNT)).value(),
                 "the declaration was given a rule it did not have");
         assertNotSame(checked, c.db().ask(new Bodies.CheckedBehavior("shop.cart", "paidOn")),
                 "a body checked against the declaration was not checked again");

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatTheLanguageDeclaresIsPublishedLikeAnythingElseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatTheLanguageDeclaresIsPublishedLikeAnythingElseTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclarationMeaning;
+import souther.compiler.types.TypeKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the language declares is published like anything else.
+ *
+ * <p>A declaration is asked for by its address, and a reader elsewhere has no way of telling which
+ * of them a module wrote. So every one of them is answered about — including the ones no module
+ * wrote, which resolve and type like any other and belong to no module here.
+ *
+ * <p>They are read differently for a reason, and this is what holds the reason to being true. A
+ * declaration's clauses are read in a reading made over the scope of the module that wrote it, and
+ * asked for the module of one of these a compilation answers that it holds no such module. So what
+ * the language declares is read without one — which is only sound because a sum names its cases and
+ * a unit names itself, and neither says anything a reading answers.
+ */
+class WhatTheLanguageDeclaresIsPublishedLikeAnythingElseTest {
+
+    private static final String SOURCE = """
+            module demo
+
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    @Test
+    void everyDeclarationTheLanguageGivesIsAnsweredFor() {
+        Compilation c = Compilation.ofSource(SOURCE, "Main");
+        c.answerEverything();
+        Map<TypeKey, Hir.Def> language =
+                c.db().ask(new Front.Library()).value().languageDeclarations();
+        assertFalse(language.isEmpty(), "the library declares something, or this asks nothing");
+
+        for (TypeKey declared : language.keySet()) {
+            Answer<DeclarationMeaning> said = c.db().ask(new Shapes.MeaningOf(declared));
+            assertTrue(said.present(),
+                    "`" + declared + "` is declared by the language and nothing is published"
+                            + " about it");
+            assertTrue(said.value().declares().equals(declared),
+                    "`" + declared + "` was published as `" + said.value().declares() + "`");
+        }
+    }
+
+    /**
+     * And a module of the compilation cannot be asked for one of them.
+     *
+     * <p>The reason the reading is made the other way, held rather than described. Take it away and
+     * the answer above is one that happens to work.
+     */
+    @Test
+    void andTheModuleOneIsAddressedInIsNoModuleThisCompilationHolds() {
+        Compilation c = Compilation.ofSource(SOURCE, "Main");
+        c.answerEverything();
+        Map<TypeKey, Hir.Def> language =
+                c.db().ask(new Front.Library()).value().languageDeclarations();
+
+        for (TypeKey declared : language.keySet()) {
+            assertFalse(c.modules().contains(declared.module()),
+                    "`" + declared + "` is addressed in a module this compilation writes, so the"
+                            + " reading of it would have been made after all");
+        }
+    }
+}


### PR DESCRIPTION
The first part of #1472. A declaration is already a cut at the module boundary, and what that cut carries is the authored tree — every node of one holds where it was written, so a declaration moved down its file, saying nothing different, arrives at every module that imports it as a declaration that changed.

This defines the other fact and moves the readers that mean it. It does not yet stop the propagation; what is left is #1504, and the measurement below says why.

## What a declaration says

`DeclarationMeaning` is what a module reading somebody else's declaration observes: which kind it is, what it is made of, what it spreads, and what must hold of a value. Not a filtered tree — a component the tree gains later belongs here only if a reader elsewhere would mean it, and adding one is publishing something.

It is held to reading every part and to carrying what they say, because those are not the same thing. One check walks the components as the records declare them and reads the compiled producer to see which it asked for, so a component that is neither read nor written down as said elsewhere fails there. Another edits a declaration one way at a time — its fields laid out differently, a field of another type, its spreads in another order, its clauses written in another order, and a line written above it — because a producer that gathered the parts into something orderless would pass the first and lose the difference.

Its fields are its own and in order. Its own, because what a value is made of in full is a question about this declaration and the ones it spreads. In order, because that order is the order of the parameters of the entry a value is built through, and a module elsewhere calls it.

What a declaration spreads is carried as which declaration it reaches, or, where it reaches none, as the name it was written under. Name resolution reports and carries on, and two declarations spreading two names that reach nothing are not saying the same thing.

## Where it is written

Beside it and never from it, as `ClauseLocations` already is for a clause. The address is settled first and asked two things, rather than the declaration being found twice: where a report may send a reader, and where its code is as a citation. Those are two answers and not one at two resolutions — a place nobody settled, and one settled in a text this compilation does not hold, are states one of the readers here observes and the other question cannot express at all.

The capabilities are beside `Symbols` rather than on it. A carrier of symbols answers what a declaration is in the form it reads declarations in, and answering the same question in two forms is what that interface says it exists to refuse.

## The readers moved

They came out differently from each other.

The reading that runs a program's rows wanted only which kind a declaration is; moving it onto the boundary left it holding no carrier of symbols at all.

The reader that says a type has no value was asking the tree for two things at once, and one of them turned out not to be a question — the identity it holds already carries the name. What is left is where to put the caret.

The reader that names the lines a declaration draws needs both, and now asks both of the one address. The note there saying a caller must not find one declaration twice is kept, and says which rule it is: about how a declaration is found, not about what may be asked of it once it has been.

## What still crosses

A watch is left in, holding what an edit that only moves a declaration reaches today and named for the answer that carries it. What the boundary answers is already right — asked before and after such an edit, it comes out equal. What reads it is not, so the answers above it are still remade. That is #1504, and it is a different question: the clauses a body is checked against arrive as the tree they were written in, and what reads them works over a form that a boundary answer may not hand out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
