### PR TITLE
Ask one compilation what a code action is, and let a repair say where it goes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/WrittenName.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/WrittenName.java
@@ -156,6 +156,19 @@ public record WrittenName(String canonical, String spelling, List<Region> segmen
     }
 
     /**
+     * Where the parts before the last are written — the {@code up} of {@code up.Amount} — or null
+     * where the name has no qualifier or nobody wrote it.
+     *
+     * <p>One stretch, dots and all, because a qualifier of several parts is one answer to one
+     * question: which module. Whatever separates its parts is under it for the same reason
+     * {@link #region()} is continuous.
+     */
+    public Region qualifier() {
+        return segments.size() < 2 ? null
+                : new Region(segments.get(0).start(), segments.get(segments.size() - 2).end());
+    }
+
+    /**
      * Whether a cursor at {@code at} is on this name.
      *
      * <p>Inside a part, plainly. And at the end of the last part, because that is where a caret

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -1561,8 +1561,7 @@ public final class Elaborator {
         }
         return CompileException.of(Diagnostic
                         .at(v.written().reportedAt())
-                        
-                        .suggestion(Suggest.candidate(v.name(), env.spellings()))
+                        .repair(v.written().reportedAt(), Suggest.candidate(v.name(), env.spellings()))
                         .say(new NameMessage.NoValueOfThatNameInScope(v.name())).build());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -730,7 +730,7 @@ public final class Resolve {
     private Hir.Var required(Ast.Var ref, String by) {
         return behaviorNamed(ref, (name, candidates) -> CompileException.of(Diagnostic
                 .at(name.written().reportedAt())
-                .suggestion(Suggest.candidate(name.name(), candidates))
+                .repair(name.written().reportedAt(), Suggest.candidate(name.name(), candidates))
                 .hint(new DeclarationMessage.DeclareItHereOrImportIt(name.name()))
                 .say(new DeclarationMessage.DependsOnNamesNoSuchBehavior(by, name.name())).build()));
     }
@@ -746,7 +746,7 @@ public final class Resolve {
     private Hir.Var standsInFor(Ast.Var ref) {
         return behaviorNamed(ref, (name, candidates) -> CompileException.of(Diagnostic
                 .at(name.written().reportedAt())
-                .suggestion(Suggest.candidate(name.name(), candidates))
+                .repair(name.written().reportedAt(), Suggest.candidate(name.name(), candidates))
                 .hint(new DeclarationMessage.DeclareItHereOrImportIt(name.name()))
                 .say(new ExampleMessage.AFakeNamesNoBehavior(name.written().quoted())).build()));
     }
@@ -840,7 +840,7 @@ public final class Resolve {
         String name = written.canonical();
         return CompileException.of(Diagnostic
                 .at(written.reportedAt())
-                .suggestion(Suggest.candidate(name, candidates))
+                .repair(written.reportedAt(), Suggest.candidate(name, candidates))
                 .say(new NameMessage.NoBehaviorOfThatNameInThisPipeline(written.quoted())).build());
     }
 
@@ -1662,7 +1662,7 @@ public final class Resolve {
         List<String> candidates = reachable(bound);
         Diagnostic.Builder report = Diagnostic
                 .at(written.reportedAt())
-                .suggestion(Suggest.candidate(name, candidates));
+                .repair(written.reportedAt(), Suggest.candidate(name, candidates));
         // A name another module of this compilation exposes is the one kind of unresolved name that
         // has somewhere to go, and it is what a name left off an import list looks like from here.
         // Said as what is known — that module has it — rather than as an instruction, since reaching

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1960,9 +1960,13 @@ public final class TypeOps {
             String name = canonical.substring(dot + 1);
             String module = symbols.scope().moduleOfQualifier(qualifier);
             if (module == null) {
+                // Said over the whole name, since which of the two parts is wrong is what the
+                // message settles, and repaired over the qualifier alone: the candidate is a
+                // qualifier, and writing it over `up.Amount` would take the type name with it.
                 return CompileException.of(Diagnostic.say(new ModuleMessage.NoModuleOfThatName(qualifier, name))
                                 .at(written.reportedAt())
-                                .suggestion(Suggest.candidate(qualifier, symbols.scope().qualifiers()))
+                                .repair(written.qualifier(),
+                                        Suggest.candidate(qualifier, symbols.scope().qualifiers()))
                                 .build());
             }
             boolean declared = symbols.declares(new TypeKey(module, name));
@@ -1971,14 +1975,16 @@ public final class TypeOps {
                                     ? new ModuleMessage.ItIsDeclaredThereAndNotExposed(name, module)
                                     : new ModuleMessage.TheModuleDeclaresNoSuchQualifiedName(name,
                                             module))
-                            .suggestion(Suggest.candidate(name, symbols.declaredNamesIn(module)))
+                            // The module is the one the author meant; the part after the dot is
+                            // what it has no such name for, and is the part to write over.
+                            .repair(written.lastSegment(),
+                                    Suggest.candidate(name, symbols.declaredNamesIn(module)))
                             .build());
         }
         Set<String> known = symbols.scope().namesInScope();
         return CompileException.of(Diagnostic
                         .at(written.reportedAt())
-                        
-                        .suggestion(Suggest.candidate(canonical, known))
+                        .repair(written.reportedAt(), Suggest.candidate(canonical, known))
                         .say(new NameMessage.NoTypeOfThatName(written.quoted())).build());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -611,15 +612,19 @@ public final class Compilation {
     /**
      * Every repair a reader of {@code source} is in a position to be offered.
      *
-     * <p>Whether this file marks the problem, and where, are one question with one answer: what
-     * {@link DiagnosticView} anchors here. A report this file is not published under anchors
-     * nothing, so it is left out by the same step that would have said where to stand. Asked twice
-     * — once of the publication and again of the anchor — one of the two askings can never come out
-     * differently, which is a check that says nothing and is not kept.
+     * <p>Every report in the workspace is walked, and most of them are about other files. Whether
+     * this one is a report {@code source} reads at all is asked before it is read
+     * ({@link #asReadIn}), because reading it is refused for a file it says nothing about rather
+     * than answered emptily — and a walk that asked anyway lost the whole request, this file's own
+     * offers with it.
      *
-     * <p>Left out too is a finding that knows the word and no place to write it
-     * ({@link Repair.AWord}). What it has to say is said in the message; there is no edit to offer,
-     * and one made up from where the report points would rewrite whatever happens to be there.
+     * <p>A report this file reads and anchors nothing of is left out too. It has no marker here, so
+     * there is nowhere for an offer to stand: {@link #diagnostics()} falls back to the head of the
+     * document for such a report, which is a place to put a marker and not a place to offer an edit.
+     *
+     * <p>So is a finding that knows the word and no place to write it ({@link Repair.AWord}). What
+     * it has to say is said in the message; there is no edit to offer, and one made up from where
+     * the report points would rewrite whatever happens to be there.
      */
     public List<RepairOffer> repairs(SourceId source) {
         answerEverything();
@@ -628,12 +633,28 @@ public final class Compilation {
             if (!(found.report().diagnostic().repair() instanceof Repair.AnEdit edit)) {
                 continue;
             }
-            DiagnosticView view = DiagnosticView.of(found.report().diagnostic(),
-                    ReportContext.of(filedUnderOf(found), source));
-            view.anchor().ifPresent(
+            asReadIn(found, source).flatMap(DiagnosticView::anchor).ifPresent(
                     shown -> offers.add(new RepairOffer(shown.spot().region(), edit)));
         }
         return List.copyOf(offers);
+    }
+
+    /**
+     * How {@code source} reads {@code found}, or empty where it is not one of the files that report
+     * is said in.
+     *
+     * <p>The two together because the second is only a question inside the first.
+     * {@link DiagnosticView} answers where a marker goes for a file the report reaches, and refuses
+     * a file it does not — being asked about an unrelated file is a caller that did not look, not a
+     * file with nothing to show. So the looking is here, where the view is made, and no caller holds
+     * a view it had to earn separately.
+     */
+    private Optional<DiagnosticView> asReadIn(Db.Found found, SourceId source) {
+        if (!publishSourceIdsOf(found).contains(source)) {
+            return Optional.empty();
+        }
+        return Optional.of(DiagnosticView.of(found.report().diagnostic(),
+                ReportContext.of(filedUnderOf(found), source)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -14,6 +14,7 @@ import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.Primary;
+import souther.compiler.diag.Repair;
 import souther.compiler.diag.ReportContext;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.diag.WhereCodeIsWritten;
@@ -581,6 +582,31 @@ public final class Compilation {
         Map<SourceId, List<Located>> published = new LinkedHashMap<>();
         byId.forEach((id, found) -> published.put(id, List.copyOf(found)));
         return published;
+    }
+
+    /**
+     * The edits that answer this compilation's findings and land in {@code source}.
+     *
+     * <p>Chosen by where each edit applies, which is not where its finding is published. A problem
+     * written in two files is said in both ({@link #diagnostics()}), and the characters that make it
+     * go away are in one of them: the second file's reader is shown the report and offered nothing
+     * to apply to a line that is not what is wrong. The same holds for a report about code out of
+     * sight, said at the import that reached it while its repair stays where somebody typed it.
+     *
+     * <p>Publication does not come into it at all, so nothing here reads what a file is filed under
+     * or which of a report's places is its anchor. That is the whole reason this is a query of its
+     * own rather than a reading of the diagnostics.
+     */
+    public List<Repair> repairs(SourceId source) {
+        answerEverything();
+        List<Repair> found = new ArrayList<>();
+        for (Db.Found report : reports()) {
+            Repair repair = report.report().diagnostic().repair();
+            if (repair != null && repair.target().start().isIn(source)) {
+                found.add(repair);
+            }
+        }
+        return List.copyOf(found);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -611,20 +611,21 @@ public final class Compilation {
     /**
      * Every repair a reader of {@code source} is in a position to be offered.
      *
-     * <p>A report with nothing this file anchors is left out. It has no marker here, so there is
-     * nowhere for an offer to stand — {@link #diagnostics()} falls back to the head of the document
-     * for such a report, which is a place to put a marker and not a place to offer an edit.
+     * <p>Whether this file marks the problem, and where, are one question with one answer: what
+     * {@link DiagnosticView} anchors here. A report this file is not published under anchors
+     * nothing, so it is left out by the same step that would have said where to stand. Asked twice
+     * — once of the publication and again of the anchor — one of the two askings can never come out
+     * differently, which is a check that says nothing and is not kept.
      *
-     * <p>So is a finding that knows the word and no place to write it ({@link Repair.AWord}). What
-     * it has to say is said in the message; there is no edit to offer, and one made up from where
-     * the report points would rewrite whatever happens to be there.
+     * <p>Left out too is a finding that knows the word and no place to write it
+     * ({@link Repair.AWord}). What it has to say is said in the message; there is no edit to offer,
+     * and one made up from where the report points would rewrite whatever happens to be there.
      */
     public List<RepairOffer> repairs(SourceId source) {
         answerEverything();
         List<RepairOffer> offers = new ArrayList<>();
         for (Db.Found found : reports()) {
-            if (!(found.report().diagnostic().repair() instanceof Repair.AnEdit edit)
-                    || !publishSourceIdsOf(found).contains(source)) {
+            if (!(found.report().diagnostic().repair() instanceof Repair.AnEdit edit)) {
                 continue;
             }
             DiagnosticView view = DiagnosticView.of(found.report().diagnostic(),

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -14,6 +14,8 @@ import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.Primary;
+import souther.compiler.diag.DiagnosticView;
+import souther.compiler.diag.Region;
 import souther.compiler.diag.Repair;
 import souther.compiler.diag.ReportContext;
 import souther.compiler.diag.SourceProvenance;
@@ -585,28 +587,52 @@ public final class Compilation {
     }
 
     /**
-     * The edits that answer this compilation's findings and land in {@code source}.
+     * A repair as a reader of {@code source} meets it: the stretch of that file the problem is
+     * marked over, and the edit that answers it.
      *
-     * <p>Chosen by where each edit applies, which is not where its finding is published. A problem
-     * written in two files is said in both ({@link #diagnostics()}), and the characters that make it
-     * go away are in one of them: the second file's reader is shown the report and offered nothing
-     * to apply to a line that is not what is wrong. The same holds for a report about code out of
-     * sight, said at the import that reached it while its repair stays where somebody typed it.
+     * <p>Three questions and not two. Where the problem is marked is where a reader looks and so
+     * where an offer has to stand; where the edit writes is the characters that make the problem go
+     * away; what it writes is the third. The first two are the same stretch often enough to be
+     * mistaken for one, and a qualified name nothing denotes is where they part — marked over the
+     * whole of {@code up.Amuont}, because which of its parts is wrong is what the message settles,
+     * and answered by rewriting one part. An offer that compared a caret against the part would not
+     * be there where the reader is looking.
      *
-     * <p>Publication does not come into it at all, so nothing here reads what a file is filed under
-     * or which of a report's places is its anchor. That is the whole reason this is a query of its
-     * own rather than a reading of the diagnostics.
+     * <p>Which file the edit is applied to is not said here. The edit's own place answers it, and it
+     * may be another of this compilation's files: an offer is made where a reader meets the problem
+     * and applied where the characters are.
+     *
+     * @param offeredAt where this file marks the problem — {@link #diagnostics()} draws its marker
+     *        over the same stretch, both being what {@link DiagnosticView} says this file anchors
+     * @param repair the edit itself
      */
-    public List<Repair> repairs(SourceId source) {
+    public record RepairOffer(Region offeredAt, Repair.AnEdit repair) {}
+
+    /**
+     * Every repair a reader of {@code source} is in a position to be offered.
+     *
+     * <p>A report with nothing this file anchors is left out. It has no marker here, so there is
+     * nowhere for an offer to stand — {@link #diagnostics()} falls back to the head of the document
+     * for such a report, which is a place to put a marker and not a place to offer an edit.
+     *
+     * <p>So is a finding that knows the word and no place to write it ({@link Repair.AWord}). What
+     * it has to say is said in the message; there is no edit to offer, and one made up from where
+     * the report points would rewrite whatever happens to be there.
+     */
+    public List<RepairOffer> repairs(SourceId source) {
         answerEverything();
-        List<Repair> found = new ArrayList<>();
-        for (Db.Found report : reports()) {
-            Repair repair = report.report().diagnostic().repair();
-            if (repair != null && repair.target().start().isIn(source)) {
-                found.add(repair);
+        List<RepairOffer> offers = new ArrayList<>();
+        for (Db.Found found : reports()) {
+            if (!(found.report().diagnostic().repair() instanceof Repair.AnEdit edit)
+                    || !publishSourceIdsOf(found).contains(source)) {
+                continue;
             }
+            DiagnosticView view = DiagnosticView.of(found.report().diagnostic(),
+                    ReportContext.of(filedUnderOf(found), source));
+            view.anchor().ifPresent(
+                    shown -> offers.add(new RepairOffer(shown.spot().region(), edit)));
         }
-        return List.copyOf(found);
+        return List.copyOf(offers);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
@@ -71,7 +71,7 @@ class HighValueDiagnosticTest {
                 let f (amount) = N { value = amont }
                 """);
         assertEquals("check.unknown.title", d.titleKey());
-        assertEquals("amount", d.suggestion());
+        assertEquals("amount", d.repair().with());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/diag/MovingAReportDoesNotMoveItsRepairTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/MovingAReportDoesNotMoveItsRepairTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Where a report is said and where its repair writes come apart the moment the report is moved.
@@ -43,8 +44,42 @@ class MovingAReportDoesNotMoveItsRepairTest {
                 new ModuleMessage.ItIsReachedFromHereToo());
 
         assertNotNull(moved.repair(), "moving the caret is not dropping the edit");
-        assertEquals(new Repair(misspelling, "atLeast"), moved.repair());
+        assertEquals(new Repair.AnEdit(misspelling, "atLeast"), moved.repair());
         assertNotEquals(moved.primary(), Primary.at(misspelling),
                 "and the report is said at the import, which is the point of moving it");
+    }
+
+    /**
+     * A borrowed position is not a place to write. An expansion's copy sits at a line of the
+     * author's file and says nothing about what is there, so an edit made over it would rewrite
+     * text that has nothing to do with the finding.
+     *
+     * <p>Refused where an edit is made, so no pass can hand one on and no reader has to check.
+     */
+    @Test
+    void anEditCannotBeMadeOverCodeThatWasCopiedHere() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Repair.AnEdit(borrowed(), "atLeast"));
+    }
+
+    /**
+     * And a check that knows the word still says it. What a reader is told does not depend on
+     * whether a machine could act on it — the name inside the copied body is still probably a
+     * misspelling of the one nearby — so the word comes out and the edit does not.
+     */
+    @Test
+    void aWordIsStillSaidWhereThereIsNowhereToWriteIt() {
+        Diagnostic said = Diagnostic.at(borrowed().start())
+                .repair(borrowed(), "atLeast")
+                .say(new ModuleMessage.CannotReadAFieldOnASum("x", "S"))
+                .build();
+
+        assertEquals(new Repair.AWord("atLeast"), said.repair());
+    }
+
+    private static Region borrowed() {
+        SourcePos wrote = new SourcePos(4, 20, new SourceId("app.sou"));
+        DeclaringCode declaring = new DeclaringCode(THE_CODE.asDeclared());
+        return new Region(wrote.standingInFor(declaring), wrote.standingInFor(declaring));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/diag/MovingAReportDoesNotMoveItsRepairTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/MovingAReportDoesNotMoveItsRepairTest.java
@@ -1,0 +1,50 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.msg.ModuleMessage;
+import souther.compiler.source.SourceId;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Where a report is said and where its repair writes come apart the moment the report is moved.
+ *
+ * <p>{@link Diagnostic#reachedFrom} is for a finding about code this compile has no source for: the
+ * caret goes to the nearest place on the way to that module a file here writes, which is an
+ * {@code import} line. The characters that answer the finding did not move — they are in the
+ * module's own text, wherever that is — so the repair is what it was.
+ *
+ * <p>Read together with {@code Compilation.repairs}, which offers an edit in the file it writes
+ * into: a repair left pointing at text nobody holds is offered nowhere, and one that followed the
+ * caret would be offered on an import line, whose characters it says nothing about.
+ */
+class MovingAReportDoesNotMoveItsRepairTest {
+
+    private static final SourceProvenance THE_CODE =
+            new SourceProvenance.APublishedModule("lib.rule", "lib.rule.atLeast");
+
+    @Test
+    void theRepairStaysWhereItsCharactersAre() {
+        Placement published = Placement.whatAModulePublished(THE_CODE);
+        Region misspelling = new Region(published.at(4, 20), published.at(4, 25));
+        Diagnostic said = Diagnostic.at(published.at(4, 20))
+                .repair(misspelling, "atLeast")
+                .say(new ModuleMessage.CannotReadAFieldOnASum("x", "S"))
+                .build();
+
+        Diagnostic moved = said.reachedFrom(
+                List.of(new SourcePos(2, 1, new SourceId("app.sou"))),
+                THE_CODE.asDeclared(),
+                new ModuleMessage.ItIsReachedFromHereToo());
+
+        assertNotNull(moved.repair(), "moving the caret is not dropping the edit");
+        assertEquals(new Repair(misspelling, "atLeast"), moved.repair());
+        assertNotEquals(moved.primary(), Primary.at(misspelling),
+                "and the report is said at the import, which is the point of moving it");
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -47,6 +47,7 @@ import souther.compiler.diag.Messages;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.Spot;
 import souther.compiler.diag.Region;
+import souther.compiler.diag.QuotedFrom;
 import souther.compiler.diag.Repair;
 import souther.compiler.diag.UnnamedRegion;
 import souther.compiler.diag.ReportContext;
@@ -753,19 +754,32 @@ public final class Analyzer {
     /**
      * The compiler's repairs for {@code uri}, as actions, for the ones the request's range reaches.
      *
-     * <p>Each repair says where it applies, so nothing here works a range out from where the report
-     * was said. The two are the same stretch for a plain misspelled name and are not for a qualified
-     * one — {@code up.Amuont} is reported over the whole name and repaired over the part after the
-     * dot — and an action built from the report's range would write the suggested part over both.
+     * <p>Reached is compared against where the problem is marked, and never against where the edit
+     * writes. The two are the same stretch for a plain misspelled name and are not for a qualified
+     * one: {@code up.Amuont} is marked over the whole name and repaired after the dot, and a caret
+     * on the {@code up} is on the squiggle its author is asking about. Compared against the edit,
+     * the offer is missing from most of what is underlined.
+     *
+     * <p>The edit goes to the file the repair's own characters are in, read off the place they are
+     * at. That is this file for every repair the compiler makes today, and reading it rather than
+     * assuming it is what makes the offer and the edit two answers.
      */
     private List<CodeAction> repairs(String uri, Range requested, Compilation compilation) {
         List<CodeAction> out = new ArrayList<>();
-        for (Repair repair : compilation.repairs(new SourceId(uri))) {
-            Range target = rangeOfRegion(repair.target());
-            if (overlaps(target, requested)) {
-                out.add(new CodeAction.Applied("Replace with '" + repair.with() + "'",
-                        new CodeAction.Edit(uri, target, repair.with())));
+        for (Compilation.RepairOffer offer : compilation.repairs(new SourceId(uri))) {
+            if (!overlaps(rangeOfRegion(offer.offeredAt()), requested)) {
+                continue;
             }
+            Repair.AnEdit edit = offer.repair();
+            // A workspace names its sources by document URI, so a source id is already the name an
+            // editor opens. A place in a text this workspace has no file for is nothing an editor
+            // could apply an edit to, so there is no offer to make.
+            if (!(edit.target().start().quotedFrom()
+                    instanceof QuotedFrom.ASourceThisCompileHolds(SourceId written))) {
+                continue;
+            }
+            out.add(new CodeAction.Applied("Replace with '" + edit.with() + "'",
+                    new CodeAction.Edit(written.value(), rangeOfRegion(edit.target()), edit.with())));
         }
         return out;
     }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -42,13 +42,12 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.editor.EditorSymbols;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticRenderer;
-import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.diag.DiagnosticView;
 import souther.compiler.diag.Messages;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.Spot;
 import souther.compiler.diag.Region;
-import souther.compiler.diag.Primary;
+import souther.compiler.diag.Repair;
 import souther.compiler.diag.UnnamedRegion;
 import souther.compiler.diag.ReportContext;
 import souther.compiler.diag.SourceContext;
@@ -725,54 +724,44 @@ public final class Analyzer {
     }
 
     /**
-     * Quick-fix code actions overlapping {@code requested}: currently, replacing a misspelled name
-     * with the compiler's did-you-mean suggestion. The suggestion lives on the structured compiler
-     * diagnostic — which the published {@link LspDiagnostic} drops — so this recomputes the first
-     * semantic error to recover it. The type checker reports only that first error, so at most one
-     * fix is offered per compile.
-     */
-    public List<CodeAction> codeActions(String uri, String text, Range requested) {
-        return codeActions(uri, text, requested, null);
-    }
-
-    /**
-     * The same, with the workspace in reach: what a behavior's rows do not cover can be filled in
-     * from here.
+     * The code actions overlapping {@code requested}: the compiler's repairs for what it found here,
+     * and the rows the behavior under the cursor does not cover.
      *
-     * <p>{@code graph} may be null, and is where the request arrived without one. The generated rows
-     * need the whole workspace — the values a row writes are built through the module's derived
-     * decoders, and its imports are part of that — so with one document there is nothing to offer.
+     * <p>Both read one compilation, taken once. They are two questions about one document at one
+     * moment, and asking them of two compiles is how an offer to fix a name and an offer to write
+     * rows came to be about two different readings of the same text. It also settles what the two
+     * cost together: the workspace's compile is the one a diagnose keeps up to date, so a request
+     * arriving between edits pays for what has already been worked out.
      */
     public List<CodeAction> codeActions(String uri, String text, Range requested,
                                         ModuleGraph graph) {
         List<CodeAction> out = new ArrayList<>();
         CstParser.Result parsed = CstParser.parse(text);
         if (!parsed.errors().isEmpty()) {
-            return out;   // a semantic suggestion needs a clean parse
+            return out;   // a semantic answer needs a clean parse
         }
-        if (graph != null) {
-            out.addAll(rowsToWrite(uri, text, parsed.root(), requested, graph));
-        }
-        Diagnostic d = firstSemanticDiagnostic(text);
-        if (d == null || d.suggestion() == null) {
-            return out;
-        }
-        // The compile behind this read the document's own text and could not name it, so what it
-        // points at is a stretch of the text in front of the author. A report with nothing to point
-        // at has no edit to offer: an action needs a range, and a sentence about a module is not
-        // one.
-        Region diagnosed = switch (d.primary()) {
-            case Primary.InSource(DiagnosticPlace.InSource place) -> place.region();
-            case Primary.InAnUnnamedText(UnnamedRegion where) -> where.region();
-            case Primary.Unavailable _, Primary.Nowhere _ -> null;
-        };
-        if (diagnosed == null) {
-            return out;
-        }
-        Range diagRange = rangeOfRegion(diagnosed);
-        if (overlaps(diagRange, requested)) {
-            out.add(new CodeAction.Applied("Replace with '" + d.suggestion() + "'",
-                    new CodeAction.Edit(uri, diagRange, d.suggestion())));
+        Compilation compilation = compileOf(graph);
+        out.addAll(rowsToWrite(uri, text, parsed.root(), requested, graph, compilation));
+        out.addAll(repairs(uri, requested, compilation));
+        return out;
+    }
+
+    /**
+     * The compiler's repairs for {@code uri}, as actions, for the ones the request's range reaches.
+     *
+     * <p>Each repair says where it applies, so nothing here works a range out from where the report
+     * was said. The two are the same stretch for a plain misspelled name and are not for a qualified
+     * one — {@code up.Amuont} is reported over the whole name and repaired over the part after the
+     * dot — and an action built from the report's range would write the suggested part over both.
+     */
+    private List<CodeAction> repairs(String uri, Range requested, Compilation compilation) {
+        List<CodeAction> out = new ArrayList<>();
+        for (Repair repair : compilation.repairs(new SourceId(uri))) {
+            Range target = rangeOfRegion(repair.target());
+            if (overlaps(target, requested)) {
+                out.add(new CodeAction.Applied("Replace with '" + repair.with() + "'",
+                        new CodeAction.Edit(uri, target, repair.with())));
+            }
         }
         return out;
     }
@@ -793,7 +782,7 @@ public final class Analyzer {
      * landed somewhere surprising.
      */
     private List<CodeAction> rowsToWrite(String uri, String text, SyntaxNode root, Range requested,
-                                         ModuleGraph graph) {
+                                         ModuleGraph graph, Compilation compilation) {
         if (!measure.level().readsRows()) {
             return List.of();
         }
@@ -814,7 +803,6 @@ public final class Analyzer {
             return List.of();
         }
         int declaredAt = writtenFrom(declaration);
-        Compilation compilation = compileOf(graph);
         String module = moduleOf(compilation, graph, uri);
         if (module == null) {
             return List.of();
@@ -1004,24 +992,6 @@ public final class Analyzer {
         Position end = new Position((int) text.lines().count(), 0);
         return new CodeAction.Edit(offer.uri(), new Range(end, end),
                 System.lineSeparator() + block.text());
-    }
-
-    /** The first semantic error a self-contained compile turns up, as the structured compiler
-     * {@link Diagnostic} (carrying its suggestion and region), or {@code null} when there is none —
-     * mirrors the semantic path of {@link #diagnostics(String)}. */
-    private Diagnostic firstSemanticDiagnostic(String text) {
-        try {
-            Ast.Module module = CstFrontend.parse(text, "Main");
-            if (!module.imports().isEmpty() || module.exampleFileTarget() != null) {
-                return null;   // a multi-module or examples file cannot be resolved from one file
-            }
-            Compiler.compile(text, "Main");
-            return null;
-        } catch (CompileException e) {
-            return e.diagnostic();
-        } catch (RuntimeException | StackOverflowError _) {
-            return null;   // no suggestion to recover; the diagnostics pass reports the failure
-        }
     }
 
     private static boolean overlaps(Range a, Range b) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -740,9 +740,13 @@ public final class Analyzer {
         if (!parsed.errors().isEmpty()) {
             return out;   // a semantic answer needs a clean parse
         }
-        Compilation compilation = compileOf(graph);
-        out.addAll(rowsToWrite(uri, text, parsed.root(), requested, graph, compilation));
-        out.addAll(repairs(uri, requested, compilation));
+        try {
+            Compilation compilation = compileOf(graph);
+            out.addAll(rowsToWrite(uri, text, parsed.root(), requested, graph, compilation));
+            out.addAll(repairs(uri, requested, compilation));
+        } catch (RuntimeException | StackOverflowError _) {
+            return List.of();   // nothing to offer, which is an answer; the diagnose says what broke
+        }
         return out;
     }
 

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -443,14 +443,6 @@ class AdequacyLensTest {
                 () -> "the rows are right there: " + taken.newText());
     }
 
-    /** With one document there is nothing to offer: the values a row writes are built through the
-     * module's derived decoders, and its imports are part of that. */
-    @Test
-    void withNoWorkspaceThereIsNothingToOffer() {
-        assertEquals(List.of(),
-                measuring(Adequacy.Level.ALL).codeActions(MODULE, TRIP, on(9)));
-    }
-
     /**
      * The offer stands at every position the declaration is written over, and at no other.
      *

--- a/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
@@ -237,6 +237,43 @@ class LspServerTest {
         assertEquals("value", newText);
     }
 
+    /**
+     * A client sends back the diagnostics it holds, which are the ones it was last published, and
+     * the document may have been edited since. So what it sends says there may be something to offer
+     * here and never what: the offer is worked out from the text this server holds now.
+     */
+    @Test
+    void aDiagnosticTheDocumentNoLongerHasOffersNothing() {
+        String uri = "file:///q3.sou";
+        String typo = "module demo\nbehavior f : (value: Int) -> Int\nlet f (value) = valuee\n";
+        String fixed = "module demo\nbehavior f : (value: Int) -> Int\nlet f (value) = value\n";
+        Map<String, Object> changed = new LinkedHashMap<>();
+        changed.put("textDocument", Map.of("uri", uri));
+        changed.put("contentChanges", List.of(Map.of("text", fixed)));
+        byte[] input = frames(
+                message(1, "initialize", Map.of()),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", uri, "text", typo))),
+                message(null, "textDocument/didChange", changed),
+                message(2, "textDocument/codeAction", Map.of(
+                        "textDocument", Map.of("uri", uri),
+                        "range", Map.of("start", Map.of("line", 2, "character", 16),
+                                "end", Map.of("line", 2, "character", 21)),
+                        // what the client still holds from before the edit
+                        "context", Map.of("diagnostics", List.of(Map.of(
+                                "range", Map.of("start", Map.of("line", 2, "character", 16),
+                                        "end", Map.of("line", 2, "character", 22)),
+                                "message", "unknown identifier"))))));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        JsonNode actions = responseFor(readFrames(out.toByteArray()), 2);
+        assertEquals(0, actions.size(),
+                () -> "the name is spelled right now: " + actions);
+    }
+
     @Test
     void codeActionWithNoContextDiagnosticsOffersNothing() {
         String uri = "file:///q2.sou";

--- a/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
@@ -272,6 +272,31 @@ class LspServerTest {
         JsonNode actions = responseFor(readFrames(out.toByteArray()), 2);
         assertEquals(0, actions.size(),
                 () -> "the name is spelled right now: " + actions);
+        // And the same request before the edit does offer one, so the emptiness above is the edit
+        // and not the request having gone wrong for some reason of its own.
+        assertEquals(1, offeredOn(uri, typo).size(), "the typo is offerable before it is fixed");
+    }
+
+    /** What a client is offered with the caret on the misspelling in {@code text}. */
+    private List<JsonNode> offeredOn(String uri, String text) {
+        byte[] input = frames(
+                message(1, "initialize", Map.of()),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", uri, "text", text))),
+                message(2, "textDocument/codeAction", Map.of(
+                        "textDocument", Map.of("uri", uri),
+                        "range", Map.of("start", Map.of("line", 2, "character", 16),
+                                "end", Map.of("line", 2, "character", 22)),
+                        "context", Map.of("diagnostics", List.of(Map.of(
+                                "range", Map.of("start", Map.of("line", 2, "character", 16),
+                                        "end", Map.of("line", 2, "character", 22)),
+                                "message", "unknown identifier"))))));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+        List<JsonNode> offered = new ArrayList<>();
+        responseFor(readFrames(out.toByteArray()), 2).forEach(offered::add);
+        return offered;
     }
 
     @Test

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
@@ -113,7 +113,13 @@ class ARepairSaysWhereItGoesTest {
         assertEquals(List.of("draft", "agreement"), written);
     }
 
-    /** Away from every repair there is nothing to offer, whatever the document is wrong about. */
+    /**
+     * Away from every repair there is nothing to offer, whatever the document is wrong about.
+     *
+     * <p>Asked beside the range that does offer one, in the same document and the same run. An
+     * offer that goes missing for any reason at all leaves an empty list too, and that is what an
+     * emptiness on its own cannot be told apart from.
+     */
     @Test
     void aRangeReachingNoRepairIsOfferedNothing() {
         String text = """
@@ -124,6 +130,8 @@ class ARepairSaysWhereItGoesTest {
             behavior price : (draft: Draft) -> Int
             let price (draft) = drft.plannedCost
             """;
+        assertEquals(1, actions(text, on(text, "drft")).size(),
+                "there is an offer in this document to go missing");
         assertEquals(List.of(), actions(text, on(text, "module m")));
     }
 
@@ -243,6 +251,52 @@ class ARepairSaysWhereItGoesTest {
             assertEquals("ledger", edit.newText());
             assertEquals(spanOf(text, "ledgr"), edit.range());
         }
+    }
+
+    /**
+     * Two files, each with a misspelling of its own, and each keeps its own fix.
+     *
+     * <p>What a file reads a report as is asked of the files that report is said in, and asking it
+     * of one it says nothing about is refused rather than answered emptily. A walk over every
+     * report in the workspace meets both of these on the way to either, so a walk that asked
+     * without looking lost the fix that was there — not the other file's, its own, and every other
+     * offer in the request with it.
+     *
+     * <p>Said as what is offered rather than as what is not. An offer that goes missing looks the
+     * same from outside as one there was never anything to make, and the second is what a test
+     * asserting emptiness cannot tell it from.
+     */
+    @Test
+    void eachOfTwoFilesKeepsItsOwnFix() {
+        String first = """
+            module first
+
+            behavior price : (draft: Int) -> Int
+            let price (draft) = drft
+            """;
+        String second = """
+            module second
+
+            behavior agreed : (agreement: Int) -> Int
+            let agreed (agreement) = agrement
+            """;
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///first.sou", first);
+        sources.put("file:///second.sou", second);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+
+        List<CodeAction> onFirst = analyzer.codeActions("file:///first.sou", first,
+                caretAt(first, first.indexOf("drft")), graph);
+        assertEquals(1, onFirst.size(), onFirst::toString);
+        assertEquals("draft",
+                assertInstanceOf(CodeAction.Applied.class, onFirst.getFirst()).edit().newText());
+
+        List<CodeAction> onSecond = analyzer.codeActions("file:///second.sou", second,
+                caretAt(second, second.indexOf("agrement")), graph);
+        assertEquals(1, onSecond.size(), onSecond::toString);
+        assertEquals("agreement",
+                assertInstanceOf(CodeAction.Applied.class, onSecond.getFirst()).edit().newText());
     }
 
     private static List<CodeAction> actions(String text, Range requested) {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
@@ -1,0 +1,195 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.CodeAction;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a quick fix writes, which is not where the report that produced it was said.
+ *
+ * <p>The two are the same stretch for a plain misspelled name, which is the only case the offer used
+ * to be tried on, and they are not for a name written under a qualifier: the report is about the
+ * whole of {@code l.Cst} because which of its two parts is wrong is what it settles, and the edit is
+ * about the part after the dot. An offer built from the report's range wrote the type name over
+ * both and left the document naming no module at all.
+ *
+ * <p>Every expectation here is read off the source rather than counted out by hand, so a test says
+ * where the edit goes and not what some column happened to be while it was written.
+ */
+class ARepairSaysWhereItGoesTest {
+
+    private static final String URI = "file:///m.sou";
+    private static final String LIB_URI = "file:///lib.sou";
+
+    private static final String LIB = """
+            module lib
+
+            data Cost = Int
+            """;
+
+    @Test
+    void aNameWrittenUnderAQualifierIsRepairedAfterTheDot() {
+        String text = """
+            module m
+
+            import lib as l ( Cost )
+
+            data Draft = { plannedCost: l.Cst }
+            """;
+        CodeAction.Edit edit = theOneEdit(text, on(text, "l.Cst"));
+
+        assertEquals("Cost", edit.newText());
+        assertEquals(spanOf(text, "Cst"), edit.range(),
+                "the module was named right; the part after the dot is what it has no such name for");
+    }
+
+    @Test
+    void aQualifierNamingNoModuleIsRepairedBeforeTheDot() {
+        String text = """
+            module m
+
+            import lib as ledger ( Cost )
+
+            data Draft = { plannedCost: ledgr.Cost }
+            """;
+        CodeAction.Edit edit = theOneEdit(text, on(text, "ledgr.Cost"));
+
+        assertEquals("ledger", edit.newText());
+        assertEquals(spanOf(text, "ledgr"), edit.range(),
+                "the type name was written right; the qualifier is what names no module");
+    }
+
+    /** The offer used to give up on any document with an import, because the compile it recovered
+     *  the suggestion from was of that document alone and could not resolve one. */
+    @Test
+    void aDocumentWithImportsIsOffered() {
+        String text = """
+            module m
+
+            import lib as l ( Cost )
+
+            data Draft = { plannedCost: Cost }
+
+            behavior price : (draft: Draft) -> Cost
+            let price (draft) = drft.plannedCost
+            """;
+        CodeAction.Edit edit = theOneEdit(text, on(text, "drft"));
+
+        assertEquals("draft", edit.newText());
+        assertEquals(spanOf(text, "drft"), edit.range());
+    }
+
+    /**
+     * A selection is drawn by somebody dragging over the document, so it reaches as many repairs as
+     * it covers and the reader picks. One of the two is what the range happens to start on, and an
+     * offer answering with that one would be answering a question about a position.
+     */
+    @Test
+    void aSelectionOverTwoMisspellingsOffersBoth() {
+        String text = """
+            module m
+
+            data Draft = { plannedCost: Int }
+
+            behavior price : (draft: Draft) -> Int
+            let price (draft) = drft.plannedCost
+            behavior agreed : (agreement: Draft) -> Int
+            let agreed (agreement) = agrement.plannedCost
+            """;
+        List<String> written = new ArrayList<>();
+        for (CodeAction action : actions(text, over(text, "drft", "agrement"))) {
+            written.add(assertInstanceOf(CodeAction.Applied.class, action).edit().newText());
+        }
+        assertEquals(List.of("draft", "agreement"), written);
+    }
+
+    /** Away from every repair there is nothing to offer, whatever the document is wrong about. */
+    @Test
+    void aRangeReachingNoRepairIsOfferedNothing() {
+        String text = """
+            module m
+
+            data Draft = { plannedCost: Int }
+
+            behavior price : (draft: Draft) -> Int
+            let price (draft) = drft.plannedCost
+            """;
+        assertEquals(List.of(), actions(text, on(text, "module m")));
+    }
+
+    /**
+     * The file an edit lands in is the file it is offered in, and a report published in two of them
+     * is one report. The reader of the other file is shown the marker and offered nothing to apply
+     * to a line that is not what is wrong.
+     */
+    @Test
+    void aRepairIsOfferedOnlyInTheFileItsEditIsWrittenIn() {
+        String text = """
+            module m
+
+            import lib as l ( Cost )
+
+            data Draft = { plannedCost: l.Cst }
+            """;
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, text);
+        sources.put(LIB_URI, LIB);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+
+        Range everywhereInLib = new Range(new Position(0, 0),
+                new Position((int) LIB.lines().count(), 0));
+        assertEquals(List.of(), analyzer.codeActions(LIB_URI, LIB, everywhereInLib, graph),
+                "the misspelling is in the other file, whatever this one is told about it");
+        assertTrue(!analyzer.codeActions(URI, text, on(text, "l.Cst"), graph).isEmpty(),
+                "and the file that holds it is offered the edit");
+    }
+
+    private static List<CodeAction> actions(String text, Range requested) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, text);
+        sources.put(LIB_URI, LIB);
+        return new Analyzer().codeActions(URI, text, requested, ModuleGraph.of(sources));
+    }
+
+    private static CodeAction.Edit theOneEdit(String text, Range requested) {
+        List<CodeAction> offered = actions(text, requested);
+        assertEquals(1, offered.size(), offered.toString());
+        return assertInstanceOf(CodeAction.Applied.class, offered.get(0)).edit();
+    }
+
+    /** The range an editor sends with the caret somewhere in {@code written}. */
+    private static Range on(String text, String written) {
+        return spanOf(text, written);
+    }
+
+    /** The range an editor sends for a selection drawn from the first of these to the last. */
+    private static Range over(String text, String from, String to) {
+        return new Range(spanOf(text, from).start(), spanOf(text, to).end());
+    }
+
+    /** Where {@code written} is in {@code text}, in the editor's line and character numbers. */
+    private static Range spanOf(String text, String written) {
+        int at = text.indexOf(written);
+        assertTrue(at >= 0, () -> "the source does not contain `" + written + "`");
+        assertEquals(at, text.lastIndexOf(written),
+                () -> "`" + written + "` is written more than once, so it names no one place");
+        return new Range(positionOf(text, at), positionOf(text, at + written.length()));
+    }
+
+    private static Position positionOf(String text, int offset) {
+        String before = text.substring(0, offset);
+        int line = (int) before.lines().count() - (before.endsWith("\n") ? 0 : 1);
+        return new Position(line, offset - (before.lastIndexOf('\n') + 1));
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
@@ -155,6 +155,50 @@ class ARepairSaysWhereItGoesTest {
                 "and the file that holds it is offered the edit");
     }
 
+    /**
+     * A module written over two files answers about the file the edit is in, not the file its
+     * module is declared in. What a report is filed under falls back to the module's own source
+     * where the report claims none, and the rows are in the attached file — so a fix offered by
+     * publication would be offered on the model's text and applied to whatever sits at those
+     * numbers there.
+     */
+    @Test
+    void anEditInAnAttachedFileIsOfferedOnThatFile() {
+        String model = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+            """;
+        String attached = """
+            examples for m
+
+            let origin = D { v = 1 }
+
+            example f
+                | "a" : (orign) -> D { v = 1 }
+            """;
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, model);
+        sources.put("file:///m.examples.sou", attached);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+
+        List<CodeAction> onTheAttached = analyzer.codeActions("file:///m.examples.sou", attached,
+                on(attached, "orign"), graph);
+        assertEquals(1, onTheAttached.size(), onTheAttached.toString());
+        CodeAction.Edit edit =
+                assertInstanceOf(CodeAction.Applied.class, onTheAttached.get(0)).edit();
+        assertEquals("origin", edit.newText());
+        assertEquals(spanOf(attached, "orign"), edit.range());
+
+        Range everywhereInTheModel = new Range(new Position(0, 0),
+                new Position((int) model.lines().count(), 0));
+        assertEquals(List.of(), analyzer.codeActions(URI, model, everywhereInTheModel, graph),
+                "the model's own file holds none of the characters this edit rewrites");
+    }
+
     private static List<CodeAction> actions(String text, Range requested) {
         Map<String, String> sources = new LinkedHashMap<>();
         sources.put(URI, text);

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ARepairSaysWhereItGoesTest.java
@@ -128,12 +128,12 @@ class ARepairSaysWhereItGoesTest {
     }
 
     /**
-     * The file an edit lands in is the file it is offered in, and a report published in two of them
-     * is one report. The reader of the other file is shown the marker and offered nothing to apply
-     * to a line that is not what is wrong.
+     * An offer stands where the problem is marked, so a file the problem is not marked in is
+     * offered nothing however much it is asked. The imported module is fine; what is wrong is the
+     * name written in the file that imports it.
      */
     @Test
-    void aRepairIsOfferedOnlyInTheFileItsEditIsWrittenIn() {
+    void aFileTheProblemIsNotMarkedInIsOfferedNothing() {
         String text = """
             module m
 
@@ -150,20 +150,18 @@ class ARepairSaysWhereItGoesTest {
         Range everywhereInLib = new Range(new Position(0, 0),
                 new Position((int) LIB.lines().count(), 0));
         assertEquals(List.of(), analyzer.codeActions(LIB_URI, LIB, everywhereInLib, graph),
-                "the misspelling is in the other file, whatever this one is told about it");
+                "nothing is marked here, whatever this file is asked");
         assertTrue(!analyzer.codeActions(URI, text, on(text, "l.Cst"), graph).isEmpty(),
-                "and the file that holds it is offered the edit");
+                "and the file the problem is marked in is offered the edit");
     }
 
     /**
-     * A module written over two files answers about the file the edit is in, not the file its
-     * module is declared in. What a report is filed under falls back to the module's own source
-     * where the report claims none, and the rows are in the attached file — so a fix offered by
-     * publication would be offered on the model's text and applied to whatever sits at those
-     * numbers there.
+     * A module written over two files marks the problem in the file it is written in, and that is
+     * the file the offer stands in. Not the file the module is declared in: a reader looking at the
+     * model is looking at text this problem says nothing about.
      */
     @Test
-    void anEditInAnAttachedFileIsOfferedOnThatFile() {
+    void aProblemInAnAttachedFileIsOfferedOnThatFile() {
         String model = """
             module m
 
@@ -196,7 +194,55 @@ class ARepairSaysWhereItGoesTest {
         Range everywhereInTheModel = new Range(new Position(0, 0),
                 new Position((int) model.lines().count(), 0));
         assertEquals(List.of(), analyzer.codeActions(URI, model, everywhereInTheModel, graph),
-                "the model's own file holds none of the characters this edit rewrites");
+                "the model's own file marks nothing about the rows in the other one");
+    }
+
+    /**
+     * The offer stands wherever the problem is marked, and the marked stretch is not the stretch
+     * the edit rewrites. A caret on the qualifier of {@code l.Cst} is on the squiggle the author is
+     * looking at; the characters to change are after the dot, and an offer that compared the caret
+     * against those is an offer that is not there where the author asks for it.
+     */
+    @Test
+    void theOfferStandsAtEveryPositionTheProblemIsMarkedAt() {
+        String text = """
+            module m
+
+            import lib as l ( Cost )
+
+            data Draft = { plannedCost: l.Cst }
+            """;
+        Range marked = spanOf(text, "l.Cst");
+        for (int at = 0; at < "l.Cst".length(); at++) {
+            Range caret = caretAt(text, text.indexOf("l.Cst") + at);
+            List<CodeAction> offered = actions(text, caret);
+            assertEquals(1, offered.size(),
+                    () -> "the caret is inside " + marked + " at " + caret + ": " + offered);
+            assertEquals("Cost",
+                    assertInstanceOf(CodeAction.Applied.class, offered.getFirst()).edit().newText());
+        }
+    }
+
+    /** And the same where the part to rewrite is the qualifier: a caret on the type name is on the
+     *  same marker, and the fix it is offered writes before the dot. */
+    @Test
+    void theOfferStandsOnTheWholeMarkerWhenTheEditIsTheQualifier() {
+        String text = """
+            module m
+
+            import lib as ledger ( Cost )
+
+            data Draft = { plannedCost: ledgr.Cost }
+            """;
+        for (int at = 0; at < "ledgr.Cost".length(); at++) {
+            Range caret = caretAt(text, text.indexOf("ledgr.Cost") + at);
+            List<CodeAction> offered = actions(text, caret);
+            assertEquals(1, offered.size(), () -> "at " + caret + ": " + offered);
+            CodeAction.Edit edit =
+                    assertInstanceOf(CodeAction.Applied.class, offered.getFirst()).edit();
+            assertEquals("ledger", edit.newText());
+            assertEquals(spanOf(text, "ledgr"), edit.range());
+        }
     }
 
     private static List<CodeAction> actions(String text, Range requested) {
@@ -212,9 +258,15 @@ class ARepairSaysWhereItGoesTest {
         return assertInstanceOf(CodeAction.Applied.class, offered.get(0)).edit();
     }
 
-    /** The range an editor sends with the caret somewhere in {@code written}. */
+    /** The range an editor sends for a selection drawn over {@code written}. */
     private static Range on(String text, String written) {
         return spanOf(text, written);
+    }
+
+    /** The range an editor sends with the caret at {@code offset} and nothing selected. */
+    private static Range caretAt(String text, int offset) {
+        Position at = positionOf(text, offset);
+        return new Range(at, at);
     }
 
     /** The range an editor sends for a selection drawn from the first of these to the last. */

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -667,9 +667,14 @@ class AnalyzerTest {
     @Test
     void codeActionIsEmptyWhenTheRangeIsAwayFromTheError() {
         String text = "module demo\nbehavior f : (value: Int) -> Int\nlet f (value) = valuee\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///m.sou", text));
+        // Beside the range that does offer one: an emptiness on its own is the same answer a
+        // request that failed altogether gives.
+        Range onTheTypo = new Range(new Position(2, 16), new Position(2, 22));
+        assertEquals(1, analyzer.codeActions("file:///m.sou", text, onTheTypo, graph).size(),
+                "there is an offer in this document to go missing");
         Range onTheHeader = new Range(new Position(0, 0), new Position(0, 5));
-        assertEquals(List.of(), analyzer.codeActions("file:///m.sou", text, onTheHeader,
-                ModuleGraph.of(java.util.Map.of("file:///m.sou", text))));
+        assertEquals(List.of(), analyzer.codeActions("file:///m.sou", text, onTheHeader, graph));
     }
 
     private static java.util.Set<String> keys(List<Location> refs) {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -655,7 +655,8 @@ class AnalyzerTest {
         // `valuee` in the body is a typo of the param `value`; the compiler carries a did-you-mean
         String text = "module demo\nbehavior f : (value: Int) -> Int\nlet f (value) = valuee\n";
         Range onTheTypo = new Range(new Position(2, 16), new Position(2, 22));
-        List<CodeAction> actions = analyzer.codeActions("file:///m.sou", text, onTheTypo);
+        List<CodeAction> actions = analyzer.codeActions("file:///m.sou", text, onTheTypo,
+                ModuleGraph.of(java.util.Map.of("file:///m.sou", text)));
 
         assertEquals(1, actions.size(), actions.toString());
         assertEquals("Replace with 'value'", actions.get(0).title());
@@ -667,7 +668,8 @@ class AnalyzerTest {
     void codeActionIsEmptyWhenTheRangeIsAwayFromTheError() {
         String text = "module demo\nbehavior f : (value: Int) -> Int\nlet f (value) = valuee\n";
         Range onTheHeader = new Range(new Position(0, 0), new Position(0, 5));
-        assertEquals(List.of(), analyzer.codeActions("file:///m.sou", text, onTheHeader));
+        assertEquals(List.of(), analyzer.codeActions("file:///m.sou", text, onTheHeader,
+                ModuleGraph.of(java.util.Map.of("file:///m.sou", text))));
     }
 
     private static java.util.Set<String> keys(List<Location> refs) {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
@@ -48,12 +48,12 @@ import java.util.Set;
  *
  * <p>Observed, on the workspace this generates (7 modules, 3264 lines), medians:
  * <pre>
- *   query    settled:   diagnostics    0.04 ms   repairs    0.04 ms
- *   query    asked:     diagnostics   59.56 ms   repairs   57.71 ms
- *   query    elsewhere: diagnostics   55.83 ms   repairs   56.49 ms
- *   query    cold:      diagnostics  990.68 ms   repairs  947.43 ms
- *   request  settled:     0.73 ms     after an edit elsewhere:  61.16 ms
- *   alone (one self-contained document, a third the size):     154.92 ms
+ *   query    settled:   diagnostics    0.06 ms   repairs    0.06 ms
+ *   query    asked:     diagnostics   63.25 ms   repairs   60.28 ms
+ *   query    elsewhere: diagnostics   56.43 ms   repairs   54.33 ms
+ *   query    cold:      diagnostics  939.47 ms   repairs  969.05 ms
+ *   request  settled:     0.73 ms     after an edit elsewhere:  62.19 ms
+ *   alone (one self-contained document, a third the size):     160.94 ms
  * </pre>
  *
  * <p>Settled is the state a cursor move arrives in. A request there costs most of a millisecond,

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
@@ -1,0 +1,217 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.source.SourceId;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a code action request costs, by which compilation it asks.
+ *
+ * <p>To re-measure, take the {@code @Disabled} off and run
+ * {@code mvn -o test -Dtest=WhatACodeActionCostsBenchmark -Dsurefire.failIfNoSpecifiedTests=false}.
+ * The run's JVM flags are the reactor's — {@code -XX:TieredStopAtLevel=1 -XX:+UseSerialGC} — so
+ * these are C1-only, serial-collector numbers, good for the increment between two of them and not
+ * for saying whether a figure fits an editor's budget.
+ *
+ * <p><b>What is measured.</b> Three ways of getting the compiler's did-you-mean to a quick fix, on
+ * one workspace in one run. {@code alone} is a compile of the one document, started from nothing,
+ * which is what the offer used to do on every request. {@code diagnostics} and {@code repairs} both
+ * ask the workspace's own compilation — the one a diagnose keeps up to date — and differ in how much
+ * of it they ask for: every marker for every file, against the edits that land in one file. The two
+ * are taken by turns in both orders, so a drift over the run cannot land on one of them.
+ *
+ * <p>Four states, because what a request costs depends on what has happened since the last one:
+ * settled on the revision the last diagnose answered, after an edit to the file being asked about,
+ * after an edit to another file, and from nothing.
+ *
+ * <p>{@code alone} is measured on a self-contained document because that is the only kind it ever
+ * ran on: given a document with an import it returned before compiling, and the offer was not made
+ * at all. So its column is what the old path cost where it worked, and the row it does not have is
+ * every workspace of more than one module.
+ *
+ * <p>Observed, on the workspace this generates (7 modules, 3264 lines), medians:
+ * <pre>
+ *   settled:   diagnostics    0.03 ms   repairs    0.03 ms
+ *   asked:     diagnostics   54.53 ms   repairs   54.58 ms
+ *   elsewhere: diagnostics   52.70 ms   repairs   53.94 ms
+ *   cold:      diagnostics  882.63 ms   repairs  869.07 ms
+ *   alone (one self-contained document, a third the size):  145.24 ms
+ * </pre>
+ *
+ * <p>Settled is the state a cursor move arrives in, and it is where the old path spent its whole
+ * cost: a compile of the document from nothing, every request, against a store that already held
+ * the answer. The other rows are an edit being paid for once — by whichever of the diagnose and the
+ * request reaches the store first, since what either of them answers is kept.
+ *
+ * <p>The two queries do not differ. Asking for every marker in the workspace costs what asking for
+ * one file's edits costs, because both are {@code answerEverything} and the publication map beside
+ * it is nothing. So the narrower query is not here for its cost: it is here because publication and
+ * applicability are different questions, and a query that answered one while being read for the
+ * other would be right only while every finding stayed in the file it was published in.
+ */
+@Disabled("manual benchmark; run explicitly to re-measure — see class javadoc")
+class WhatACodeActionCostsBenchmark {
+
+    private static final int ROUNDS = 40;
+    private static final int MODULES = 7;
+    private static final int BEHAVIORS = 180;
+
+    /** The document the request is about, and the one the misspelling is in. */
+    private static final String ASKED = "file:///m" + (MODULES - 1) + ".sou";
+
+    @Test
+    void measureWhatEachWayOfAskingCosts() {
+        Map<String, String> byId = workspace();
+        System.out.printf("workspace: %d modules, %d lines%n", byId.size(), lines(byId));
+
+        Compilation compilation = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        SourceId asked = new SourceId(ASKED);
+        if (compilation.repairs(asked).isEmpty()) {
+            throw new IllegalStateException("the corpus is meant to hold a misspelling to repair");
+        }
+
+        System.out.printf("settled:  %s%n", byTurns(compilation, asked, byId, Edit.NONE));
+        System.out.printf("asked:    %s%n", byTurns(compilation, asked, byId, Edit.THE_FILE_ASKED));
+        System.out.printf("elsewhere:%s%n", byTurns(compilation, asked, byId, Edit.ANOTHER_FILE));
+        System.out.printf("cold:      diagnostics %6.2f ms   repairs %6.2f ms%n",
+                medianMillis(round -> fresh(byId).diagnostics(), ROUNDS / 4),
+                medianMillis(round -> fresh(byId).repairs(asked), ROUNDS / 4));
+
+        String own = selfContained();
+        System.out.printf("alone (one self-contained document): %6.2f ms%n",
+                medianMillis(round -> compileAlone(own), ROUNDS / 4));
+    }
+
+    /** What has happened to the documents since the last request. */
+    private enum Edit { NONE, THE_FILE_ASKED, ANOTHER_FILE }
+
+    /**
+     * The two queries alternated, and in both orders, so that whichever runs first in a round is not
+     * what the difference between them measures.
+     */
+    private static String byTurns(Compilation compilation, SourceId asked,
+                                  Map<String, String> byId, Edit edit) {
+        List<Long> diagnosing = new ArrayList<>();
+        List<Long> repairing = new ArrayList<>();
+        for (int round = 0; round < ROUNDS * 2; round++) {
+            boolean repairsFirst = round % 2 == 0;
+            apply(compilation, byId, edit, round);
+            long opened = System.nanoTime();
+            if (repairsFirst) {
+                compilation.repairs(asked);
+            } else {
+                compilation.diagnostics();
+            }
+            long between = System.nanoTime();
+            if (repairsFirst) {
+                compilation.diagnostics();
+            } else {
+                compilation.repairs(asked);
+            }
+            long closed = System.nanoTime();
+            if (round >= ROUNDS) {
+                repairing.add(repairsFirst ? between - opened : closed - between);
+                diagnosing.add(repairsFirst ? closed - between : between - opened);
+            }
+        }
+        return String.format(" diagnostics %6.2f ms   repairs %6.2f ms",
+                median(diagnosing), median(repairing));
+    }
+
+    private static void apply(Compilation compilation, Map<String, String> byId, Edit edit,
+                              int round) {
+        if (edit == Edit.NONE) {
+            return;
+        }
+        String touched = edit == Edit.THE_FILE_ASKED ? ASKED : "file:///m1.sou";
+        Map<String, String> now = new LinkedHashMap<>(byId);
+        now.put(touched, byId.get(touched) + added(round));
+        compilation.update(now, Set.of());
+    }
+
+    private static String added(int round) {
+        return "\nbehavior added" + round + " : (d: D) -> Int\nlet added" + round + " (d) = d.v\n";
+    }
+
+    private static Compilation fresh(Map<String, String> byId) {
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    /** What the offer used to do: a compile of the one document, from nothing, thrown away. */
+    private static void compileAlone(String text) {
+        try {
+            Compiler.compile(text, "Main");
+        } catch (CompileException _) {
+            // the misspelling, which is what it was compiling to find
+        }
+    }
+
+    private static Map<String, String> workspace() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("file:///m0.sou", "module m0 exposing ( D )\n\ndata D = { v: Int, w: Text }\n");
+        for (int m = 1; m < MODULES; m++) {
+            StringBuilder source = new StringBuilder("module m" + m + "\n\nimport m0 ( D )\n");
+            for (int b = 0; b < BEHAVIORS; b++) {
+                source.append("\nbehavior f").append(m).append('_').append(b)
+                        .append(" : (d: D) -> Int\nlet f").append(m).append('_').append(b)
+                        .append(" (d) = d.v\n");
+            }
+            if (m == MODULES - 1) {
+                // the misspelling the request is about: `writen` for the parameter `written`
+                source.append("\nbehavior spelt : (written: D) -> Int\n")
+                        .append("let spelt (written) = writen.v\n");
+            }
+            byId.put("file:///m" + m + ".sou", source.toString());
+        }
+        return byId;
+    }
+
+    /** One document that resolves on its own, which is the only kind the old path compiled. */
+    private static String selfContained() {
+        StringBuilder source = new StringBuilder(
+                "module Main\n\ndata D = { v: Int, w: Text }\n");
+        for (int b = 0; b < BEHAVIORS; b++) {
+            source.append("\nbehavior g").append(b)
+                    .append(" : (d: D) -> Int\nlet g").append(b).append(" (d) = d.v\n");
+        }
+        source.append("\nbehavior spelt : (written: D) -> Int\nlet spelt (written) = writen.v\n");
+        return source.toString();
+    }
+
+    private static int lines(Map<String, String> byId) {
+        int total = 0;
+        for (String text : byId.values()) {
+            total += (int) text.lines().count();
+        }
+        return total;
+    }
+
+    private static double medianMillis(java.util.function.IntConsumer work, int rounds) {
+        for (int i = 0; i < rounds; i++) {
+            work.accept(i);
+        }
+        List<Long> nanos = new ArrayList<>();
+        for (int i = 0; i < rounds; i++) {
+            long began = System.nanoTime();
+            work.accept(rounds + i);
+            nanos.add(System.nanoTime() - began);
+        }
+        return median(nanos);
+    }
+
+    private static double median(List<Long> nanos) {
+        List<Long> sorted = new ArrayList<>(nanos);
+        sorted.sort(Long::compareTo);
+        return sorted.get(sorted.size() / 2) / 1_000_000.0;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatACodeActionCostsBenchmark.java
@@ -7,6 +7,8 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 import souther.compiler.source.SourceId;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -39,25 +41,34 @@ import java.util.Set;
  * at all. So its column is what the old path cost where it worked, and the row it does not have is
  * every workspace of more than one module.
  *
+ * <p>Two layers, said apart because they are two numbers. The query rows are one step of a request
+ * — the compilation being asked, with the compilation already in hand. The request row is what an
+ * editor waits on: {@link Analyzer#codeActions} sorting the workspace into what can join a compile,
+ * bringing the compilation up to date, and answering both halves of what an action is.
+ *
  * <p>Observed, on the workspace this generates (7 modules, 3264 lines), medians:
  * <pre>
- *   settled:   diagnostics    0.03 ms   repairs    0.03 ms
- *   asked:     diagnostics   54.53 ms   repairs   54.58 ms
- *   elsewhere: diagnostics   52.70 ms   repairs   53.94 ms
- *   cold:      diagnostics  882.63 ms   repairs  869.07 ms
- *   alone (one self-contained document, a third the size):  145.24 ms
+ *   query    settled:   diagnostics    0.04 ms   repairs    0.04 ms
+ *   query    asked:     diagnostics   59.56 ms   repairs   57.71 ms
+ *   query    elsewhere: diagnostics   55.83 ms   repairs   56.49 ms
+ *   query    cold:      diagnostics  990.68 ms   repairs  947.43 ms
+ *   request  settled:     0.73 ms     after an edit elsewhere:  61.16 ms
+ *   alone (one self-contained document, a third the size):     154.92 ms
  * </pre>
  *
- * <p>Settled is the state a cursor move arrives in, and it is where the old path spent its whole
- * cost: a compile of the document from nothing, every request, against a store that already held
- * the answer. The other rows are an edit being paid for once — by whichever of the diagnose and the
- * request reaches the store first, since what either of them answers is kept.
+ * <p>Settled is the state a cursor move arrives in. A request there costs most of a millisecond,
+ * nearly all of it above the query: sorting the workspace is per request and grows with the
+ * workspace rather than with the edit. It is where the old path spent its whole cost — a compile of
+ * the document from nothing, every request, against a store that already held the answer — and, for
+ * a workspace of more than one module, where it gave up and offered nothing.
+ *
+ * <p>The other rows are an edit being paid for once, by whichever of the diagnose and the request
+ * reaches the store first, since what either of them answers is kept.
  *
  * <p>The two queries do not differ. Asking for every marker in the workspace costs what asking for
- * one file's edits costs, because both are {@code answerEverything} and the publication map beside
- * it is nothing. So the narrower query is not here for its cost: it is here because publication and
- * applicability are different questions, and a query that answered one while being read for the
- * other would be right only while every finding stayed in the file it was published in.
+ * one file's repairs costs, because both are {@code answerEverything} and what is built beside it is
+ * nothing. So the narrower query is not here for its cost: it is here because it answers three
+ * questions a code action asks and {@code diagnostics} answers one of them.
  */
 @Disabled("manual benchmark; run explicitly to re-measure — see class javadoc")
 class WhatACodeActionCostsBenchmark {
@@ -90,6 +101,36 @@ class WhatACodeActionCostsBenchmark {
         String own = selfContained();
         System.out.printf("alone (one self-contained document): %6.2f ms%n",
                 medianMillis(round -> compileAlone(own), ROUNDS / 4));
+
+        requestCost(byId);
+    }
+
+    /**
+     * The whole request, which is the number an editor waits on: the analyzer sorting the workspace
+     * into what can join a compile, bringing its compilation up to date, and answering both halves
+     * of what an action is. The rows above are one of those steps.
+     */
+    private static void requestCost(Map<String, String> byId) {
+        Map<String, String> sources = new LinkedHashMap<>(byId);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+        String text = byId.get(ASKED);
+        int at = text.indexOf("writen");
+        Position caret = new Position((int) text.substring(0, at).lines().count() - 1,
+                at - (text.substring(0, at).lastIndexOf('\n') + 1));
+        Range asking = new Range(caret, caret);
+        if (analyzer.codeActions(ASKED, text, asking, graph).isEmpty()) {
+            throw new IllegalStateException("the caret is meant to be on something to repair");
+        }
+
+        double settled = medianMillis(_ -> analyzer.codeActions(ASKED, text, asking, graph), ROUNDS);
+        double afterAnEdit = medianMillis(round -> {
+            Map<String, String> now = new LinkedHashMap<>(byId);
+            now.put("file:///m1.sou", byId.get("file:///m1.sou") + added(round));
+            analyzer.codeActions(ASKED, text, asking, ModuleGraph.of(now));
+        }, ROUNDS);
+        System.out.printf("request:   settled %6.2f ms   after an edit elsewhere %6.2f ms%n",
+                settled, afterAnEdit);
     }
 
     /** What has happened to the documents since the last request. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -34,11 +34,11 @@ public final class Diagnostic {
     private final Message said;
     private final TypeComparison diff;
     private final List<Note> notes;
-    private final String suggestion;
+    private final Repair repair;
 
     private Diagnostic(Severity severity, DiagnosticCode code, Primary primary,
                        List<LabeledRegion> secondary, String literalMessage,
-                       TypeComparison diff, List<Note> notes, String suggestion, Message said) {
+                       TypeComparison diff, List<Note> notes, Repair repair, Message said) {
         this.severity = severity;
         this.code = code;
         this.primary = primary;
@@ -46,7 +46,7 @@ public final class Diagnostic {
         this.literalMessage = literalMessage;
         this.diff = diff;
         this.notes = notes;
-        this.suggestion = suggestion;
+        this.repair = repair;
         this.said = said;
     }
 
@@ -143,8 +143,15 @@ public final class Diagnostic {
         return notes;
     }
 
-    public String suggestion() {
-        return suggestion;
+    /**
+     * The edit that answers this, or null where nothing is known to.
+     *
+     * <p>The one place a machine-applicable edit is read from. A renderer quoting
+     * {@link Repair#with} is quoting the word, and where it applies is
+     * {@link Repair#target} — which no caller works out from {@link #primary()}.
+     */
+    public Repair repair() {
+        return repair;
     }
 
     /**
@@ -169,6 +176,10 @@ public final class Diagnostic {
      * the rest are labelled {@code alsoHere}, which says they are part of what is found wrong
      * ({@link souther.compiler.diag.msg.FindingRegion}) and is what puts the report in front of each
      * of those authors.
+     *
+     * <p>The repair comes along unchanged too, and it is the one part of this that keeps pointing
+     * where it did. Moving the caret changes where a reader is sent; the characters to rewrite are
+     * still the ones somebody wrote, in the file they wrote them in.
      *
      * <p>The labels this already had come along unchanged. Each of them says where it is on its own
      * ({@link DiagnosticPlace}), so none of them meant anything different while the caret was
@@ -206,7 +217,7 @@ public final class Diagnostic {
         return new Diagnostic(severity, code,
                 Primary.at(Region.point(where.get(0).standingInFor(declaring))),
                 List.copyOf(also),
-                literalMessage, diff, notes, suggestion, said);
+                literalMessage, diff, notes, repair, said);
     }
 
     /**
@@ -246,12 +257,12 @@ public final class Diagnostic {
      */
     public record Identity(Severity severity, String code, String titleKey, Primary primary,
                            List<LabeledRegion> secondary, String literalMessage,
-                           TypeComparison diff, List<Note> notes, String suggestion, Message said) {}
+                           TypeComparison diff, List<Note> notes, Repair repair, Message said) {}
 
     public Identity identity() {
         return new Identity(severity, code(), titleKey(), primary,
                 secondary == null ? List.of() : secondary, literalMessage, diff,
-                notes == null ? List.of() : notes, suggestion, said);
+                notes == null ? List.of() : notes, repair, said);
     }
 
     /** A pre-formatted English message wrapped verbatim — the compatibility path for a site that
@@ -303,7 +314,7 @@ public final class Diagnostic {
         private final List<LabeledRegion> secondary = new ArrayList<>();
         private TypeComparison diff;
         private final List<Note> notes = new ArrayList<>();
-        private String suggestion;
+        private Repair repair;
 
         private Builder() {
         }
@@ -426,8 +437,17 @@ public final class Diagnostic {
             return this;
         }
 
-        public Builder suggestion(String suggestion) {
-            this.suggestion = suggestion;
+        /**
+         * What to write and where, as one thing, because they are one fact. A site that could hand
+         * over the word on its own would be a site whose reader had to find the place, and the only
+         * value in reach to find it from is the primary region — which is the stretch the report is
+         * said about and is not always the stretch to rewrite.
+         *
+         * <p>Either half absent leaves no repair: nothing near enough to be worth offering, or a
+         * name nobody wrote, which has no place in any file to write over.
+         */
+        public Builder repair(Region target, String with) {
+            this.repair = target == null || with == null ? null : new Repair(target, with);
             return this;
         }
 
@@ -443,7 +463,7 @@ public final class Diagnostic {
                         "a diagnostic says where it points; call `at` or `nowhere`");
             }
             return new Diagnostic(code.severity(), code, primary, List.copyOf(secondary), null,
-                    diff, List.copyOf(notes), suggestion, said);
+                    diff, List.copyOf(notes), repair, said);
         }
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -438,16 +438,27 @@ public final class Diagnostic {
         }
 
         /**
-         * What to write and where, as one thing, because they are one fact. A site that could hand
+         * What to write and where, as one call, because they are one fact. A site that could hand
          * over the word on its own would be a site whose reader had to find the place, and the only
          * value in reach to find it from is the primary region — which is the stretch the report is
          * said about and is not always the stretch to rewrite.
          *
-         * <p>Either half absent leaves no repair: nothing near enough to be worth offering, or a
-         * name nobody wrote, which has no place in any file to write over.
+         * <p>Which of the two shapes it comes out as is decided here and not at the site, because
+         * what decides it is a property of the position rather than of the check: a name nobody
+         * wrote has no place, and one inside a body an expansion copied in has a borrowed one. Both
+         * leave the word, which is what the reader is told; neither leaves an edit.
+         *
+         * <p>No word leaves nothing. There was nothing near enough to be worth saying.
          */
         public Builder repair(Region target, String with) {
-            this.repair = target == null || with == null ? null : new Repair(target, with);
+            if (with == null) {
+                this.repair = null;
+            } else if (target == null
+                    || target.start().wasCopiedHere() || target.end().wasCopiedHere()) {
+                this.repair = new Repair.AWord(with);
+            } else {
+                this.repair = new Repair.AnEdit(target, with);
+            }
             return this;
         }
 

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -144,11 +144,12 @@ public final class Diagnostic {
     }
 
     /**
-     * The edit that answers this, or null where nothing is known to.
+     * What would answer this, or null where nothing is known to.
      *
      * <p>The one place a machine-applicable edit is read from. A renderer quoting
-     * {@link Repair#with} is quoting the word, and where it applies is
-     * {@link Repair#target} — which no caller works out from {@link #primary()}.
+     * {@link Repair#with()} is quoting the word, which every shape has; where it applies is
+     * {@link Repair.AnEdit#target()}, which only that shape has and which no caller works out from
+     * {@link #primary()}.
      */
     public Repair repair() {
         return repair;

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -65,8 +65,8 @@ public interface DiagnosticRenderer {
         for (Note note : d.notes() == null ? List.<Note>of() : d.notes()) {
             said.append(' ').append(Messages.render(note.said(), written));
         }
-        if (d.suggestion() != null) {
-            said.append(' ').append(Messages.get("diag.suggestion", written, d.suggestion()));
+        if (d.repair() != null) {
+            said.append(' ').append(Messages.get("diag.suggestion", written, d.repair().with()));
         }
         return said.toString();
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
@@ -78,9 +78,9 @@ public final class HumanRenderer implements DiagnosticRenderer {
             out.append(Messages.get("diag.diff.expected", locale)).append('\n');
             out.append("    ").append(d.diff().expectedType()).append('\n');
         }
-        if (d.suggestion() != null) {
+        if (d.repair() != null) {
             out.append(hintLabel(locale))
-                    .append(Messages.get("diag.suggestion", locale, d.suggestion())).append('\n');
+                    .append(Messages.get("diag.suggestion", locale, d.repair().with())).append('\n');
         }
         for (Note note : d.notes()) {
             out.append(hintLabel(locale))

--- a/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
@@ -138,8 +138,8 @@ public final class JsonRenderer implements DiagnosticRenderer {
         if (!hints.isEmpty()) {
             obj.put("hints", hints);
         }
-        if (d.suggestion() != null) {
-            obj.put("suggestion", d.suggestion());
+        if (d.repair() != null) {
+            obj.put("suggestion", d.repair().with());
         }
         return JSON.writeValueAsString(obj);
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
@@ -139,7 +139,18 @@ public final class JsonRenderer implements DiagnosticRenderer {
             obj.put("hints", hints);
         }
         if (d.repair() != null) {
+            // The word, which is what a person is shown, and — where there is one — the edit as an
+            // edit. A tool handed the word alone has one region in front of it and it is the wrong
+            // one: `region` is what the report is about, and a qualified name nothing denotes is
+            // about the whole name while the edit is one part of it. So the stretch to rewrite is
+            // written out, and its absence is the answer that there is nothing to apply.
             obj.put("suggestion", d.repair().with());
+            if (d.repair() instanceof Repair.AnEdit edit) {
+                Map<String, Object> repair = new LinkedHashMap<>();
+                repair.put("region", region(edit.target()));
+                repair.put("with", edit.with());
+                obj.put("repair", repair);
+            }
         }
         return JSON.writeValueAsString(obj);
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
@@ -3,23 +3,57 @@ package souther.compiler.diag;
 import java.util.Objects;
 
 /**
- * An edit that answers a finding: replace {@code target} with {@code with}.
+ * What would answer a finding: the text to write, and — where the finding knows it — the characters
+ * to write it over.
  *
- * <p>The whole of what a machine may apply. A deletion is an empty replacement and an insertion is a
- * replacement of an empty stretch, so one shape says all three, and nothing here is sorted into
- * kinds a caller would have to tell apart.
+ * <p>Two shapes because a check can know the word without there being anywhere here to put it. A
+ * name inside a body an expansion copied in sits at a line of the author's file and says nothing
+ * about what is written there, and a name nobody wrote has no place at all; the reader is still
+ * better told what was probably meant. So the word travels either way and the edit does not, and a
+ * caller that needs to write something has to say which of the two it is looking at.
  *
- * <p>{@code target} is the answer to a different question from a diagnostic's {@link Primary}. What
- * a finding is said about and what makes it go away are the same stretch often enough to be
- * mistaken for one rule, and they are not: a qualified name nothing denotes is reported over the
- * whole name and repaired by rewriting the one part that is wrong, and a report moved to where a
- * reader can reach it ({@link Diagnostic#reachedFrom}) is said at an import while the text to change
- * stays where it was written. So the two are carried separately and a repair says its own place.
+ * <p>{@link AnEdit#target} is the answer to a different question from a diagnostic's
+ * {@link Primary}. What a finding is said about and what makes it go away are the same stretch often
+ * enough to be mistaken for one rule, and they are not: a qualified name nothing denotes is reported
+ * over the whole name and repaired by rewriting the one part that is wrong, and a report moved to
+ * where a reader can reach it ({@link Diagnostic#reachedFrom}) is said at an import while the text
+ * to change stays where it was written.
+ *
+ * <p>And both are a third question again from where an offer to apply it stands, which is where the
+ * problem is marked. Nothing here answers that: a repair is what an author gets for saying yes, not
+ * what puts the question in front of them.
  */
-public record Repair(Region target, String with) {
+public sealed interface Repair {
 
-    public Repair {
-        Objects.requireNonNull(target, "a repair says where it applies");
-        Objects.requireNonNull(with, "a repair says what to write");
+    /** The text that answers the finding — what a reader is told either way. */
+    String with();
+
+    /** The word alone, there being nowhere in a file anyone holds to write it over. */
+    record AWord(String with) implements Repair {
+
+        public AWord {
+            Objects.requireNonNull(with, "a repair says what to write");
+        }
+    }
+
+    /**
+     * The word and the characters to write it over.
+     *
+     * <p>{@code target} is code somebody typed, because an edit rewrites characters. A position
+     * standing in for code written elsewhere is a place to send a reader and not a place to write,
+     * and is refused here rather than described — so a caller holding one of these is holding an
+     * edit that can be applied, and nothing downstream asks again.
+     */
+    record AnEdit(Region target, String with) implements Repair {
+
+        public AnEdit {
+            Objects.requireNonNull(target, "an edit says where it applies");
+            Objects.requireNonNull(with, "a repair says what to write");
+            if (target.start().wasCopiedHere() || target.end().wasCopiedHere()) {
+                throw new IllegalArgumentException(
+                        "an edit rewrites code that was written where it points, and this was"
+                                + " copied here: " + target);
+            }
+        }
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
@@ -1,0 +1,25 @@
+package souther.compiler.diag;
+
+import java.util.Objects;
+
+/**
+ * An edit that answers a finding: replace {@code target} with {@code with}.
+ *
+ * <p>The whole of what a machine may apply. A deletion is an empty replacement and an insertion is a
+ * replacement of an empty stretch, so one shape says all three, and nothing here is sorted into
+ * kinds a caller would have to tell apart.
+ *
+ * <p>{@code target} is the answer to a different question from a diagnostic's {@link Primary}. What
+ * a finding is said about and what makes it go away are the same stretch often enough to be
+ * mistaken for one rule, and they are not: a qualified name nothing denotes is reported over the
+ * whole name and repaired by rewriting the one part that is wrong, and a report moved to where a
+ * reader can reach it ({@link Diagnostic#reachedFrom}) is said at an import while the text to change
+ * stays where it was written. So the two are carried separately and a repair says its own place.
+ */
+public record Repair(Region target, String with) {
+
+    public Repair {
+        Objects.requireNonNull(target, "a repair says where it applies");
+        Objects.requireNonNull(with, "a repair says what to write");
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Repair.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  * better told what was probably meant. So the word travels either way and the edit does not, and a
  * caller that needs to write something has to say which of the two it is looking at.
  *
- * <p>{@link AnEdit#target} is the answer to a different question from a diagnostic's
+ * <p>{@link AnEdit#target()} is the answer to a different question from a diagnostic's
  * {@link Primary}. What a finding is said about and what makes it go away are the same stretch often
  * enough to be mistaken for one rule, and they are not: a qualified name nothing denotes is reported
  * over the whole name and repaired by rewriting the one part that is wrong, and a report moved to


### PR DESCRIPTION
Closes #1514.

The did-you-mean quick fix recovered its suggestion by compiling the document from scratch, on every code action request. What it was recovering is a field the published marker drops, and the compile it started was a second reading of text the workspace's own compilation had already read. So a request the cursor triggered paid for a whole compile against a store that already held the answer, and a document with an import was given up on before the compile even started — no fix was offered there at all.

The offer now asks the compilation the request already has. `codeActions` takes it once and both halves read it: the rows a behavior does not cover, and the repairs the compiler found. A request is one reading of one document at one moment rather than two.

Underneath that are three questions a code action asks, where there used to be one value answering all of them.

**Where the problem is marked** is where a reader looks, so it is where the offer has to stand. It is what the file being asked about anchors, which is the same stretch the published marker is drawn over. Asked only of the files the report is said in: reading a report as a file it says nothing about is refused, not answered emptily.

**Where the edit writes** is the characters that make the problem go away. Not the same stretch: a qualified name nothing denotes is marked over the whole name, because which of its parts is wrong is what the message settles, and it is answered by rewriting one part. Aimed at the report's own region, the fix wrote the suggested type name over `up.Amuont` entire and left the document naming no module. Compared against the edit instead, the offer went missing from most of what is underlined — a caret on the `up` is on the squiggle its author is asking about.

**What to write** is the word, and a finding can know it with nowhere here to put it. A name inside a body an expansion copied in sits at a line of the author's file and says nothing about what is there. Carrying only an edit drops the word the reader deserves; carrying only a word is what let an edit be aimed at the wrong stretch. So both, as two shapes, and a caller that writes has to say which one it is holding — including at the JSON boundary, where a tool used to be handed the word beside the report's region and one wrong place to put it.

An edit is refused over a borrowed position where it is made, rather than described as a rule for producers to keep.

`Diagnostic.suggestion()` is gone rather than kept as a view: an accessor that hands over the word alone is an accessor whose reader has to find the place, and finding it is the defect.

The cursor-move state — a request arriving with nothing changed since the last diagnose — is where the old path spent its whole cost, and the store answers it out of what it already holds. The rest of a request's cost is an edit, paid once by whichever of the diagnose and the request reaches the store first. `WhatACodeActionCostsBenchmark` carries the measurement, at both layers: the query, and the request it is one step of.

Mutations, each red: the offer compared against where the edit writes; the edit aimed at the marked stretch; the report read as a file it is not said in; `reachedFrom` dropping the repair; an edit made over copied code.

An offer that goes missing and an offer there was never anything to make look the same from outside, and a request that fails returns the second. So every emptiness asserted here stands beside an offer that has to be there, in the same document and the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)