### PR TITLE
Ask the operation where a walk over these answers starts and stops

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p><b>Three rules and not one, because they are three claims.</b> The widest names every nest
  * that touches a settled answer at all — said as a constant, or asked of one through the operations
  * that observe and compose settledness, since {@code a.joined(b)} carries a positive answer onwards
- * without spelling one. Inside it is who may make the positive answer. Inside that is the one the
+ * without spelling one. Inside it is who may decide the positive answer. Inside that is the one the
  * contract is about: which nests outside the readings themselves say it.
  *
  * <p><b>What these rules do not say.</b> They fix who may name a settled answer, and not who may
@@ -410,13 +410,19 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
                     + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH));
 
-    /** Putting several answers together: the operations that compose two, and the ones a walk over
-     *  many asks about the operation it is walking under. */
-    private static final Set<String> COMPOSES = Set.of("met", "joined",
-            "identityForMeet", "identityForJoin", "endsAMeet", "endsAJoin");
+    /** The operations that make one of these answers out of two. Where a walk starts and where it
+     *  stops are questions asked about an operation and answer for none of it, so a place that asks
+     *  them and composes nothing is not composing. */
+    private static final Set<String> COMPOSES = Set.of("met", "joined");
 
     /**
-     * And the readings that put several of these answers together.
+     * And the readings that make one of these answers out of several.
+     *
+     * <p>Out of several and into one of them, which is not every way two are read together:
+     * {@link Emptiness.SidesShownEmpty} takes two and answers which of them were shown empty, and
+     * what comes back is an observation for a connective to value rather than an answer about a
+     * position. A reading of that is a reading of the classification, and this is about the
+     * arithmetic.
      *
      * <p>Three of them walk, and one shape between the three: an alternative stands where every
      * block of it does, and a reading stands where any alternative does. Each starts where the
@@ -505,13 +511,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     @Test
-    void andTheseAreTheReadingsThatPutSeveralOfThemTogether() {
+    void andTheseAreTheReadingsThatMakeOneOfThemOutOfSeveral() {
         assertEquals(COMPOSES_SEVERAL_ANSWERS,
                 placesSaying(saidInProduction(), use -> COMPOSES.contains(use.said())),
                 "a walk that takes these answers in one at a time answers about a set with a walk"
                         + " over one order of it, and stops on reaching what the operation cannot be"
-                        + " moved from: a reading arriving here is one composing several answers,"
-                        + " and what says it may is where the operations are written");
+                        + " moved from: a reading arriving here is one answering out of several"
+                        + " answers, and what says it may is where the operations are written");
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -262,19 +262,20 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
             "souther/compiler/values/TextExtents");
 
     /**
-     * And who may make the settled positive answer.
+     * And who may decide that the settled positive answer is the answer.
      *
-     * <p>{@code Settlement} is one nest that says a position is settled without ever saying it
-     * admits something: it joins two branches' answers and reads whether the join came out empty. A
-     * nest arriving here is one that has begun to claim something exists, which is what these rules
-     * are about.
+     * <p>{@code Settlement} is one nest that says a position is settled without ever deciding that
+     * something is admitted: it joins two branches' answers and reads whether the join came out
+     * empty. A nest arriving here is one that has begun to claim something exists, which is what
+     * these rules are about.
      *
-     * <p><b>Holding the answer is not making it.</b> The walks over what a reading holds carry a
-     * positive answer out of every alternative that stands, and the answers they carry are the ones
-     * the caller's question gave them and the one the arithmetic starts a walk from
-     * ({@link #FOLDS_THESE_ANSWERS}) — neither of which is theirs to decide. What puts a nest here
-     * is answering in its own words that something is admitted: {@code PlannedValues} does, for a
-     * position whose plan is already a set and needs no machine.
+     * <p><b>Returning the answer is not deciding it.</b> The walks over what a reading holds hand a
+     * positive answer back out of every alternative that stands, and the answers they hand back are
+     * the one the caller's question gave them and the one the arithmetic starts a walk from
+     * ({@link #COMPOSES_SEVERAL_ANSWERS}) — an empty conjunction comes out positive because that is
+     * where a meet begins, which the word decides and the walk carries. What puts a nest here is
+     * saying in its own words which answer is the answer: {@code PlannedValues} does, for a position
+     * whose plan is already a set and needs no machine.
      */
     private static final List<String> SAYS_SOMETHING_IS_ADMITTED = List.of(
             "souther/compiler/check/Carrier",
@@ -409,27 +410,38 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
                     + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH));
 
