### PR TITLE
Draw the line a choice of bounds on a position leaves

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -97,12 +97,25 @@ interface ClauseReading<S, E> {
      */
     default S read(Core e, boolean positive, E at, ClauseScope<E> scope,
                    java.util.function.BiConsumer<Core, S> per) {
+        return read(e, positive, at, scope, per, ClauseView.whole());
+    }
+
+    /**
+     * The same, read in the world {@code view} describes rather than in the one the author wrote.
+     *
+     * <p>What a reader asking what one conjunct was holding compares against. A part outside that
+     * world is not read, is not composed with what is read, and is told to nothing: the tree walked
+     * here is the tree of the rules that world has, so honouring the omission is not something a
+     * reading is asked to remember to do.
+     */
+    default S read(Core e, boolean positive, E at, ClauseScope<E> scope,
+                   java.util.function.BiConsumer<Core, S> per, ClauseView view) {
         // The clause is named once more here, on the outside of everything its shape was written
         // as, which is where a caller holding the clause and nothing under it looks. What it came
         // to is not told to {@code per} a second time: the walk below has already said it of the
         // very same node, and a reader counting what it was told would count the whole clause
         // twice and every part of it once.
-        return from(e, over(ClauseExpr.of(e, positive), at, scope, per));
+        return from(e, over(ClauseExpr.of(e, positive), at, scope, per, view));
     }
 
     /**
@@ -114,21 +127,39 @@ interface ClauseReading<S, E> {
      * each recognised {@code &&} for themselves agreed until one of them learned something.
      */
     private S over(ClauseExpr shape, E at, ClauseScope<E> scope,
-                   java.util.function.BiConsumer<Core, S> per) {
+                   java.util.function.BiConsumer<Core, S> per, ClauseView view) {
         S out = switch (shape) {
             case ClauseExpr.Leaf it -> whole(it, at);
             // How far this reading goes is its own answer, and taking the connective whole is
             // reading the node an author wrote it at as a part. A reading told to descend and
             // unable to compose what it found had nowhere to say so.
+            //
+            // A reading that takes a conjunction whole reads whatever is under it, this world's
+            // omissions included: what it composes is not the clause's connective, so there is no
+            // side for a part to be left out of. Which is why the omission is answered where the
+            // reading descends and nowhere else.
             case ClauseExpr.Joined it -> switch (at(it)) {
                 case Descent.Whole<S> _ -> whole(it, at);
-                case Descent.Into<S> into -> into.compose().apply(
-                        over(it.left(), at, scope, per), over(it.right(), at, scope, per));
+                // A side holding no rule of this world is not read and not composed with. What a
+                // conjunction of one rule and no rule comes to is that rule, and reading the
+                // missing side as a state saying nothing would be the same answer arrived at by
+                // having read a rule that is not there — which a walk collecting parts, and every
+                // account made of one, can tell apart.
+                case Descent.Into<S> into -> {
+                    if (view.omits(it.left())) {
+                        yield over(it.right(), at, scope, per, view);
+                    }
+                    if (view.omits(it.right())) {
+                        yield over(it.left(), at, scope, per, view);
+                    }
+                    yield into.compose().apply(over(it.left(), at, scope, per, view),
+                            over(it.right(), at, scope, per, view));
+                }
             };
             // The one place the environment changes, and it changes for what is under the binding
             // alone. What the binding means is not worked out here and not by the reading either.
             case ClauseExpr.Scoped it ->
-                    over(it.body(), scope.inside(it.binding(), at), scope, per);
+                    over(it.body(), scope.inside(it.binding(), at), scope, per, view);
         };
         // Every node that was written as this shape, so a reader asking about the node it is
         // holding finds what this made of it — the denial as well as what is under it, since the

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -97,7 +97,7 @@ interface ClauseReading<S, E> {
      */
     default S read(Core e, boolean positive, E at, ClauseScope<E> scope,
                    java.util.function.BiConsumer<Core, S> per) {
-        return read(e, positive, at, scope, per, ClauseView.whole());
+        return read(e, positive, at, scope, per, ClauseView.asWritten());
     }
 
     /**
@@ -130,31 +130,28 @@ interface ClauseReading<S, E> {
                    java.util.function.BiConsumer<Core, S> per, ClauseView view) {
         S out = switch (shape) {
             case ClauseExpr.Leaf it -> whole(it, at);
+            // A side holding no rule of this world is not read, whatever any reading would have
+            // made of it. What a conjunction of one rule and no rule comes to is that rule, and
+            // reading the missing side as a state saying nothing would be the same answer arrived
+            // at by having read a rule that is not there — which a walk collecting parts, and every
+            // account made of one, can tell apart.
+            //
+            // Above how far this reading goes, because which rules there are is not a reading's to
+            // decide. Asked under it, a reading that takes a conjunction whole would be handed the
+            // node with the conjunct still under it, and the world would hold for the readings that
+            // descend and for no others.
+            case ClauseExpr.Joined it when view.omits(it.left()) ->
+                    over(it.right(), at, scope, per, view);
+            case ClauseExpr.Joined it when view.omits(it.right()) ->
+                    over(it.left(), at, scope, per, view);
             // How far this reading goes is its own answer, and taking the connective whole is
             // reading the node an author wrote it at as a part. A reading told to descend and
             // unable to compose what it found had nowhere to say so.
-            //
-            // A reading that takes a conjunction whole reads whatever is under it, this world's
-            // omissions included: what it composes is not the clause's connective, so there is no
-            // side for a part to be left out of. Which is why the omission is answered where the
-            // reading descends and nowhere else.
             case ClauseExpr.Joined it -> switch (at(it)) {
                 case Descent.Whole<S> _ -> whole(it, at);
-                // A side holding no rule of this world is not read and not composed with. What a
-                // conjunction of one rule and no rule comes to is that rule, and reading the
-                // missing side as a state saying nothing would be the same answer arrived at by
-                // having read a rule that is not there — which a walk collecting parts, and every
-                // account made of one, can tell apart.
-                case Descent.Into<S> into -> {
-                    if (view.omits(it.left())) {
-                        yield over(it.right(), at, scope, per, view);
-                    }
-                    if (view.omits(it.right())) {
-                        yield over(it.left(), at, scope, per, view);
-                    }
-                    yield into.compose().apply(over(it.left(), at, scope, per, view),
-                            over(it.right(), at, scope, per, view));
-                }
+                case Descent.Into<S> into -> into.compose().apply(
+                        over(it.left(), at, scope, per, view),
+                        over(it.right(), at, scope, per, view));
             };
             // The one place the environment changes, and it changes for what is under the binding
             // alone. What the binding means is not worked out here and not by the reading either.

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -3,19 +3,26 @@ package souther.compiler.check;
 import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
 /**
- * Which of the parts an author wrote are rules of the world a clause is being read in.
+ * One clause the author wrote, as the world a reading is made in holds it.
  *
  * <p>A reading asked what one conjunct was holding is a reading of the declaration under a rule set
  * the author did not write ({@link InvariantChecker.Reach#withoutParts}), and every question about
- * that world has to be answered out of that rule set. Made once from the reach and handed to each
- * reading, so that whether a reader honours it is not a question anybody has to ask of the reader:
- * what is left out is left out of the tree it walks.
+ * that world has to be answered out of that rule set. This is the one answer to what that rule set
+ * is for one clause: which of its parts are rules here, and where under the tree they are.
+ *
+ * <p><b>Handed out and never asked for.</b> Which parts a world holds is decided where the world is
+ * ({@link PartsLeftOut#viewOf}), and nothing anywhere is given a way to ask about one part on its
+ * own. A reading holds this and reads {@link #present} or walks past what {@link #omits} says is not
+ * here; a reading that only had a rule to consult is a reading that can be written without
+ * consulting it, which is what left the connectives composed over conjuncts their world had taken
+ * away while every walk beside them left the same conjuncts out.
  *
  * <p><b>A part outside this world is not a part nothing could read.</b> The two arrive at the same
  * place in every state — nothing is said about the positions it names — and they are different
@@ -31,46 +38,86 @@ import java.util.Set;
  */
 final class ClauseView {
 
-    /** The part roots this world does not hold, by identity: two conjuncts spelled alike are two
+    /** Every part the author wrote, whether or not this world holds it. */
+    private final List<Clauses.StatedPart> authored;
+    /** The ones it holds, in the order they were written. */
+    private final List<Clauses.StatedPart> present;
+    /** And the roots of the ones it does not, by identity: two conjuncts spelled alike are two
      *  parts, and a set comparing them by what they say would leave out both. */
     private final Set<Core> omitted;
 
-    private ClauseView(Set<Core> omitted) {
+    private ClauseView(List<Clauses.StatedPart> authored, List<Clauses.StatedPart> present,
+                       Set<Core> omitted) {
+        this.authored = authored;
+        this.present = present;
         this.omitted = omitted;
     }
 
-    /** The world the author wrote, where every part of every clause is a rule. */
-    private static final ClauseView WHOLE = new ClauseView(Collections.emptySet());
-
-    /** The same, for a reading of the declaration as it stands. */
-    static ClauseView whole() {
-        return WHOLE;
+    /**
+     * The clause whole, which is what the author wrote and what almost every reading is made in.
+     *
+     * <p>Nothing is worked out: a world holding every part omits no root, and the parts it holds are
+     * the parts there are. A clause is viewed for every clause of every value, so what a reading of
+     * the declaration as it stands pays to be told that is nothing.
+     */
+    static ClauseView whole(List<Clauses.StatedPart> authored) {
+        return new ClauseView(authored, authored, Set.of());
     }
+
+    /** The world the author wrote, told without the parts of any clause — see {@link #asWritten}. */
+    private static final ClauseView AS_WRITTEN = new ClauseView(null, null, Set.of());
 
     /**
-     * The world {@code without} leaves of a clause whose parts are {@code parts}.
+     * The world the author wrote, for a reading with no clause's parts in hand.
      *
-     * <p>{@link #whole()} where it leaves none of them out, so that a reading under a reach that
-     * omits nothing is the reading of the clause as written and is that by being it.
+     * <p>A form nobody split into parts is read through this, and so is a question about a tree
+     * asked of the shape alone. Nothing is left out, so nothing is walked past — and there are no
+     * parts here to present, which {@link #present} says by refusing rather than by answering that
+     * a world holding everything holds nothing.
      */
-    static ClauseView of(List<Clauses.StatedPart> parts, PartsLeftOut without) {
-        // Asked before the parts are walked, because almost every reading there is asks for the
-        // declaration whole: a clause is viewed for every clause of every value, and a reading that
-        // leaves nothing out would otherwise build a set to find nothing in.
-        if (!without.leavesAnythingOut()) {
-            return WHOLE;
-        }
-        Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (Clauses.StatedPart each : parts) {
-            if (without.excludes(each.id())) {
-                out.add(each.expr());
-            }
-        }
-        return out.isEmpty() ? WHOLE : new ClauseView(out);
+    static ClauseView asWritten() {
+        return AS_WRITTEN;
     }
 
-    /** Whether every part of every clause is a rule of this world, which almost every reading is
-     *  made in. Asked where working out the shape of a clause would be the cost of finding out. */
+    /** The same clause with {@code omitted} left out, which is how a counterfactual holds it. */
+    static ClauseView without(List<Clauses.StatedPart> authored, Set<Core> omitted) {
+        List<Clauses.StatedPart> here = new ArrayList<>(authored.size());
+        for (Clauses.StatedPart each : authored) {
+            if (!omitted.contains(each.expr())) {
+                here.add(each);
+            }
+        }
+        return new ClauseView(authored, Collections.unmodifiableList(here),
+                Collections.unmodifiableSet(omitted));
+    }
+
+    /** An identity set for {@link #without}, which is what a world's omissions are told apart by. */
+    static Set<Core> roots() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    /** Every part the author wrote, for the readers that are about the clause rather than about
+     *  what any world holds of it. */
+    List<Clauses.StatedPart> authored() {
+        if (authored == null) {
+            throw new IllegalStateException(
+                    "this world was not made from a clause's parts and has none to name");
+        }
+        return authored;
+    }
+
+    /** The parts this world holds, which is what a reading of it reads. Empty where the world holds
+     *  none of the clause, which is a clause that is no rule of it. */
+    List<Clauses.StatedPart> present() {
+        if (present == null) {
+            throw new IllegalStateException(
+                    "this world was not made from a clause's parts and has none to present");
+        }
+        return present;
+    }
+
+    /** Whether every part of the clause is a rule of this world, which almost every reading is made
+     *  in. Asked where working out the shape of a clause would be the cost of finding out. */
     boolean omitsNothing() {
         return omitted.isEmpty();
     }
@@ -102,6 +149,6 @@ final class ClauseView {
 
     @Override
     public String toString() {
-        return omitted.isEmpty() ? "the whole clause" : "without " + omitted.size() + " part(s)";
+        return omitted.isEmpty() ? "the whole clause" : "without " + omitted.size() + " of it";
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -1,0 +1,95 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.semantics.ConditionJoin;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which of the parts an author wrote are rules of the world a clause is being read in.
+ *
+ * <p>A reading asked what one conjunct was holding is a reading of the declaration under a rule set
+ * the author did not write ({@link InvariantChecker.Reach#withoutParts}), and every question about
+ * that world has to be answered out of that rule set. Made once from the reach and handed to each
+ * reading, so that whether a reader honours it is not a question anybody has to ask of the reader:
+ * what is left out is left out of the tree it walks.
+ *
+ * <p><b>A part outside this world is not a part nothing could read.</b> The two arrive at the same
+ * place in every state — nothing is said about the positions it names — and they are different
+ * facts about the reading, which is why nothing here is recorded as read: a subtree this omits is
+ * never handed to {@link ClauseReading#whole}, never told to the walk that collects parts, and never
+ * one an account can name. What a reading of this world says about the conjunct is nothing, and what
+ * it says about how far it got is that the conjunct was not among its rules.
+ *
+ * <p><b>The parts are the author's and this only chooses among them.</b> Which parts a clause has
+ * was settled where it was split ({@link Clauses.StatedPart}), so nothing here recognises a
+ * connective: a node is out of this world by being one of those parts and by nothing else, and a
+ * conjunction of them is out where all of them are.
+ */
+final class ClauseView {
+
+    /** The part roots this world does not hold, by identity: two conjuncts spelled alike are two
+     *  parts, and a set comparing them by what they say would leave out both. */
+    private final Set<Core> omitted;
+
+    private ClauseView(Set<Core> omitted) {
+        this.omitted = omitted;
+    }
+
+    /** The world the author wrote, where every part of every clause is a rule. */
+    private static final ClauseView WHOLE = new ClauseView(Collections.emptySet());
+
+    /** The same, for a reading of the declaration as it stands. */
+    static ClauseView whole() {
+        return WHOLE;
+    }
+
+    /**
+     * The world {@code without} leaves of a clause whose parts are {@code parts}.
+     *
+     * <p>{@link #whole()} where it leaves none of them out, so that a reading under a reach that
+     * omits nothing is the reading of the clause as written and is that by being it.
+     */
+    static ClauseView of(List<Clauses.StatedPart> parts, PartsLeftOut without) {
+        Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Clauses.StatedPart each : parts) {
+            if (without.excludes(each.id())) {
+                out.add(each.expr());
+            }
+        }
+        return out.isEmpty() ? WHOLE : new ClauseView(out);
+    }
+
+    /**
+     * Whether no rule of this world is anywhere under {@code shape}.
+     *
+     * <p>A part by itself, and a conjunction every part of which is out. A choice is one part
+     * however many comparisons stand between its brackets — an author writes an alternative and
+     * cannot write half of one — so it is out only by being the part that is out.
+     */
+    boolean omits(ClauseExpr shape) {
+        if (omitted.isEmpty()) {
+            return false;
+        }
+        for (Core each : shape.spelled()) {
+            if (omitted.contains(each)) {
+                return true;
+            }
+        }
+        return switch (shape) {
+            case ClauseExpr.Scoped it -> omits(it.body());
+            case ClauseExpr.Joined it ->
+                    it.how() == ConditionJoin.BOTH && it.positive()
+                            && omits(it.left()) && omits(it.right());
+            case ClauseExpr.Leaf _ -> false;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return omitted.isEmpty() ? "the whole clause" : "without " + omitted.size() + " part(s)";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -38,9 +38,10 @@ import java.util.Set;
  */
 final class ClauseView {
 
-    /** Every part the author wrote, whether or not this world holds it. */
+    /** Every part the author wrote, kept for the one thing they answer that this world does not:
+     *  which rule of the model the clause is. Not shown, for the reason {@link #present} gives. */
     private final List<Clauses.StatedPart> authored;
-    /** The ones it holds, in the order they were written. */
+    /** The parts this world holds, in the order they were written. */
     private final List<Clauses.StatedPart> present;
     /** And the roots of the ones it does not, by identity: two conjuncts spelled alike are two
      *  parts, and a set comparing them by what they say would leave out both. */
@@ -61,58 +62,76 @@ final class ClauseView {
      * the declaration as it stands pays to be told that is nothing.
      */
     static ClauseView whole(List<Clauses.StatedPart> authored) {
-        return new ClauseView(authored, authored, Set.of());
+        List<Clauses.StatedPart> here = List.copyOf(authored);
+        return new ClauseView(here, here, Set.of());
     }
 
-    /** The world the author wrote, told without the parts of any clause — see {@link #asWritten}. */
-    private static final ClauseView AS_WRITTEN = new ClauseView(null, null, Set.of());
+    /** The world the author wrote, of a form nobody split into parts — see {@link #asWritten}. */
+    private static final ClauseView AS_WRITTEN = whole(List.of());
 
     /**
      * The world the author wrote, for a reading with no clause's parts in hand.
      *
      * <p>A form nobody split into parts is read through this, and so is a question about a tree
-     * asked of the shape alone. Nothing is left out, so nothing is walked past — and there are no
-     * parts here to present, which {@link #present} says by refusing rather than by answering that
-     * a world holding everything holds nothing.
+     * asked of the shape alone. Nothing is left out, so nothing is walked past, and the parts here
+     * are none because none were written — which is not the same fact as a world holding none of a
+     * clause, and is told from it where it matters: a clause reaching a value is written in parts
+     * ({@code InvariantChecker.Written}), so one made from this is refused there rather than read
+     * as a clause every world has taken away.
      */
     static ClauseView asWritten() {
         return AS_WRITTEN;
     }
 
-    /** The same clause with {@code omitted} left out, which is how a counterfactual holds it. */
-    static ClauseView without(List<Clauses.StatedPart> authored, Set<Core> omitted) {
+    /**
+     * The same clause with the parts {@code left} names left out, which is how a counterfactual
+     * holds it.
+     *
+     * <p>Told which parts by their names and never by their trees, which is what a world is asked
+     * with ({@link PartsLeftOut}); the roots are worked out here so that what the walk matches on is
+     * the very node this clause holds. Handed a set of nodes instead, a caller could build one that
+     * tells two conjuncts spelled alike apart by what they say, and both would go.
+     */
+    static ClauseView without(List<Clauses.StatedPart> authored,
+                              Set<PartId<RuleRef.Invariant>> left) {
         List<Clauses.StatedPart> here = new ArrayList<>(authored.size());
+        Set<Core> omitted = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Clauses.StatedPart each : authored) {
-            if (!omitted.contains(each.expr())) {
+            if (left.contains(each.id())) {
+                omitted.add(each.expr());
+            } else {
                 here.add(each);
             }
         }
-        return new ClauseView(authored, Collections.unmodifiableList(here),
-                Collections.unmodifiableSet(omitted));
+        return omitted.isEmpty() ? whole(authored)
+                : new ClauseView(List.copyOf(authored), Collections.unmodifiableList(here),
+                        omitted);
     }
 
-    /** An identity set for {@link #without}, which is what a world's omissions are told apart by. */
-    static Set<Core> roots() {
-        return Collections.newSetFromMap(new IdentityHashMap<>());
+    /**
+     * Which rule of the model the clause is, read off the parts the author wrote it in.
+     *
+     * <p>The one thing the author's parts answer that this world's do not. Every part of a clause is
+     * a part of that clause, so the rule is the parts' answer and not a second thing anybody
+     * carries — held beside them, a value about one rule could be built about two
+     * ({@code OneWayFromAStateToTheRuleItIsAboutTest}). And the author's rather than this world's,
+     * since which rule a clause is does not turn on what a counterfactual left out and a world
+     * holding none of the clause would have no part left to answer from.
+     */
+    RuleRef.Invariant rule() {
+        return authored.get(0).id().rule();
     }
 
-    /** Every part the author wrote, for the readers that are about the clause rather than about
-     *  what any world holds of it. */
-    List<Clauses.StatedPart> authored() {
-        if (authored == null) {
-            throw new IllegalStateException(
-                    "this world was not made from a clause's parts and has none to name");
-        }
-        return authored;
-    }
-
-    /** The parts this world holds, which is what a reading of it reads. Empty where the world holds
-     *  none of the clause, which is a clause that is no rule of it. */
+    /**
+     * The parts this world holds, which is what a reading of it reads. Empty where the world holds
+     * none of the clause, which is a clause that is no rule of it.
+     *
+     * <p>The only parts this shows. What the author wrote is the clause's and belongs where a
+     * clause is named — offered here beside these, a reader holding a world would have both lists
+     * and would have to be written to take the right one, which is the whole of what handing it a
+     * world instead of a rule was for.
+     */
     List<Clauses.StatedPart> present() {
-        if (present == null) {
-            throw new IllegalStateException(
-                    "this world was not made from a clause's parts and has none to present");
-        }
         return present;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -54,6 +54,12 @@ final class ClauseView {
      * omits nothing is the reading of the clause as written and is that by being it.
      */
     static ClauseView of(List<Clauses.StatedPart> parts, PartsLeftOut without) {
+        // Asked before the parts are walked, because almost every reading there is asks for the
+        // declaration whole: a clause is viewed for every clause of every value, and a reading that
+        // leaves nothing out would otherwise build a set to find nothing in.
+        if (!without.leavesAnythingOut()) {
+            return WHOLE;
+        }
         Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Clauses.StatedPart each : parts) {
             if (without.excludes(each.id())) {
@@ -61,6 +67,12 @@ final class ClauseView {
             }
         }
         return out.isEmpty() ? WHOLE : new ClauseView(out);
+    }
+
+    /** Whether every part of every clause is a rule of this world, which almost every reading is
+     *  made in. Asked where working out the shape of a clause would be the cost of finding out. */
+    boolean omitsNothing() {
+        return omitted.isEmpty();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -18,6 +18,7 @@ import souther.compiler.values.Refusal;
 import souther.compiler.values.Sameness;
 import souther.compiler.values.ValueSet;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -757,6 +758,24 @@ sealed interface Confinement<A> {
          *  {@link Planned#derived()}. */
         BoundaryState derived() {
             return derived;
+        }
+
+        /**
+         * How far the values at each position reach, for the readers that draw lines.
+         *
+         * <p>The one way out of here for what the connectives came to on the positions' own orders.
+         * A reader drawing a line is handed this and never the order it is read off: holding the
+         * order, it would hold half of what says whether a value exists, and composing a choice a
+         * second time is what the whole of this arrangement is against.
+         *
+         * <p>Which is why nothing is stored. The projection is of this reading and is wanted by
+         * whoever made it — a counterfactual is a reading of its own and takes its own answer, and
+         * one lent this one would find every end exactly where it left it.
+         *
+         * @param aliases the names each position answers to, in the vocabulary of the reader asking
+         */
+        SettledOrderEnvelope envelopeOver(Map<RuleKey, ? extends Collection<A>> aliases) {
+            return SettledOrderEnvelope.of(ordered, carriers, aliases);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -78,7 +78,8 @@ public final class FieldDomains {
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(),
                     Set.of(RuleKey.THE_VALUE),
                     Map.of(), Map.of(), Map.of(), Map.of(), StringFacts.NONE, KnownExtents.NONE,
-                    Map.of(), Map.of(), BoundaryState.nothing());
+                    Map.of(), Map.of(), BoundaryState.nothing(),
+                    SettledOrderEnvelope.nothing());
 
     private final Map<RuleKey, NumericDomain.Bounds> byName;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -129,6 +130,16 @@ public final class FieldDomains {
      * rules admit.
      */
     private final BoundaryState derived;
+    /**
+     * And where the same reading left the positions themselves, which the interval algebra cannot
+     * reach for the same reason ({@link SettledOrderEnvelope}).
+     *
+     * <p>The two are one arrangement asked of two kinds of number, and which of them answers is
+     * decided by the number and never by the caller: a position's own order is settled where the
+     * branches have their fate and a count's is settled beside it, so each kind has one reader
+     * holding it and {@link #leftAt} picks between them off the coordinate it was handed.
+     */
+    private final SettledOrderEnvelope settledOrder;
     /** Which choice an author is sent to for a line on one of those numbers that nothing placed —
      *  see {@link #endsLeftOpenAt}. */
     private final Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>> boundsLeftOpen;
@@ -254,10 +265,11 @@ public final class FieldDomains {
                          Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
                          Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>>
                                  boundsLeftOpen,
-                         BoundaryState derived) {
+                         BoundaryState derived, SettledOrderEnvelope settledOrder) {
         this.endsLeftOpen = endsLeftOpen;
         this.boundsLeftOpen = boundsLeftOpen;
         this.derived = derived;
+        this.settledOrder = settledOrder;
         this.stringMachines = stringMachines;
         this.known = known;
         this.byName = byName;
@@ -486,7 +498,8 @@ public final class FieldDomains {
                 seeded.constraints(), named, data, source, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
                 seeded.readBy(), seeded.spacing(), seeded.stringMachines(), machines.extents(),
-                seeded.endsLeftOpen(), seeded.boundsLeftOpen(), seeded.derived());
+                seeded.endsLeftOpen(), seeded.boundsLeftOpen(), seeded.derived(),
+                seeded.settledOrder());
     }
 
     /**
@@ -1909,28 +1922,55 @@ public final class FieldDomains {
         // `String` is measured two ways — its own order, and the length of it — and answering with
         // the wrong one clamps a line drawn on one axis by the range of the other.
         FactSubject atom = subjectAt(path, kind);
+        OrderedInterval settled = settledAt(path, kind);
+        // A position ordered on something the interval algebra has no words for is at no atom of
+        // its own, and the rules stop it all the same: what a choice of two bounds on a string
+        // leaves is settled by the reading that composes the connectives, and where there is no
+        // algebra to meet with, that answer is the whole of what is known. Null still where
+        // neither reading has anything, which is what a caller reads as a number no range is taken
+        // of here.
         if (atom == null) {
-            return null;
+            return settled == null ? null
+                    : new NumericDomain.Bounds(settled.low(), settled.high());
         }
         NumericDomain.Bounds held = constraints.numbers().boundsOf(atom);
-        // Nothing to meet where no choice settled a number of this value, which is most of them.
-        // Asked all the same, every lookup of every coordinate builds a subject to find nothing
-        // under, and this one is asked once per candidate per counterfactual.
-        if (derived.byNumber().isEmpty()) {
-            return held;
-        }
         // And what the choices leave it, which the algebra has no way to: it reads a clause as
-        // written and never enters an alternative, so a length bounded in both branches of a
+        // written and never enters an alternative, so a number bounded in both branches of a
         // choice comes back from it unbounded. Met rather than preferred — the two are readings of
         // the same rules and each holds what the other cannot.
         //
-        // And nothing where that reading stops the number nowhere a value of it is: what has been
-        // read there is that the rules contradict, which is said by whoever answers whether a
-        // value exists, and a line off those ends would fall where the order does not reach.
-        DerivedNumber number = DerivedNumber.of(new NumberAt<>(path, kind));
-        OrderedInterval settled = number == null ? null : derived.knownAt(number);
+        // Which of the two readings holds that answer is decided by the number and not here. A
+        // position's own order is settled where the branches have their fate and a count's is
+        // settled beside it, so each kind has one reader holding it: asked of one of them for both,
+        // whichever kind that reader has no word for comes back from the algebra alone, which is
+        // what left a bound written under a choice out of every line this compiler draws.
         return settled == null ? held
                 : held.meet(new NumericDomain.Bounds(settled.low(), settled.high()));
+    }
+
+    /**
+     * Where the reading that composed this value's connectives stops one of its numbers, or null
+     * where no line may be drawn on it.
+     *
+     * <p>Null for a number no rule spoke of and for one the rules leave no value at, which are the
+     * two neither reader writes down: the first runs as far as it ever did, and what has been read
+     * in the second is that the rules contradict — which is said by whoever answers whether a value
+     * exists, and a line off those ends would fall where the order does not reach.
+     */
+    private OrderedInterval settledAt(RuleKey path, NumberAt.OfWhatNumber kind) {
+        return switch (kind) {
+            case NumberAt.OfWhatNumber.OfItsOwnValue _ -> settledOrder.knownAt(path);
+            case NumberAt.OfWhatNumber.OfWhatAnOperationAnswers _ -> {
+                // Nothing to look for where no choice settled a number of this value, which is most
+                // of them. Asked all the same, every lookup builds a number to find nothing under,
+                // and this one is asked once per candidate per counterfactual.
+                if (derived.byNumber().isEmpty()) {
+                    yield null;
+                }
+                DerivedNumber number = DerivedNumber.of(new NumberAt<>(path, kind));
+                yield number == null ? null : derived.knownAt(number);
+            }
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1926,12 +1926,15 @@ public final class FieldDomains {
         // A position ordered on something the interval algebra has no words for is at no atom of
         // its own, and the rules stop it all the same: what a choice of two bounds on a string
         // leaves is settled by the reading that composes the connectives, and where there is no
-        // algebra to meet with, that answer is the whole of what is known. Null still where
-        // neither reading has anything, which is what a caller reads as a number no range is taken
-        // of here.
+        // algebra to meet with, that answer is the whole of what is known.
+        //
+        // Of a position and not of what an operation answers. A count is a whole number whatever it
+        // counts, so the algebra has words for every one of them and a count with no atom is one no
+        // range was taken of here — which is what a caller reads a missing answer as, and is not
+        // something this has anything to add to.
         if (atom == null) {
-            return settled == null ? null
-                    : new NumericDomain.Bounds(settled.low(), settled.high());
+            return kind instanceof NumberAt.OfWhatNumber.OfItsOwnValue && settled != null
+                    ? new NumericDomain.Bounds(settled.low(), settled.high()) : null;
         }
         NumericDomain.Bounds held = constraints.numbers().boundsOf(atom);
         // And what the choices leave it, which the algebra has no way to: it reads a clause as

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -496,7 +496,7 @@ public final class InvariantChecker {
                   StringFacts stringMachines,
                   Map<RuleRef.Invariant, EndsLeftOpen> endsLeftOpen,
                   Map<RuleRef.Invariant, Map<OpenEnd, EndsLeftOpen.Behind>> boundsLeftOpen,
-                  BoundaryState derived) {
+                  BoundaryState derived, SettledOrderEnvelope settledOrder) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
          *  which operation it is a count of. Projected rather than kept beside {@link #held()}: two
@@ -950,7 +950,18 @@ public final class InvariantChecker {
         // where its clauses landed in a table.
         StatedByClauses.Asked<Written> asked = new StatedByClauses.Asked<>();
         for (Written each : written) {
-            asked.read(reader, at, each, each.clause());
+            // The rules of this world and not the ones the author wrote. A reader asking what one
+            // conjunct was holding compares two readings of this declaration, and they are two
+            // readings of one world unless the conjunct is out of both — which is what left a
+            // choice composed the same way with the conjunct and without it, so that every end it
+            // was holding came back held by nobody.
+            ClauseView view = ClauseView.of(each.parts(), reach.withoutParts());
+            // And a clause this world holds no part of is no rule of it. Read as one, the reading
+            // would compose a tree of nothing at all, which is not the shape a clause has.
+            if (view.omits(ClauseExpr.of(each.clause(), true))) {
+                continue;
+            }
+            asked.read(reader, at, each, each.clause(), view);
         }
         // And now that every rule about this value has been said, what its positions admit is
         // worked out — and with it what each clause and each part of it took in, since a branch
@@ -1119,7 +1130,12 @@ public final class InvariantChecker {
                 // taken from the reading with the choices settled. The interval algebra never
                 // enters an alternative, so this is the one answer that says where a choice of two
                 // bounds on a length stops it.
-                answered.whole().confinement().derived());
+                answered.whole().confinement().derived(),
+                // And the same of the positions themselves, which the same reading settled and
+                // nothing carried out of it. Both names each position answers to, because a clause
+                // is filed under whichever the reading that read it recognised — asked of one, what
+                // a choice left a position would turn on how the rule was spelled.
+                answered.whole().confinement().envelopeOver(aliasesOf(atoms, keys)));
     }
 
     /**
@@ -1157,6 +1173,21 @@ public final class InvariantChecker {
             names.add(key);
         }
         return names;
+    }
+
+    /**
+     * Every name every position of this value answers to, keyed by the position.
+     *
+     * <p>The names alone, and never a count's. What a count is is a number taken of what stands at
+     * a name, and where it stops is settled by a reading of its own ({@link BoundaryState}) — put
+     * in here, one path would carry two orders and whichever was met last would be the one a line
+     * was drawn from.
+     */
+    private static Map<RuleKey, List<FactSubject>> aliasesOf(Map<RuleKey, FactSubject> atoms,
+                                                             Map<RuleKey, FactSubject> keys) {
+        Map<RuleKey, List<FactSubject>> out = new LinkedHashMap<>();
+        written(atoms, keys).forEach(path -> out.put(path, named(atoms, keys, path)));
+        return out;
     }
 
     /** The atom of a count that may not be there, which every lookup of one wants. */
@@ -2218,10 +2249,19 @@ public final class InvariantChecker {
             return BETWEEN;
         }
         return switch (canonicalFormOf(read, at, byName)) {
-            // The walk stopped inside a side, so which number the rule stops the values on is what
-            // reading further would say — and every number the leaf writes about is one waiting on
-            // that reading, the numbers an operation answers among them.
-            case CanonicalForm.NotRead _ -> ELSEWHERE;
+            // The walk stopped inside a side. Where one whole side is a position and the other
+            // names none, the line is on that position and the arithmetic stopping says nothing
+            // about it: what it could not read is an order it has no words for, and a rule holding
+            // a string or a case of an enumeration against a constant states where those values
+            // stop as plainly as a bound on a number does.
+            //
+            // Anywhere else, which number the rule stops the values on is what reading further
+            // would say — and every number the leaf writes about is one waiting on that reading,
+            // the numbers an operation answers among them.
+            case CanonicalForm.NotRead _ -> {
+                Coordinate against = heldAgainstAConstant(bin, at, byName);
+                yield against == null ? ELSEWHERE : statedOn(against);
+            }
             // The positions cancelled, and what is left is a number against a number. Read as
             // written, which is what the residue is a residue of: under a denial the same form
             // states the opposite of what it reads as, and both answers are here.
@@ -2233,6 +2273,33 @@ public final class InvariantChecker {
             case CanonicalForm.Over over -> over.numbers().size() == 1
                     ? statedOn(over.numbers().iterator().next()) : ELSEWHERE;
         };
+    }
+
+    /**
+     * The position one whole side of {@code bin} is, where the other side names none, or null
+     * where the comparison is not of that shape.
+     *
+     * <p>The one shape the arithmetic answers nothing about and a line still falls on. Asked of the
+     * two sides whole, which is the same question {@link Relates#twoPositions} asks and the answer
+     * it did not have a use for: a comparison naming one position and holding it against something
+     * with no position in it stops that position's values, whatever the order is made of.
+     *
+     * <p>Reached only where the form was not read. A comparison the arithmetic followed is
+     * classified by what it followed to, so this adds no second answer to a question that has one —
+     * it answers where the first reading said it had none, and it says a number rather than a
+     * narrower one.
+     */
+    private Coordinate heldAgainstAConstant(Core.Binary bin, Denotations at,
+                                            Map<FactSubject, Coordinate> byName) {
+        Coordinate left = byName.get(nameOf(bin.left(), at));
+        Coordinate right = byName.get(nameOf(bin.right(), at));
+        if (left != null && right == null && coordinatesIn(bin.right(), at, byName).isEmpty()) {
+            return left;
+        }
+        if (right != null && left == null && coordinatesIn(bin.left(), at, byName).isEmpty()) {
+            return right;
+        }
+        return null;
     }
 
     /** Which of the two a line on {@code number} is, said by the number itself. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -786,7 +786,7 @@ public final class InvariantChecker {
             @Override
             public void gathered(RuleRef.Invariant from, Core clause,
                                  List<Clauses.StatedPart> parts, Set<FactSubject> spokenFor) {
-                written.add(new Written(clause, parts));
+                written.add(new Written(clause, reach.withoutParts().viewOf(parts)));
                 spokenFor.forEach(spoken -> took.record(from, spoken));
             }
 
@@ -848,16 +848,14 @@ public final class InvariantChecker {
             }
             // The clause as one reading, and the parts its author wrote as subtrees of it. Which
             // parts there are was settled where the clause was split; nothing here decides it.
-            Written wrote = new Written(stated, declared.shape().onto(stated, origin));
+            Written wrote = new Written(stated,
+                    reach.withoutParts().viewOf(declared.shape().onto(stated, origin)));
             written.add(wrote);
-            // A part at a time, and the ones this reading was asked for. Which parts a clause has
-            // was settled where it was split, so a part left out is one left out of the list —
-            // never a node a walk was told to step over.
+            // A part at a time, and the ones this world holds. Which parts a clause has was settled
+            // where it was split, so a part left out is one left out of the list — never a node a
+            // walk was told to step over.
             Predicates.Owed owed = null;
             for (Clauses.StatedPart part : wrote.parts()) {
-                if (reach.withoutParts().excludes(part.id())) {
-                    continue;
-                }
                 Predicates.Owed said = c.predicates.assumed(part.expr(), at, false,
                         (of, came) -> gathering.constrained(origin, of, partRead(came)));
                 owed = owed == null ? said : owed.and(said);
@@ -950,23 +948,21 @@ public final class InvariantChecker {
         // where its clauses landed in a table.
         StatedByClauses.Asked<Written> asked = new StatedByClauses.Asked<>();
         for (Written each : written) {
-            // The rules of this world and not the ones the author wrote. A reader asking what one
-            // conjunct was holding compares two readings of this declaration, and they are two
-            // readings of one world unless the conjunct is out of both — which is what left a
-            // choice composed the same way with the conjunct and without it, so that every end it
-            // was holding came back held by nobody.
-            ClauseView view = ClauseView.of(each.parts(), reach.withoutParts());
-            // And a clause this world holds no part of is no rule of it. Read as one, the reading
-            // would compose a tree of nothing at all, which is not the shape a clause has.
+            // A clause this world holds no part of is no rule of it. Read as one, the reading would
+            // compose a tree of nothing at all, which is not the shape a clause has.
             //
-            // Asked of the view before the shape is worked out. Working one out walks the clause
-            // and builds a node for every part of it, and this runs for every clause of every value
-            // — so a reading that leaves nothing out, which is almost all of them, does not pay to
-            // be told that it leaves nothing out.
-            if (!view.omitsNothing() && view.omits(ClauseExpr.of(each.clause(), true))) {
+            // Read off what the world holds rather than worked out from the tree: which parts are
+            // here was settled when the clause was viewed, and a walk of the shape to find out
+            // would be the same answer at the cost of building one.
+            if (each.parts().isEmpty()) {
                 continue;
             }
-            asked.read(reader, at, each, each.clause(), view);
+            // And the clause read in this world. A reader asking what one conjunct was holding
+            // compares two readings of this declaration, and they are two readings of one world
+            // only where the conjunct is out of both — which is what left a choice composed the
+            // same way with the conjunct and without it, so that every end it was holding came back
+            // held by nobody.
+            asked.read(reader, at, each, each.clause(), each.view());
         }
         // And now that every rule about this value has been said, what its positions admit is
         // worked out — and with it what each clause and each part of it took in, since a branch
@@ -1359,13 +1355,26 @@ public final class InvariantChecker {
      * a line drawn on a position is attributed to, and each of them is a subtree of that same
      * reading — carrying which part of the clause it is, settled where the clause was split.
      */
-    private record Written(Core clause, List<Clauses.StatedPart> parts) {
+    private record Written(Core clause, ClauseView view) {
 
         Written {
-            if (parts.isEmpty()) {
+            if (view.authored().isEmpty()) {
                 throw new IllegalArgumentException("a clause reaching a value is written in parts");
             }
-            parts = List.copyOf(parts);
+        }
+
+        /**
+         * The parts of it this reading's world holds, which is what every walk over this clause
+         * reads.
+         *
+         * <p>The parts as the author wrote them are reachable through the view and are wanted by
+         * nothing that walks: a walk of a world reads that world's rules, and a walk given the
+         * whole clause beside them is a walk that has to remember which of the two it is about —
+         * which is what left the connectives composed over conjuncts every walk beside them had
+         * left out.
+         */
+        List<Clauses.StatedPart> parts() {
+            return view.present();
         }
 
         /**
@@ -1374,9 +1383,13 @@ public final class InvariantChecker {
          * <p>Every part of a clause is a part of that clause, so the rule is the parts' answer and
          * not a second thing to carry: held beside them, a value about one rule could be built
          * about two.
+         *
+         * <p>Off what the author wrote and not off what this world holds. Which rule a clause is is
+         * the model's and does not turn on what a counterfactual left out, and a world holding none
+         * of the clause would have no part to answer from.
          */
         RuleRef.Invariant from() {
-            return parts.get(0).id().rule();
+            return view.authored().get(0).id().rule();
         }
     }
 
@@ -1715,15 +1728,14 @@ public final class InvariantChecker {
         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
-        // A part this reading was not asked for is not read, which is the same list of parts the
-        // reader of predicates was given: a part one of them reached that the other never read is a
-        // value whose rules were not gathered ({@link APartNoReadingSaw}).
-        stated.forEach(each -> each.parts().stream()
-                .filter(part -> !withoutParts.excludes(part.id()))
-                .forEach(part ->
-                        direct(part.expr(), each.from(), part.id(), at, byName, out, noLines,
-                                withoutAnEnd, aboutOneCoordinate, narrowers,
-                                raised, took, typeAt, parts, raisedByPart, standing)));
+        // The parts this world holds, which is the same list every other walk over these clauses
+        // was given: a part one of them reached that another never read is a value whose rules were
+        // not gathered ({@link APartNoReadingSaw}). One list and not one rule each of them
+        // consults, so the agreement is not something a walk has to be written to keep.
+        stated.forEach(each -> each.parts().forEach(part ->
+                direct(part.expr(), each.from(), part.id(), at, byName, out, noLines,
+                        withoutAnEnd, aboutOneCoordinate, narrowers,
+                        raised, took, typeAt, parts, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines), List.copyOf(withoutAnEnd),

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -958,7 +958,12 @@ public final class InvariantChecker {
             ClauseView view = ClauseView.of(each.parts(), reach.withoutParts());
             // And a clause this world holds no part of is no rule of it. Read as one, the reading
             // would compose a tree of nothing at all, which is not the shape a clause has.
-            if (view.omits(ClauseExpr.of(each.clause(), true))) {
+            //
+            // Asked of the view before the shape is worked out. Working one out walks the clause
+            // and builds a node for every part of it, and this runs for every clause of every value
+            // — so a reading that leaves nothing out, which is almost all of them, does not pay to
+            // be told that it leaves nothing out.
+            if (!view.omitsNothing() && view.omits(ClauseExpr.of(each.clause(), true))) {
                 continue;
             }
             asked.read(reader, at, each, each.clause(), view);

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -786,7 +786,7 @@ public final class InvariantChecker {
             @Override
             public void gathered(RuleRef.Invariant from, Core clause,
                                  List<Clauses.StatedPart> parts, Set<FactSubject> spokenFor) {
-                written.add(new Written(clause, reach.withoutParts().viewOf(parts)));
+                written.add(Written.of(clause, parts, reach.withoutParts()));
                 spokenFor.forEach(spoken -> took.record(from, spoken));
             }
 
@@ -848,8 +848,8 @@ public final class InvariantChecker {
             }
             // The clause as one reading, and the parts its author wrote as subtrees of it. Which
             // parts there are was settled where the clause was split; nothing here decides it.
-            Written wrote = new Written(stated,
-                    reach.withoutParts().viewOf(declared.shape().onto(stated, origin)));
+            Written wrote = Written.of(stated, declared.shape().onto(stated, origin),
+                    reach.withoutParts());
             written.add(wrote);
             // A part at a time, and the ones this world holds. Which parts a clause has was settled
             // where it was split, so a part left out is one left out of the list — never a node a
@@ -1030,7 +1030,7 @@ public final class InvariantChecker {
         // And which of the clauses place an edge, asked once the positions have names to be
         // recognised by.
         Reading reading = c.directsIn(written, at, numbers, typeAt, took,
-                new PartsRead(readBy, adoptedBy, narrowedBy), reach.withoutParts());
+                new PartsRead(readBy, adoptedBy, narrowedBy));
         ConstraintState<FactSubject> constraints = k.constraints()
                 .takingRead(answered.whole().confinement(), allowed, c.answers);
         // How each atom's values are spaced, kept so that settling one afterwards states the
@@ -1357,39 +1357,30 @@ public final class InvariantChecker {
      */
     private record Written(Core clause, ClauseView view) {
 
-        Written {
-            if (view.authored().isEmpty()) {
+        /** The clause {@code authored} was written in, as {@code world} holds it. */
+        static Written of(Core clause, List<Clauses.StatedPart> authored, PartsLeftOut world) {
+            if (authored.isEmpty()) {
                 throw new IllegalArgumentException("a clause reaching a value is written in parts");
             }
+            return new Written(clause, world.viewOf(authored));
+        }
+
+        /** Which rule of the model this is — see {@link ClauseView#rule}. */
+        RuleRef.Invariant from() {
+            return view.rule();
         }
 
         /**
          * The parts of it this reading's world holds, which is what every walk over this clause
          * reads.
          *
-         * <p>The parts as the author wrote them are reachable through the view and are wanted by
-         * nothing that walks: a walk of a world reads that world's rules, and a walk given the
-         * whole clause beside them is a walk that has to remember which of the two it is about —
-         * which is what left the connectives composed over conjuncts every walk beside them had
-         * left out.
+         * <p>The only parts a walk can reach from here. What the author wrote is spent above, on
+         * naming the rule; offered beside these, a walk would have both lists and would have to be
+         * written to take the right one — which is what left the connectives composed over
+         * conjuncts every walk beside them had left out.
          */
         List<Clauses.StatedPart> parts() {
             return view.present();
-        }
-
-        /**
-         * Which rule of the model this is, read off the parts it was written in.
-         *
-         * <p>Every part of a clause is a part of that clause, so the rule is the parts' answer and
-         * not a second thing to carry: held beside them, a value about one rule could be built
-         * about two.
-         *
-         * <p>Off what the author wrote and not off what this world holds. Which rule a clause is is
-         * the model's and does not turn on what a counterfactual left out, and a world holding none
-         * of the clause would have no part to answer from.
-         */
-        RuleRef.Invariant from() {
-            return view.authored().get(0).id().rule();
         }
     }
 
@@ -1717,8 +1708,7 @@ public final class InvariantChecker {
     private Reading directsIn(List<Written> stated, Denotations at,
                                    Map<FactSubject, Coordinate> byName,
                                    Map<RuleKey, Type> typeAt,
-                                   ReadingEvidence took, PartsRead parts,
-                                   PartsLeftOut withoutParts) {
+                                   ReadingEvidence took, PartsRead parts) {
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
         List<FieldDomains.WithoutAnEnd> withoutAnEnd = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
@@ -1,7 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.core.Core;
-
 import java.util.List;
 import java.util.Set;
 
@@ -87,13 +85,7 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
 
         @Override
         public ClauseView viewOf(List<Clauses.StatedPart> written) {
-            Set<Core> out = ClauseView.roots();
-            for (Clauses.StatedPart each : written) {
-                if (parts.contains(each.id())) {
-                    out.add(each.expr());
-                }
-            }
-            return out.isEmpty() ? ClauseView.whole(written) : ClauseView.without(written, out);
+            return ClauseView.without(written, parts);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
@@ -1,5 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.core.Core;
+
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -32,13 +35,19 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
     boolean leavesAnythingOut();
 
     /**
-     * Whether this reading was asked to leave {@code part} out.
+     * The clause written in {@code parts}, as this world holds it.
      *
-     * <p>Asked once, by everything that walks the clause. Two walks over one clause skip the part
-     * together — a part one reached that the other never read is a value whose rules were not
-     * gathered — so asking in two ways is two answers that have to agree, and there is one.
+     * <p><b>Handed out and never asked about.</b> Two walks over one clause have to leave the same
+     * parts out — a part one reached that the other never read is a value whose rules were not
+     * gathered — and a rule saying which one to leave out is a rule a walk can be written without
+     * consulting. So what a reading is given is the clause this world has ({@link ClauseView}), and
+     * there is nothing here to ask about a part on its own.
+     *
+     * <p>What such a reading is for is not here. A reader comparing what a value's rules leave with
+     * and without one part is asking what that part was holding; nothing about the comparison
+     * belongs to the world that answers it.
      */
-    boolean excludes(PartId<RuleRef.Invariant> part);
+    ClauseView viewOf(List<Clauses.StatedPart> parts);
 
     /** Nothing is left out. */
     record Nothing() implements PartsLeftOut {
@@ -49,8 +58,8 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
         }
 
         @Override
-        public boolean excludes(PartId<RuleRef.Invariant> part) {
-            return false;
+        public ClauseView viewOf(List<Clauses.StatedPart> parts) {
+            return ClauseView.whole(parts);
         }
     }
 
@@ -77,8 +86,14 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
         }
 
         @Override
-        public boolean excludes(PartId<RuleRef.Invariant> part) {
-            return parts.contains(part);
+        public ClauseView viewOf(List<Clauses.StatedPart> written) {
+            Set<Core> out = ClauseView.roots();
+            for (Clauses.StatedPart each : written) {
+                if (parts.contains(each.id())) {
+                    out.add(each.expr());
+                }
+            }
+            return out.isEmpty() ? ClauseView.whole(written) : ClauseView.without(written, out);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/SettledOrderEnvelope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SettledOrderEnvelope.java
@@ -94,8 +94,12 @@ final class SettledOrderEnvelope {
      * of them.
      */
     private static OrderedInterval stated(OrderedInterval reach, OrderedInterval extent) {
+        // And nothing where the position is ordered on nothing this reading names. Such a position
+        // is one no rule of the order reached either, so what is here is already every value there
+        // is — and the answer that costs nothing to be wrong about is the one that states no end,
+        // rather than one that keeps an end nothing could tell from where the order stops anyway.
         if (extent == null) {
-            return reach;
+            return OrderedInterval.OPEN;
         }
         return new OrderedInterval(
                 reach.low() == null || reach.low().equals(extent.low()) ? null : reach.low(),

--- a/souther-compiler/src/main/java/souther/compiler/check/SettledOrderEnvelope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SettledOrderEnvelope.java
@@ -1,0 +1,148 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * How far the values at each position of one declaration reach, once every connective its clauses
+ * are written with has been spent.
+ *
+ * <p>An observation of a reading that is over, and not a reading. What a choice of two bounds
+ * leaves a position is worked out where the branches have their fate ({@link Confinement.Planned});
+ * this is that answer read off and carried to where a line is drawn, in the vocabulary a reader of
+ * the declaration's names has. Nothing here composes anything, and no operation takes one of these
+ * and answers with another — a second composition of one choice is two answers about it, and the
+ * cost of that is what {@link BoundaryState} was written to stop on the numbers beside these.
+ *
+ * <p><b>An envelope, and never the values.</b> {@code n == 2 || n == 5} leaves the outermost ends
+ * at two and five, and nothing stands at three: what is here is the smallest run covering what
+ * either alternative reaches, which is where the lines are and is not what the rules admit. Which
+ * values may stand at a position is the values reading's, and a caller that took this for it would
+ * offer a row at a value every rule refuses.
+ *
+ * <p><b>And no part of whether a value exists.</b> A position the rules leave nothing at is absent
+ * here, told apart from one no rule spoke of by nothing — both are positions no line may be drawn
+ * on, and that is the whole of what a reader of this asks. The distinction the composition needed
+ * ({@link BoundaryState.Left.NothingLeft}) was needed because a choice between an empty branch and
+ * a live one leaves what the live one leaves, and there is no choice left to take here. So the
+ * losing of it is deliberate: what cannot be read back cannot be read for an answer that belongs to
+ * whoever settles whether anybody is in a branch.
+ */
+final class SettledOrderEnvelope {
+
+    /** Every position some rule stopped, and where. A position absent from this is one no line may
+     *  be drawn on, whether because nothing spoke of it or because nothing is left at it. */
+    private final Map<RuleKey, OrderedInterval> byPosition;
+
+    private SettledOrderEnvelope(Map<RuleKey, OrderedInterval> byPosition) {
+        this.byPosition = byPosition;
+    }
+
+    /** What a declaration none of whose positions any rule stopped leaves them. */
+    private static final SettledOrderEnvelope NOTHING = new SettledOrderEnvelope(Map.of());
+
+    /** The same, for a caller with no reading to project. */
+    static SettledOrderEnvelope nothing() {
+        return NOTHING;
+    }
+
+    /**
+     * The envelope of {@code ordered}, spelled by the names {@code aliases} files each position
+     * under.
+     *
+     * <p>Made from an order and not from a map of ranges, so that what is here came from a reading
+     * that had composed the connectives: the one type holding an order is the one that composes it
+     * ({@code WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest}), and a caller cannot arrive
+     * with an envelope of its own.
+     */
+    static <A> SettledOrderEnvelope of(OrderedIntervals<A> ordered, Map<A, Carrier> carriers,
+                                       Map<RuleKey, ? extends Collection<A>> aliases) {
+        Map<RuleKey, OrderedInterval> out = new LinkedHashMap<>();
+        aliases.forEach((position, subjects) -> {
+            OrderedInterval reach = acrossAliases(ordered, subjects);
+            // A position the rules stop nowhere runs as far as it ever did, and one they stop past
+            // themselves has no value for a line to fall at. Neither is written down: what a reader
+            // here does with a position it does not find is leave the order where it was, which is
+            // the answer to the first — and the second is a contradiction, which is said by whoever
+            // answers whether a value exists and never by a line drawn where the order does not
+            // reach.
+            if (reach.holdsNothing()) {
+                return;
+            }
+            OrderedInterval stated = stated(reach, extentOf(carriers, subjects));
+            if (stated.equals(OrderedInterval.OPEN)) {
+                return;
+            }
+            out.put(position, stated);
+        });
+        return out.isEmpty() ? NOTHING : new SettledOrderEnvelope(out);
+    }
+
+    /**
+     * The ends of {@code reach} some rule put there, which are the ones it does not share with
+     * {@code extent}.
+     *
+     * <p>Every whole number stops at the largest one whether or not a rule was written, and this is
+     * read for the line an author drew. Taken whole, every choice of two bounds on a number would
+     * put an end where the order already was — and a reader downstream cannot tell that end from one
+     * a rule states, so it would draw a line at it and send somebody to a rule that says nothing
+     * about it. The same answer {@link OrderedLeaf.Left.Leaves#stated} gives a leaf, given a choice
+     * of them.
+     */
+    private static OrderedInterval stated(OrderedInterval reach, OrderedInterval extent) {
+        if (extent == null) {
+            return reach;
+        }
+        return new OrderedInterval(
+                reach.low() == null || reach.low().equals(extent.low()) ? null : reach.low(),
+                reach.high() == null || reach.high().equals(extent.high()) ? null : reach.high());
+    }
+
+    /** What the position is ordered on, or null where nothing here says. Every name of one answers
+     *  the same, as they are names of one position. */
+    private static <A> OrderedInterval extentOf(Map<A, Carrier> carriers, Collection<A> subjects) {
+        for (A each : subjects) {
+            Carrier carrier = carriers.get(each);
+            if (carrier != null) {
+                return carrier.extent();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * What the order leaves one position, taken over every name it answers to.
+     *
+     * <p>Not a conjunction. The names are one position's, filed as two because a clause is filed
+     * under whichever of them the reading that read it recognised — so each is a reading of the
+     * same values and every value of the position is inside both, which is what makes the tighter
+     * of them an answer about the position rather than about a pair of them.
+     */
+    private static <A> OrderedInterval acrossAliases(OrderedIntervals<A> ordered,
+                                                     Collection<A> subjects) {
+        OrderedInterval reach = OrderedInterval.OPEN;
+        for (A each : subjects) {
+            reach = reach.meet(ordered.at(each));
+        }
+        return reach;
+    }
+
+    /** Where the rules stop {@code position}, or null where no line may be drawn on it. */
+    OrderedInterval knownAt(RuleKey position) {
+        return byPosition.get(position);
+    }
+
+    /** Whether the rules stopped no position of this declaration anywhere, which is most of them. */
+    boolean isEmpty() {
+        return byPosition.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return byPosition.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -517,13 +517,25 @@ sealed interface StatedByClauses {
      * of every node an author wrote.
      */
     static boolean mirrors(Core clause, StatedByClauses read) {
+        return mirrors(clause, read, ClauseView.whole());
+    }
+
+    /**
+     * The same of a reading made in the world {@code view} describes.
+     *
+     * <p>The tree that world holds, which is the author's with the parts it leaves out gone and
+     * every other node where the author put it. What a conjunction of one rule and no rule was read
+     * as is that rule, so the node above it stands over what is left rather than over a state
+     * standing in for what is not there.
+     */
+    static boolean mirrors(Core clause, StatedByClauses read, ClauseView view) {
         // The fold names the clause once as it starts and again as the shape of it is finished, so
         // the outermost of these is the one the caller put there.
         return read instanceof CameFrom it && it.node() == clause
-                && mirrors(ClauseExpr.of(clause, true), it.of());
+                && mirrors(ClauseExpr.of(clause, true), it.of(), view);
     }
 
-    private static boolean mirrors(ClauseExpr shape, StatedByClauses read) {
+    private static boolean mirrors(ClauseExpr shape, StatedByClauses read, ClauseView view) {
         StatedByClauses under = read;
         // Every node the shape was spelled as, innermost first: that is the order the fold wrapped
         // them in, and a reading that recorded a part anywhere else is one this does not accept.
@@ -536,14 +548,24 @@ sealed interface StatedByClauses {
         }
         return switch (shape) {
             case ClauseExpr.Leaf _ -> under instanceof Said;
-            case ClauseExpr.Scoped it -> mirrors(it.body(), under);
+            case ClauseExpr.Scoped it -> mirrors(it.body(), under, view);
             case ClauseExpr.Joined it -> switch (it.how()) {
-                case BOTH -> under instanceof Both both
-                        && mirrors(it.left(), both.left())
-                        && mirrors(it.right(), both.right());
+                case BOTH -> {
+                    // A side this world holds no rule of was never read, so what stands here is
+                    // the other side and not a conjunction of it with anything.
+                    if (view.omits(it.left())) {
+                        yield mirrors(it.right(), under, view);
+                    }
+                    if (view.omits(it.right())) {
+                        yield mirrors(it.left(), under, view);
+                    }
+                    yield under instanceof Both both
+                            && mirrors(it.left(), both.left(), view)
+                            && mirrors(it.right(), both.right(), view);
+                }
                 case EITHER -> under instanceof Either choice && choice.writtenAt() == it.of()
-                        && mirrors(it.left(), choice.left())
-                        && mirrors(it.right(), choice.right());
+                        && mirrors(it.left(), choice.left(), view)
+                        && mirrors(it.right(), choice.right(), view);
             };
         };
     }
@@ -1492,12 +1514,22 @@ sealed interface StatedByClauses {
         /** One clause read from {@code at}, with the parts of it noted in the order the reading
          *  reached them. */
         StatedByClauses read(Reading reader, Denotations at, K key, Core clause) {
+            return read(reader, at, key, clause, ClauseView.whole());
+        }
+
+        /** The same, read in the world {@code view} describes — see {@link ClauseView}. */
+        StatedByClauses read(Reading reader, Denotations at, K key, Core clause, ClauseView view) {
             List<Core> parts = new ArrayList<>();
             StatedByClauses one = reader.read(clause, true, at, reader.scope(),
-                    (part, _) -> parts.add(part));
+                    (part, _) -> parts.add(part), view);
             // An assertion because it is about this compiler and not about any model, and here
             // rather than in one test because every clause a corpus holds is read through it.
-            assert mirrors(clause, one)
+            //
+            // Asked of the tree this world holds and not of the one the author wrote. A part left
+            // out of the world is left out of the reading, so the two differ by exactly what the
+            // view says — and an assertion kept against the written tree would have to be weakened
+            // to a shape it no longer states.
+            assert mirrors(clause, one, view)
                     : "the reading of a clause is not the tree its author wrote it as";
             byClause.put(key, clause);
             byPart.put(key, parts);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -503,7 +503,8 @@ sealed interface StatedByClauses {
     }
 
     /**
-     * Whether {@code read} is the tree {@code clause} was written as.
+     * Whether {@code read} is the tree {@code clause} was written as, in the world {@code view}
+     * describes.
      *
      * <p>What this type is for, said as a predicate. Every question a choice answers is asked of its
      * two alternatives, and an alternative is what stands between the brackets — so a reading that

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -515,18 +515,11 @@ sealed interface StatedByClauses {
      * number of choices where it was — {@code (a || b) && c} and {@code (a && c) || (b && c)} are
      * one {@code ||} each — so what is held is which node stands under which, down to the identity
      * of every node an author wrote.
-     */
-    static boolean mirrors(Core clause, StatedByClauses read) {
-        return mirrors(clause, read, ClauseView.whole());
-    }
-
-    /**
-     * The same of a reading made in the world {@code view} describes.
      *
-     * <p>The tree that world holds, which is the author's with the parts it leaves out gone and
-     * every other node where the author put it. What a conjunction of one rule and no rule was read
-     * as is that rule, so the node above it stands over what is left rather than over a state
-     * standing in for what is not there.
+     * <p><b>The tree the world {@code view} describes holds</b>, which is the author's with the
+     * parts that world leaves out gone and every other node where the author put it. What a
+     * conjunction of one rule and no rule was read as is that rule, so the node above it stands
+     * over what is left rather than over a state standing in for what is not there.
      */
     static boolean mirrors(Core clause, StatedByClauses read, ClauseView view) {
         // The fold names the clause once as it starts and again as the shape of it is finished, so
@@ -1511,13 +1504,9 @@ sealed interface StatedByClauses {
         private final Map<K, List<Core>> byPart = new LinkedHashMap<>();
         private final Map<K, StatedByClauses> trees = new LinkedHashMap<>();
 
-        /** One clause read from {@code at}, with the parts of it noted in the order the reading
-         *  reached them. */
-        StatedByClauses read(Reading reader, Denotations at, K key, Core clause) {
-            return read(reader, at, key, clause, ClauseView.whole());
-        }
-
-        /** The same, read in the world {@code view} describes — see {@link ClauseView}. */
+        /** One clause read from {@code at} in the world {@code view} describes
+         *  ({@link ClauseView}), with the parts of it noted in the order the reading reached
+         *  them. */
         StatedByClauses read(Reading reader, Denotations at, K key, Core clause, ClauseView view) {
             List<Core> parts = new ArrayList<>();
             StatedByClauses one = reader.read(clause, true, at, reader.scope(),

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -167,16 +167,13 @@ final class TypeGuarantees {
         // so that no reader of the reading has to decide which of the rules of the model it holds.
         List<TypeGuarantee.Part> parts = new ArrayList<>();
         List<Quantified> quantified = new ArrayList<>();
-        // A part at a time, and the ones the caller asked for. Which parts a clause has was settled
+        // A part at a time, and the ones this world holds. Which parts a clause has was settled
         // where it was split, so leaving one out is leaving a part out of the list and never a node
         // out of a walk — and the same list answers for what the clause owes and for what it
         // quantifies, since a part left out of the one and left in the other is a clause taken half
-        // away.
+        // away. Which of them are here is the world's answer and not a rule this consults.
         Predicates.Owed owed = null;
-        for (Clauses.StatedPart part : one.parts()) {
-            if (withoutParts.excludes(part.id())) {
-                continue;
-            }
+        for (Clauses.StatedPart part : withoutParts.viewOf(one.parts()).present()) {
             Predicates.Owed said = predicates.assumed(part.expr(), denotations, false,
                     (of, came) -> parts.add(new TypeGuarantee.Part(of, came)));
             owed = owed == null ? said : owed.and(said);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -99,7 +99,14 @@ final class TypeGuarantees {
                     clauses.statedAt(owner.named(), given);
             for (Clauses.Stated one : stated.clauses()) {
                 if (already.add(one.clause())) {
-                    here.add(read(one, denotations, withoutParts));
+                    // The world's rules on the way in, and the clause's own parts kept out here.
+                    // What is read is what this world has ({@link ClauseView}); what the guarantee
+                    // is filed under is what the author wrote, which is a fact about the clause and
+                    // not about any world of it — so the reading is handed one list and cannot pick
+                    // the other.
+                    Read said = read(withoutParts.viewOf(one.parts()), denotations);
+                    here.add(new TypeGuarantee(one.expr(), one.parts(), said.owed(),
+                            said.quantified(), said.parts()));
                 }
             }
             for (RuleRef.Invariant each : stated.lost()) {
@@ -154,26 +161,32 @@ final class TypeGuarantees {
         return false;
     }
 
+    /** What reading the rules of one world made of one clause, before it is filed under the clause
+     *  the author wrote. */
+    private record Read(Predicates.Owed owed, List<Quantified> quantified,
+                        List<TypeGuarantee.Part> parts) {}
+
     /**
-     * One clause, read as something that holds of this value.
+     * The rules {@code view} holds, read as something that holds of this value.
      *
      * <p>What each part of it came to is read here and kept, rather than handed to a caller as it
      * happens. A reader told mid-reading is a reader the reading has to know about; a reader given
      * the parts afterwards is one this does not.
+     *
+     * <p><b>The world's rules and no way to the clause behind them.</b> Which parts a clause has
+     * was settled where it was split, so leaving one out is leaving a part out of the list and
+     * never a node out of a walk — and the same list answers for what the clause owes and for what
+     * it quantifies, since a part left out of the one and left in the other is a clause taken half
+     * away. Handed the clause and the world instead, this would be a reading that has to be written
+     * to narrow one by the other, which is the defect that put a world here at all.
      */
-    private TypeGuarantee read(Clauses.Stated one, Denotations denotations,
-                               PartsLeftOut withoutParts) {
+    private Read read(ClauseView view, Denotations denotations) {
         // Where this clause becomes a rule of the model something can be attributed to. Settled here
         // so that no reader of the reading has to decide which of the rules of the model it holds.
         List<TypeGuarantee.Part> parts = new ArrayList<>();
         List<Quantified> quantified = new ArrayList<>();
-        // A part at a time, and the ones this world holds. Which parts a clause has was settled
-        // where it was split, so leaving one out is leaving a part out of the list and never a node
-        // out of a walk — and the same list answers for what the clause owes and for what it
-        // quantifies, since a part left out of the one and left in the other is a clause taken half
-        // away. Which of them are here is the world's answer and not a rule this consults.
         Predicates.Owed owed = null;
-        for (Clauses.StatedPart part : withoutParts.viewOf(one.parts()).present()) {
+        for (Clauses.StatedPart part : view.present()) {
             Predicates.Owed said = predicates.assumed(part.expr(), denotations, false,
                     (of, came) -> parts.add(new TypeGuarantee.Part(of, came)));
             owed = owed == null ? said : owed.and(said);
@@ -181,8 +194,7 @@ final class TypeGuarantees {
         }
         // Nothing owed where every part was left out, which is a clause with all of it taken away
         // and not a clause that holds.
-        return new TypeGuarantee(one.expr(), one.parts(),
-                owed == null ? Predicates.Owed.unread() : owed, quantified, parts);
+        return new Read(owed == null ? Predicates.Owed.unread() : owed, quantified, parts);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
@@ -67,6 +67,30 @@ class AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest {
     }
 
     /**
+     * And which position such a rule is about does not turn on which side it was written on.
+     *
+     * <p>What a leaf states is one question with one answer, and the reading that answers it for an
+     * order the arithmetic has no words for asks the two sides whole. That is the shape a second,
+     * narrower reading of the same question takes — so what is held here is that it is not one: the
+     * four spellings below are one rule about the string at a position, and a choice offering any
+     * of them draws the line that rule draws.
+     */
+    @Test
+    void andWhichPositionItIsAboutDoesNotTurnOnWhichSideItIsWrittenOn() {
+        assertEquals(
+                List.of("s > \"a\" || s > \"b\": a",
+                        "\"a\" < s || s > \"b\": a",
+                        "s > \"a\" || \"b\" < s: a",
+                        "\"a\" < s || \"b\" < s: a"),
+                linesAt("s > \"a\" || s > \"b\"",
+                        "\"a\" < s || s > \"b\"",
+                        "s > \"a\" || \"b\" < s",
+                        "\"a\" < s || \"b\" < s"),
+                "each alternative holds the string at a position above a constant, whichever side"
+                        + " of the comparison the author put the position on");
+    }
+
+    /**
      * And a choice bounds a position only where both of its alternatives do.
      *
      * <p>The control, and the one thing that tells reading the settled answer from gathering what

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
@@ -1,0 +1,177 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A choice of bounds on one position leaves the line its alternatives leave together.
+ *
+ * <p>Every value satisfying {@code n >= 2 || n >= 3} is at least two, so the rules stop the position
+ * at two and a row at two is a row at a line the model draws. Written with {@code &&} between them
+ * the same two bounds are a line this compiler draws, and written alone either of them is — so a
+ * choice coming back as a rule that draws none was a sentence about the model, and the model draws
+ * one.
+ *
+ * <p><b>Not a list of shapes.</b> What each of these holds is where an answer comes from: what a
+ * choice leaves a position is settled once, where the branches have their fate, and every reader
+ * that draws a line is reading that one answer. A shape below that came back short would be a
+ * second reading of the same choice, arrived at by whichever road the model happened to take.
+ */
+class AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest {
+
+    /**
+     * A choice of two bounds on a number stops it where the wider of them does.
+     *
+     * <p>And says so however the alternatives are ordered, however many there are, and however they
+     * are bracketed: what a choice leaves is what either alternative leaves, which reads the same
+     * way round, and an answer that moved with the brackets would be an answer about the writing.
+     */
+    @Test
+    void aChoiceOfBoundsOnANumberStopsItWhereTheWiderOfThemDoes() {
+        assertEquals(
+                List.of("n >= 2: 2",
+                        "n >= 3 || n >= 2: 2",
+                        "n >= 2 || n >= 3: 2",
+                        "n >= 2 || n >= 3 || n >= 4: 2",
+                        "(n >= 2 || n >= 3) || n >= 4: 2",
+                        "n >= 2 || (n >= 3 || n >= 4): 2"),
+                linesAt("n >= 2", "n >= 3 || n >= 2", "n >= 2 || n >= 3",
+                        "n >= 2 || n >= 3 || n >= 4", "(n >= 2 || n >= 3) || n >= 4",
+                        "n >= 2 || (n >= 3 || n >= 4)"),
+                "each of them admits exactly the values from two up, so each draws the line at two");
+    }
+
+    /**
+     * And an order that is not one of numbers is stopped the same way.
+     *
+     * <p>The reading that composes a choice is over the positions and not over the numbers among
+     * them, so what settles a choice of bounds on a string is the answer that settles one on a
+     * number. Read through the arithmetic alone, a rule about strings is a rule about no number
+     * this could name — which is what left the choice below saying the model draws no line while
+     * either alternative written by itself drew one.
+     */
+    @Test
+    void andAnOrderThatIsNotOneOfNumbersIsStoppedTheSameWay() {
+        assertEquals(
+                List.of("s > \"a\": a", "s > \"a\" || s > \"b\": a", "s > \"b\" || s > \"a\": a"),
+                linesAt("s > \"a\"", "s > \"a\" || s > \"b\"", "s > \"b\" || s > \"a\""),
+                "every string above \"b\" is above \"a\", so the choice stops the position at \"a\"");
+    }
+
+    /**
+     * And a choice bounds a position only where both of its alternatives do.
+     *
+     * <p>The control, and the one thing that tells reading the settled answer from gathering what
+     * the branches said. A value taking the alternative that says nothing about the position stands
+     * anywhere on it, so the choice does — and a reader that collected the bounds its branches
+     * wrote would draw a line at two on a model that admits every number there is.
+     */
+    @Test
+    void andAChoiceBoundsAPositionOnlyWhereBothAlternativesDo() {
+        assertEquals(
+                List.of("n >= 2 || s > \"a\": nothing", "s > \"a\" || n >= 2: nothing"),
+                linesAt("n >= 2 || s > \"a\"", "s > \"a\" || n >= 2"),
+                "either alternative leaves the position the other bounds at every value");
+    }
+
+    /**
+     * And an alternative nobody can be in leaves the choice what the other one leaves.
+     *
+     * <p>Where the ends of a branch have crossed, every value of the choice is in the branch beside
+     * it — so the line is that branch's, and a reading that let the empty branch widen the answer
+     * would draw none at all.
+     */
+    @Test
+    void andAnAlternativeNobodyCanBeInLeavesTheChoiceWhatTheOtherLeaves() {
+        assertEquals(List.of("(n >= 5 && n <= 3) || n >= 2: 2"),
+                linesAt("(n >= 5 && n <= 3) || n >= 2"),
+                "nothing satisfies the first alternative, so the rules are the second alternative");
+    }
+
+    /**
+     * And what the choice leaves is where the lines are and not which values stand there.
+     *
+     * <p>Two alternatives naming one value each leave the run between them, and no value has a
+     * number in there. The outermost ends are two and five and the model draws a line at each; what
+     * is between them is a run nothing can be written in, and it comes back saying so. Read as the
+     * values the rules admit, the run would be offered as somewhere a row could stand.
+     */
+    @Test
+    void andWhatTheChoiceLeavesIsWhereTheLinesAreAndNotWhichValuesStandThere() {
+        List<String> lines = linesOf("n == 2 || n == 5");
+
+        assertEquals(List.of("border      borders 2   obligations 0/0"),
+                lines.stream().filter(each -> each.startsWith("border")).toList(),
+                "the outermost ends of the two named values are the lines the rules draw");
+        assertEquals(2, lines.stream()
+                        .filter(each -> each.contains("nothing composed one")).count(),
+                "and the runs between them hold no value, which is said rather than offered");
+    }
+
+    /**
+     * And one line is drawn once, whatever else the rule says beside it.
+     *
+     * <p>Which conjunct a line is owed to is answered by reading the declaration again without it,
+     * and the two readings are readings of one world only where the conjunct is out of both. While
+     * the reading that composes the choices held the conjunct either way, no single conjunct moved
+     * the end and the pair of them did — so the end came back owed to both, and the same line was
+     * written twice.
+     */
+    @Test
+    void andOneLineIsDrawnOnceWhateverElseTheRuleSaysBesideIt() {
+        assertEquals(
+                List.of("border      borders 1   obligations 0/0"),
+                linesOf("(String.length(s) >= 2 || String.length(s) >= 3)"
+                        + " && String.length(s) >= 1").stream()
+                        .filter(each -> each.startsWith("border")).toList(),
+                "the length stops at two, and the bound written beside the choice is not a second"
+                        + " rule drawing the same line");
+    }
+
+    /** What the document says the model draws on the position each clause is about. */
+    private static List<String> linesAt(String... clauses) {
+        List<String> out = new java.util.ArrayList<>();
+        for (String clause : clauses) {
+            out.add(clause + ": " + drawnIn(clause));
+        }
+        return out;
+    }
+
+    /** Where the one line of {@code clause} falls, or {@code nothing} where it draws none. */
+    private static String drawnIn(String clause) {
+        List<String> at = linesOf(clause).stream()
+                .filter(each -> each.startsWith("· no ") && each.contains(" point is owed at "))
+                .map(each -> each.substring(each.indexOf(" at ") + " at ".length()))
+                .map(each -> each.substring(each.indexOf('=') + 1, each.indexOf('(')).strip())
+                .distinct()
+                .toList();
+        return at.isEmpty() ? "nothing" : String.join(", ", at);
+    }
+
+    private static List<String> linesOf(String clause) {
+        Compilation compilation = Compilation.ofSource("""
+                module demo
+                data Yes
+                data No
+                data Answer = Yes | No
+                data N = { n: Int, s: String }
+                    invariant r = %s
+
+                behavior check : (v: N) -> Answer
+                let check (v) = Yes
+                """.formatted(clause), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity()).lines()
+                .map(String::strip)
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingOfAClauseIsTheTreeItsAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingOfAClauseIsTheTreeItsAuthorWroteTest.java
@@ -78,13 +78,15 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
 
     @Test
     void aReadingStandsWhereTheClauseDoes() {
-        assertTrue(StatedByClauses.mirrors(BESIDE_THE_BRACKET, asWritten()),
+        assertTrue(StatedByClauses.mirrors(BESIDE_THE_BRACKET, asWritten(),
+                        ClauseView.asWritten()),
                 "the conjunction is a conjunction of the choice, which is what the author wrote");
     }
 
     @Test
     void aConjunctionMovedIntoTheBranchesIsRefused() {
-        assertFalse(StatedByClauses.mirrors(BESIDE_THE_BRACKET, distributed()),
+        assertFalse(StatedByClauses.mirrors(BESIDE_THE_BRACKET, distributed(),
+                        ClauseView.asWritten()),
                 "the conjunct written beside the brackets stands inside both alternatives, so each"
                         + " of them is a clause nobody wrote and the choice would be answerable"
                         + " for what one of them left open");
@@ -107,7 +109,8 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
                                                 new ChoiceId(), choice,
                                                 part(C, part(A, said())),
                                                 part(C, part(B, said())))),
-                                        part(C, said()))))),
+                                        part(C, said())))),
+                        ClauseView.asWritten()),
                 "the whole clause is recorded as what each alternative came to, so a reader asking"
                         + " what it came to is answered by one branch of a choice");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
@@ -1,0 +1,118 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.ConstructOccurrence;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which rules a world has is settled before a reading says how far into them it goes.
+ *
+ * <p>A reading asked what one conjunct was holding reads the declaration under a rule set the
+ * author did not write, and the conjunct left out is not a rule of that world at all. How far a
+ * reading descends is its own answer ({@link Descent}) — a conjunction one takes whole is a part to
+ * it and two parts to the reading beside it — and neither answer is about which rules there are.
+ *
+ * <p>Asked the other way round, a world holds for the readings that descend and for no others: a
+ * reading that takes a conjunction whole is handed the node with the conjunct still under it and
+ * reads a rule its world does not have. Every reading of a declaration's connectives descends
+ * today, so nothing a model can be written as shows it — which is why this is asked of the fold
+ * itself, with a reading that stops where the ones in this compiler do not.
+ */
+class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final Core LEFT = leaf("left");
+    private static final Core RIGHT = leaf("right");
+    private static final Core BOTH = new Core.Binary(BinOp.AND, LEFT, RIGHT,
+            ConstructOccurrence.unwritten(), Type.BOOL, POS);
+
+    /**
+     * A reading that takes a conjunction whole is handed only what its world has.
+     *
+     * <p>It never descends, so nothing about composing two answers can be what carries the
+     * omission: what reaches it is one part, and the part is the one the world holds.
+     */
+    @Test
+    void aReadingThatTakesAConjunctionWholeIsHandedOnlyWhatItsWorldHas() {
+        assertEquals(List.of("right"), whatReached(withoutTheLeft()),
+                "the left conjunct is no rule of this world, so a reading that would have taken"
+                        + " the whole conjunction is handed the rule that is there");
+    }
+
+    /**
+     * And the same reading in the world the author wrote is handed the conjunction.
+     *
+     * <p>The control. Without it the case above would pass on a fold that never hands a reading a
+     * connective at all, which is a different mechanism answering the same way.
+     */
+    @Test
+    void andInTheWorldTheAuthorWroteItIsHandedTheConjunction() {
+        assertEquals(List.of("left && right"), whatReached(ClauseView.asWritten()),
+                "both conjuncts are rules here, so what the reading stops at is the conjunction");
+    }
+
+    /** What a reading that stops at every connective was handed, in the order it reached them. */
+    private static List<String> whatReached(ClauseView view) {
+        List<String> reached = new java.util.ArrayList<>();
+        ClauseReading<String, Void> stopping = new ClauseReading<>() {
+
+            @Override
+            public String whole(ClauseExpr.Part part, Void at) {
+                reached.add(spelled(part.of()));
+                return spelled(part.of());
+            }
+
+            /** Never, which is the point: how far this goes is its own answer and says nothing
+             *  about which rules its world has. */
+            @Override
+            public Descent<String> at(ClauseExpr.Joined join) {
+                return new Descent.Whole<>();
+            }
+        };
+        stopping.read(BOTH, true, null, ClauseScope.unchanged(), null, view);
+        return List.copyOf(reached);
+    }
+
+    /** The world that holds the right conjunct and not the left one. */
+    private static ClauseView withoutTheLeft() {
+        RuleRef.Invariant rule = new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("demo", "R")), 0),
+                Optional.empty()));
+        PartId<RuleRef.Invariant> left = new PartId<>(rule, 0);
+        PartId<RuleRef.Invariant> right = new PartId<>(rule, 1);
+        return PartsLeftOut.without(Set.of(left)).viewOf(
+                List.of(new Clauses.StatedPart(left, LEFT),
+                        new Clauses.StatedPart(right, RIGHT)));
+    }
+
+    /** What a node reads as here, which is enough to tell the two conjuncts and the whole apart. */
+    private static String spelled(Core node) {
+        if (node == LEFT) {
+            return "left";
+        }
+        if (node == RIGHT) {
+            return "right";
+        }
+        return node == BOTH ? "left && right" : "something else";
+    }
+
+    /** A clause of no connective, named by which of them it is. */
+    private static Core leaf(String named) {
+        return new Core.Binary(BinOp.EQ, new Core.Str(named, Type.STRING, POS),
+                new Core.Str(named, Type.STRING, POS), ConstructOccurrence.unwritten(),
+                Type.BOOL, POS);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest.java
@@ -89,19 +89,20 @@ class WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest {
      */
     @Test
     void andTheOneWayInWantsAnOrderNobodyButTheReadingHolds() {
-        List<Method> made = new ArrayList<>();
+        Set<String> made = new TreeSet<>();
         for (Method each : SettledOrderEnvelope.class.getDeclaredMethods()) {
-            if (each.getReturnType() == SettledOrderEnvelope.class
-                    && each.getParameterCount() > 0) {
-                made.add(each);
+            if (each.getReturnType() != SettledOrderEnvelope.class) {
+                continue;
             }
+            made.add(each.getName() + "/" + (each.getParameterCount() == 0 ? "nothing"
+                    : each.getParameterTypes()[0].getSimpleName()));
         }
-        assertEquals(1, made.size(),
-                "one way to make one of these, and it is the one that is looked at: " + made);
-        assertEquals(souther.compiler.numeric.OrderedIntervals.class,
-                made.get(0).getParameterTypes()[0],
-                "what it is made from is an order, and an order is held by the reading that"
-                        + " composed the connectives over it");
+        // Both of them, written out: a way in that says nothing is one nothing can be read off, and
+        // a way in that is given a reading's answer is one only that reading can take. A third
+        // fails here whichever of the two it looks like.
+        assertEquals(Set.of("of/OrderedIntervals", "nothing/nothing"), made,
+                "an envelope is made from an order and from nothing else, and an order is held by"
+                        + " the reading that composed the connectives over it");
     }
 
     private static boolean takesOne(Class<?>[] these) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a choice leaves a position is composed once, and what leaves that reading is an observation.
+ *
+ * <p>The alternatives of a choice are readings of the whole value, so what one leaves a position is
+ * settled where both of the languages that decide a branch's fate are held ({@link Confinement}).
+ * A second composition of the same choice is a second answer about one model, and the two agree
+ * only until somebody changes one of them — which is what this stops, on the one thing that leaves
+ * that reading.
+ *
+ * <p><b>Said of the operations and not of their names.</b> Forbidding {@code join} and {@code
+ * either} leaves the next algebra to be written under another name; what an algebra is, is an
+ * operation over its own type, and there is none here. What may be asked of
+ * {@link SettledOrderEnvelope} is where a position stops, and the answer to that is not another one
+ * of these.
+ */
+class WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest {
+
+    /**
+     * Nothing anywhere takes one of these and answers with another.
+     *
+     * <p>Over every class this compiler holds and not over the type alone: an algebra written
+     * beside it — a static method over two of them, a builder holding one and returning one — is
+     * the same second answer arrived at from outside.
+     */
+    @Test
+    void nothingTakesASettledOrderAndAnswersWithAnother() {
+        Set<String> composing = new TreeSet<>();
+        int mentioning = 0;
+        for (Class<?> each : compiled()) {
+            for (Method method : each.getDeclaredMethods()) {
+                boolean takes = takesOne(method.getParameterTypes());
+                boolean answers = method.getReturnType() == SettledOrderEnvelope.class;
+                if (!takes && !answers) {
+                    continue;
+                }
+                mentioning++;
+                if (takes && answers) {
+                    composing.add(each.getName() + "." + method.getName());
+                }
+            }
+            // A constructor answers with the class it is of, so one taking a settled order is a
+            // reader holding what it was handed. The exception is this type's own: made from
+            // another of these, it would be the same operation under the one name that does not
+            // read as one.
+            for (Constructor<?> made : each.getDeclaredConstructors()) {
+                if (takesOne(made.getParameterTypes())) {
+                    mentioning++;
+                    if (each == SettledOrderEnvelope.class) {
+                        composing.add(each.getName() + ".<init>");
+                    }
+                }
+            }
+        }
+        assertTrue(mentioning > 0,
+                "found nothing that is asked about a settled order at all — the scan missed it");
+        assertEquals(Set.of(), composing,
+                "an operation over two of these is a second composition of one choice, and the"
+                        + " model it answers about is the same one the first composed");
+    }
+
+    /**
+     * And the one that makes them is asked for an order, which only the reading that composes one
+     * holds.
+     *
+     * <p>The other half of the same rule. What is here came from a reading that had spent the
+     * connectives, and the way that is kept true is that a caller cannot arrive with an envelope of
+     * its own: the way in wants what {@code WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest}
+     * lets only {@link Confinement} hold.
+     */
+    @Test
+    void andTheOneWayInWantsAnOrderNobodyButTheReadingHolds() {
+        List<Method> made = new ArrayList<>();
+        for (Method each : SettledOrderEnvelope.class.getDeclaredMethods()) {
+            if (each.getReturnType() == SettledOrderEnvelope.class
+                    && each.getParameterCount() > 0) {
+                made.add(each);
+            }
+        }
+        assertEquals(1, made.size(),
+                "one way to make one of these, and it is the one that is looked at: " + made);
+        assertEquals(souther.compiler.numeric.OrderedIntervals.class,
+                made.get(0).getParameterTypes()[0],
+                "what it is made from is an order, and an order is held by the reading that"
+                        + " composed the connectives over it");
+    }
+
+    private static boolean takesOne(Class<?>[] these) {
+        for (Class<?> each : these) {
+            if (each == SettledOrderEnvelope.class) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Every class of this compiler, loaded for what it declares.
+     *
+     * <p>Not initialised, for the reason the reading of orders beside it gives: what is read here is
+     * what a type declares, and running its static initialisers would make this test depend on what
+     * they touch.
+     */
+    private static List<Class<?>> compiled() {
+        List<Class<?>> found = new ArrayList<>();
+        for (String entry : System.getProperty("java.class.path").split(File.pathSeparator)) {
+            Path root = Path.of(entry);
+            if (!entry.contains("souther-") || !Files.isDirectory(root)) {
+                continue;
+            }
+            try (Stream<Path> walk = Files.walk(root)) {
+                walk.filter(each -> each.toString().endsWith(".class"))
+                        .map(each -> root.relativize(each).toString())
+                        .forEach(name -> load(name, found));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return found;
+    }
+
+    private static void load(String path, List<Class<?>> into) {
+        String named = path.substring(0, path.length() - ".class".length())
+                .replace(File.separatorChar, '.').replace('/', '.');
+        if (!named.startsWith("souther.") || named.endsWith("package-info")
+                || named.endsWith("module-info")) {
+            return;
+        }
+        try {
+            into.add(Class.forName(named, false,
+                    WhatIsSettledAfterAChoiceIsObservedAndNotComposedAgainTest.class
+                            .getClassLoader()));
+        } catch (ClassNotFoundException | LinkageError _) {
+            // a class this test's path cannot resolve says nothing about the rule
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which of a clause's parts a reading's world holds is handed to the reading, never asked about.
+ *
+ * <p>A reader asking what one conjunct was holding reads the declaration in a world the author did
+ * not write, and every walk over that declaration has to be a walk of the same world: a part one of
+ * them reached that another never read is a value whose rules were not gathered.
+ *
+ * <p>That agreement used to rest on each walk remembering to consult a rule. Four of them did and
+ * one did not, so the connectives were composed over conjuncts every walk beside them had left out,
+ * the settled answer was the same with a conjunct and without it, and every end a choice was
+ * holding came back held by nobody.
+ *
+ * <p><b>So the rule is gone and what is left is a producer.</b> A world hands out the clause it has
+ * ({@link PartsLeftOut#viewOf}), and there is nowhere to ask whether one part is in it. A walk
+ * written tomorrow reads what it is given; it cannot read the whole clause by forgetting to ask,
+ * because forgetting is no longer a thing it can do.
+ */
+class WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest {
+
+    /**
+     * Nothing can ask a world about one part.
+     *
+     * <p>Said of what the type offers rather than of who calls it. A predicate over a part is a
+     * question every walk has to be written to ask, and the walk that is written without asking it
+     * is the one this is about — so what is checked is that the question cannot be put.
+     */
+    @Test
+    void nothingCanAskAWorldAboutOnePart() {
+        Set<String> asking = new TreeSet<>();
+        for (Method each : PartsLeftOut.class.getDeclaredMethods()) {
+            for (Class<?> takes : each.getParameterTypes()) {
+                if (takes == PartId.class) {
+                    asking.add(each.getName());
+                }
+            }
+        }
+        assertEquals(Set.of(), asking,
+                "a world answering about one part is one every walk over a clause has to be"
+                        + " written to consult, and the walk that is not written to is the defect");
+    }
+
+    /**
+     * And what it hands out is the clause, which is the one thing a walk can be given.
+     *
+     * <p>The other half: a world that offered nothing would leave every walk to work out what it
+     * holds, which is the same defect reached from the other side.
+     */
+    @Test
+    void andWhatItHandsOutIsTheClauseThisWorldHas() {
+        List<Method> handing = new ArrayList<>();
+        for (Method each : PartsLeftOut.class.getDeclaredMethods()) {
+            if (each.getReturnType() == ClauseView.class) {
+                handing.add(each);
+            }
+        }
+        assertEquals(1, handing.size(),
+                "one way to be told what a world holds of a clause, and it is the one every walk"
+                        + " is given: " + handing);
+    }
+
+    /**
+     * And every walk over a declaration's clauses is given one.
+     *
+     * <p>Over the compiler and not over the walks somebody listed. What a walk of a world reads is
+     * the parts that world holds, so a walk holding a world and working out the parts for itself is
+     * a second answer to a question with one — and the shape that answer takes is a method that has
+     * both in hand.
+     */
+    @Test
+    void andNothingHoldsAWorldBesideThePartsItWouldHaveHandedOut() {
+        Set<String> both = new TreeSet<>();
+        int holding = 0;
+        for (Class<?> each : compiled()) {
+            if (each == PartsLeftOut.class || PartsLeftOut.class.isAssignableFrom(each)) {
+                continue;
+            }
+            for (Method method : each.getDeclaredMethods()) {
+                boolean world = false;
+                boolean parts = false;
+                for (Class<?> takes : method.getParameterTypes()) {
+                    world |= takes == PartsLeftOut.class;
+                    parts |= takes == ClauseView.class;
+                }
+                if (world) {
+                    holding++;
+                }
+                if (world && parts) {
+                    both.add(each.getName() + "." + method.getName());
+                }
+            }
+        }
+        assertTrue(holding > 0, "found nothing that is handed a world at all — the scan missed it");
+        assertEquals(Set.of(), both,
+                "a reader given a world and the clause it holds can read one and walk the other,"
+                        + " which is the two readings of one world this arrangement is against");
+    }
+
+    /**
+     * Every class of this compiler, loaded for what it declares.
+     *
+     * <p>Not initialised, for the reason the readings of orders beside it give: what is read here is
+     * what a type declares, and running its static initialisers would make this test depend on what
+     * they touch.
+     */
+    private static List<Class<?>> compiled() {
+        List<Class<?>> found = new ArrayList<>();
+        for (String entry : System.getProperty("java.class.path").split(File.pathSeparator)) {
+            Path root = Path.of(entry);
+            if (!entry.contains("souther-") || !Files.isDirectory(root)) {
+                continue;
+            }
+            try (Stream<Path> walk = Files.walk(root)) {
+                walk.filter(each -> each.toString().endsWith(".class"))
+                        .map(each -> root.relativize(each).toString())
+                        .forEach(name -> load(name, found));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return found;
+    }
+
+    private static void load(String path, List<Class<?>> into) {
+        String named = path.substring(0, path.length() - ".class".length())
+                .replace(File.separatorChar, '.').replace('/', '.');
+        if (!named.startsWith("souther.") || named.endsWith("package-info")
+                || named.endsWith("module-info")) {
+            return;
+        }
+        try {
+            into.add(Class.forName(named, false,
+                    WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest.class.getClassLoader()));
+        } catch (ClassNotFoundException | LinkageError _) {
+            // a class this test's path cannot resolve says nothing about the rule
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest.java
@@ -78,15 +78,19 @@ class WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest {
     }
 
     /**
-     * And every walk over a declaration's clauses is given one.
+     * And nothing is handed a world beside the clause that world would narrow.
      *
-     * <p>Over the compiler and not over the walks somebody listed. What a walk of a world reads is
-     * the parts that world holds, so a walk holding a world and working out the parts for itself is
-     * a second answer to a question with one — and the shape that answer takes is a method that has
-     * both in hand.
+     * <p>Which is the shape the defect takes and not the one place it was found. A reader holding
+     * both has to be written to narrow one by the other, and the reader that is not written to is
+     * the one this is about — so the pair is what is forbidden, whether the second half arrives as
+     * the clause, as one of its parts, or as the answer a world would have given.
+     *
+     * <p>Over the compiler and not over the readers somebody listed. A world is converted where it
+     * is received and what travels on is the clause this world has; a reader further in that could
+     * still be given both is one this finds without being told where to look.
      */
     @Test
-    void andNothingHoldsAWorldBesideThePartsItWouldHaveHandedOut() {
+    void andNothingIsHandedAWorldBesideTheClauseItWouldNarrow() {
         Set<String> both = new TreeSet<>();
         int holding = 0;
         for (Class<?> each : compiled()) {
@@ -95,23 +99,31 @@ class WhichRulesAWorldHasIsHandedOutAndNotAskedAboutTest {
             }
             for (Method method : each.getDeclaredMethods()) {
                 boolean world = false;
-                boolean parts = false;
+                boolean narrowed = false;
                 for (Class<?> takes : method.getParameterTypes()) {
                     world |= takes == PartsLeftOut.class;
-                    parts |= takes == ClauseView.class;
+                    narrowed |= narrowedByAWorld(takes);
                 }
                 if (world) {
                     holding++;
                 }
-                if (world && parts) {
+                if (world && narrowed) {
                     both.add(each.getName() + "." + method.getName());
                 }
             }
         }
         assertTrue(holding > 0, "found nothing that is handed a world at all — the scan missed it");
         assertEquals(Set.of(), both,
-                "a reader given a world and the clause it holds can read one and walk the other,"
+                "a reader given a world and what it would narrow can read one and walk the other,"
                         + " which is the two readings of one world this arrangement is against");
+    }
+
+    /** What a world's answer is about: a clause, a part of one, or the answer itself. */
+    private static boolean narrowedByAWorld(Class<?> takes) {
+        return takes == ClauseView.class
+                || takes == Clauses.Stated.class
+                || takes == Clauses.StatedPart.class
+                || takes == Clauses.StatedClauses.class;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
@@ -93,6 +93,13 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
             return axis.cuts().get(0);
         }
 
+        /** The line the rules drew at {@code place}, of however many they drew. */
+        Cut lineAt(String place) {
+            return axis.cuts().stream().filter(each -> each.key().equals(place)).findFirst()
+                    .orElseThrow(() -> new AssertionError("no line at " + place + ", among "
+                            + axis.cuts().stream().map(Cut::key).toList()));
+        }
+
         Carrier carrier() {
             return orders.answered();
         }
@@ -208,13 +215,17 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
      * What answers is where the value it holds sits on the position's order, written down when the
      * class was made — so a position whose rules name its values is narrowed by a comparison on it,
      * as it was while the line was turned back into a value to ask.
+     *
+     * <p>The guard's is one of the lines this model draws and not the only one: the invariant names
+     * three values under a choice, so the rules stop the level at one and at three as well, and the
+     * line asked about here is named rather than taken as whatever the model happened to draw.
      */
     @Test
     void aClassOfANamedValueHoldsTheLineDrawnAtThatValue() {
         Measured named = measured(NAMED, "gate/slot.level");
 
         assertEquals(List.of("2"),
-                named.holding(named.line()).stream().map(PartitionClass::id).toList(),
+                named.holding(named.lineAt("2")).stream().map(PartitionClass::id).toList(),
                 "the line is at two, and the class holding two is the one that holds it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
@@ -224,6 +224,10 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
     void aClassOfANamedValueHoldsTheLineDrawnAtThatValue() {
         Measured named = measured(NAMED, "gate/slot.level");
 
+        assertEquals(List.of("1", "2", "3"),
+                named.axis().cuts().stream().map(Cut::key).sorted().toList(),
+                "the guard cuts at two and the invariant stops the level at the outermost of the"
+                        + " values it names, so those are the lines this model draws");
         assertEquals(List.of("2"),
                 named.holding(named.lineAt("2")).stream().map(PartitionClass::id).toList(),
                 "the line is at two, and the class holding two is the one that holds it");


### PR DESCRIPTION
A rule this compiler reads to the end came back, written under a choice, as one that divides the position no way and draws no line. `n >= 2 || n >= 3` admits exactly the values from two up; written with `&&` between them, or written alone, either bound is a line this compiler draws.

The answer already existed. What two alternatives leave a position is settled where the branches have their fate, and the range is in hand by the time anything asks. Three things stood between it and a line.

## The settled order had no way out of the reading that composed it

`SettledOrderEnvelope` is that way out: an observation of a reading that is over, keyed by the position, holding no operation that takes one of these and answers with another. It states the ends some rule put there and not the ones the carrier supplies, and it is made from an order — which only the reading that composes the connectives holds.

`FieldDomains.leftAt` now picks the reader off the coordinate rather than off the caller: a position's own order from this, a count's from the reading beside it. A caller cannot ask the wrong one.

## A counterfactual was not one world

A reader asking what a conjunct was holding left it out of the interval algebra and out of the walk over comparisons, and read it all the same in the reading that composes the connectives. So the two readings the attribution compares were readings of two worlds, the settled answer was the same either way, and every end a choice was holding came back held by nobody.

`ClauseView` says which parts a world has, is made once from the reach, and is what the fold walks. A part outside it is not read, not composed with, and not told to anything that collects parts — so whether a reading honours the omission is not a question anybody has to ask of the reading.

This was live on the numbers an operation answers as well. A count whose atom disappeared with its last conjunct was standing in for the difference, and a rule with another conjunct beside the choice had the same line written once per conjunct.

## An order the arithmetic has no words for

A rule holding a string against a constant came back about no number this could name. Where the form was not read and one whole side is a position held against something naming none, the line is on that position — the arm the classification always had a place for and no model reached.

## What is held

Each test is a rule about where an answer comes from. A choice stops a position where the wider of its alternatives does, whatever order they are written in and however they are bracketed. An order that is not one of numbers is stopped the same way. A choice bounds a position only where both alternatives do — the control that tells reading the settled answer from gathering what the branches said. An alternative nobody can be in leaves the choice what the other leaves. What the choice leaves is where the lines are and not which values stand there, so two alternatives naming one value each leave a run that comes back saying nothing can be written in it. And one line is drawn once however many conjuncts the rule has.

Beside them, the rule the arrangement turns on, said of the operations rather than of the names they could be given: nothing takes a settled order and answers with another.

The line a guard draws is now one of several on a model whose invariant names its values under a choice, so the test asking which class holds it names the line it is about instead of taking the only one.

Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)