### PR TITLE
Ask which declaration a caret is in, not where a lens is drawn

### DIFF
--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -801,10 +801,16 @@ public final class Analyzer {
         // Ahead of the compile because it is what the rest is about: everything below answers about
         // a behavior, and there is no behavior to answer about until this says so.
         LineIndex lines = new LineIndex(text);
-        SyntaxNode declaration = defReaching(root,
+        // The first behavior it reaches, and not the first definition. A selection is drawn over as
+        // many declarations as somebody drags it over, and a `data` above the behavior is not an
+        // answer about the behavior. Over more than one behavior it is the one written first: an
+        // offer writes the rows of one declaration, so one of them is what it can be about.
+        SyntaxNode declaration = defsReaching(root,
                 lines.offsetOf(requested.start().line(), requested.start().character()),
-                lines.offsetOf(requested.end().line(), requested.end().character()));
-        if (declaration == null || declaration.kind() != SyntaxKind.BEHAVIOR_DEF) {
+                lines.offsetOf(requested.end().line(), requested.end().character())).stream()
+                .filter(def -> def.kind() == SyntaxKind.BEHAVIOR_DEF)
+                .findFirst().orElse(null);
+        if (declaration == null) {
             return List.of();
         }
         int declaredAt = writtenFrom(declaration);
@@ -2329,19 +2335,27 @@ public final class Analyzer {
      * it.
      */
     private SyntaxNode enclosingDef(SyntaxNode root, int offset) {
-        return defReaching(root, offset, offset);
+        List<SyntaxNode> reached = defsReaching(root, offset, offset);
+        return reached.isEmpty() ? null : reached.get(0);
     }
 
     /**
-     * The same for a stretch of the document rather than a position: the top-level definition the
-     * request from {@code from} to {@code to} is in, or null where it is in none.
+     * The top-level definitions the stretch from {@code from} to {@code to} reaches, in the order
+     * they are written.
      *
-     * <p>A position and a stretch are asked differently. A position at either end of a definition is
-     * on it, which is what a caret at the end of a line is. A stretch meets a definition where the
-     * two share a character — read as a position is, a selection of the blank line above would
-     * reach the definition below by ending where its first character begins.
+     * <p>Every one of them, because a stretch reaches as many as it is drawn over and a caller has
+     * to say which of those it wanted. A position is the case where there is at most one, and
+     * {@link #enclosingDef} is that case — asked for one, a stretch would answer with whichever
+     * definition is written first, which is an answer about the order of the file rather than about
+     * what was asked for.
+     *
+     * <p>A position and a stretch are also bounded differently. A position at either end of a
+     * definition is on it, which is what a caret at the end of a line is. A stretch meets a
+     * definition where the two share a character — bounded as a position is, a selection of the
+     * blank line above would reach the definition below by ending where its first character begins.
      */
-    private SyntaxNode defReaching(SyntaxNode root, int from, int to) {
+    private List<SyntaxNode> defsReaching(SyntaxNode root, int from, int to) {
+        List<SyntaxNode> reached = new ArrayList<>();
         for (SyntaxNode def : root.childNodes()) {
             if (!DEFINITIONS.contains(def.kind())) {
                 continue;
@@ -2354,10 +2368,10 @@ public final class Analyzer {
                     ? from >= written && from <= def.end()
                     : from < def.end() && written < to;
             if (reaches) {
-                return def;
+                reached.add(def);
             }
         }
-        return null;
+        return reached;
     }
 
     /** Where {@code node}'s own text begins: its first code token, past the trivia in front of it. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -588,7 +588,7 @@ public final class Analyzer {
             }
             String title = lensTitle(compilation, module, behavior.name(), adequacy);
             if (title != null) {
-                out.add(new CodeLens(pointRange(behavior.pos()), title));
+                out.add(new CodeLens(lensAnchorRange(behavior.pos()), title));
             }
         }
         return out;
@@ -712,8 +712,14 @@ public final class Analyzer {
         return owed.coverage().settled();
     }
 
-    /** The caret at one position, as a range of no width. */
-    private static Range pointRange(SourcePos pos) {
+    /**
+     * Where a lens is drawn: the declaration's position, as a range of no width.
+     *
+     * <p>An editor reads the line a lens's range starts on and nothing else of it, so a point says
+     * everything a lens needs. It says nothing about what a caret is in, which is a different
+     * question and is answered from the declaration a caret is written inside of.
+     */
+    private static Range lensAnchorRange(SourcePos pos) {
         Position at = new Position(pos.line() - 1, pos.column() - 1);
         return new Range(at, at);
     }
@@ -740,11 +746,12 @@ public final class Analyzer {
     public List<CodeAction> codeActions(String uri, String text, Range requested,
                                         ModuleGraph graph) {
         List<CodeAction> out = new ArrayList<>();
-        if (!CstParser.parse(text).errors().isEmpty()) {
+        CstParser.Result parsed = CstParser.parse(text);
+        if (!parsed.errors().isEmpty()) {
             return out;   // a semantic suggestion needs a clean parse
         }
         if (graph != null) {
-            out.addAll(rowsToWrite(uri, text, requested, graph));
+            out.addAll(rowsToWrite(uri, text, parsed.root(), requested, graph));
         }
         Diagnostic d = firstSemanticDiagnostic(text);
         if (d == null || d.suggestion() == null) {
@@ -785,11 +792,21 @@ public final class Analyzer {
      * module's own source or an attached file — and moving a block is easier than finding out why one
      * landed somewhere surprising.
      */
-    private List<CodeAction> rowsToWrite(String uri, String text, Range requested,
+    private List<CodeAction> rowsToWrite(String uri, String text, SyntaxNode root, Range requested,
                                          ModuleGraph graph) {
         if (!measure.level().readsRows()) {
             return List.of();
         }
+        // Which declaration is being asked about, before anything is compiled to answer about it.
+        // This reads the document the request arrived with and costs a walk of its top-level nodes;
+        // what comes after is a workspace compile and a search over what it holds, and an editor
+        // asks this every time the cursor moves.
+        LineIndex lines = new LineIndex(text);
+        SyntaxNode declaration = behaviorDeclarationAsked(root, lines, requested);
+        if (declaration == null) {
+            return List.of();
+        }
+        int writtenFrom = writtenFrom(declaration);
         Compilation compilation = compileOf(graph);
         String module = moduleOf(compilation, graph, uri);
         if (module == null) {
@@ -802,7 +819,7 @@ public final class Analyzer {
         }
         for (Hir.BehaviorDef behavior : written.behaviors()) {
             if (!isWrittenIn(behavior, uri, graph)
-                    || !overlaps(pointRange(behavior.pos()), requested)) {
+                    || !startsWithin(lines, behavior.pos(), writtenFrom, declaration.end())) {
                 continue;
             }
             // Whether the model owes this behavior anything a row could answer. Asked of the
@@ -839,6 +856,46 @@ public final class Analyzer {
      */
     private boolean isWrittenIn(Hir.BehaviorDef behavior, String uri, ModuleGraph graph) {
         return uri.equals(documentOf(behavior.pos(), null, graph));
+    }
+
+    /**
+     * The behavior declaration the request is in, or null where it is in none.
+     *
+     * <p>A declaration is what a caret is inside of while reading it, and it runs from its first
+     * code token to the end of its last. Not the node's span: a node reaches back over the blank
+     * lines and comments in front of it, and a caret on the line above a declaration is where the
+     * next one is written rather than inside this one.
+     *
+     * <p>A caret and a selection are asked differently. A caret is a position, and a position at
+     * either end of a declaration is on it. A selection is a stretch, and it meets the declaration
+     * where the two share a character — so a selection of the blank line above stops at the first
+     * code token rather than reaching past it.
+     */
+    private SyntaxNode behaviorDeclarationAsked(SyntaxNode root, LineIndex lines, Range requested) {
+        int from = lines.offsetOf(requested.start().line(), requested.start().character());
+        int to = lines.offsetOf(requested.end().line(), requested.end().character());
+        for (SyntaxNode def : root.childNodes()) {
+            if (def.kind() != SyntaxKind.BEHAVIOR_DEF) {
+                continue;
+            }
+            int written = writtenFrom(def);
+            if (written < 0) {
+                continue;
+            }
+            boolean asked = from == to
+                    ? from >= written && from <= def.end()
+                    : from < def.end() && written < to;
+            if (asked) {
+                return def;
+            }
+        }
+        return null;
+    }
+
+    /** Whether a compiler position is one this document writes between two of its offsets. */
+    private static boolean startsWithin(LineIndex lines, SourcePos pos, int from, int to) {
+        int at = lines.offsetOf(pos.line() - 1, pos.column() - 1);
+        return at >= from && at <= to;
     }
 
     /** Whether anything this behavior is short of is a thing writing a row could answer. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -797,16 +797,17 @@ public final class Analyzer {
         if (!measure.level().readsRows()) {
             return List.of();
         }
-        // Which declaration is being asked about, before anything is compiled to answer about it.
-        // This reads the document the request arrived with and costs a walk of its top-level nodes;
-        // what comes after is a workspace compile and a search over what it holds, and an editor
-        // asks this every time the cursor moves.
+        // Which declaration is being asked about, asked of the document the request arrived with.
+        // Ahead of the compile because it is what the rest is about: everything below answers about
+        // a behavior, and there is no behavior to answer about until this says so.
         LineIndex lines = new LineIndex(text);
-        SyntaxNode declaration = behaviorDeclarationAsked(root, lines, requested);
-        if (declaration == null) {
+        SyntaxNode declaration = defReaching(root,
+                lines.offsetOf(requested.start().line(), requested.start().character()),
+                lines.offsetOf(requested.end().line(), requested.end().character()));
+        if (declaration == null || declaration.kind() != SyntaxKind.BEHAVIOR_DEF) {
             return List.of();
         }
-        int writtenFrom = writtenFrom(declaration);
+        int declaredAt = writtenFrom(declaration);
         Compilation compilation = compileOf(graph);
         String module = moduleOf(compilation, graph, uri);
         if (module == null) {
@@ -818,8 +819,7 @@ public final class Analyzer {
             return List.of();
         }
         for (Hir.BehaviorDef behavior : written.behaviors()) {
-            if (!isWrittenIn(behavior, uri, graph)
-                    || !startsWithin(lines, behavior.pos(), writtenFrom, declaration.end())) {
+            if (!isWrittenIn(behavior, uri, graph) || !declaredBy(lines, behavior, declaredAt)) {
                 continue;
             }
             // Whether the model owes this behavior anything a row could answer. Asked of the
@@ -859,43 +859,17 @@ public final class Analyzer {
     }
 
     /**
-     * The behavior declaration the request is in, or null where it is in none.
+     * Whether {@code behavior} is what the declaration written at {@code declaredAt} declares.
      *
-     * <p>A declaration is what a caret is inside of while reading it, and it runs from its first
-     * code token to the end of its last. Not the node's span: a node reaches back over the blank
-     * lines and comments in front of it, and a caret on the line above a declaration is where the
-     * next one is written rather than inside this one.
-     *
-     * <p>A caret and a selection are asked differently. A caret is a position, and a position at
-     * either end of a declaration is on it. A selection is a stretch, and it meets the declaration
-     * where the two share a character — so a selection of the blank line above stops at the first
-     * code token rather than reaching past it.
+     * <p>The two are the same declaration read by the two halves of this server, and each says where
+     * it begins: a syntax node's first code token is the {@code behavior} keyword, and so is a
+     * {@link Hir.BehaviorDef}'s own position. So they are joined on that and not on the name — a name
+     * is canonical on one side and as spelled on the other, and a declaration written in a
+     * decomposed spelling would be joined to nothing.
      */
-    private SyntaxNode behaviorDeclarationAsked(SyntaxNode root, LineIndex lines, Range requested) {
-        int from = lines.offsetOf(requested.start().line(), requested.start().character());
-        int to = lines.offsetOf(requested.end().line(), requested.end().character());
-        for (SyntaxNode def : root.childNodes()) {
-            if (def.kind() != SyntaxKind.BEHAVIOR_DEF) {
-                continue;
-            }
-            int written = writtenFrom(def);
-            if (written < 0) {
-                continue;
-            }
-            boolean asked = from == to
-                    ? from >= written && from <= def.end()
-                    : from < def.end() && written < to;
-            if (asked) {
-                return def;
-            }
-        }
-        return null;
-    }
-
-    /** Whether a compiler position is one this document writes between two of its offsets. */
-    private static boolean startsWithin(LineIndex lines, SourcePos pos, int from, int to) {
-        int at = lines.offsetOf(pos.line() - 1, pos.column() - 1);
-        return at >= from && at <= to;
+    private static boolean declaredBy(LineIndex lines, Hir.BehaviorDef behavior, int declaredAt) {
+        SourcePos pos = behavior.pos();
+        return lines.offsetOf(pos.line() - 1, pos.column() - 1) == declaredAt;
     }
 
     /** Whether anything this behavior is short of is a thing writing a row could answer. */
@@ -2355,12 +2329,31 @@ public final class Analyzer {
      * it.
      */
     private SyntaxNode enclosingDef(SyntaxNode root, int offset) {
+        return defReaching(root, offset, offset);
+    }
+
+    /**
+     * The same for a stretch of the document rather than a position: the top-level definition the
+     * request from {@code from} to {@code to} is in, or null where it is in none.
+     *
+     * <p>A position and a stretch are asked differently. A position at either end of a definition is
+     * on it, which is what a caret at the end of a line is. A stretch meets a definition where the
+     * two share a character — read as a position is, a selection of the blank line above would
+     * reach the definition below by ending where its first character begins.
+     */
+    private SyntaxNode defReaching(SyntaxNode root, int from, int to) {
         for (SyntaxNode def : root.childNodes()) {
             if (!DEFINITIONS.contains(def.kind())) {
                 continue;
             }
             int written = writtenFrom(def);
-            if (written >= 0 && offset >= written && offset <= def.end()) {
+            if (written < 0) {
+                continue;
+            }
+            boolean reaches = from == to
+                    ? from >= written && from <= def.end()
+                    : from < def.end() && written < to;
+            if (reaches) {
                 return def;
             }
         }

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -120,7 +120,12 @@ class AdequacyLensTest {
                 .codeLenses(MODULE, graphOf(Map.of(MODULE, TRIP)));
 
         assertEquals(1, lenses.size());
-        assertEquals(9, lenses.get(0).range().start().line(), "the `behavior` line, zero-based");
+        // And drawn at a point. A lens is read for the line its range starts on, and the offer to
+        // write the rows is what the stretch of a declaration is for — the two are separate answers
+        // about the same declaration, and a lens given a width would be the one lent to the other.
+        int line = lineOf(TRIP, "behavior submit");
+        assertEquals(new Range(new Position(line, 0), new Position(line, 0)),
+                lenses.get(0).range());
         assertEquals("1 row · out 1/2 · boundary 2/5 · branch 1/2", lenses.get(0).title());
     }
 

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -446,6 +446,107 @@ class AdequacyLensTest {
                 measuring(Adequacy.Level.ALL).codeActions(MODULE, TRIP, on(9)));
     }
 
+    /**
+     * The offer stands at every position the declaration is written over, and at no other.
+     *
+     * <p>Asked from every position in the document rather than from the one column a helper sends.
+     * A lens is drawn at a point, and the point a declaration begins at was what the offer compared
+     * a caret against — so the offer was made at the first column of the {@code behavior} line and
+     * nowhere else on it, which no test said either way.
+     *
+     * <p>What decides it here is read off the source: from the first character of {@code behavior}
+     * to the last of the declaration's final line. The offer works it out from the syntax tree, so
+     * the two would have to be wrong in the same way to agree.
+     */
+    @Test
+    void theOfferStandsExactlyWhereTheDeclarationIsWritten() {
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(MODULE, TRIP));
+        String lastLine = "    constructs Submitted, Waiting";
+        int from = TRIP.indexOf("behavior submit");
+        int to = TRIP.indexOf(lastLine) + lastLine.length();
+
+        List<String> offeredOutsideIt = new ArrayList<>();
+        List<String> withheldInsideIt = new ArrayList<>();
+        String[] lines = TRIP.split("\n", -1);
+        int startOfLine = 0;
+        for (int line = 0; line < lines.length; line++) {
+            for (int column = 0; column <= lines[line].length(); column++) {
+                boolean offered = offersRows(analyzer, MODULE, TRIP, caret(line, column), graph);
+                int at = startOfLine + column;
+                if (offered != (at >= from && at <= to)) {
+                    (offered ? offeredOutsideIt : withheldInsideIt).add(line + ":" + column);
+                }
+            }
+            startOfLine += lines[line].length() + 1;
+        }
+
+        assertEquals(List.of(), withheldInsideIt,
+                "the offer stands wherever the caret is in the declaration");
+        assertEquals(List.of(), offeredOutsideIt, "and nowhere it is not");
+    }
+
+    /**
+     * A comment above a declaration is not inside it.
+     *
+     * <p>The syntax tree covers every character, so the blank lines and the comment in front of a
+     * declaration are part of its node. They are not part of what it writes: a caret there is where
+     * the comment is being written, and the declaration below it is the next thing on the page
+     * rather than the thing the caret is in.
+     */
+    @Test
+    void aCommentAboveADeclarationIsNotInsideIt() {
+        String noted = ONLY_EDGES.replace("behavior keep",
+                "// what this keeps\nbehavior keep");
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(EDGES, noted));
+
+        assertFalse(offersRows(analyzer, EDGES, noted, caret(7, 3), graph),
+                "the caret is in the comment");
+        assertTrue(offersRows(analyzer, EDGES, noted, caret(8, 3), graph),
+                "and on the line under it, in the declaration");
+    }
+
+    /**
+     * A selection meets the declaration where the two share a character.
+     *
+     * <p>A caret is a position and is inside the declaration at either end of it. A selection is a
+     * stretch, and read the same way a selection of the blank line above would reach the
+     * declaration below by touching its first character — which is the boundary the point range
+     * got wrong at the other end.
+     */
+    @Test
+    void aSelectionMeetsTheDeclarationWhereTheyShareACharacter() {
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(MODULE, TRIP));
+        int endOfTheDeclaration = "    constructs Submitted, Waiting".length();
+
+        assertFalse(offersRows(analyzer, MODULE, TRIP, over(8, 0, 9, 0), graph),
+                "the blank line above, up to where the declaration starts");
+        assertTrue(offersRows(analyzer, MODULE, TRIP, over(8, 0, 9, 1), graph),
+                "and one character further, into it");
+        assertFalse(offersRows(analyzer, MODULE, TRIP, over(10, endOfTheDeclaration, 12, 0), graph),
+                "from where the declaration ends, down");
+        assertTrue(offersRows(analyzer, MODULE, TRIP, over(10, endOfTheDeclaration - 1, 12, 0), graph),
+                "and one character back, from inside it");
+    }
+
+    /** Whether the rows this behavior does not cover are on offer for {@code asked}. */
+    private static boolean offersRows(Analyzer analyzer, String uri, String text, Range asked,
+                                      ModuleGraph graph) {
+        return analyzer.codeActions(uri, text, asked, graph).stream()
+                .anyMatch(action -> action.title().startsWith("Write the rows"));
+    }
+
+    private static Range caret(int line, int column) {
+        Position at = new Position(line, column);
+        return new Range(at, at);
+    }
+
+    private static Range over(int line, int column, int toLine, int toColumn) {
+        return new Range(new Position(line, column), new Position(toLine, toColumn));
+    }
+
     /** And nothing is offered where nothing was asked to be measured. */
     @Test
     void anEditorThatDidNotAskIsOfferedNothing() {

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -589,6 +589,43 @@ class AdequacyLensTest {
                         .get(0).title());
     }
 
+    /**
+     * A selection that starts in another declaration still reaches the behavior it ends in.
+     *
+     * <p>What a stretch reaches is as many declarations as it is drawn over, and which of them the
+     * offer is about is the offer's to say. Asked for one, the walk answers with whichever is
+     * written first — an answer about the order of the file — and a `data` above the behavior would
+     * take the place of the behavior.
+     */
+    @Test
+    void aSelectionReachesTheBehaviorItEndsInFromAnotherDeclaration() {
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(MODULE, TRIP));
+        int data = lineOf(TRIP, "data Waiting");
+        int behavior = lineOf(TRIP, "behavior submit");
+
+        assertTrue(offersRows(analyzer, MODULE, TRIP, over(data, 5, behavior, 1), graph),
+                "the selection runs from inside the data declaration into the behavior");
+    }
+
+    /**
+     * A selection over both behaviors is an offer about one of them.
+     *
+     * <p>The rows an offer writes are the rows of one declaration, so a stretch drawn over two is
+     * answered about the one written first rather than about both or about neither.
+     */
+    @Test
+    void aSelectionOverTwoBehaviorsIsAnOfferAboutTheFirst() {
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(TWO_URI, TWO));
+        int first = lineOf(TWO, "behavior first");
+        int second = lineOf(TWO, "behavior second");
+
+        assertEquals("Write the rows `first` does not cover",
+                analyzer.codeActions(TWO_URI, TWO, over(first, 0, second + 1, 0), graph)
+                        .get(0).title());
+    }
+
     /** The zero-based line {@code written} is on. */
     private static int lineOf(String text, String written) {
         String[] lines = text.split("\n", -1);

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -501,9 +501,10 @@ class AdequacyLensTest {
         Analyzer analyzer = measuring(Adequacy.Level.ALL);
         ModuleGraph graph = graphOf(Map.of(EDGES, noted));
 
-        assertFalse(offersRows(analyzer, EDGES, noted, caret(7, 3), graph),
+        int comment = lineOf(noted, "// what this keeps");
+        assertFalse(offersRows(analyzer, EDGES, noted, caret(comment, 3), graph),
                 "the caret is in the comment");
-        assertTrue(offersRows(analyzer, EDGES, noted, caret(8, 3), graph),
+        assertTrue(offersRows(analyzer, EDGES, noted, caret(comment + 1, 3), graph),
                 "and on the line under it, in the declaration");
     }
 
@@ -519,16 +520,79 @@ class AdequacyLensTest {
     void aSelectionMeetsTheDeclarationWhereTheyShareACharacter() {
         Analyzer analyzer = measuring(Adequacy.Level.ALL);
         ModuleGraph graph = graphOf(Map.of(MODULE, TRIP));
-        int endOfTheDeclaration = "    constructs Submitted, Waiting".length();
+        String lastLine = "    constructs Submitted, Waiting";
+        int first = lineOf(TRIP, "behavior submit");
+        int last = lineOf(TRIP, lastLine);
+        int ends = lastLine.length();
 
-        assertFalse(offersRows(analyzer, MODULE, TRIP, over(8, 0, 9, 0), graph),
+        assertFalse(offersRows(analyzer, MODULE, TRIP, over(first - 1, 0, first, 0), graph),
                 "the blank line above, up to where the declaration starts");
-        assertTrue(offersRows(analyzer, MODULE, TRIP, over(8, 0, 9, 1), graph),
+        assertTrue(offersRows(analyzer, MODULE, TRIP, over(first - 1, 0, first, 1), graph),
                 "and one character further, into it");
-        assertFalse(offersRows(analyzer, MODULE, TRIP, over(10, endOfTheDeclaration, 12, 0), graph),
+        assertFalse(offersRows(analyzer, MODULE, TRIP, over(last, ends, last + 2, 0), graph),
                 "from where the declaration ends, down");
-        assertTrue(offersRows(analyzer, MODULE, TRIP, over(10, endOfTheDeclaration - 1, 12, 0), graph),
+        assertTrue(offersRows(analyzer, MODULE, TRIP, over(last, ends - 1, last + 2, 0), graph),
                 "and one character back, from inside it");
+    }
+
+    private static final String TWO_URI = "file:///two.sou";
+
+    /** Two behaviors alike in everything but their names, each short of the rows its edges want. */
+    private static final String TWO = """
+            module two
+
+            data Amount = Int
+                invariant value >= 0 && value <= 10
+
+            data Ok = { n: Amount }
+
+            behavior first : (a: Amount) -> Ok
+                constructs Ok
+
+            behavior second : (a: Amount) -> Ok
+                constructs Ok
+
+            let first (a) = Ok { n = a }
+            let second (a) = Ok { n = a }
+
+            example first
+                | "mid" : (Amount(5)) -> Ok { n = Amount(5) }
+
+            example second
+                | "mid" : (Amount(5)) -> Ok { n = Amount(5) }
+            """;
+
+    /**
+     * The offer is for the declaration the caret is in, and not for the first one the module holds.
+     *
+     * <p>Two readings of the same declaration meet here: the syntax node the caret is in, and the
+     * behavior the compile prepared. They are joined on where each says the declaration begins, and
+     * a join that let anything else through would answer every caret in the module with whichever
+     * behavior came first. Everything else about these two is the same, so the name in the title is
+     * the whole of what tells the answers apart.
+     */
+    @Test
+    void theOfferNamesTheBehaviorTheCaretIsIn() {
+        Analyzer analyzer = measuring(Adequacy.Level.ALL);
+        ModuleGraph graph = graphOf(Map.of(TWO_URI, TWO));
+
+        assertEquals("Write the rows `first` does not cover",
+                analyzer.codeActions(TWO_URI, TWO, caret(lineOf(TWO, "behavior first"), 4), graph)
+                        .get(0).title());
+        assertEquals("Write the rows `second` does not cover",
+                analyzer.codeActions(TWO_URI, TWO, caret(lineOf(TWO, "behavior second"), 4), graph)
+                        .get(0).title());
+    }
+
+    /** The zero-based line {@code written} is on. */
+    private static int lineOf(String text, String written) {
+        String[] lines = text.split("\n", -1);
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith(written)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("not in the source: " + written);
     }
 
     /** Whether the rows this behavior does not cover are on offer for {@code asked}. */


### PR DESCRIPTION
Closes #1474.

The offer to write a behavior's missing rows compared a caret against the point a declaration begins at. Two ranges of no width meet only where they are equal, so the offer stood at the first column of the `behavior` line and nowhere else on it. A caret on the word `behavior`, or on the name the declaration binds, was offered nothing. The point is the right value for the lens, which is drawn above the line its range starts on and reads nothing else of it.

Underneath, the offer was asking the module what the caret was on. A behavior in the HIR carries the position of its keyword and the occurrence of its name, and nothing about how far the declaration runs, so that position was the only value there was to compare. The question belongs to the document in front of the caret, and this class already walks it for one: `enclosingDef` finds the top-level definition a cursor is in, past the trivia in front of it, so a caret on the blank line above a declaration is where the next one is written rather than inside this one.

That walk now takes a stretch rather than a position — `enclosingDef` is a position through it — and the offer asks it for the declaration the request is in, from its first code token to the end of its last. A caret is inside the declaration at either end of it; a selection meets it where they share a character, which keeps a selection of the blank line above from reaching the declaration below by touching it. The tree walked is the parse the request already made for its clean-parse check and threw away. `pointRange` is `lensAnchorRange`, which says what it is for.

The syntax node and the prepared behavior are joined on where each says the declaration begins: a node's first code token is the `behavior` keyword, and so is the behavior's own position. Not on the name, which is canonical on one side and as spelled on the other.

The offer and the outline read the same declaration of the grammar, each off a parse of its own. They do not take the same boundary from it: an outline symbol covers the comments written above a declaration, which is what an editor folds, and the offer starts at the first code token, which is where a caret is in the declaration rather than above it.

A caret is in at most one declaration, and a selection is drawn over as many as somebody drags it over. So the walk answers with what a request reaches rather than with one of them, and the offer takes the first behavior among those — a selection running from a `data` into a behavior is about the behavior.

## Where the caret is asked from

Every test that asked for these actions went through one helper that sent column zero, so neither that the offer was withheld in the middle of a declaration nor that it was made there was stated by anything. The check now asks from every position in the document and reads what decides it off the source — the first character of `behavior` to the last of the declaration's final line — so the check and the offer would have to be wrong in the same way to agree. Beside it: a comment above a declaration, the two ends a selection meets it at, a module declaring two behaviors alike in everything but their names, and the lens, which is asked to be a point and not merely to start on the right line.

## What it costs

Reading the tree first puts the question the rest is about before the work that answers it: the workspace compile, the search over what it holds, and — for a client that will not come back for the edit — composing the rows themselves now run only once the caret is known to be in a declaration.

Widening the region is what makes the eager path a real one, so it was measured against the bench corpus, interleaved in both orders. Composing the rows is a small part of what a request costs and no cache was added for it. What dominates is elsewhere and was there before this: recovering a did-you-mean suggestion compiles the document from scratch on every request. Filed as #1514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