-    /** The operations a walk over many answers asks about the operation it is walking under. */
-    private static final Set<String> FOLDS = Set.of(
+    /** Putting several answers together: the operations that compose two, and the ones a walk over
+     *  many asks about the operation it is walking under. */
+    private static final Set<String> COMPOSES = Set.of("met", "joined",
             "identityForMeet", "identityForJoin", "endsAMeet", "endsAJoin");
 
     /**
-     * And the readings that walk over many of these answers at once.
+     * And the readings that put several of these answers together.
      *
-     * <p>Three walks and one shape between them: an alternative stands where every block of it
-     * does, and a reading stands where any alternative does. Each of them starts where the operation
-     * it walks under starts and stops where that operation can no longer be moved, and asks the word
-     * for both — a walk that named either would be saying the arithmetic's fact in its own words,
-     * true of these three answers by a coincidence nobody wrote down.
+     * <p>Three of them walk, and one shape between the three: an alternative stands where every
+     * block of it does, and a reading stands where any alternative does. Each starts where the
+     * operation it walks under starts and stops where that operation can no longer be moved, and
+     * asks the word for both — a walk that named either would be saying the arithmetic's fact in its
+     * own words, true of these three answers by a coincidence nobody wrote down. The fourth composes
+     * two answers and no more, so there is no place in it to start from or stop at: what two
+     * occurrences of one branch come to is one call.
+     *
+     * <p><b>Directly, which is the whole of what this holds.</b> What each of these does with the
+     * answers it put together is its own, and no walk here follows a call into what it calls. A
+     * reading that handed the composing to something beside it would leave here and that something
+     * would arrive, which is the finding to read: the composing moved, and where the questions a
+     * fold asks are answered moved with it.
      *
      * <p>Written down because the shape is what makes such a walk possible and nothing about a walk
-     * announces it. What holds these three to it is the operations being ones a fold may be taken
-     * over at all, which is asked where they are written; what is held here is that these are the
-     * folds there are. A fourth is a reading to look at: it is walking over a set of answers whose
-     * order is somebody's, and it is entitled to what these are entitled to only if it is the same
-     * shape.
+     * announces it. What holds these to it is the operations being ones a fold may be taken over at
+     * all, which is asked where they are written. A reading arriving here is walking over answers
+     * whose order is somebody's, and is entitled to what these are entitled to only if it is the
+     * same shape.
      */
-    private static final List<String> FOLDS_THESE_ANSWERS = List.of(
+    private static final List<String> COMPOSES_SEVERAL_ANSWERS = List.of(
+            "souther/compiler/check/Settlement$Sided#alsoSeen"
+                    + "(Lsouther/compiler/check/Settlement$Sided;)"
+                    + "Lsouther/compiler/check/Settlement$Sided;",
             "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;"
                     + "Lsouther/compiler/values/AskedOfARelation;)"
@@ -493,13 +505,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     @Test
-    void andTheseAreTheReadingsThatWalkOverManyOfThem() {
-        assertEquals(FOLDS_THESE_ANSWERS,
-                placesSaying(saidInProduction(), use -> FOLDS.contains(use.said())),
+    void andTheseAreTheReadingsThatPutSeveralOfThemTogether() {
+        assertEquals(COMPOSES_SEVERAL_ANSWERS,
+                placesSaying(saidInProduction(), use -> COMPOSES.contains(use.said())),
                 "a walk that takes these answers in one at a time answers about a set with a walk"
                         + " over one order of it, and stops on reaching what the operation cannot be"
-                        + " moved from: a reading arriving here is one making both of those"
-                        + " assumptions, and what says it may is where the operations are written");
+                        + " moved from: a reading arriving here is one composing several answers,"
+                        + " and what says it may is where the operations are written");
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -94,11 +94,13 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      *  {@code UNDECIDED} settles nothing and is named freely. */
     private static final Set<String> SETTLED = Set.of("EMPTY", "NONEMPTY");
 
-    /** The operations that read whether an answer is settled or carry one onwards. A caller of
-     *  these holds a settled answer without naming one, which is why calling them counts as saying
-     *  it. */
+    /** The operations that read whether an answer is settled, carry one onwards, or hand one out. A
+     *  caller of these holds a settled answer without naming one, which is why calling them counts
+     *  as saying it — a walk asking an operation where it starts is handed whichever answer that is,
+     *  and one asking where it stops is holding the answer it stopped on. */
     private static final Set<String> OBSERVES_OR_COMPOSES =
-            Set.of("isEmpty", "isDecided", "met", "joined", "of", "bothStand");
+            Set.of("isEmpty", "isDecided", "met", "joined", "of", "bothStand",
+                    "identityForMeet", "identityForJoin", "endsAMeet", "endsAJoin");
 
     /** What javac writes for a switch over this word: a synthetic table of its constants, read by
      *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
@@ -262,18 +264,23 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /**
      * And who may make the settled positive answer.
      *
-     * <p>{@code Settlement} is the one nest that says a position is settled without ever saying it
+     * <p>{@code Settlement} is one nest that says a position is settled without ever saying it
      * admits something: it joins two branches' answers and reads whether the join came out empty. A
      * nest arriving here is one that has begun to claim something exists, which is what these rules
      * are about.
+     *
+     * <p><b>Holding the answer is not making it.</b> The walks over what a reading holds carry a
+     * positive answer out of every alternative that stands, and the answers they carry are the ones
+     * the caller's question gave them and the one the arithmetic starts a walk from
+     * ({@link #FOLDS_THESE_ANSWERS}) — neither of which is theirs to decide. What puts a nest here
+     * is answering in its own words that something is admitted: {@code PlannedValues} does, for a
+     * position whose plan is already a set and needs no machine.
      */
     private static final List<String> SAYS_SOMETHING_IS_ADMITTED = List.of(
             "souther/compiler/check/Carrier",
             "souther/compiler/check/Confinement",
             "souther/compiler/check/StatedByClauses",
-            "souther/compiler/values/AdmissibleValues",
             "souther/compiler/values/Apartness",
-            "souther/compiler/values/ConjoinedAdmissibleValues",
             "souther/compiler/values/PlannedValues",
             "souther/compiler/values/Realized",
             "souther/compiler/values/TextExtents");
@@ -383,34 +390,57 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     private record Open(String place, String question) {}
 
-    /** What a settled positive answer is worth, beside a position nobody could build and at the top
-     *  of what a join can reach. */
-    private static final String WHAT_AN_ANSWER_IS_WORTH = "souther-lang/souther#1493";
+    /** What a settled positive answer is worth beside a position nobody could build. */
+    private static final String WHAT_AN_ANSWER_IS_WORTH = "souther-lang/souther#1498";
 
     /**
      * And the readings of this word whose meaning nobody has decided yet.
      *
      * <p>One question and no owner for it. {@code admission} reads what a settled positive answer is
-     * worth beside a position nobody could build. The two {@code anyAlternativeAdmits} read that a
-     * joined answer has reached the top of what a choice can be, which is a fact about the
-     * arithmetic and is known here rather than where the arithmetic is.
+     * worth beside a position nobody could build, which is a rule about what a reading that asked
+     * less than the rules say may publish rather than about which of the three an answer is.
      *
-     * <p>Each of them is a question this word could be given an owner for, and none of them is one
-     * this compiler has decided. Naming a reading here says that; it does not say that the reading
-     * was left alone.
+     * <p>It is a question this word could be given an owner for, and it is not one this compiler has
+     * decided. Naming a reading here says that; it does not say that the reading was left alone.
      */
     private static final List<Open> COMPARED_IN_PRODUCTION = List.of(
             new Open("souther/compiler/check/Confinement$Worked#admission"
                     + "(Lsouther/compiler/check/PositionEnvelope$Restrictions;"
                     + "Lsouther/compiler/values/StringMachineAnswers;)"
-                    + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH),
-            new Open("souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
+                    + "Lsouther/compiler/check/Confinement$Admission;", WHAT_AN_ANSWER_IS_WORTH));
+
+    /** The operations a walk over many answers asks about the operation it is walking under. */
+    private static final Set<String> FOLDS = Set.of(
+            "identityForMeet", "identityForJoin", "endsAMeet", "endsAJoin");
+
+    /**
+     * And the readings that walk over many of these answers at once.
+     *
+     * <p>Three walks and one shape between them: an alternative stands where every block of it
+     * does, and a reading stands where any alternative does. Each of them starts where the operation
+     * it walks under starts and stops where that operation can no longer be moved, and asks the word
+     * for both — a walk that named either would be saying the arithmetic's fact in its own words,
+     * true of these three answers by a coincidence nobody wrote down.
+     *
+     * <p>Written down because the shape is what makes such a walk possible and nothing about a walk
+     * announces it. What holds these three to it is the operations being ones a fold may be taken
+     * over at all, which is asked where they are written; what is held here is that these are the
+     * folds there are. A fourth is a reading to look at: it is walking over a set of answers whose
+     * order is somebody's, and it is entitled to what these are entitled to only if it is the same
+     * shape.
+     */
+    private static final List<String> FOLDS_THESE_ANSWERS = List.of(
+            "souther/compiler/values/AdmissibleValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;"
                     + "Lsouther/compiler/values/AskedOfARelation;)"
-                    + "Lsouther/compiler/values/Emptiness;", WHAT_AN_ANSWER_IS_WORTH),
-            new Open("souther/compiler/values/PlannedValues#anyAlternativeAdmits"
+                    + "Lsouther/compiler/values/Emptiness;",
+            "souther/compiler/values/ConjoinedAdmissibleValues#anyAlternativeAdmits"
+                    + "(Lsouther/compiler/values/AskedOfEachBlock;"
+                    + "Lsouther/compiler/values/AskedOfARelation;)"
+                    + "Lsouther/compiler/values/Emptiness;",
+            "souther/compiler/values/PlannedValues#anyAlternativeAdmits"
                     + "(Lsouther/compiler/values/AskedOfEachBlock;)"
-                    + "Lsouther/compiler/values/Emptiness;", WHAT_AN_ANSWER_IS_WORTH));
+                    + "Lsouther/compiler/values/Emptiness;");
 
     /**
      * One saying of the word, and whose code holds it.
@@ -460,6 +490,16 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                 "an admission is worked out in the readings; outside them it is made at the bottom"
                         + " of the pair, by the pair itself, and read once where two branches that"
                         + " both stand are held open");
+    }
+
+    @Test
+    void andTheseAreTheReadingsThatWalkOverManyOfThem() {
+        assertEquals(FOLDS_THESE_ANSWERS,
+                placesSaying(saidInProduction(), use -> FOLDS.contains(use.said())),
+                "a walk that takes these answers in one at a time answers about a set with a walk"
+                        + " over one order of it, and stops on reaching what the operation cannot be"
+                        + " moved from: a reading arriving here is one making both of those"
+                        + " assumptions, and what says it may is where the operations are written");
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1307,23 +1307,24 @@ public final class AdmissibleValues<A> {
      */
     public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked, AskedOfARelation<A> relating) {
         if (held() instanceof Held.Alternatives<A> it) {
-            Emptiness any = Emptiness.EMPTY;
+            Emptiness any = Emptiness.identityForJoin();
             for (Alternative<A> box : it.boxes()) {
-                Emptiness stands = Emptiness.NONEMPTY;
+                Emptiness stands = Emptiness.identityForMeet();
                 for (Map.Entry<Sameness.Block<A>, ValueSet> each : box.at().entrySet()) {
                     stands = stands.met(asked.of(each.getKey(), each.getValue()));
-                    if (stands.isEmpty()) {
+                    if (stands.endsAMeet()) {
                         break;
                     }
                 }
                 // And what its denials come to, asked after the blocks and not before. An
-                // alternative already refused at a block is one no relation has to be read for,
-                // and reading it first would spend on every alternative what one question settled.
-                if (!stands.isEmpty()) {
+                // alternative the blocks have already settled is one no relation has to be read
+                // for, and reading it first would spend on every alternative what one question
+                // settled.
+                if (!stands.endsAMeet()) {
                     stands = stands.met(relating.of(box.apart(), box.product()).emptiness());
                 }
                 any = any.joined(stands);
-                if (any == Emptiness.NONEMPTY) {
+                if (any.endsAJoin()) {
                     return any;
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -153,10 +153,10 @@ public final class ConjoinedAdmissibleValues<A> {
      * question is one about which values a rule leaves, and no rule left any.
      */
     public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked, AskedOfARelation<A> relating) {
-        Emptiness stands = Emptiness.NONEMPTY;
+        Emptiness stands = Emptiness.identityForMeet();
         for (AdmissibleValues<A> each : factors) {
             stands = stands.met(each.anyAlternativeAdmits(asked, relating));
-            if (stands.isEmpty()) {
+            if (stands.endsAMeet()) {
                 return stands;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Emptiness.java
@@ -26,6 +26,13 @@ package souther.compiler.values;
  * {@link SidesShownEmpty} where the question is about two answers at once: which of the two were
  * shown empty is the observation, and what a connective does about that is the connective's
  * ({@link Alternatives} for a choice).
+ *
+ * <p><b>And what an operation over many of them starts from and can no longer be moved from is the
+ * operation's.</b> A walk that seeded itself with a constant, or stopped on reaching one, would be
+ * saying where {@link #met} or {@link #joined} begins and ends in its own words — true of the three
+ * by arithmetic nobody wrote down, and left standing by an answer added to them. So each operation
+ * is asked ({@link #identityForMeet} and {@link #endsAMeet}, {@link #identityForJoin} and
+ * {@link #endsAJoin}), and a walk is told nothing about which answers those come to.
  */
 public enum Emptiness {
 
@@ -38,7 +45,15 @@ public enum Emptiness {
     /** Neither, until what the position admits has been worked out. */
     UNDECIDED;
 
-    /** Whether this is the settled answer that nothing is admitted. */
+    /**
+     * Whether this is the settled answer that nothing is admitted.
+     *
+     * <p>A fact about the answer, and not about whether an operation can still be moved from it. A
+     * walk holding what it has taken in so far asks {@link #endsAMeet} or {@link #endsAJoin}, which
+     * are about the arithmetic it is walking under: that those two and this agree on any of the
+     * three is the arithmetic's doing, and a walk reading it here would be deciding the shape of an
+     * operation from one of its answers.
+     */
     public boolean isEmpty() {
         return switch (this) {
             case EMPTY -> true;
@@ -68,10 +83,20 @@ public enum Emptiness {
      * Where one is settled that something is admitted and the other is not known, the two together
      * are what the second one is — which is not known either, since what each of them says is about
      * a different part of the same value.
+     *
+     * <p><b>Every pair is answered, and none of them from the answer on one side alone.</b> An
+     * answer that settles this whatever stands beside it settles it because of what the other
+     * answers are, and an arm written to say so would go on saying it about an answer added to the
+     * three — which is the one thing nobody would have decided. So each answer is asked about each
+     * of them, and an answer added here is a row and a column and not a row.
      */
     public Emptiness met(Emptiness other) {
         return switch (this) {
-            case EMPTY -> EMPTY;
+            case EMPTY -> switch (other) {
+                case EMPTY -> EMPTY;
+                case NONEMPTY -> EMPTY;
+                case UNDECIDED -> EMPTY;
+            };
             case NONEMPTY -> switch (other) {
                 case EMPTY -> EMPTY;
                 case NONEMPTY -> NONEMPTY;
@@ -79,8 +104,40 @@ public enum Emptiness {
             };
             case UNDECIDED -> switch (other) {
                 case EMPTY -> EMPTY;
-                case NONEMPTY, UNDECIDED -> UNDECIDED;
+                case NONEMPTY -> UNDECIDED;
+                case UNDECIDED -> UNDECIDED;
             };
+        };
+    }
+
+    /**
+     * What nothing at all held together comes to, which is where a walk over such a pairing starts.
+     *
+     * <p>The answer {@link #met} leaves whatever it is put beside, so a walk that has taken nothing
+     * in yet stands where this does. Asked of the operation and not written at the walk: which
+     * answer that is follows from what holding things together means, and a walk naming it would be
+     * saying the arithmetic's own fact in the walk's words.
+     *
+     * <p>Which is not the same fact as what an empty conjunction admits. That nothing was read
+     * leaves every value at every position, and the reading saying so is the reading's — this says
+     * only that such a reading is what the arithmetic starts from.
+     */
+    public static Emptiness identityForMeet() {
+        return NONEMPTY;
+    }
+
+    /**
+     * Whether anything held together with this could come to anything else.
+     *
+     * <p>What a walk asks to stop early: an answer this cannot be moved from is the answer, and the
+     * conjuncts after it are conjuncts nobody has to look at. A fact about {@link #met} and not
+     * about which of the three this is — said the second way it would claim the same answer settles
+     * every operation, which {@link #joined} is the counterexample to.
+     */
+    public boolean endsAMeet() {
+        return switch (this) {
+            case EMPTY -> true;
+            case NONEMPTY, UNDECIDED -> false;
         };
     }
 
@@ -90,19 +147,50 @@ public enum Emptiness {
      * <p>Something is admitted where either side admits something, and nothing where both admit
      * nothing. Where one is settled empty and the other is not known, the choice is what the other
      * one is — which is not known either.
+     *
+     * <p>Every pair is answered here too, and for the reason {@link #met} says.
      */
     public Emptiness joined(Emptiness other) {
         return switch (this) {
-            case NONEMPTY -> NONEMPTY;
             case EMPTY -> switch (other) {
                 case EMPTY -> EMPTY;
                 case NONEMPTY -> NONEMPTY;
                 case UNDECIDED -> UNDECIDED;
             };
-            case UNDECIDED -> switch (other) {
+            case NONEMPTY -> switch (other) {
+                case EMPTY -> NONEMPTY;
                 case NONEMPTY -> NONEMPTY;
-                case EMPTY, UNDECIDED -> UNDECIDED;
+                case UNDECIDED -> NONEMPTY;
             };
+            case UNDECIDED -> switch (other) {
+                case EMPTY -> UNDECIDED;
+                case NONEMPTY -> NONEMPTY;
+                case UNDECIDED -> UNDECIDED;
+            };
+        };
+    }
+
+    /**
+     * What a choice between nothing at all comes to, which is where a walk over one starts.
+     *
+     * <p>{@link #identityForMeet}'s counterpart, and owned here for the same reason: the answer
+     * {@link #joined} leaves whatever it is put beside is the arithmetic's fact about itself.
+     */
+    public static Emptiness identityForJoin() {
+        return EMPTY;
+    }
+
+    /**
+     * Whether a further alternative could reach anything a choice ending in this has not.
+     *
+     * <p>{@link #endsAMeet}'s counterpart, and a different answer: what a choice cannot be moved
+     * from is not what a conjunction cannot be moved from, and a walk that asked one question for
+     * both would be reading the alternatives under the conjunction's arithmetic.
+     */
+    public boolean endsAJoin() {
+        return switch (this) {
+            case NONEMPTY -> true;
+            case EMPTY, UNDECIDED -> false;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -282,9 +282,12 @@ public sealed interface PlannedValues<A> {
                         // Said of the alternative that holds them and not of the reading, which is
                         // the grain the question is asked at — an alternative beside one carrying a
                         // denial stands on its own rules.
+                        //
+                        // And held together with what the blocks came to, since an alternative
+                        // stands where its blocks and its denials both leave it standing.
                         if (!stands.endsAMeet() && !box.apart().isEmpty()) {
-                            stands = box.apart().holdsABlockApartFromItself()
-                                    ? Emptiness.EMPTY : Emptiness.UNDECIDED;
+                            stands = stands.met(box.apart().holdsABlockApartFromItself()
+                                    ? Emptiness.EMPTY : Emptiness.UNDECIDED);
                         }
                         any = any.joined(stands);
                         if (any.endsAJoin()) {

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -264,13 +264,13 @@ public sealed interface PlannedValues<A> {
             case Settled<A> it -> switch (it.held()) {
                 case PlannedHeld.Nothing<A> _ -> Emptiness.EMPTY;
                 case PlannedHeld.Alternatives<A> boxes -> {
-                    Emptiness any = Emptiness.EMPTY;
+                    Emptiness any = Emptiness.identityForJoin();
                     for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
-                        Emptiness stands = Emptiness.NONEMPTY;
+                        Emptiness stands = Emptiness.identityForMeet();
                         for (Map.Entry<Sameness.Block<A>, AdmittedPlan> each
                                 : box.at().entrySet()) {
                             stands = stands.met(askedOf(each.getKey(), each.getValue(), asked));
-                            if (stands.isEmpty()) {
+                            if (stands.endsAMeet()) {
                                 break;
                             }
                         }
@@ -282,12 +282,12 @@ public sealed interface PlannedValues<A> {
                         // Said of the alternative that holds them and not of the reading, which is
                         // the grain the question is asked at — an alternative beside one carrying a
                         // denial stands on its own rules.
-                        if (!stands.isEmpty() && !box.apart().isEmpty()) {
+                        if (!stands.endsAMeet() && !box.apart().isEmpty()) {
                             stands = box.apart().holdsABlockApartFromItself()
                                     ? Emptiness.EMPTY : Emptiness.UNDECIDED;
                         }
                         any = any.joined(stands);
-                        if (any == Emptiness.NONEMPTY) {
+                        if (any.endsAJoin()) {
                             yield any;
                         }
                     }

--- a/souther-compiler/src/test/java/souther/compiler/values/APlannedReadingAnswersTheSameInEitherIterationOrderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/APlannedReadingAnswersTheSameInEitherIterationOrderTest.java
@@ -5,18 +5,21 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * What a walk over a reading that is still a description has to reach before it answers.
+ * What a walk over a reading that is still a description may answer from.
  *
  * <p>An alternative stands where every block of it still admits something, and the reading stands
- * where any alternative does. The walk stops as soon as one of those is decided, which is a
- * question about the operation it is walking under and not about the answer it is holding: stopped
- * on the wrong one, it answers about the blocks it had reached and calls that the reading's answer.
+ * where any alternative does. The walk takes them in one at a time and stops as soon as what it is
+ * holding cannot be moved, so what it read is the blocks up to that one and no further — and it may
+ * answer from those only because they settled the walk, which is a question about the operation it
+ * is walking under and not about the answer it is holding. Stopped on the other operation's
+ * question, it answers from a run of blocks that settled nothing.
  *
- * <p>Both orders of each, because what a walk reaches first is the order the blocks of an
- * alternative and the alternatives of a reading happen to be in, and neither order is anybody's
- * claim. A reading written the other way round is the same reading.
+ * <p>So what is asked of these is not how much they read. It is that the answer is the same wherever
+ * in the order the block or the alternative that settles it happens to fall: the blocks of an
+ * alternative are named in the order an author wrote the rules, the alternatives of a choice in the
+ * order the branches were written, and a reading written the other way round is the same reading.
  */
-class EveryBlockOfAnAlternativeIsAskedAndEveryAlternativeOfAReadingTest {
+class APlannedReadingAnswersTheSameInEitherIterationOrderTest {
 
     private static final Value A = Value.text("A");
 
@@ -48,22 +51,22 @@ class EveryBlockOfAnAlternativeIsAskedAndEveryAlternativeOfAReadingTest {
     }
 
     @Test
-    void anAlternativeIsAskedAboutAtEveryBlockItNames() {
+    void anAlternativeIsRefusedByAnyBlockInEitherOrder() {
         assertEquals(Emptiness.EMPTY,
                 plans("here", A).meet(plans("there", B)).anyAlternativeAdmits(admitting(HERE)),
-                "an alternative holding a block nothing admits at stands for nothing, however many"
-                        + " of its blocks were answered before that one was reached");
+                "an alternative holding a block nothing admits at stands for nothing, whether that"
+                        + " block was the one the walk reached first or the one it reached last");
         assertEquals(Emptiness.EMPTY,
                 plans("there", B).meet(plans("here", A)).anyAlternativeAdmits(admitting(HERE)));
     }
 
     @Test
-    void andAReadingIsAskedAboutAtEveryAlternativeItHolds() {
+    void andAReadingAdmitsWhenAnyAlternativeDoesInEitherOrder() {
         assertEquals(Emptiness.NONEMPTY,
                 alternative(A, B).joinLiveApart(alternative(C, C))
                         .anyAlternativeAdmits(admittingWhatIsPlanned(C)),
-                "and a reading one alternative of which stands admits something, however many"
-                        + " alternatives were refused before that one was reached");
+                "and a reading one alternative of which stands admits something, whether the"
+                        + " alternatives refused were written before that one or after it");
         assertEquals(Emptiness.NONEMPTY,
                 alternative(C, C).joinLiveApart(alternative(A, B))
                         .anyAlternativeAdmits(admittingWhatIsPlanned(C)));

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryBlockOfAnAlternativeIsAskedAndEveryAlternativeOfAReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryBlockOfAnAlternativeIsAskedAndEveryAlternativeOfAReadingTest.java
@@ -1,0 +1,71 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a walk over a reading that is still a description has to reach before it answers.
+ *
+ * <p>An alternative stands where every block of it still admits something, and the reading stands
+ * where any alternative does. The walk stops as soon as one of those is decided, which is a
+ * question about the operation it is walking under and not about the answer it is holding: stopped
+ * on the wrong one, it answers about the blocks it had reached and calls that the reading's answer.
+ *
+ * <p>Both orders of each, because what a walk reaches first is the order the blocks of an
+ * alternative and the alternatives of a reading happen to be in, and neither order is anybody's
+ * claim. A reading written the other way round is the same reading.
+ */
+class EveryBlockOfAnAlternativeIsAskedAndEveryAlternativeOfAReadingTest {
+
+    private static final Value A = Value.text("A");
+
+    private static final Value B = Value.text("B");
+
+    private static final Value C = Value.text("C");
+
+    private static final Sameness.Block<String> HERE = Sameness.Block.of("here");
+
+    /** A rule about one position while it is still a description. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
+    /** A question nothing but {@code where} answers, settled either way and never waiting. */
+    private static AskedOfEachBlock<String> admitting(Sameness.Block<String> where) {
+        return (block, _) -> block.equals(where) ? Emptiness.NONEMPTY : Emptiness.EMPTY;
+    }
+
+    /** One alternative of two, told apart by what it admits rather than by where: alternatives
+     *  held apart are over the same blocks, and a question about a block would be about both. */
+    private static AskedOfEachBlock<String> admittingWhatIsPlanned(Value value) {
+        return (_, set) -> set.equals(ValueSet.just(value)) ? Emptiness.NONEMPTY : Emptiness.EMPTY;
+    }
+
+    /** An alternative naming two positions, which is what a choice cannot merge into a product. */
+    private static PlannedValues<String> alternative(Value here, Value there) {
+        return plans("here", here).meet(plans("there", there));
+    }
+
+    @Test
+    void anAlternativeIsAskedAboutAtEveryBlockItNames() {
+        assertEquals(Emptiness.EMPTY,
+                plans("here", A).meet(plans("there", B)).anyAlternativeAdmits(admitting(HERE)),
+                "an alternative holding a block nothing admits at stands for nothing, however many"
+                        + " of its blocks were answered before that one was reached");
+        assertEquals(Emptiness.EMPTY,
+                plans("there", B).meet(plans("here", A)).anyAlternativeAdmits(admitting(HERE)));
+    }
+
+    @Test
+    void andAReadingIsAskedAboutAtEveryAlternativeItHolds() {
+        assertEquals(Emptiness.NONEMPTY,
+                alternative(A, B).joinLiveApart(alternative(C, C))
+                        .anyAlternativeAdmits(admittingWhatIsPlanned(C)),
+                "and a reading one alternative of which stands admits something, however many"
+                        + " alternatives were refused before that one was reached");
+        assertEquals(Emptiness.NONEMPTY,
+                alternative(C, C).joinLiveApart(alternative(A, B))
+                        .anyAlternativeAdmits(admittingWhatIsPlanned(C)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/TheseAnswersMayBeFoldedInAnyOrderAndSayWhereAFoldStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/TheseAnswersMayBeFoldedInAnyOrderAndSayWhereAFoldStopsTest.java
@@ -1,0 +1,106 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * What a walk over many answers is entitled to assume about the operation it walks under.
+ *
+ * <p>The readings that ask what a whole reading admits fold {@link Emptiness#met} over the blocks of
+ * an alternative and {@link Emptiness#joined} over the alternatives. A fold is an answer read off
+ * one order of one bracketing, offered as an answer about a set: the alternatives of a reading are
+ * a set, and the blocks of one are named by rules whose order is the author's. So what is held here
+ * is that the operations cannot tell those apart, and that where a fold stops early it stops
+ * where the operation says rather than where one of the answers is.
+ *
+ * <p><b>Asked of {@link Emptiness#values()}, so that an answer added to the three is asked too.</b>
+ * The operations are written as a switch over every pair, so such an answer cannot compile until
+ * somebody has said what each pairing comes to; what nothing would otherwise ask is whether what
+ * they then say is still something a walk may fold, and whether the two words a walk stops on
+ * still name the answers that stop it.
+ *
+ * <p>Nothing here holds the three answers to a particular table. The laws below settle every
+ * pairing of these three between them, so a table written out beside them would be the same claim
+ * twice — and the second copy would be the one somebody edited to match a change. What a further
+ * answer means is a claim about that answer, and belongs where it is introduced.
+ *
+ * <p>Distribution is not asked for. A fold reaches one answer over one collection, and no reading
+ * here takes an operation through the other.
+ */
+class TheseAnswersMayBeFoldedInAnyOrderAndSayWhereAFoldStopsTest {
+
+    @Test
+    void aFoldOverNothingStandsWhereTheOperationSaysItStarts() {
+        for (Emptiness one : Emptiness.values()) {
+            assertSame(one, Emptiness.identityForMeet().met(one),
+                    "a conjunct met with what a walk starts from is what the conjunct said");
+            assertSame(one, one.met(Emptiness.identityForMeet()));
+            assertSame(one, Emptiness.identityForJoin().joined(one),
+                    "and an alternative joined onto what a walk starts from is that alternative");
+            assertSame(one, one.joined(Emptiness.identityForJoin()));
+        }
+    }
+
+    @Test
+    void neitherOperationCanTellTheOrderOfWhatItWasGiven() {
+        for (Emptiness one : Emptiness.values()) {
+            for (Emptiness other : Emptiness.values()) {
+                assertSame(one.met(other), other.met(one),
+                        "the blocks of an alternative are named in the order an author wrote the"
+                                + " rules, and what they come to is not about that order");
+                assertSame(one.joined(other), other.joined(one));
+            }
+        }
+    }
+
+    @Test
+    void norTheBracketingOfIt() {
+        for (Emptiness one : Emptiness.values()) {
+            for (Emptiness other : Emptiness.values()) {
+                for (Emptiness third : Emptiness.values()) {
+                    assertSame(one.met(other).met(third), one.met(other.met(third)),
+                            "a walk takes them in one at a time, and the answer is about the whole");
+                    assertSame(one.joined(other).joined(third), one.joined(other.joined(third)));
+                }
+            }
+        }
+    }
+
+    @Test
+    void andOneAnswerTwiceIsThatAnswer() {
+        for (Emptiness one : Emptiness.values()) {
+            assertSame(one, one.met(one), "two rules saying the same thing are one rule");
+            assertSame(one, one.joined(one));
+        }
+    }
+
+    @Test
+    void whatIsAskedOfAWholeIsNotChangedByAskingItOfAPartFirst() {
+        for (Emptiness one : Emptiness.values()) {
+            for (Emptiness other : Emptiness.values()) {
+                assertSame(one, one.met(one.joined(other)),
+                        "an alternative beside this one leaves this one where it was");
+                assertSame(one, one.joined(one.met(other)));
+            }
+        }
+    }
+
+    @Test
+    void aFoldStopsExactlyWhereTheOperationCanNoLongerBeMoved() {
+        for (Emptiness one : Emptiness.values()) {
+            boolean meetIsFinished = true;
+            boolean joinIsFinished = true;
+            for (Emptiness other : Emptiness.values()) {
+                meetIsFinished &= one.met(other) == one;
+                joinIsFinished &= one.joined(other) == one;
+            }
+            assertEquals(meetIsFinished, one.endsAMeet(),
+                    "a walk that stopped where a further conjunct could still move it would answer"
+                            + " about the conjuncts it had reached, and one that went on where"
+                            + " nothing could move it would ask after the answer was fixed");
+            assertEquals(joinIsFinished, one.endsAJoin());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1493.

A walk that stops early is claiming that nothing further can move the answer it has reached, which is a fact about the operation it is folding. The walks over what a reading holds said it as a fact about which answer they were holding — a constant for the choice, the word for a settled empty answer for the conjunction — and those agree with the operations only by arithmetic written down nowhere.

`Emptiness` now owns both ends of each operation: where a walk over nothing starts, and what the operation can no longer be moved from. The walks name neither answer. `met` and `joined` answer every pairing rather than reading one side and saying what that settles, so an answer added to the three is asked what it comes to beside each of them instead of inheriting an arm about one side.

What lets a walk take one order of a set and stop partway is held beside the answers, over the whole vocabulary: the operations cannot tell the order or the bracketing of what they were given, one answer twice is that answer, and the words a walk stops on name exactly the answers the operations cannot be moved from. No table is written out beside them — the laws settle every pairing between them, and a second copy is the one that gets edited to fit a change.

Both stops of the walk over a reading that is still a description answered the same whichever question they were asked, so nothing held it to answering from a run of blocks that had settled the walk rather than from the run it happened to reach. What is asked of it now is that the answer is the same wherever in the order the block or the alternative that settles it falls. A choice over positions a product can hold is merged back into one, so a reading built that way leaves such a walk with a single alternative to reach — which is why the tests that were there never reached either stop. Held apart, they do.

The rule that writes down who says this word reads the composing itself now, rather than the words a walk asks the operation it walks under: a walk that composed without asking either — the shape this vocabulary replaces — would have been on no list. Who may decide that the settled positive answer is the answer is said in those words, since returning one is not deciding it. What is left comparing against a constant is the reading #1498 is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)