### PR TITLE
Address what a reading made of a part by where in the clause the part is

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
-import souther.compiler.core.Core;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,10 +84,10 @@ public sealed interface AuthoredShape {
      * Each part of the clause with the subtree of the expanded {@code read} it became, as a part of
      * {@code rule}.
      *
-     * <p>The same recovery {@link #onto(Core, RuleRef.Invariant)} does of a reading, done of the
-     * tree an expansion left. What a helper's body joined stands under a binding there, so a reader
-     * splitting that tree for itself would find parts this shape never issued — which is why the
-     * shape drives the descent here as well.
+     * <p>The same recovery {@link #onto(ClauseExpr, RuleRef.Invariant)} does of a reading, done of
+     * the tree an expansion left. What a helper's body joined stands under a binding there, so a
+     * reader splitting that tree for itself would find parts this shape never issued — which is
+     * why the shape drives the descent here as well.
      */
     default List<Written> onto(Hir.Expr read, RuleRef.Invariant rule) {
         List<Written> out = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
@@ -58,7 +58,7 @@ public sealed interface AuthoredShape {
      * ruled out there), and what an author is answerable for is the parts; both come out of the one
      * reading, which is why this recovers them from it rather than reading them apart.
      */
-    default List<Clauses.StatedPart> onto(Core read, RuleRef.Invariant rule) {
+    default List<Clauses.StatedPart> onto(ClauseExpr read, RuleRef.Invariant rule) {
         List<Clauses.StatedPart> out = new ArrayList<>();
         found(read, rule, out);
         return List.copyOf(out);
@@ -111,7 +111,7 @@ public sealed interface AuthoredShape {
         }
     }
 
-    private void found(Core read, RuleRef.Invariant rule, List<Clauses.StatedPart> out) {
+    private void found(ClauseExpr read, RuleRef.Invariant rule, List<Clauses.StatedPart> out) {
         switch (this) {
             case One it -> out.add(new Clauses.StatedPart(it.part().idFor(rule), read));
             case Both it -> {
@@ -119,13 +119,13 @@ public sealed interface AuthoredShape {
                 // of the tree instead — whether this node joins two conditions — this would be a
                 // second reading of what a clause is made of, and the reading it agreed with until
                 // somebody changed one of them.
-                if (!(read instanceof Core.Binary bin)) {
+                if (!(read instanceof ClauseExpr.Joined joined)) {
                     throw new IllegalStateException("an author wrote two rules where this reading"
                             + " has one " + read.getClass().getSimpleName() + ", so the clause was"
                             + " read into a shape it was not written in");
                 }
-                it.left().found(bin.left(), rule, out);
-                it.right().found(bin.right(), rule, out);
+                it.left().found(joined.left(), rule, out);
+                it.right().found(joined.right(), rule, out);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -82,6 +82,12 @@ sealed interface ClauseExpr {
      */
     record Occurrence(int ordinal) {
 
+        /** The clause itself, which takes the first number before anything under it does — see
+         *  {@link ClauseExpr#under}. */
+        static Occurrence ofTheClause() {
+            return new Occurrence(0);
+        }
+
         public Occurrence {
             if (ordinal < 0) {
                 throw new IllegalArgumentException(

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -111,7 +111,8 @@ interface ClauseReading<S, E> {
      * shapes it reads, so there is nothing under one of them for a view to leave out.
      */
     default S read(ClauseExpr shape, E at, ClauseScope<E> scope, PerPart<S> per) {
-        return from(shape.written(), over(shape, at, scope, per, ClauseView.asWritten()));
+        return from(shape, shape.written(),
+                over(shape, at, scope, per, ClauseView.asWritten()));
     }
 
     /**
@@ -140,7 +141,8 @@ interface ClauseReading<S, E> {
         // to is not told to {@code per} a second time: the walk below has already said it of the
         // very same node, and a reader counting what it was told would count the whole clause
         // twice and every part of it once.
-        return from(e, over(ClauseExpr.of(e, positive), at, scope, per, view));
+        ClauseExpr shape = ClauseExpr.of(e, positive);
+        return from(shape, e, over(shape, at, scope, per, view));
     }
 
     /**
@@ -188,7 +190,7 @@ interface ClauseReading<S, E> {
         // two are one shape, and the binding as well as the clause under it, since a binding states
         // what the clause under it states.
         for (Core each : shape.spelled()) {
-            out = from(each, out);
+            out = from(shape, each, out);
             if (per != null) {
                 per.read(shape, each, out);
             }
@@ -197,15 +199,21 @@ interface ClauseReading<S, E> {
     }
 
     /**
-     * The same reading, remembering that it is what {@code e} came to.
+     * The same reading, remembering that it is what {@code e} came to, which {@code shape} says
+     * which occurrence of the clause it is.
      *
      * <p>For a reading that has to answer about the parts of a clause afterwards. Kept in what the
      * reading carries rather than handed to somebody who keeps it: a part of a branch that turns
      * out dead is answered differently from the same part in a branch that stands, and everything
      * that decides which of those it was happens above here. Kept outside, the part would be read
      * again against a tree the decision had not reached.
+     *
+     * <p>The occurrence beside the node, so that a reading filing what it made of a part files it
+     * under where in the clause the part is. A clause is read once per place the walk opens a
+     * value at, over whatever tree a substitution built for that reading, and the node is that
+     * tree's; the occurrence is the clause's and is the same in every reading of it.
      */
-    default S from(Core e, S out) {
+    default S from(ClauseExpr shape, Core e, S out) {
         return out;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -100,6 +100,21 @@ interface ClauseReading<S, E> {
     }
 
     /**
+     * The same over a shape a caller already read the clause into.
+     *
+     * <p>For a reader whose part of a clause is a subtree of a shape somebody else read out of the
+     * tree. Read again from the part, the occurrences under it would be numbered afresh from the
+     * part rather than from the clause, and what two readers said about one of them would be said
+     * in two numberings.
+     *
+     * <p>The shape as written: which parts a world holds was settled where the caller chose the
+     * shapes it reads, so there is nothing under one of them for a view to leave out.
+     */
+    default S read(ClauseExpr shape, E at, ClauseScope<E> scope, PerPart<S> per) {
+        return from(shape.written(), over(shape, at, scope, per, ClauseView.asWritten()));
+    }
+
+    /**
      * The same, telling {@code per} what each part of the clause came to as it is read.
      *
      * <p>Told as the reading makes it, so that whoever keeps the reading keeps what it made of

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -195,7 +195,8 @@ final class Clauses {
                 // very reading. Read apart instead, a conjunct would be read without the conjunct
                 // beside it, and a branch one of them rules out would stand.
                 stated.add(new Stated(clause, one,
-                        inv.shape().onto(one, new RuleRef.Invariant(clause))));
+                        inv.shape().onto(ClauseExpr.of(one, true),
+                                new RuleRef.Invariant(clause))));
             } else {
                 lost.add(new RuleRef.Invariant(clause));
             }
@@ -264,12 +265,17 @@ final class Clauses {
      * worked out here: which part of a clause a tree is is not something a reader of the tree can
      * answer, and a reader that counted them would be a second walk deciding which parts there are.
      */
-    record StatedPart(PartId<RuleRef.Invariant> id, Core expr) {
+    record StatedPart(PartId<RuleRef.Invariant> id, ClauseExpr of) {
 
         public StatedPart {
-            if (id == null || expr == null) {
+            if (id == null || of == null) {
                 throw new IllegalArgumentException("a part read here is some rule's part and a form");
             }
+        }
+
+        /** The part as the tree holds it, which is the outermost node its shape was spelled as. */
+        Core expr() {
+            return of.written();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -842,8 +842,11 @@ public final class InvariantChecker {
             }
             // The clause as one reading, and the parts its author wrote as subtrees of it. Which
             // parts there are was settled where the clause was split; nothing here decides it.
-            ClauseView view =
-                    reach.withoutParts().viewOf(declared.shape().onto(stated, origin));
+            // The shape of the whole clause, read out of the tree once. The parts are subtrees of
+            // it, so what a reader says about an occurrence of one is said in the numbering the
+            // clause hands out rather than in a numbering that starts wherever a part does.
+            ClauseView view = reach.withoutParts()
+                    .viewOf(declared.shape().onto(ClauseExpr.of(stated, true), origin));
             // A part at a time, and the ones this world holds. Which parts a clause has was settled
             // where it was split, so a part left out is one left out of the list — never a node a
             // walk was told to step over.
@@ -856,7 +859,7 @@ public final class InvariantChecker {
                     new LinkedHashMap<>();
             Predicates.Owed owed = null;
             for (Clauses.StatedPart part : view.present()) {
-                Predicates.Owed said = c.predicates.assumed(part.expr(), at, false,
+                Predicates.Owed said = c.predicates.assumed(part.of(), at, false,
                         (of, _, came) -> constrained
                                 .computeIfAbsent(part.id(), _ -> new LinkedHashMap<>())
                                 .put(of.at(), new PartAsRead(of, partRead(came))));
@@ -1744,11 +1747,11 @@ public final class InvariantChecker {
         // not gathered ({@link APartNoReadingSaw}). One list and not one rule each of them
         // consults, so the agreement is not something a walk has to be written to keep.
         stated.forEach(each -> each.parts().forEach(part ->
-                // The shape of the whole part, read out of the tree once and walked from there.
-                // Read again at each step, the occurrences under one part would be numbered afresh
-                // from wherever this reader happened to stop, and an answer filed by the reading
-                // that seeded it would be asked for under a number this walk made up.
-                direct(ClauseExpr.of(part.expr(), true), each, part.id(), at, byName, out, noLines,
+                // The part as the clause was read into, walked from there. Read out of the tree
+                // again, the occurrences under one part would be numbered afresh from wherever the
+                // part begins, and an answer filed by the reading that seeded it would be asked
+                // for under a number this walk made up.
+                direct(part.of(), each, part.id(), at, byName, out, noLines,
                         withoutAnEnd, aboutOneCoordinate, narrowers,
                         raised, took, typeAt, parts, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1367,7 +1367,7 @@ public final class InvariantChecker {
     record Written(Core clause, ClauseView view,
                    Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>>
                            constrained,
-                   Map<Core, ReadByClauses.OfAPart> adopted) {
+                   Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> adopted) {
 
         Written {
             constrained = Map.copyOf(constrained);
@@ -1392,16 +1392,17 @@ public final class InvariantChecker {
          * of them — so an account of all of them together is told apart by nothing but which
          * objects those substitutions happened to allocate.
          */
-        Written alsoAdopting(List<Map.Entry<Core, ReadByClauses.OfAPart>> account) {
-            Map<Core, ReadByClauses.OfAPart> out = new IdentityHashMap<>();
+        Written alsoAdopting(
+                List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> account) {
+            Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> out = new LinkedHashMap<>();
             account.forEach(each -> out.put(each.getKey(), each.getValue()));
             return new Written(clause, view, constrained, Collections.unmodifiableMap(out));
         }
 
-        /** What this reading made of {@code part} of the clause, or null where it read no such
-         *  part — which is not the same as having read it and made nothing of it. */
-        ReadByClauses.OfAPart adoptedAt(Core part) {
-            return adopted.get(part);
+        /** What this reading made of the part at {@code at}, or null where it read no such part —
+         *  which is not the same as having read it and made nothing of it. */
+        ReadByClauses.OfAPart adoptedAt(ClauseExpr.Occurrence at) {
+            return adopted.get(at);
         }
 
         /**
@@ -1826,7 +1827,7 @@ public final class InvariantChecker {
         if (about.isEmpty()) {
             return;
         }
-        ReadByClauses.OfAPart adopted = of.adoptedAt(part);
+        ReadByClauses.OfAPart adopted = of.adoptedAt(at);
         Set<FactSubject> here = adopted == null ? null : adopted.adopted();
         // What this very reading made of this very part, as it said so when it read it. Asked
         // again here, the part was read a second time, and two readings of one conjunct agree only
@@ -1928,8 +1929,8 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(clause, from, of, part, byName, parts, out);
-        restricting(clause, from, of, part, byName, parts, noLines, runs);
+        RunsRead runs = runsOf(clause, saidAs.at(), from, of, part, byName, parts, out);
+        restricting(clause, saidAs.at(), from, of, part, byName, parts, noLines, runs);
         aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
@@ -2675,11 +2676,11 @@ public final class InvariantChecker {
      * beside a rule that says nothing lends the second its narrowing — and the reason goes out
      * against the one rule that holds the position to nothing.
      */
-    private void restricting(Core clause, RuleRef.Invariant from, Written of,
-                             PartId<RuleRef.Invariant> part,
+    private void restricting(Core clause, ClauseExpr.Occurrence at, RuleRef.Invariant from,
+                             Written of, PartId<RuleRef.Invariant> part,
                              Map<FactSubject, Coordinate> byName, PartsRead parts,
                              List<FieldDomains.NoLine> noLines, RunsRead runs) {
-        ReadByClauses.OfAPart account = of.adoptedAt(clause);
+        ReadByClauses.OfAPart account = of.adoptedAt(at);
         ReadByClauses.OfARule rule = parts.ruleIn(from);
         if (account == null || rule == null) {
             return;
@@ -2775,10 +2776,10 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private RunsRead runsOf(Core clause, RuleRef.Invariant from, Written of,
-                        PartId<RuleRef.Invariant> part,
+    private RunsRead runsOf(Core clause, ClauseExpr.Occurrence at, RuleRef.Invariant from,
+                        Written of, PartId<RuleRef.Invariant> part,
                         Map<FactSubject, Coordinate> byName, PartsRead parts, List<Direct> out) {
-        ReadByClauses.OfAPart account = of.adoptedAt(clause);
+        ReadByClauses.OfAPart account = of.adoptedAt(at);
         if (account == null) {
             return RunsRead.NOTHING;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -785,7 +785,8 @@ public final class InvariantChecker {
                                  Map<PartId<RuleRef.Invariant>,
                                          Map<ClauseExpr.Occurrence, PartAsRead>> constrained,
                                  Set<FactSubject> spokenFor) {
-                written.add(Written.of(clause, parts, reach.withoutParts(), constrained));
+                written.add(Written.of(new ReadingId(written.size()), clause, parts,
+                        reach.withoutParts(), constrained));
                 spokenFor.forEach(spoken -> took.record(from, spoken));
             }
 
@@ -865,7 +866,8 @@ public final class InvariantChecker {
                                 .put(of.at(), new PartAsRead(of, partRead(came))));
                 owed = owed == null ? said : owed.and(said);
             }
-            written.add(new Written(stated, view, constrained, Map.of()));
+            written.add(new Written(new ReadingId(written.size()), stated, view, constrained,
+                    Map.of()));
             if (owed == null) {
                 owed = Predicates.Owed.unread();
             }
@@ -1039,7 +1041,7 @@ public final class InvariantChecker {
         // And which of the clauses place an edge, asked once the positions have names to be
         // recognised by.
         Reading reading = c.directsIn(accounted, at, numbers, typeAt, took,
-                new PartsRead(narrowedBy));
+                new RulesRead(narrowedBy));
         ConstraintState<FactSubject> constraints = k.constraints()
                 .takingRead(answered.whole().confinement(), allowed, c.answers);
         // How each atom's values are spaced, kept so that settling one afterwards states the
@@ -1356,6 +1358,33 @@ public final class InvariantChecker {
     }
 
     /**
+     * Which of the readings this walk opened one is.
+     *
+     * <p>Issued by the walk that opens them, counted from nought, and meaning nothing away from it
+     * — a reading of one declaration and a reading of another are both the first thing their walk
+     * did. What pairs it with the declaration is the walk holding both.
+     *
+     * <p>Here so that two readings are two because the walk opened two, and not because the trees
+     * a substitution built for them happen to differ. A clause is read once per place the walk
+     * opens a value at, and what each of those made of a part is the reading's own; told apart by
+     * the representation instead, two readings that arrived at the same tree would be one, and
+     * which of them that was would be a fact about the substitution.
+     */
+    record ReadingId(int ordinal) {
+
+        ReadingId {
+            if (ordinal < 0) {
+                throw new IllegalArgumentException("a reading is counted from zero: " + ordinal);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "reading #" + ordinal;
+        }
+    }
+
+    /**
      * One clause reaching a value, rebased onto the positions of that value, which clause it is,
      * and the parts its author wrote it in.
      *
@@ -1363,8 +1392,11 @@ public final class InvariantChecker {
      * inside one reading, and a branch one of them rules out is ruled out there. The parts are what
      * a line drawn on a position is attributed to, and each of them is a subtree of that same
      * reading — carrying which part of the clause it is, settled where the clause was split.
+     *
+     * <p>And which reading of them this is ({@link ReadingId}), because what it made of each part
+     * is its own and a rule is read once per place the walk opens a value at.
      */
-    record Written(Core clause, ClauseView view,
+    record Written(ReadingId opened, Core clause, ClauseView view,
                    Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>>
                            constrained,
                    Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> adopted) {
@@ -1375,13 +1407,14 @@ public final class InvariantChecker {
 
         /** The clause {@code authored} was written in, as {@code world} holds it, with what the
          *  reading that built it made of each occurrence of each part it holds. */
-        static Written of(Core clause, List<Clauses.StatedPart> authored, PartsLeftOut world,
+        static Written of(ReadingId opened, Core clause, List<Clauses.StatedPart> authored,
+                          PartsLeftOut world,
                           Map<PartId<RuleRef.Invariant>,
                                   Map<ClauseExpr.Occurrence, PartAsRead>> constrained) {
             if (authored.isEmpty()) {
                 throw new IllegalArgumentException("a clause reaching a value is written in parts");
             }
-            return new Written(clause, world.viewOf(authored), constrained, Map.of());
+            return new Written(opened, clause, world.viewOf(authored), constrained, Map.of());
         }
 
         /**
@@ -1396,7 +1429,8 @@ public final class InvariantChecker {
                 List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> account) {
             Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> out = new LinkedHashMap<>();
             account.forEach(each -> out.put(each.getKey(), each.getValue()));
-            return new Written(clause, view, constrained, Collections.unmodifiableMap(out));
+            return new Written(opened, clause, view, constrained,
+                    Collections.unmodifiableMap(out));
         }
 
         /** What this reading made of the part at {@code at}, or null where it read no such part —
@@ -1557,19 +1591,19 @@ public final class InvariantChecker {
     }
 
     /**
-     * What each reading made of each part of each rule, as each of them said so while reading it.
+     * What each rule's own tree came to, once every branch of the value is decided.
      *
-     * <p>Per part, because a conjunction is one rule read a conjunct at a time and evidence gathered
-     * for the whole answers a clause half of which nothing read on the strength of the half that
-     * was. Keyed by the part as the tree holds it, so the walk that reads the clause afterwards
-     * finds this reading's own answer about the very node it holds rather than reading it again.
+     * <p>What a part of a rule came to is not here. That is the reading's own and is held by the
+     * reading that made it ({@link Written#adoptedAt}), because a rule is read once per place the
+     * walk opens a value at and an answer about a part means nothing without saying which of those
+     * readings said it.
      *
      * @param byRule  what each rule's own tree came to, which is the only thing that answers what
      *                that rule did to a position. The declaration's answer is met from every rule
      *                reaching the position, so a reader taking it for one rule's would lend a rule
      *                that narrows nothing whatever its neighbours narrowed
      */
-    record PartsRead(Map<RuleRef.Invariant, ReadByClauses.OfARule> byRule) {
+    record RulesRead(Map<RuleRef.Invariant, ReadByClauses.OfARule> byRule) {
 
         /** What {@code rule}'s own tree left, or null where no reading answered over it. */
         ReadByClauses.OfARule ruleIn(RuleRef rule) {
@@ -1741,7 +1775,7 @@ public final class InvariantChecker {
     private Reading directsIn(List<Written> stated, Denotations at,
                                    Map<FactSubject, Coordinate> byName,
                                    Map<RuleKey, Type> typeAt,
-                                   ReadingEvidence took, PartsRead parts) {
+                                   ReadingEvidence took, RulesRead rules) {
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
         List<FieldDomains.WithoutAnEnd> withoutAnEnd = new ArrayList<>();
@@ -1762,7 +1796,7 @@ public final class InvariantChecker {
                 // for under a number this walk made up.
                 direct(part.of(), each, part.id(), at, byName, out, noLines,
                         withoutAnEnd, aboutOneCoordinate, narrowers,
-                        raised, took, typeAt, parts, raisedByPart, standing)));
+                        raised, took, typeAt, rules, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines), List.copyOf(withoutAnEnd),
@@ -1793,7 +1827,6 @@ public final class InvariantChecker {
                         ClauseStates states, InvariantBound.Read placed,
                         Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
-                        PartsRead parts,
                         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart) {
         raises(raised, rule, states);
         // And what this part of it raises, kept apart from what the rule raises. A reader that found
@@ -1881,7 +1914,7 @@ public final class InvariantChecker {
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
-                        PartsRead parts,
+                        RulesRead rules,
                         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing) {
@@ -1894,7 +1927,7 @@ public final class InvariantChecker {
         if (saidAs instanceof ClauseExpr.Scoped scoped
                 && scoped.spelled().get(0) == scoped.binding()) {
             direct(scoped.body(), of, part, terms.inside(scoped.binding(), at), byName, out,
-                    noLines, withoutAnEnd, naming, narrowers, raised, took, typeAt, parts,
+                    noLines, withoutAnEnd, naming, narrowers, raised, took, typeAt, rules,
                     raisedByPart, standing);
             return;
         }
@@ -1914,9 +1947,9 @@ public final class InvariantChecker {
         if (saidAs instanceof ClauseExpr.Joined joined
                 && joined.how() == ConditionJoin.BOTH && joined.positive()) {
             direct(joined.left(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, parts, raisedByPart, standing);
+                    narrowers, raised, took, typeAt, rules, raisedByPart, standing);
             direct(joined.right(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, parts, raisedByPart, standing);
+                    narrowers, raised, took, typeAt, rules, raisedByPart, standing);
             return;
         }
         // The node the author wrote this as, which is the outermost of what the shape is spelled
@@ -1929,15 +1962,15 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(clause, saidAs.at(), from, of, part, byName, parts, out);
-        restricting(clause, saidAs.at(), from, of, part, byName, parts, noLines, runs);
+        RunsRead runs = runsOf(clause, saidAs.at(), of, part, byName, out);
+        restricting(clause, saidAs.at(), from, of, part, byName, rules, noLines, runs);
         aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
             // the classification to be handed.
             settle(clause, from, of, part, saidAs.at(), states(clause, at, byName, null, runs),
                     new InvariantBound.Read.NoEnd(),
-                    byName, raised, took, parts, raisedByPart);
+                    byName, raised, took, raisedByPart);
             return;
         }
         // Where this clause is recognised as a comparison, and the one place it is. What each
@@ -1960,7 +1993,7 @@ public final class InvariantChecker {
         if (asWritten == null) {
             settle(bin, from, of, part, saidAs.at(), states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
-                    byName, raised, took, parts, raisedByPart);
+                    byName, raised, took, raisedByPart);
             return;
         }
         // Which number this conjunct is about, written down before anything is asked about what it
@@ -1986,7 +2019,7 @@ public final class InvariantChecker {
         if (asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
             settle(bin, from, of, part, saidAs.at(), states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
-                    byName, raised, took, parts, raisedByPart);
+                    byName, raised, took, raisedByPart);
             // And handed on, which is not the same as being reported. A rule that rules one value
             // out places no end and is no failure of this reading, so there is nothing here for an
             // author to lift and there is a conjunct for the reading that draws lines to make what
@@ -2049,7 +2082,7 @@ public final class InvariantChecker {
                                             List.of(part))
                                     : had.and(part)));
         }
-        settle(bin, from, of, part, saidAs.at(), shape, end, byName, raised, took, parts,
+        settle(bin, from, of, part, saidAs.at(), shape, end, byName, raised, took,
                 raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
             // A rule saying where the values stop that no end came out of, said as that. Here,
@@ -2678,10 +2711,10 @@ public final class InvariantChecker {
      */
     private void restricting(Core clause, ClauseExpr.Occurrence at, RuleRef.Invariant from,
                              Written of, PartId<RuleRef.Invariant> part,
-                             Map<FactSubject, Coordinate> byName, PartsRead parts,
+                             Map<FactSubject, Coordinate> byName, RulesRead rules,
                              List<FieldDomains.NoLine> noLines, RunsRead runs) {
         ReadByClauses.OfAPart account = of.adoptedAt(at);
-        ReadByClauses.OfARule rule = parts.ruleIn(from);
+        ReadByClauses.OfARule rule = rules.ruleIn(from);
         if (account == null || rule == null) {
             return;
         }
@@ -2776,9 +2809,9 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private RunsRead runsOf(Core clause, ClauseExpr.Occurrence at, RuleRef.Invariant from,
+    private RunsRead runsOf(Core clause, ClauseExpr.Occurrence at,
                         Written of, PartId<RuleRef.Invariant> part,
-                        Map<FactSubject, Coordinate> byName, PartsRead parts, List<Direct> out) {
+                        Map<FactSubject, Coordinate> byName, List<Direct> out) {
         ReadByClauses.OfAPart account = of.adoptedAt(at);
         if (account == null) {
             return RunsRead.NOTHING;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -865,7 +865,7 @@ public final class InvariantChecker {
                                 .put(of.at(), new PartAsRead(of, partRead(came))));
                 owed = owed == null ? said : owed.and(said);
             }
-            written.add(new Written(stated, view, constrained));
+            written.add(new Written(stated, view, constrained, Map.of()));
             if (owed == null) {
                 owed = Predicates.Owed.unread();
             }
@@ -931,7 +931,6 @@ public final class InvariantChecker {
         // the two went unanswered would turn on the order they were written in.
         Allowance<FactSubject> allowed =
                 policy.allowanceForAdmittedValues(c.answers.lending());
-        Map<RuleRef.Invariant, Map<Core, ReadByClauses.OfAPart>> adoptedBy = new LinkedHashMap<>();
         Map<RuleRef.Invariant, ReadByClauses.OfARule> narrowedBy = new LinkedHashMap<>();
         // The numbers this value's clauses can be about, read before any of them is. Both the fold
         // below and the walk that classifies a comparison are given this one table.
@@ -1002,11 +1001,15 @@ public final class InvariantChecker {
                     boundsLeftOpen.computeIfAbsent(each.from(), _ -> new LinkedHashMap<>())
                             .merge(number, behind, EndsLeftOpen.Behind::and));
         });
-        answered.perPart().forEach((each, parts) -> {
-            Map<Core, ReadByClauses.OfAPart> out = adoptedBy
-                    .computeIfAbsent(each.from(), _ -> new java.util.IdentityHashMap<>());
-            parts.forEach(part -> out.put(part.getKey(), part.getValue()));
-        });
+        // And each reading with the account of its own parts, which is what the walk below reads
+        // them off. One rule is read once per place the walk opens a value at, and each of those
+        // readings walks the tree a substitution built for it — so an account of every reading
+        // together is one whose entries are told apart by which objects those substitutions
+        // allocated, and a reader walking one reading finds another reading's answer as readily.
+        List<Written> accounted = new ArrayList<>(written.size());
+        for (Written each : written) {
+            accounted.add(each.alsoAdopting(answered.perPart().getOrDefault(each, List.of())));
+        }
         // And the same after it. Reading the account is reading an answer: the whole was worked
         // out once above, and what each clause and each part of it took in is looked up in
         // that. Worked out again per clause instead, asking what a rule adopted bought machines
@@ -1035,8 +1038,8 @@ public final class InvariantChecker {
                         + " alternatives past a counted " + expansion;
         // And which of the clauses place an edge, asked once the positions have names to be
         // recognised by.
-        Reading reading = c.directsIn(written, at, numbers, typeAt, took,
-                new PartsRead(adoptedBy, narrowedBy));
+        Reading reading = c.directsIn(accounted, at, numbers, typeAt, took,
+                new PartsRead(narrowedBy));
         ConstraintState<FactSubject> constraints = k.constraints()
                 .takingRead(answered.whole().confinement(), allowed, c.answers);
         // How each atom's values are spaced, kept so that settling one afterwards states the
@@ -1363,7 +1366,8 @@ public final class InvariantChecker {
      */
     record Written(Core clause, ClauseView view,
                    Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>>
-                           constrained) {
+                           constrained,
+                   Map<Core, ReadByClauses.OfAPart> adopted) {
 
         Written {
             constrained = Map.copyOf(constrained);
@@ -1377,7 +1381,27 @@ public final class InvariantChecker {
             if (authored.isEmpty()) {
                 throw new IllegalArgumentException("a clause reaching a value is written in parts");
             }
-            return new Written(clause, world.viewOf(authored), constrained);
+            return new Written(clause, world.viewOf(authored), constrained, Map.of());
+        }
+
+        /**
+         * The same reading, with the account it came to once every branch of the value was decided.
+         *
+         * <p>Held by the reading it is an account of. A clause is read once per place the walk
+         * opens a value at, and the readings of one rule walk trees a substitution built for each
+         * of them — so an account of all of them together is told apart by nothing but which
+         * objects those substitutions happened to allocate.
+         */
+        Written alsoAdopting(List<Map.Entry<Core, ReadByClauses.OfAPart>> account) {
+            Map<Core, ReadByClauses.OfAPart> out = new IdentityHashMap<>();
+            account.forEach(each -> out.put(each.getKey(), each.getValue()));
+            return new Written(clause, view, constrained, Collections.unmodifiableMap(out));
+        }
+
+        /** What this reading made of {@code part} of the clause, or null where it read no such
+         *  part — which is not the same as having read it and made nothing of it. */
+        ReadByClauses.OfAPart adoptedAt(Core part) {
+            return adopted.get(part);
         }
 
         /**
@@ -1539,28 +1563,12 @@ public final class InvariantChecker {
      * was. Keyed by the part as the tree holds it, so the walk that reads the clause afterwards
      * finds this reading's own answer about the very node it holds rather than reading it again.
      *
-     * @param account what each reading made of each part, as each of them wrote it down. The
-     *                account itself and not one projection of it: what a part adopted and what it
-     *                put a constraint on are two questions, and a walk handed the first alone
-     *                answers the second by reading a set that holds more than it
      * @param byRule  what each rule's own tree came to, which is the only thing that answers what
      *                that rule did to a position. The declaration's answer is met from every rule
      *                reaching the position, so a reader taking it for one rule's would lend a rule
      *                that narrows nothing whatever its neighbours narrowed
      */
-    record PartsRead(Map<RuleRef.Invariant, Map<Core, ReadByClauses.OfAPart>> account,
-                     Map<RuleRef.Invariant, ReadByClauses.OfARule> byRule) {
-
-        /** What every reading made of {@code part} of {@code rule}, or null where none read it. */
-        ReadByClauses.OfAPart accountIn(RuleRef rule, Core part) {
-            Map<Core, ReadByClauses.OfAPart> said = account.get(rule);
-            return said == null ? null : said.get(part);
-        }
-
-        Set<FactSubject> adoptedIn(RuleRef rule, Core part) {
-            ReadByClauses.OfAPart said = accountIn(rule, part);
-            return said == null ? null : said.adopted();
-        }
+    record PartsRead(Map<RuleRef.Invariant, ReadByClauses.OfARule> byRule) {
 
         /** What {@code rule}'s own tree left, or null where no reading answered over it. */
         ReadByClauses.OfARule ruleIn(RuleRef rule) {
@@ -1818,7 +1826,8 @@ public final class InvariantChecker {
         if (about.isEmpty()) {
             return;
         }
-        Set<FactSubject> here = parts.adoptedIn(rule, part);
+        ReadByClauses.OfAPart adopted = of.adoptedAt(part);
+        Set<FactSubject> here = adopted == null ? null : adopted.adopted();
         // What this very reading made of this very part, as it said so when it read it. Asked
         // again here, the part was read a second time, and two readings of one conjunct agree only
         // for as long as nobody changes one of them.
@@ -1919,8 +1928,8 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(clause, from, part, byName, parts, out);
-        restricting(clause, from, part, byName, parts, noLines, runs);
+        RunsRead runs = runsOf(clause, from, of, part, byName, parts, out);
+        restricting(clause, from, of, part, byName, parts, noLines, runs);
         aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
@@ -2666,10 +2675,11 @@ public final class InvariantChecker {
      * beside a rule that says nothing lends the second its narrowing — and the reason goes out
      * against the one rule that holds the position to nothing.
      */
-    private void restricting(Core clause, RuleRef.Invariant from, PartId<RuleRef.Invariant> part,
+    private void restricting(Core clause, RuleRef.Invariant from, Written of,
+                             PartId<RuleRef.Invariant> part,
                              Map<FactSubject, Coordinate> byName, PartsRead parts,
                              List<FieldDomains.NoLine> noLines, RunsRead runs) {
-        ReadByClauses.OfAPart account = parts.accountIn(from, clause);
+        ReadByClauses.OfAPart account = of.adoptedAt(clause);
         ReadByClauses.OfARule rule = parts.ruleIn(from);
         if (account == null || rule == null) {
             return;
@@ -2765,9 +2775,10 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private RunsRead runsOf(Core clause, RuleRef.Invariant from, PartId<RuleRef.Invariant> part,
+    private RunsRead runsOf(Core clause, RuleRef.Invariant from, Written of,
+                        PartId<RuleRef.Invariant> part,
                         Map<FactSubject, Coordinate> byName, PartsRead parts, List<Direct> out) {
-        ReadByClauses.OfAPart account = parts.accountIn(from, clause);
+        ReadByClauses.OfAPart account = of.adoptedAt(clause);
         if (account == null) {
             return RunsRead.NOTHING;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -605,6 +605,15 @@ final class Predicates {
         return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, per);
     }
 
+    /**
+     * The same over a shape the caller already read the clause into, so that what is said about an
+     * occurrence is said in the numbering the clause handed out.
+     */
+    Owed assumed(ClauseExpr of, Denotations at, boolean decidesFalse, PerPart per) {
+        return new Owing(this, Set.of(), decidesFalse, Discharge.AN_ASSUMPTION)
+                .read(of, at, terms::inside, per == null ? null : per::read);
+    }
+
     /** Told what one part of a clause owed, by the shape of the clause it was read at. */
     interface PerPart {
         void read(ClauseExpr of, Core part, Owed owed);

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -34,8 +34,7 @@ import java.util.Set;
  */
 record ReadByClauses(Confinement.Worked<FactSubject> confinement,
                      Adoption<FactSubject, ReadingLanguage.Values> byValues,
-                     Adoption<FactSubject, ReadingLanguage.Order> byOrder,
-                     java.util.Map<souther.compiler.core.Core, OfAPart> parts) {
+                     Adoption<FactSubject, ReadingLanguage.Order> byOrder) {
 
     /** What every position of this reading may hold. */
     AdmissibleValues<FactSubject> values() {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -19,7 +19,6 @@ import souther.compiler.values.ValueSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -119,11 +118,13 @@ sealed interface StatedByClauses {
      * pushed down into the branches of a choice would be a part of each of them, and every question
      * the choice asks of an alternative would be answerable from a clause written above it.
      */
-    record CameFrom(Core node, StatedByClauses of) implements StatedByClauses {
+    record CameFrom(Core node, ClauseExpr.Occurrence at, StatedByClauses of)
+            implements StatedByClauses {
 
         public CameFrom {
-            if (node == null || of == null) {
-                throw new IllegalArgumentException("a part is some node, read into something");
+            if (node == null || at == null || of == null) {
+                throw new IllegalArgumentException(
+                        "a part is some node, somewhere in its clause, read into something");
             }
         }
     }
@@ -764,8 +765,8 @@ sealed interface StatedByClauses {
          * the author wrote.
          */
         @Override
-        public StatedByClauses from(Core e, StatedByClauses out) {
-            return new CameFrom(e, out);
+        public StatedByClauses from(ClauseExpr shape, Core e, StatedByClauses out) {
+            return new CameFrom(e, shape.at(), out);
         }
 
         /**
@@ -1188,14 +1189,14 @@ sealed interface StatedByClauses {
             return out;
         }
 
-        private Map<Core, PartAccount> partsOf(Taken took, Settlement made,
-                                               Set<OpenEnd> stillOpen) {
+        private Map<ClauseExpr.Occurrence, PartAccount> partsOf(Taken took, Settlement made,
+                                                               Set<OpenEnd> stillOpen) {
             Set<FactSubject> unbuilt = made.made().unbuilt();
             // And what could not be built is given up on here too. What a leaf said it adopted was
             // said before any machine was made, so a position whose answer the whole reading did
             // not work out is one the account still calls taken in — while the values beside it
             // say it holds every value because nobody worked it out.
-            Map<Core, PartAccount> parts = new IdentityHashMap<>();
+            Map<ClauseExpr.Occurrence, PartAccount> parts = new LinkedHashMap<>();
             took.parts().forEach((each, part) -> parts.put(each, new PartAccount(
                     part.byValues().unbuiltAt(unbuilt),
                     part.byOrder().unbuiltAt(unbuilt),
@@ -1225,7 +1226,7 @@ sealed interface StatedByClauses {
                                 Map<ChoiceId, Settlement.OfAChoice> outcomes) {
             return switch (read) {
                 case Said it -> new Taken(it.took(), Map.of(), Set.of());
-                case CameFrom it -> accounted(it.of(), outcomes).alsoAt(it.node());
+                case CameFrom it -> accounted(it.of(), outcomes).alsoAt(it.at());
                 case Both it -> accounted(it.left(), outcomes)
                         .both(accounted(it.right(), outcomes));
                 case Either it -> {
@@ -1278,12 +1279,12 @@ sealed interface StatedByClauses {
      * nothing is written under two branches of a tree — so putting two of these together is a union
      * and never a merge, which is what the tree keeping the author's shape buys.
      */
-    record Taken(Part took, Map<Core, Part> parts, Set<FactSubject> opened) {
+    record Taken(Part took, Map<ClauseExpr.Occurrence, Part> parts, Set<FactSubject> opened) {
 
-        /** The same, with what a written part came to filed under it. */
-        Taken alsoAt(Core node) {
-            Map<Core, Part> out = new IdentityHashMap<>(parts);
-            out.put(node, took);
+        /** The same, with what a written part came to filed under where in the clause it is. */
+        Taken alsoAt(ClauseExpr.Occurrence at) {
+            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>(parts);
+            out.put(at, took);
             return new Taken(took, out, opened);
         }
 
@@ -1303,7 +1304,7 @@ sealed interface StatedByClauses {
 
         /** Every part of this, answered again — for what a settlement could not build in it. */
         Taken mapped(UnaryOperator<Part> answer) {
-            Map<Core, Part> out = new IdentityHashMap<>();
+            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>();
             parts.forEach((each, part) -> out.put(each, answer.apply(part)));
             return new Taken(answer.apply(took), out, opened);
         }
@@ -1404,11 +1405,12 @@ sealed interface StatedByClauses {
                     opened(opened(opened, other.opened()), opening.byValues().positions()));
         }
 
-        private static Map<Core, Part> joined(Map<Core, Part> these, Map<Core, Part> those) {
+        private static Map<ClauseExpr.Occurrence, Part> joined(
+                Map<ClauseExpr.Occurrence, Part> these, Map<ClauseExpr.Occurrence, Part> those) {
             if (those.isEmpty()) {
                 return these;
             }
-            Map<Core, Part> out = new IdentityHashMap<>(these);
+            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>(these);
             out.putAll(those);
             return out;
         }
@@ -1502,17 +1504,23 @@ sealed interface StatedByClauses {
      */
     final class Asked<K> {
 
-        private final Map<K, Core> byClause = new LinkedHashMap<>();
-        private final Map<K, List<Core>> byPart = new LinkedHashMap<>();
+        private final Map<K, List<ClauseExpr.Occurrence>> byPart = new LinkedHashMap<>();
         private final Map<K, StatedByClauses> trees = new LinkedHashMap<>();
 
         /** One clause read from {@code at} in the world {@code view} describes
          *  ({@link ClauseView}), with the parts of it noted in the order the reading reached
          *  them. */
         StatedByClauses read(Reading reader, Denotations at, K key, Core clause, ClauseView view) {
-            List<Core> parts = new ArrayList<>();
+            // Where in the clause each part is, in the order the reading reached them, and once
+            // however many nodes one of them was spelled as: a part written `!(x)` and read at the
+            // denial and at what it denies is one part of the clause, in one place.
+            List<ClauseExpr.Occurrence> parts = new ArrayList<>();
             StatedByClauses one = reader.read(clause, true, at, reader.scope(),
-                    (_, part, _) -> parts.add(part), view);
+                    (shape, _, _) -> {
+                        if (parts.isEmpty() || !parts.getLast().equals(shape.at())) {
+                            parts.add(shape.at());
+                        }
+                    }, view);
             // An assertion because it is about this compiler and not about any model, and here
             // rather than in one test because every clause a corpus holds is read through it.
             //
@@ -1522,7 +1530,6 @@ sealed interface StatedByClauses {
             // to a shape it no longer states.
             assert mirrors(clause, one, view)
                     : "the reading of a clause is not the tree its author wrote it as";
-            byClause.put(key, clause);
             byPart.put(key, parts);
             trees.put(key, one);
             return one;
@@ -1560,7 +1567,7 @@ sealed interface StatedByClauses {
             // written elsewhere shows dead takes what it could not read with it, and which branches
             // those are is what the settlement above answers.
             Set<FactSubject> opened = new LinkedHashSet<>();
-            Map<Core, PartAccount> said = new IdentityHashMap<>();
+            Map<K, Map<ClauseExpr.Occurrence, PartAccount>> said = new LinkedHashMap<>();
             Map<K, Set<FactSubject>> narrowed = new LinkedHashMap<>();
             Adoption<FactSubject, ReadingLanguage.Values> byValues = Adoption.nothing();
             Adoption<FactSubject, ReadingLanguage.Order> byOrder = Adoption.nothing();
@@ -1581,9 +1588,9 @@ sealed interface StatedByClauses {
                 // with a narrowing it did not do.
                 Account mine = reader.accountOf(each.getValue(),
                         projected.get(each.getKey()), made, by);
-                said.putAll(mine.parts());
+                said.put(each.getKey(), mine.parts());
                 opened.addAll(mine.opened());
-                PartAccount clause = mine.parts().get(byClause.get(each.getKey()));
+                PartAccount clause = mine.parts().get(ClauseExpr.Occurrence.ofTheClause());
                 narrowed.put(each.getKey(), mine.narrowed());
                 byValues = byValues.both(clause.byValues());
                 byOrder = byOrder.both(clause.byOrder());
@@ -1607,7 +1614,7 @@ sealed interface StatedByClauses {
             // on its own, which the answer had no use for — charged to it, what a position is read
             // to admit would turn on what a reader downstream was promised, and the assertion above
             // would be true of the accounts and false of the reading as a whole.
-            Map<Core, ReadByClauses.OfAPart> published =
+            Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> published =
                     published(said, handingOn, answered.values());
             // And the answer's allowance is where it was. What a position admits is answered under
             // the allowance for it and nothing else reaches that allowance, so what this
@@ -1618,16 +1625,17 @@ sealed interface StatedByClauses {
                     : "handing the rules of " + made.made().values().subjects()
                             + " on spent the allowance for what they admit";
             Map<K, ReadByClauses.OfARule> clauses = new LinkedHashMap<>();
-            narrowed.forEach((key, these) -> clauses.put(key,
-                    new ReadByClauses.OfARule(these, published.get(byClause.get(key)))));
-            ReadByClauses read = new ReadByClauses(answered, byValues, byOrder, published);
-            Map<K, List<Map.Entry<Core, ReadByClauses.OfAPart>>> parts =
+            narrowed.forEach((key, these) -> clauses.put(key, new ReadByClauses.OfARule(these,
+                    published.get(key).get(ClauseExpr.Occurrence.ofTheClause()))));
+            ReadByClauses read = new ReadByClauses(answered, byValues, byOrder);
+            Map<K, List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>>> parts =
                     new LinkedHashMap<>();
             byPart.forEach((key, these) -> {
-                List<Map.Entry<Core, ReadByClauses.OfAPart>> out =
+                Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> mine = published.get(key);
+                List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> out =
                         new ArrayList<>();
                 these.forEach(each -> {
-                    ReadByClauses.OfAPart one = published.get(each);
+                    ReadByClauses.OfAPart one = mine == null ? null : mine.get(each);
                     if (one != null) {
                         out.add(Map.entry(each, one));
                     }
@@ -1674,15 +1682,18 @@ sealed interface StatedByClauses {
          *
          * @param answered what the positions came to, asked whether each of them is exact
          */
-        private Map<Core, ReadByClauses.OfAPart> published(
-                Map<Core, PartAccount> said, Allowance<FactSubject> handingOn,
+        private Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> published(
+                Map<K, Map<ClauseExpr.Occurrence, PartAccount>> said,
+                Allowance<FactSubject> handingOn,
                 AdmissibleValues<FactSubject> answered) {
             Map<FactSubject, Set<AdmittedPlan>> asked = new LinkedHashMap<>();
-            said.values().forEach(part -> part.aboutStrings().forEach((position, stated) -> {
-                if (stated instanceof StringRestriction.Admitting it) {
-                    asked.computeIfAbsent(position, _ -> new LinkedHashSet<>()).add(it.plan());
-                }
-            }));
+            said.values().forEach(mine -> mine.values().forEach(part ->
+                    part.aboutStrings().forEach((position, stated) -> {
+                        if (stated instanceof StringRestriction.Admitting it) {
+                            asked.computeIfAbsent(position, _ -> new LinkedHashSet<>())
+                                    .add(it.plan());
+                        }
+                    })));
             Map<FactSubject, Realizations> answers = new LinkedHashMap<>();
             // Built for the block the position is on, which is what the machine is being made for:
             // positions the rules hold as one value have one answer between them, and one purse.
@@ -1690,11 +1701,15 @@ sealed interface StatedByClauses {
                     answered.speaksFor(position)
                             ? handingOn.realizeAll(answered.blockOf(position), plans)
                             : new Realizations.NotBuilt()));
-            Map<Core, ReadByClauses.OfAPart> out = new IdentityHashMap<>();
-            said.forEach((each, part) -> out.put(each, new ReadByClauses.OfAPart(
-                    part.byValues(), part.byOrder(), part.aboutARule(),
-                    admitted(part.aboutStrings(), answers), part.endsLeftOpen(),
-                    part.boundsLeftOpen())));
+            Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> out = new LinkedHashMap<>();
+            said.forEach((key, mine) -> {
+                Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> here = new LinkedHashMap<>();
+                mine.forEach((each, part) -> here.put(each, new ReadByClauses.OfAPart(
+                        part.byValues(), part.byOrder(), part.aboutARule(),
+                        admitted(part.aboutStrings(), answers), part.endsLeftOpen(),
+                        part.boundsLeftOpen())));
+                out.put(key, here);
+            });
             return out;
         }
 
@@ -1735,7 +1750,8 @@ sealed interface StatedByClauses {
      * nothing, because the work was done once and what is here is what it came to.
      */
     record Answered<K>(ReadByClauses whole, Map<K, ReadByClauses.OfARule> perClause,
-                       Map<K, List<Map.Entry<Core, ReadByClauses.OfAPart>>> perPart) {}
+                       Map<K, List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>>>
+                               perPart) {}
 
     /**
      * What one rule's own tree came to: what it leaves narrowed, what each of its parts took in,
@@ -1749,7 +1765,7 @@ sealed interface StatedByClauses {
      *               walked ({@code AdmissibleValues.alsoOpenedAt}). The account of the rule hears
      *               the same decision as a shortfall at the choice
      */
-    record Account(Set<FactSubject> narrowed, Map<Core, PartAccount> parts,
+    record Account(Set<FactSubject> narrowed, Map<ClauseExpr.Occurrence, PartAccount> parts,
                    Set<FactSubject> opened) {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -187,7 +187,7 @@ final class TypeGuarantees {
         List<Quantified> quantified = new ArrayList<>();
         Predicates.Owed owed = null;
         for (Clauses.StatedPart part : view.present()) {
-            Predicates.Owed said = predicates.assumed(part.expr(), denotations, false,
+            Predicates.Owed said = predicates.assumed(part.of(), denotations, false,
                     (shape, of, came) ->
                             parts.add(new TypeGuarantee.Part(part.id(), shape, of, came)));
             owed = owed == null ? said : owed.and(said);

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingOfAClauseIsTheTreeItsAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingOfAClauseIsTheTreeItsAuthorWroteTest.java
@@ -47,6 +47,12 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
     private static final Core BESIDE_THE_BRACKET =
             joined(BinOp.AND, joined(BinOp.OR, A, B), C);
 
+    /** Where in the clause each of its nodes is, read off the one thing that hands the numbers
+     *  out rather than written down again here. */
+    private static final ClauseExpr.Joined SHAPE =
+            (ClauseExpr.Joined) ClauseExpr.of(BESIDE_THE_BRACKET, true);
+    private static final ClauseExpr.Joined CHOICE = (ClauseExpr.Joined) SHAPE.left();
+
     /**
      * What the reading makes of it, node for node.
      *
@@ -55,10 +61,12 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
      */
     private static StatedByClauses asWritten() {
         Core choice = ((Core.Binary) BESIDE_THE_BRACKET).left();
-        return part(BESIDE_THE_BRACKET, part(BESIDE_THE_BRACKET, new StatedByClauses.Both(
-                part(choice, new StatedByClauses.Either(new ChoiceId(), choice,
-                        part(A, said()), part(B, said()))),
-                part(C, said()))));
+        return part(BESIDE_THE_BRACKET, SHAPE,
+                part(BESIDE_THE_BRACKET, SHAPE, new StatedByClauses.Both(
+                        part(choice, CHOICE, new StatedByClauses.Either(new ChoiceId(), choice,
+                                part(A, CHOICE.left(), said()),
+                                part(B, CHOICE.right(), said()))),
+                        part(C, SHAPE.right(), said()))));
     }
 
     /**
@@ -70,10 +78,12 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
     private static StatedByClauses distributed() {
         Core choice = ((Core.Binary) BESIDE_THE_BRACKET).left();
         ChoiceId id = new ChoiceId();
-        return part(BESIDE_THE_BRACKET, part(BESIDE_THE_BRACKET,
+        return part(BESIDE_THE_BRACKET, SHAPE, part(BESIDE_THE_BRACKET, SHAPE,
                 new StatedByClauses.Either(id, choice,
-                        new StatedByClauses.Both(part(A, said()), part(C, said())),
-                        new StatedByClauses.Both(part(B, said()), part(C, said())))));
+                        new StatedByClauses.Both(part(A, CHOICE.left(), said()),
+                                part(C, SHAPE.right(), said())),
+                        new StatedByClauses.Both(part(B, CHOICE.right(), said()),
+                                part(C, SHAPE.right(), said())))));
     }
 
     @Test
@@ -103,13 +113,15 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
     void aPartPushedIntoTheBranchesIsRefused() {
         Core choice = ((Core.Binary) BESIDE_THE_BRACKET).left();
         assertFalse(StatedByClauses.mirrors(BESIDE_THE_BRACKET,
-                        part(BESIDE_THE_BRACKET, part(BESIDE_THE_BRACKET,
+                        part(BESIDE_THE_BRACKET, SHAPE, part(BESIDE_THE_BRACKET, SHAPE,
                                 new StatedByClauses.Both(
-                                        part(choice, new StatedByClauses.Either(
+                                        part(choice, CHOICE, new StatedByClauses.Either(
                                                 new ChoiceId(), choice,
-                                                part(C, part(A, said())),
-                                                part(C, part(B, said())))),
-                                        part(C, said())))),
+                                                part(C, SHAPE.right(),
+                                                        part(A, CHOICE.left(), said())),
+                                                part(C, SHAPE.right(),
+                                                        part(B, CHOICE.right(), said())))),
+                                        part(C, SHAPE.right(), said())))),
                         ClauseView.asWritten()),
                 "the whole clause is recorded as what each alternative came to, so a reader asking"
                         + " what it came to is answered by one branch of a choice");
@@ -120,8 +132,8 @@ class AReadingOfAClauseIsTheTreeItsAuthorWroteTest {
                 StatedByClauses.Part.nothing());
     }
 
-    private static StatedByClauses part(Core node, StatedByClauses of) {
-        return new StatedByClauses.CameFrom(node, of);
+    private static StatedByClauses part(Core node, ClauseExpr where, StatedByClauses of) {
+        return new StatedByClauses.CameFrom(node, where.at(), of);
     }
 
     private static Core joined(BinOp op, Core left, Core right) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
@@ -94,8 +94,8 @@ class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
         PartId<RuleRef.Invariant> left = new PartId<>(rule, 0);
         PartId<RuleRef.Invariant> right = new PartId<>(rule, 1);
         return PartsLeftOut.without(Set.of(left)).viewOf(
-                List.of(new Clauses.StatedPart(left, LEFT),
-                        new Clauses.StatedPart(right, RIGHT)));
+                List.of(new Clauses.StatedPart(left, ClauseExpr.of(LEFT, true)),
+                        new Clauses.StatedPart(right, ClauseExpr.of(RIGHT, true))));
     }
 
     /** What a node reads as here, which is enough to tell the two conjuncts and the whole apart. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest.java
@@ -1,0 +1,150 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.ConstructOccurrence;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * One clause built twice is one clause, and what a reading made of a part of it is found either way.
+ *
+ * <p>A clause reaches a value through whatever tree the step that brought it there built. Those
+ * trees are equal and are not the same objects — a substitution that changes nothing hands back
+ * what it was given, and one that changes something builds afresh — so a reader that filed what it
+ * made of a part under the node it read it at held an address that answered for exactly one of
+ * them. Asked with the other, it found nothing, and nothing is how a part that constrained a
+ * position reads when the walk asks what it constrained.
+ *
+ * <p>What is held instead is where in the clause the part is. The occurrences are handed out once,
+ * by the one reading of the structure ({@link ClauseExpr}), and the structure is what the two trees
+ * share — so the coordinate is the same coordinate in both, while the nodes are two.
+ *
+ * <p>The control is in the second test: the nodes at one coordinate are equal and are not the same
+ * object, which is what an address made of them would have been telling apart.
+ */
+class AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final RuleRef.Invariant RULE = new RuleRef.Invariant(new Clause.Ref(
+            new Clause.Id(TypeSymbols.declared(new TypeKey("demo", "R")), 0), Optional.empty()));
+
+    /** What a reading is recorded as having made of a part. Two of them, told apart by nothing
+     *  the address could read, so finding the wrong one is a failure and not a coincidence. */
+    private static final ReadByClauses.OfAPart LEFT_SAID = accounting("left");
+    private static final ReadByClauses.OfAPart RIGHT_SAID = accounting("right");
+
+    /** {@code a == a && b == b}, built afresh each time this is called. */
+    private static Core clause() {
+        return new Core.Binary(BinOp.AND, leaf("a"), leaf("b"),
+                ConstructOccurrence.unwritten(), Type.BOOL, POS);
+    }
+
+    @Test
+    void oneClauseBuiltTwiceHandsOutOneSetOfCoordinates() {
+        ClauseExpr one = ClauseExpr.of(clause(), true);
+        ClauseExpr other = ClauseExpr.of(clause(), true);
+        Map<ClauseExpr.Occurrence, Core> here = nodesBy(one);
+        Map<ClauseExpr.Occurrence, Core> there = nodesBy(other);
+        assertEquals(here.keySet(), there.keySet(),
+                "the occurrences are the structure's, and the two trees are one structure");
+        here.forEach((at, node) -> {
+            assertEquals(node, there.get(at),
+                    "the node at " + at + " is the same node of the clause either way");
+            assertNotSame(node, there.get(at),
+                    "and it is not the same object, which is what an address made of it read");
+        });
+    }
+
+    @Test
+    void anAccountFiledOverOneTreeIsFoundOverTheOther() {
+        Core built = clause();
+        ClauseExpr shape = ClauseExpr.of(built, true);
+        ClauseExpr.Joined joined = (ClauseExpr.Joined) shape;
+        InvariantChecker.Written reading = readingOver(built, joined)
+                .alsoAdopting(List.of(Map.entry(joined.left().at(), LEFT_SAID),
+                        Map.entry(joined.right().at(), RIGHT_SAID)));
+
+        // The same clause as the step that brought it here built it a second time, which is what a
+        // reader downstream is holding.
+        ClauseExpr.Joined again = (ClauseExpr.Joined) ClauseExpr.of(clause(), true);
+        assertNotSame(joined.left().written(), again.left().written(),
+                "the trees are two, which is the whole of what this is about");
+
+        assertSame(LEFT_SAID, reading.adoptedAt(again.left().at()),
+                "what the reading made of the left conjunct, asked for at the coordinate the other"
+                        + " tree gives it");
+        assertSame(RIGHT_SAID, reading.adoptedAt(again.right().at()),
+                "and the right one, which is a different coordinate and a different answer");
+    }
+
+    @Test
+    void andACoordinateNoReadingFiledIsAbsentRatherThanEmpty() {
+        Core built = clause();
+        ClauseExpr.Joined joined = (ClauseExpr.Joined) ClauseExpr.of(built, true);
+        InvariantChecker.Written reading = readingOver(built, joined)
+                .alsoAdopting(List.of(Map.entry(joined.left().at(), LEFT_SAID)));
+        assertNull(reading.adoptedAt(joined.right().at()),
+                "a part this reading never read is not one it read and made nothing of");
+    }
+
+    /** A reading of {@code built}, in a world holding both of the parts its author wrote. */
+    private static InvariantChecker.Written readingOver(Core built, ClauseExpr.Joined joined) {
+        List<Clauses.StatedPart> authored = List.of(
+                new Clauses.StatedPart(new PartId<>(RULE, 0), joined.left()),
+                new Clauses.StatedPart(new PartId<>(RULE, 1), joined.right()));
+        return InvariantChecker.Written.of(new InvariantChecker.ReadingId(0), built, authored,
+                PartsLeftOut.without(Set.of()), Map.of());
+    }
+
+    /** Every node of the shape, under the coordinate the shape gives it. */
+    private static Map<ClauseExpr.Occurrence, Core> nodesBy(ClauseExpr shape) {
+        Map<ClauseExpr.Occurrence, Core> out = new LinkedHashMap<>();
+        gather(shape, out);
+        return out;
+    }
+
+    private static void gather(ClauseExpr shape, Map<ClauseExpr.Occurrence, Core> out) {
+        out.put(shape.at(), shape.written());
+        switch (shape) {
+            case ClauseExpr.Leaf _ -> {
+            }
+            case ClauseExpr.Scoped it -> gather(it.body(), out);
+            case ClauseExpr.Joined it -> {
+                gather(it.left(), out);
+                gather(it.right(), out);
+            }
+        }
+    }
+
+    private static ReadByClauses.OfAPart accounting(String named) {
+        List<RuleShortfall> nothing = new ArrayList<>();
+        return new ReadByClauses.OfAPart(Adoption.nothing(), Adoption.nothing(),
+                Set.of(FactSubject.of(new Term.Interner().written(named))),
+                Set.copyOf(nothing), Map.of(), EndsLeftOpen.nothing(), Map.of());
+    }
+
+    /** A clause of no connective, named by which of them it is. */
+    private static Core leaf(String named) {
+        return new Core.Binary(BinOp.EQ, new Core.Str(named, Type.STRING, POS),
+                new Core.Str(named, Type.STRING, POS), ConstructOccurrence.unwritten(),
+                Type.BOOL, POS);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsComputedWithoutAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsComputedWithoutAnAnswerTest.java
@@ -81,7 +81,7 @@ class WhatARuleRaisesIsComputedWithoutAnAnswerTest {
     private static final List<String> WHAT_ANSWERING_PRODUCES = List.of(
             "souther/compiler/check/InvariantBound",
             "souther/compiler/check/UnreadComparison$Quantity",
-            "souther/compiler/check/InvariantChecker$PartsRead",
+            "souther/compiler/check/InvariantChecker$RulesRead",
             "souther/compiler/check/InvariantChecker$PartRead",
             "souther/compiler/check/ConstraintState",
             "souther/compiler/check/ReadingEvidence",


### PR DESCRIPTION
The account of what each part of a rule took in was filed under the tree node the
reading read it at, in a table keyed by the rule. A rule is read once per place
the walk opens a value at, and each of those readings walks the tree a
substitution built for it — so what told two readings' entries apart was which
objects those substitutions happened to allocate, and two readings that shared a
subtree would have shared an address.

So the account goes to the reading it is an account of, and the address becomes
the occurrence the clause's shape hands out. An occurrence is issued once, where
the shape is read out of the tree, and every reading of that clause hands out the
same numbers; the walk that raises a rule's questions asks for the occurrence it
is standing at. Filing the parts of one rule from the clause rather than from
each part is what makes the two agree about which occurrence is which.

The table keyed across readings had no reader left once each reading kept its
own, and the clause is now the first occurrence of itself rather than a node held
beside the account to look one up by.

Shown by a mutation: read a clause over a structurally equal tree rebuilt for it,
and the account is unreachable where the address is a node, and reached where the
address is an occurrence.

Part of #1504. What is left there is the readers that still tell two parts apart
by which objects hold them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)