### PR TITLE
Read a compiled output once for the fork asking, not once for the question

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -44,7 +44,7 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
     private static final String THE_DERIVED_WORLD = internal(DerivedSymbols.class);
     private static final String THE_RESOLVED_WORLD = internal(ResolvedSymbols.class);
 
-    private static final CompiledClasses COMPILED = CompiledClasses.ofEverythingCompiledHere();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofEverythingCompiledHere();
 
     private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
 
@@ -241,10 +241,10 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
 
     @Test
     void whatIsPublishedIsNotWhatWasCompiledBesideIt() {
-        assertTrue(CompiledClasses.ofEverythingCompiledHere().find(DECLARATIONS).isPresent(),
+        assertTrue(CompiledOutputs.ofEverythingCompiledHere().find(DECLARATIONS).isPresent(),
                 "the subjects declared here are compiled where test output goes, which is the"
                         + " population this test's readings are about");
-        assertTrue(CompiledClasses.ofWhatThisRepositoryPublishes().find(DECLARATIONS).isEmpty(),
+        assertTrue(CompiledOutputs.ofWhatThisRepositoryPublishes().find(DECLARATIONS).isEmpty(),
                 "and are not in the one a rule about a compiled surface is about, which is why the"
                         + " two are named apart rather than searched together");
     }

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
@@ -14,7 +14,12 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * The class files this repository built, found through the repository.
+ * The compiled outputs a name is looked for in, and the order they are looked in.
+ *
+ * <p>Which outputs those are is what this is: a rule here asks about a class of this repository
+ * without knowing which module built it, so the question is put to several outputs in turn and the
+ * first that holds the name answers it. What one output holds is read elsewhere; the population and
+ * its order are here.
  *
  * <p>Not through {@code java.class.path}. What a module is handed there is the reactor's to decide
  * and it is not the same in every build — a module built beside this one arrives as its
@@ -32,7 +37,7 @@ import java.util.Optional;
  * <p>A name this cannot find is not a class that reaches nothing. It is a question this cannot
  * answer, and it says so rather than answering.
  */
-final class CompiledClasses {
+final class CompiledOutputs {
 
     private final RepositoryLayout repository;
 
@@ -40,19 +45,19 @@ final class CompiledClasses {
 
     private final Map<String, Optional<ClassModel>> read = new HashMap<>();
 
-    private CompiledClasses(RepositoryLayout repository, List<String> outputs) {
+    private CompiledOutputs(RepositoryLayout repository, List<String> outputs) {
         this.repository = repository;
         this.outputs = outputs;
     }
 
     /** What this repository publishes: the compiled surface a caller elsewhere reaches. */
-    static CompiledClasses ofWhatThisRepositoryPublishes() {
-        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory(), List.of("classes"));
+    static CompiledOutputs ofWhatThisRepositoryPublishes() {
+        return new CompiledOutputs(RepositoryLayout.ofWorkingDirectory(), List.of("classes"));
     }
 
     /** That and what was compiled beside it, which is where a test's own subjects are. */
-    static CompiledClasses ofEverythingCompiledHere() {
-        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory(),
+    static CompiledOutputs ofEverythingCompiledHere() {
+        return new CompiledOutputs(RepositoryLayout.ofWorkingDirectory(),
                 List.of("classes", "test-classes"));
     }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -67,8 +67,8 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
      *  is one a walk can be declared to take, and these rules have to see it arrive. */
     private static final Set<String> THE_WORLDS = worlds();
 
-    private static final CompiledClasses COMPILED =
-            CompiledClasses.ofWhatThisRepositoryPublishes();
+    private static final CompiledOutputs COMPILED =
+            CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
 

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
@@ -55,9 +55,9 @@ final class WhatASignatureReaches {
 
     private static final String OF_THIS_REPOSITORY = "souther/";
 
-    private final CompiledClasses compiled;
+    private final CompiledOutputs compiled;
 
-    WhatASignatureReaches(CompiledClasses compiled) {
+    WhatASignatureReaches(CompiledOutputs compiled) {
         this.compiled = compiled;
     }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
@@ -117,7 +117,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
      */
     @Test
     void andWhatMayBeAskedOfARelationIsTheseTwoQuestions() {
-        ClassModel asked = CompiledClasses.ofWhatThisRepositoryPublishes()
+        ClassModel asked = CompiledOutputs.ofWhatThisRepositoryPublishes()
                 .read(WHERE + "WhatARelationShows");
         List<String> waysIn = new ArrayList<>();
         for (MethodModel maker : asked.methods()) {
@@ -153,7 +153,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
      */
     @Test
     void andTheWalkFindsACallToAHalfWhereOneIsMade() {
-        assertTrue(!callsTo(CompiledClasses.ofWhatThisRepositoryPublishes().read(PROVING_ONE_HALF),
+        assertTrue(!callsTo(CompiledOutputs.ofWhatThisRepositoryPublishes().read(PROVING_ONE_HALF),
                         ONE_HALF).isEmpty(),
                 "the finder reports nothing where a half is named, so it would report nothing"
                         + " wherever a reading named one");

--- a/souther-test-support/src/main/java/souther/test/ClassFiles.java
+++ b/souther-test-support/src/main/java/souther/test/ClassFiles.java
@@ -1,0 +1,30 @@
+package souther.test;
+
+import java.lang.classfile.ClassModel;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Where a compiled class file is touched, and the only place it is.
+ *
+ * <p>Both ways of touching one are here, because a reading that asked this for the bytes and looked
+ * for the file itself would leave half of what it does outside the boundary — and a rule saying
+ * where compiled output is reached could then be met while the file system was still being asked
+ * somewhere else.
+ *
+ * <p>An interface because what a reading costs is a question about it: a caller counting what was
+ * touched hands one that counts and asks the reading, rather than the reading keeping a tally of
+ * its own. A tally kept inside would be a number nothing spends, and it would be there in every run
+ * to serve a question only a check asks.
+ */
+interface ClassFiles {
+
+    /** Every class file under {@code root}, in a settled order, so that two readings of one root
+     *  answer in the same order. */
+    List<Path> list(Path root);
+
+    /** {@code file} parsed, or nothing where no such file was built. Absence is an answer this
+     *  gives rather than a question the caller asks the file system first. */
+    Optional<ClassModel> read(Path file);
+}

--- a/souther-test-support/src/main/java/souther/test/ClassFiles.java
+++ b/souther-test-support/src/main/java/souther/test/ClassFiles.java
@@ -6,9 +6,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Where a compiled class file is touched, and the only place it is.
+ * Where a reading of a compiled output touches the file system.
  *
- * <p>Both ways of touching one are here, because a reading that asked this for the bytes and looked
+ * <p>Both ways of touching it are here, because a reading that asked this for the bytes and looked
  * for the file itself would leave half of what it does outside the boundary — and a rule saying
  * where compiled output is reached could then be met while the file system was still being asked
  * somewhere else.

--- a/souther-test-support/src/main/java/souther/test/CompiledClassReadings.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClassReadings.java
@@ -1,0 +1,70 @@
+package souther.test;
+
+import java.lang.classfile.ClassModel;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * What has been read of the compiled classes, kept for as long as the fork that read it.
+ *
+ * <p>What a check of compiled code is about was written before any test started: the compile the
+ * run is testing produced it, and nothing that happens while the tests run changes it. So a reading
+ * of it is worth keeping, and keeping it is not a cache over something that moves — there is
+ * nothing here that could go out of date, and nothing here asks whether it has.
+ *
+ * <p><b>What is kept is the reading and not an answer.</b> One check counts invocations of a
+ * method, another asks which methods take a value of some type, another reads field declarations.
+ * Kept per question, the same files would be parsed again for each of them; kept as answers, every
+ * check would have to be written against a vocabulary decided here. The parsed class is what they
+ * have in common.
+ *
+ * <p>A file is kept under the path it was read from, and a listing under the root it was taken of.
+ * A root is settled by its caller before it arrives, so two callers that found one module by
+ * different routes ask about one key rather than two, and the files beneath a settled root are
+ * settled by being built under it.
+ *
+ * <p>Absence is kept beside presence and in the same key space. Whether a module built a class is
+ * as fixed as what the class holds, and a reader that walks a name from one output to the next asks
+ * the same question of the same path however many times its walk arrives there.
+ */
+final class CompiledClassReadings {
+
+    /**
+     * The readings of the fork this runs in.
+     *
+     * <p>The lifetime is the fork rather than the run: forks are capped rather than taken as a
+     * share of the machine, so what a suite pays is one reading per fork, and a check gets the
+     * reading of whichever fork it landed in.
+     */
+    private static final CompiledClassReadings FOR_THIS_FORK =
+            new CompiledClassReadings(new ReadClassFiles());
+
+    private final ClassFiles files;
+
+    private final ConcurrentMap<Path, List<Path>> listings = new ConcurrentHashMap<>();
+
+    private final ConcurrentMap<Path, Optional<ClassModel>> parsed = new ConcurrentHashMap<>();
+
+    CompiledClassReadings(ClassFiles files) {
+        this.files = files;
+    }
+
+    /** The readings every check of this fork shares. */
+    static CompiledClassReadings forThisFork() {
+        return FOR_THIS_FORK;
+    }
+
+    /** Every class file under {@code root}, taken once however many checks ask. */
+    List<Path> listing(Path root) {
+        return listings.computeIfAbsent(root, files::list);
+    }
+
+    /** {@code file} parsed, or nothing where no such file was built, read once however many checks
+     *  ask and whether they arrive by a listing or by a name. */
+    Optional<ClassModel> at(Path file) {
+        return parsed.computeIfAbsent(file, files::read);
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/CompiledClasses.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClasses.java
@@ -1,0 +1,161 @@
+package souther.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassModel;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One compiled output, as the checks of this repository read it.
+ *
+ * <p>What a rule about compiled code is asked of. The classes under one output root are fixed for
+ * the length of a run — they were written by the compile the run is testing — and this is where a
+ * check reaches them, so that the reading is done once for the fork rather than once for the
+ * question. What each check does with them differs, so what is answered here is the classes and
+ * never a verdict about them.
+ *
+ * <p><b>Three ways of asking, and each pays for what it asks.</b> A rule about a whole module walks
+ * {@link #all}; a rule about one class asks {@link #find}, which reaches that file and no other; a
+ * rule about a package asks {@link #inPackage}, which settles which files are in it before any of
+ * them is parsed. A rule that could only have the whole module would make the narrow questions pay
+ * for the wide one, and the narrowest of them reads eight classes of four thousand.
+ *
+ * <p><b>Which output is asked is the caller's to name, and so is what to do with two of them.</b> A
+ * rule about what this repository publishes and a rule about what a test compiled beside it are
+ * about two populations, and a reader that searched several outputs in some order would be deciding
+ * for its callers which population they meant. One of these is one output root.
+ *
+ * <p>An output root is settled with {@link Path#toRealPath} before it becomes the name of anything,
+ * so that a module found through the class path and the same module found by walking the repository
+ * are one output and not two. What is found on the class path as a jar is not an output root: there
+ * is nothing to walk and nothing to settle, and a check about a module built beside this one asks
+ * about the module rather than about the artifact it was packaged into.
+ */
+public final class CompiledClasses {
+
+    private final Path root;
+
+    private final CompiledClassReadings readings;
+
+    private CompiledClasses(Path root, CompiledClassReadings readings) {
+        this.root = root;
+        this.readings = readings;
+    }
+
+    /** The output at {@code root}, read by the fork this runs in. */
+    public static CompiledClasses at(Path root) {
+        return at(root, CompiledClassReadings.forThisFork());
+    }
+
+    /**
+     * The output the module {@code marker} belongs to was compiled into.
+     *
+     * <p>Found through the class path rather than from the working directory. Where a run was
+     * started from is not something a rule about a module is about, and a module reached by the
+     * path a build happened to be invoked on answers differently under a build that was invoked
+     * elsewhere.
+     *
+     * @param marker any class of that module
+     */
+    public static CompiledClasses ofModule(Class<?> marker) {
+        String binary = marker.getName();
+        String simple = binary.substring(binary.lastIndexOf('.') + 1);
+        URL found = marker.getResource(simple + ".class");
+        if (found == null || !"file".equals(found.getProtocol())) {
+            throw new IllegalArgumentException(binary + " was not loaded from a compiled output on"
+                    + " the file system, so the module holding it has no output root to read");
+        }
+        Path at;
+        try {
+            at = Path.of(found.toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(binary + " is at " + found + ", which names no file",
+                    e);
+        }
+        for (int up = 0; up <= binary.chars().filter(each -> each == '.').count(); up++) {
+            at = at.getParent();
+        }
+        return at(at);
+    }
+
+    /** The same of a reading of somebody else's making, which is how what this costs is asked. */
+    static CompiledClasses at(Path root, CompiledClassReadings readings) {
+        try {
+            return new CompiledClasses(root.toRealPath(), readings);
+        } catch (IOException e) {
+            throw new UncheckedIOException(root.toAbsolutePath() + " is not a compiled output that"
+                    + " was built, so a rule read from it would hold nothing", e);
+        }
+    }
+
+    /** Which output this is, settled. */
+    public Path root() {
+        return root;
+    }
+
+    /**
+     * Every class the output holds.
+     *
+     * <p>A walk finding nothing is a walk of the wrong directory rather than a module that compiled
+     * to nothing, so this refuses instead of handing back an empty answer for a rule to pass on.
+     */
+    public List<ClassModel> all() {
+        List<ClassModel> found = read(readings.listing(root));
+        if (found.isEmpty()) {
+            throw new IllegalStateException(root + " holds no classes, so a rule read from it holds"
+                    + " nothing");
+        }
+        return found;
+    }
+
+    /**
+     * The class {@code binaryName} names, or nothing where the output holds no such class.
+     *
+     * <p>Reaches that one file. What the rest of the output holds is not part of this question, and
+     * a reader that answered it by walking would make a rule about a dozen classes pay for every
+     * class the module compiled.
+     *
+     * @param binaryName as Java names a class, with {@code $} before a nested name
+     */
+    public Optional<ClassModel> find(String binaryName) {
+        return readings.at(root.resolve(binaryName.replace('.', '/') + ".class"));
+    }
+
+    /**
+     * Every class of {@code packageName} and of the packages under it.
+     *
+     * <p>Under it as well, because a package's classes are not all written directly in it, and a
+     * rule about what a package holds that stopped at its own directory would answer about part of
+     * its subject while reading as though it had covered the whole.
+     *
+     * <p>Which files are in it is settled from the listing, so what is parsed is what the question
+     * is about.
+     */
+    public List<ClassModel> inPackage(String packageName) {
+        Path directory = root.resolve(packageName.replace('.', '/'));
+        List<Path> under = new ArrayList<>();
+        for (Path each : readings.listing(root)) {
+            if (each.startsWith(directory)) {
+                under.add(each);
+            }
+        }
+        if (under.isEmpty()) {
+            throw new IllegalStateException(root + " holds no classes of " + packageName + ", so a"
+                    + " rule read from that package holds nothing");
+        }
+        return read(under);
+    }
+
+    private List<ClassModel> read(List<Path> files) {
+        List<ClassModel> found = new ArrayList<>();
+        for (Path each : files) {
+            readings.at(each).ifPresent(found::add);
+        }
+        return found;
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/ReadClassFiles.java
+++ b/souther-test-support/src/main/java/souther/test/ReadClassFiles.java
@@ -1,0 +1,37 @@
+package souther.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/** The reading that goes to the file system, which is the one every fork shares. */
+final class ReadClassFiles implements ClassFiles {
+
+    @Override
+    public List<Path> list(Path root) {
+        try (Stream<Path> walk = Files.walk(root)) {
+            return walk.filter(each -> each.toString().endsWith(".class")).sorted().toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException("the compiled output at " + root + " cannot be listed",
+                    e);
+        }
+    }
+
+    @Override
+    public Optional<ClassModel> read(Path file) {
+        if (!Files.isRegularFile(file)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(ClassFile.of().parse(Files.readAllBytes(file)));
+        } catch (IOException e) {
+            throw new UncheckedIOException("the class file at " + file + " cannot be read", e);
+        }
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/ReadClassFiles.java
+++ b/souther-test-support/src/main/java/souther/test/ReadClassFiles.java
@@ -5,6 +5,7 @@ import java.io.UncheckedIOException;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -23,13 +24,21 @@ final class ReadClassFiles implements ClassFiles {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Absence is what the read itself reports and not what a question asked beforehand says.
+     * Whether a module built a class is one thing; whether this process can see the file is
+     * another, and a reading that asked whether the file was there and treated every no as the
+     * first would answer that a class was never built for a directory it may not enter. What is
+     * not there is an answer; anything else that stops the read is a failure and says so.
+     */
     @Override
     public Optional<ClassModel> read(Path file) {
-        if (!Files.isRegularFile(file)) {
-            return Optional.empty();
-        }
         try {
             return Optional.of(ClassFile.of().parse(Files.readAllBytes(file)));
+        } catch (NoSuchFileException e) {
+            return Optional.empty();
         } catch (IOException e) {
             throw new UncheckedIOException("the class file at " + file + " cannot be read", e);
         }

--- a/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
+++ b/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
@@ -1,9 +1,6 @@
 package souther.test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
@@ -11,13 +8,9 @@ import java.lang.classfile.MethodSignature;
 import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.RecordAttribute;
 import java.lang.classfile.attribute.RecordComponentInfo;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * What one module compiled, read off its class files.
@@ -32,6 +25,10 @@ import java.util.stream.Stream;
  * on disk and a module not built at all has none, so a check that swept the file system would prove
  * something about a build nobody ran. A marker class is loaded from the classpath the test was
  * given, which is the module as this run built it.
+ *
+ * <p>The classes themselves come from {@link CompiledClasses}, which is where a compiled output is
+ * read. What is asked of them is here; how many times the files behind them are opened is not a
+ * question this has to hold an answer to.
  */
 public final class WhatAModuleDeclares {
 
@@ -47,28 +44,7 @@ public final class WhatAModuleDeclares {
      * @param marker any class of that module's main sources
      */
     public static WhatAModuleDeclares of(Class<?> marker) {
-        String binary = marker.getName();
-        String simple = binary.substring(binary.lastIndexOf('.') + 1);
-        Path root;
-        try {
-            root = Path.of(marker.getResource(simple + ".class").toURI());
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("a class of " + binary + " is not on a file system,"
-                    + " so this module's classes cannot be read", e);
-        }
-        for (int up = 0; up <= binary.chars().filter(each -> each == '.').count(); up++) {
-            root = root.getParent();
-        }
-        List<ClassModel> found = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(one -> one.toString().endsWith(".class")).sorted()
-                    .toList()) {
-                found.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        return new WhatAModuleDeclares(found);
+        return new WhatAModuleDeclares(CompiledClasses.ofModule(marker).all());
     }
 
     /** Every class of it. */

--- a/souther-test-support/src/test/java/souther/test/NothingIsAnAnswerOnlyWhereTheOutputHoldsNothingTest.java
+++ b/souther-test-support/src/test/java/souther/test/NothingIsAnAnswerOnlyWhereTheOutputHoldsNothingTest.java
@@ -1,0 +1,78 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * When a reading may answer with nothing, and when it has to say it cannot answer.
+ *
+ * <p>That a module built no such class is a fact about the compile the run is testing, and a check
+ * following a name from one output to the next is entitled to it. That this process could not read
+ * a file, that the directory asked about holds no classes at all, that a name reaches no output on
+ * the file system — none of those are that fact, and answering them with the same nothing hands a
+ * check the fact it asked for whichever it met. A rule would then report that nothing declares
+ * something, having been unable to look.
+ *
+ * <p>So nothing is an answer where the output was read and holds none, and everywhere else this
+ * refuses.
+ */
+class NothingIsAnAnswerOnlyWhereTheOutputHoldsNothingTest {
+
+    private static CompiledClasses reading(Path root) {
+        return CompiledClasses.at(root, new CompiledClassReadings(new ReadClassFiles()));
+    }
+
+    private static Path anOutputHolding(Path root, String named) throws IOException {
+        Path built = root.resolve(named);
+        Files.createDirectories(built.getParent());
+        Files.copy(CompiledClasses.ofModule(RepositoryLayout.class).root()
+                .resolve("souther/test/RepositoryLayout.class"), built);
+        return root;
+    }
+
+    @Test
+    void answers_with_nothing_where_no_such_class_was_built(@TempDir Path root) throws IOException {
+        assertTrue(reading(anOutputHolding(root, "asked/Named.class")).find("asked.NeverWritten")
+                .isEmpty());
+    }
+
+    @Test
+    void refuses_where_the_read_stopped_for_any_other_reason(@TempDir Path root) throws IOException {
+        Files.createDirectories(root.resolve("asked/Named.class"));
+
+        assertThrows(UncheckedIOException.class, () -> reading(root).find("asked.Named"),
+                "a read this could not make was answered with the fact that a module builds no such"
+                        + " class, so a check that could not look reports what it did not see");
+    }
+
+    @Test
+    void refuses_an_output_that_holds_no_classes(@TempDir Path root) {
+        assertThrows(IllegalStateException.class, () -> reading(root).all(),
+                "an output with nothing in it was handed over as a population, so a rule about"
+                        + " every class of a module passes by having none to read");
+    }
+
+    @Test
+    void refuses_a_package_that_holds_no_classes(@TempDir Path root) throws IOException {
+        CompiledClasses output = reading(anOutputHolding(root, "asked/Named.class"));
+
+        assertThrows(IllegalStateException.class, () -> output.inPackage("elsewhere"),
+                "a package with nothing in it was handed over as a population, so a rule about what"
+                        + " a package holds passes by looking at the wrong one");
+    }
+
+    @Test
+    void refuses_a_class_that_reaches_no_output_on_the_file_system() {
+        assertThrows(IllegalArgumentException.class, () -> CompiledClasses.ofModule(Test.class),
+                "a class that arrived in a jar was taken to name an output root, which has nothing"
+                        + " to walk and nothing to settle");
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/OnePlaceMakesTheReadingAForkSharesTest.java
+++ b/souther-test-support/src/test/java/souther/test/OnePlaceMakesTheReadingAForkSharesTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * That a fork reads a compiled output once rests on there being one reading for it to share.
@@ -23,6 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * whether the checks of a fork are all asking it. A second reading made anywhere would be a second
  * fork-wide store, filled from the same files, and every count either of them kept would go on
  * saying that <em>it</em> read once.
+ *
+ * <p><b>One reading is two things, and a check of either alone leaves the other free.</b> Nothing
+ * else may make one, and what hands one out must hand out the one that was made. A store made in a
+ * single place and handed out afresh at every ask is made once and shared never; a store handed out
+ * from a field that anything may fill is shared until the second filler arrives. Neither half is
+ * evidence for the other, so both are here.
  *
  * <p><b>Read from the class files rather than from the sources.</b> A construction does not have to
  * be spelled {@code new}: a constructor named as a reference is a method handle in the bootstrap
@@ -54,7 +61,22 @@ class OnePlaceMakesTheReadingAForkSharesTest {
     }
 
     @Test
-    void is_the_only_way_a_class_file_is_touched() {
+    void is_the_one_that_was_made_every_time_it_is_asked_for() {
+        assertSame(CompiledClassReadings.forThisFork(), CompiledClassReadings.forThisFork(),
+                "asking for the fork's reading answered with a reading of its own, so what the"
+                        + " checks of one fork share is a way of making stores rather than a store");
+    }
+
+    /**
+     * That the boundary has one implementation, which is a narrower thing than it sounds.
+     *
+     * <p>What it does not say is that nothing else here opens a class file. A class that parses one
+     * without answering {@link ClassFiles} is outside what this reads, and saying otherwise would be
+     * claiming a rule about where compiled output is reached — which is about discovering an output
+     * rather than about parsing bytes, and belongs where the checks that discover one are.
+     */
+    @Test
+    void answers_the_boundary_in_one_implementation() {
         Set<String> answering = new LinkedHashSet<>();
         for (ClassModel each : PUBLISHED) {
             if (reaches(each, new LinkedHashSet<>())) {
@@ -62,16 +84,16 @@ class OnePlaceMakesTheReadingAForkSharesTest {
             }
         }
         assertEquals(Set.of("souther.test.ReadClassFiles"), answering,
-                "a second way of opening a class file is published here, so where compiled output"
-                        + " is reached is no longer one place");
+                "the boundary is answered somewhere else as well, so what a reading of a compiled"
+                        + " output goes through is no longer one implementation");
     }
 
     /**
-     * Whether {@code model} touches class files, through however many types in between.
+     * Whether {@code model} answers {@link ClassFiles}, through however many types in between.
      *
-     * <p>Directly or not. A type between the two is a way of being one of these and not a way of
-     * not being one, and a rule reading only what the class itself declares would be met by a
-     * second reading written as a subclass of the first.
+     * <p>Directly or not. A type between the two is a way of answering it and not a way of not
+     * answering it, and a rule reading only what the class itself declares would be met by a second
+     * implementation written as a subclass of the first.
      */
     private static boolean reaches(ClassModel model, Set<ClassDesc> seen) {
         List<ClassDesc> above = new ArrayList<>();

--- a/souther-test-support/src/test/java/souther/test/OnePlaceMakesTheReadingAForkSharesTest.java
+++ b/souther-test-support/src/test/java/souther/test/OnePlaceMakesTheReadingAForkSharesTest.java
@@ -1,0 +1,132 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.NewObjectInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * That a fork reads a compiled output once rests on there being one reading for it to share.
+ *
+ * <p>A check counting what a reading touches says what that reading does; it says nothing about
+ * whether the checks of a fork are all asking it. A second reading made anywhere would be a second
+ * fork-wide store, filled from the same files, and every count either of them kept would go on
+ * saying that <em>it</em> read once.
+ *
+ * <p><b>Read from the class files rather than from the sources.</b> A construction does not have to
+ * be spelled {@code new}: a constructor named as a reference is a method handle in the bootstrap
+ * arguments of an {@code invokedynamic} and puts no {@code new} in the caller's code at all, so a
+ * search of the text is passed by exactly the spelling a second maker would most easily be written
+ * in.
+ *
+ * <p>The population is what this module publishes. The type a fork's reading is made of is not
+ * public, so a class that could name it is a class of this package, and those are here. A test
+ * makes one of its own with a reading that counts what it touched, which is what asking the cost of
+ * something requires and is not a second store for the fork to share.
+ */
+class OnePlaceMakesTheReadingAForkSharesTest {
+
+    private static final List<ClassModel> PUBLISHED =
+            CompiledClasses.ofModule(RepositoryLayout.class).all();
+
+    private static final ClassDesc THE_READINGS =
+            CompiledClassReadings.class.describeConstable().orElseThrow();
+
+    private static final ClassDesc THE_BOUNDARY =
+            ClassFiles.class.describeConstable().orElseThrow();
+
+    @Test
+    void is_made_in_one_place() {
+        assertEquals(Set.of("souther.test.CompiledClassReadings#<clinit>"), whatMakesTheReadings(),
+                "a fork's reading is made somewhere else as well, so the checks of one fork read"
+                        + " the same files into more than one store");
+    }
+
+    @Test
+    void is_the_only_way_a_class_file_is_touched() {
+        Set<String> answering = new LinkedHashSet<>();
+        for (ClassModel each : PUBLISHED) {
+            if (reaches(each, new LinkedHashSet<>())) {
+                answering.add(named(each));
+            }
+        }
+        assertEquals(Set.of("souther.test.ReadClassFiles"), answering,
+                "a second way of opening a class file is published here, so where compiled output"
+                        + " is reached is no longer one place");
+    }
+
+    /**
+     * Whether {@code model} touches class files, through however many types in between.
+     *
+     * <p>Directly or not. A type between the two is a way of being one of these and not a way of
+     * not being one, and a rule reading only what the class itself declares would be met by a
+     * second reading written as a subclass of the first.
+     */
+    private static boolean reaches(ClassModel model, Set<ClassDesc> seen) {
+        List<ClassDesc> above = new ArrayList<>();
+        model.superclass().ifPresent(each -> above.add(each.asSymbol()));
+        model.interfaces().forEach(each -> above.add(each.asSymbol()));
+        for (ClassDesc each : above) {
+            if (each.equals(THE_BOUNDARY)) {
+                return true;
+            }
+            if (!seen.add(each)) {
+                continue;
+            }
+            ClassModel further = PUBLISHED.stream()
+                    .filter(one -> one.thisClass().asSymbol().equals(each))
+                    .findFirst().orElse(null);
+            if (further != null && reaches(further, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Every method that makes a reading, however the source spelled the construction. */
+    private static Set<String> whatMakesTheReadings() {
+        Set<String> found = new LinkedHashSet<>();
+        for (ClassModel each : PUBLISHED) {
+            for (MethodModel method : each.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
+                    continue;
+                }
+                String at = named(each) + "#" + method.methodName().stringValue();
+                for (var element : code) {
+                    switch (element) {
+                        case NewObjectInstruction made
+                                when made.className().asSymbol().equals(THE_READINGS) ->
+                                found.add(at);
+                        case InvokeDynamicInstruction reference -> {
+                            for (var argument : reference.bootstrapArgs()) {
+                                if (argument instanceof DirectMethodHandleDesc handle
+                                        && handle.kind() == DirectMethodHandleDesc.Kind.CONSTRUCTOR
+                                        && handle.owner().equals(THE_READINGS)) {
+                                    found.add(at);
+                                }
+                            }
+                        }
+                        default -> { }
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    private static String named(ClassModel of) {
+        return of.thisClass().asInternalName().replace('/', '.');
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
+++ b/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
@@ -1,0 +1,192 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a fork pays to read a compiled output.
+ *
+ * <p>The classes a check reads were written by the compile the run is testing and do not change
+ * while it runs, so what each question costs is decided by how much of the output it needs and not
+ * by how many questions there are. That is a fact about the reading rather than about the clock, so
+ * it is asked of a reading that says what it touched: a timing would answer about the machine, and
+ * would go on passing while every question read the module again.
+ *
+ * <p>The counted reading stands in for the one a fork shares. That the fork's own reading is made
+ * in one place is a different question, and {@link OnePlaceMakesTheReadingAForkSharesTest} asks it.
+ */
+class WhatIsReadOfACompiledOutputIsReadOnceTest {
+
+    /** A reading that says what it touched, wrapped round the one that goes to the file system. */
+    private static final class Counting implements ClassFiles {
+
+        private final ClassFiles real = new ReadClassFiles();
+
+        private final AtomicInteger listings = new AtomicInteger();
+
+        private final AtomicInteger reads = new AtomicInteger();
+
+        @Override
+        public List<Path> list(Path root) {
+            listings.incrementAndGet();
+            return real.list(root);
+        }
+
+        @Override
+        public Optional<ClassModel> read(Path file) {
+            reads.incrementAndGet();
+            return real.read(file);
+        }
+    }
+
+    private final Counting counting = new Counting();
+
+    private final CompiledClassReadings readings = new CompiledClassReadings(counting);
+
+    /** Where this module's main classes are, found the way a check finds them. */
+    private static final Path PUBLISHED = CompiledClasses.ofModule(RepositoryLayout.class).root();
+
+    /** Where the classes compiled beside them are, which is a second output and not this one. */
+    private static final Path COMPILED_BESIDE =
+            CompiledClasses.ofModule(WhatIsReadOfACompiledOutputIsReadOnceTest.class).root();
+
+    private CompiledClasses at(Path root) {
+        return CompiledClasses.at(root, readings);
+    }
+
+    @Test
+    void asks_the_same_question_twice_and_reads_the_output_once() {
+        List<ClassModel> first = at(PUBLISHED).all();
+        int afterOne = counting.reads.get();
+        List<ClassModel> again = at(PUBLISHED).all();
+
+        assertEquals(first.size(), again.size());
+        assertEquals(afterOne, counting.reads.get(), "the second walk read a file again");
+        assertEquals(1, counting.listings.get(), "the second walk listed the output again");
+    }
+
+    @Test
+    void asks_two_questions_of_one_output_and_reads_it_once() {
+        at(PUBLISHED).all();
+        int afterAll = counting.reads.get();
+
+        at(PUBLISHED).inPackage("souther.test");
+        at(PUBLISHED).find(RepositoryLayout.class.getName());
+
+        assertEquals(afterAll, counting.reads.get(),
+                "a second question opened a file the first had already read");
+    }
+
+    @Test
+    void is_the_same_output_whichever_class_of_the_module_names_it() {
+        Path byOne = CompiledClasses.ofModule(RepositoryLayout.class).root();
+        Path byAnother = CompiledClasses.ofModule(GitIndex.class).root();
+
+        assertEquals(byOne, byAnother);
+
+        at(byOne).all();
+        at(byAnother).all();
+
+        assertEquals(1, counting.listings.get(),
+                "one output was listed twice because two classes of it were named");
+    }
+
+    @Test
+    void is_a_different_output_when_the_classes_were_compiled_elsewhere() {
+        assertNotEquals(PUBLISHED, COMPILED_BESIDE);
+
+        at(PUBLISHED).all();
+        at(COMPILED_BESIDE).all();
+
+        assertEquals(2, counting.listings.get(),
+                "two outputs were read as one, so a rule about either was answered with both");
+    }
+
+    @Test
+    void reaches_one_class_without_listing_the_output_it_is_in() {
+        Optional<ClassModel> found = at(PUBLISHED).find(RepositoryLayout.class.getName());
+
+        assertTrue(found.isPresent());
+        assertEquals(1, counting.reads.get());
+        assertEquals(0, counting.listings.get(),
+                "asking for one class walked the output, so a check reading a dozen classes pays"
+                        + " for every class the module compiled");
+    }
+
+    @Test
+    void keeps_that_a_class_was_never_built_the_way_it_keeps_one_that_was() {
+        String never = RepositoryLayout.class.getName() + "ThatWasNeverWritten";
+
+        assertTrue(at(PUBLISHED).find(never).isEmpty());
+        assertEquals(1, counting.reads.get());
+
+        assertTrue(at(PUBLISHED).find(never).isEmpty());
+        assertEquals(1, counting.reads.get(), "the same absence was looked for twice");
+    }
+
+    /**
+     * An output holding one package inside another and a third beside it.
+     *
+     * <p>Written here because the module this test is in compiles to a single package, and a
+     * package that is the whole of an output cannot tell a reading that narrows from one that reads
+     * everything and hands back the part that was asked for. What the files hold does not matter to
+     * a question about which of them were opened, so they are copies of one that was built.
+     */
+    private static Path anOutputOfSeveralPackages(Path root) throws IOException {
+        Path one = CompiledClasses.ofModule(RepositoryLayout.class).root()
+                .resolve("souther/test/RepositoryLayout.class");
+        for (String each : List.of("asked/Named.class", "asked/deeper/Nested.class",
+                "beside/Other.class")) {
+            Path at = root.resolve(each);
+            Files.createDirectories(at.getParent());
+            Files.copy(one, at);
+        }
+        return root;
+    }
+
+    @Test
+    void is_one_output_however_the_path_that_reaches_it_is_spelled(@TempDir Path root)
+            throws IOException {
+        Path built = anOutputOfSeveralPackages(root.resolve("built"));
+        Path reached = Files.createSymbolicLink(root.resolve("reached"), built);
+
+        assertEquals(at(built).root(), at(reached).root());
+
+        at(built).all();
+        at(reached).all();
+
+        assertEquals(1, counting.listings.get(),
+                "one output was read as two because two paths reach it, so what a fork pays"
+                        + " depends on how a caller spelled its way there");
+    }
+
+    @Test
+    void reads_a_package_without_reading_the_output_round_it(@TempDir Path root) throws IOException {
+        List<ClassModel> narrower = at(anOutputOfSeveralPackages(root)).inPackage("asked");
+
+        assertEquals(2, narrower.size());
+        assertEquals(2, counting.reads.get(), "reading a package opened files outside it");
+    }
+
+    @Test
+    void reads_a_package_together_with_the_packages_under_it(@TempDir Path root) throws IOException {
+        CompiledClasses output = at(anOutputOfSeveralPackages(root));
+
+        assertEquals(3, output.all().size());
+        assertEquals(2, output.inPackage("asked").size(),
+                "a package was read without the packages under it, so a rule about what it holds"
+                        + " was answered about part of it");
+    }
+}


### PR DESCRIPTION
A check about what compiled code does walks an output, parses each class file and decodes the
methods that have bodies. Several checks here are written that way and each does that walk for
itself, and a check that declares more than one question mostly walks again per question. What they
read is the same for all of them and cannot change while the run is happening: the classes were
written by the compile the run is testing, before any test started. Read per question rather than
per fork, it is the same reading over and over, paid in the run somebody waits on while editing.

## What closes it

Where a class file is touched is one place, and both ways of touching one are there. A reading that
asked it for the bytes and looked for the file itself would leave half of what it does outside, and
a rule saying where compiled output is reached could then be met while the file system was being
asked somewhere else.

What a fork keeps is the reading rather than an answer. One check counts invocations of a method,
another asks which methods take a value of some type, another reads field declarations; kept as
answers, every check would have to be written against a vocabulary decided in one place, and the
parsed class is what they have in common. Keeping it is not a cache over something that moves —
there is nothing here that could go out of date, and nothing here asks whether it has.

Asking is in three ways because the questions cost different things. A rule about a whole module
walks it. A rule about one class reaches that file and no other, so a reader following a name from
one output to the next does not pay for every class a module compiled — which is what the checks
that never walk anything are doing today, and they go on not paying for it. A rule about a package
settles which files are in it before any of them is parsed, and the narrowest of those reads a
handful of classes out of thousands. A package is read together with the packages under it, since a
rule about what a package holds that stopped at its own directory would answer about part of its
subject while reading as though it had covered the whole.

An output is settled with its real path before it names anything, so a module found through the
class path and the same module found by walking the repository are one output and not two. What
arrives as a jar is not an output root: there is nothing to walk and nothing to settle.

Which output is asked, and what to do with two of them, stay with the caller. A rule about what this
repository publishes and a rule about what a test compiled beside it are about two populations, and
a reader searching several outputs in some order would be deciding for its callers which population
they meant. The architecture tests' `CompiledClasses` is what does that deciding, and is now
`CompiledOutputs` — the outputs a name is looked for in, and the order they are looked in.

## How it is held

What a reading costs is asked of a reading that says what it touched, rather than of the clock: a
timing would answer about the machine, and would go on passing while every question read the module
again. Asking twice reads once, two questions of one output read it once, one output named by two
classes of its module is one reading, two outputs are two, an absence is kept the way a presence is,
a name is reached without walking, and a package is read without the output round it — each of those
goes red when the reading it is about is taken out.

That a fork has one reading to share is a second question, and a counted reading cannot answer it: a
second store made anywhere would be filled from the same files, and every count either of them kept
would go on saying that it read once. It is also two things rather than one. Nothing else may make a
store, which is read off the class files, where a constructor named as a reference is a method
handle in the bootstrap arguments of an `invokedynamic` and puts no `new` in the caller's code at
all — the spelling a second maker would most easily be written in, and the one a search of the text
is passed by. And what hands a store out must hand out the one that was made, which the first says
nothing about: a store made in a single place and handed out afresh at every ask is made once and
shared never. Beside them, that the boundary is answered by one implementation, through however many
types in between — which is narrower than where a class file is opened, and does not stand in for
it.

Nothing is an answer only where the output was read and holds none. A read that stopped for any
other reason is a failure and says so, since a check told that a module built no such class will act
on it; an output holding no classes and a package holding none are refused rather than handed over
as populations, because a population of none passes a rule about every class of it by having none to
read; and a name that reaches a jar is not an output root.

`WhatAModuleDeclares` asks this for its classes now. The checks that walk compiled output for
themselves move onto it in changes of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
