### PR TITLE
Ask this module for its compiled classes rather than going to find them

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest.java
@@ -2,8 +2,6 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
@@ -18,8 +16,6 @@ import java.lang.classfile.instruction.LookupSwitchInstruction;
 import java.lang.classfile.instruction.ReturnInstruction;
 import java.lang.classfile.instruction.SwitchCase;
 import java.lang.classfile.instruction.TableSwitchInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.lang.reflect.AccessFlag;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -31,10 +27,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -304,7 +298,7 @@ class NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest {
                             + " combination rather than reporting them impossible"));
 
     @Test
-    void everyWideHandlerThatReturnsWasGivenLeaveToOnePlaceAtATime() throws IOException {
+    void everyWideHandlerThatReturnsWasGivenLeaveToOnePlaceAtATime() {
         Map<Site, Integer> allowed = new TreeMap<>();
         PLATFORM_QUESTIONS.forEach(each -> allowed.merge(each.site(), 1, Integer::sum));
 
@@ -333,7 +327,7 @@ class NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest {
      * the walk reached the code rather than only its desugaring.
      */
     @Test
-    void theHandlersSomebodyWroteAreAmongThem() throws IOException {
+    void theHandlersSomebodyWroteAreAmongThem() {
         assertTrue(scan().examined().stream()
                         .anyMatch(site -> !site.caught().equals("java.lang.Throwable")),
                 "every wide handler found names Throwable, which is what a pattern switch compiles"
@@ -341,14 +335,13 @@ class NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest {
                         + " check above passed over nothing anybody wrote");
     }
 
-    private static Scan scan() throws IOException {
+    private static Scan scan() {
         Set<Site> examined = new TreeSet<>();
         // Where each site's returning handlers begin. A set of the places rather than a count of
         // the table rows: one `catch` can be entered from several stretches of a method and is one
         // place a person wrote, while two written beside each other are two.
         Map<Site, Set<Integer>> beginningAt = new TreeMap<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String owner = model.thisClass().asInternalName();
             if (READ_A_PROGRAM.stream().noneMatch(owner::startsWith)) {
                 continue;
@@ -488,13 +481,4 @@ class NoBroadFailureBecomesAnAnswerInTheAnalysisCoreTest {
         }
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            List<Path> found = new ArrayList<>(
-                    walk.filter(p -> p.toString().endsWith(".class")).toList());
-            assertFalse(found.isEmpty(), "no compiled class was read at all, so this says nothing");
-            return found;
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A check of this module asks for the compiled output; it does not go and find one.
@@ -24,15 +25,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * build invoked elsewhere — and, having found the files, it opens them: the same files the check
  * beside it opened, for the fork to read again.
  *
- * <p><b>What is refused is going to look, and not reading a class file.</b> A test handed bytes to
- * read is doing something else entirely: this module compiles Souther models and asks what came out
- * of them, and what came out is a value in the test rather than a file anybody went looking for. A
- * rule written over parsing would refuse those as well, and there are many of them.
+ * <p><b>The population is what reaches a class file, and the rule is that none of it says where a
+ * build writes.</b> Reaching one is parsing it, or handing the shared reading a path to an output;
+ * this module has many tests that do the first, because it compiles Souther models and asks what
+ * came out of them, and what came out is a value in the test rather than a file anybody went looking
+ * for. Those are what the rule is asked of, and going looking is what it refuses.
  *
- * <p>So what is refused is the pair: a check that says where a build writes <em>and</em> reaches a
- * class file. Either alone is somebody else's business — a walk over the repository's own sources
- * says where a build writes in order to leave it out, and a test handed bytes reads a class file
- * without going anywhere — and it is holding both that makes a second way into the compiled output.
+ * <p>A check that reaches no class file is not in it. A walk over the repository's own sources says
+ * where a build writes in order to leave the build's output out, and answers a question about
+ * sources either way; this check says the word in order to look for it. Neither reaches a class
+ * file, and a rule about naming alone would be a rule about the word rather than about going to
+ * look.
  */
 class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
 
@@ -45,19 +48,27 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
             "souther/test/CompiledClasses.at");
 
     @Test
-    void nothingSaysWhereABuildWritesAndReachesAClassFileAsWell() {
-        Set<String> both = new TreeSet<>();
-        List<ClassModel> checks = CompiledClasses.ofModule(
-                NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.class).all();
-        for (ClassModel each : checks) {
+    void nothingThatReachesAClassFileSaysWhereABuildWrites() {
+        List<ClassModel> reaching = new ArrayList<>();
+        for (ClassModel each : CompiledClasses.ofModule(
+                NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.class).all()) {
+            if (reachesAClassFile(each)) {
+                reaching.add(each);
+            }
+        }
+        assertFalse(reaching.isEmpty(), "no check of this module reaches a class file at all, so"
+                + " this rule is asked of nothing and passes by having nobody to ask");
+
+        Set<String> looking = new TreeSet<>();
+        for (ClassModel each : reaching) {
             String said = whereABuildWritesAsSaidBy(each);
-            if (said != null && reachesAClassFile(each)) {
-                both.add(each.thisClass().asInternalName().replace('/', '.') + " says `" + said
+            if (said != null) {
+                looking.add(each.thisClass().asInternalName().replace('/', '.') + " says `" + said
                         + "`");
             }
         }
 
-        assertEquals(Set.of(), both,
+        assertEquals(Set.of(), looking,
                 "a check works out where this module's compiled output is instead of asking for it,"
                         + " so it answers about wherever the build was invoked from and reads files"
                         + " a check beside it has already read");

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -1,7 +1,7 @@
 package souther.compiler;
 
 import org.junit.jupiter.api.Test;
-import souther.test.CompiledClasses;
+import souther.test.RepositoryLayout;
 
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * A check of this module asks for the compiled output; it does not go and find one.
+ * A check of this module asks {@link WhatWasCompiled} for its classes; it does not go and find them.
  *
  * <p>Where the classes a rule reads are is one question and what they hold is another, and a check
  * that answers the first for itself has taken on a fact about the build. What it takes on is the
@@ -25,81 +25,78 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * build invoked elsewhere — and, having found the files, it opens them: the same files the check
  * beside it opened, for the fork to read again.
  *
- * <p><b>The population is what reaches a class file, and the rule is that none of it says where a
- * build writes.</b> Reaching one is parsing it, or handing the shared reading a path to an output;
- * this module has many tests that do the first, because it compiles Souther models and asks what
- * came out of them, and what came out is a value in the test rather than a file anybody went looking
- * for. Those are what the rule is asked of, and going looking is what it refuses.
+ * <p><b>Two ways in, and both are closed here rather than one being guessed at.</b> A check can
+ * reach an output through the shared reading by naming one of its own, or it can find the files
+ * itself and parse them. A rule that looked for the two halves of the second in one class would be
+ * a rule about where somebody wrote them: pulling the path into a class of its own leaves each half
+ * innocent, and the walk is back with every check still passing. So neither is asked as a
+ * co-occurrence. Naming an output is asked of the call that names one, and finding the files is
+ * asked of the word a build's output goes by, which nothing here has any business writing down.
  *
- * <p>A check that reaches no class file is not in it. A walk over the repository's own sources says
- * where a build writes in order to leave the build's output out, and answers a question about
- * sources either way; this check says the word in order to look for it. Neither reaches a class
- * file, and a rule about naming alone would be a rule about the word rather than about going to
- * look.
+ * <p>What is not refused is reading a class file. This module compiles Souther models and asks what
+ * came out of them, and what came out is a value in the test rather than a file anybody went looking
+ * for; a rule written over parsing would refuse those as well, and there are many of them.
  */
 class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
 
-    /** What a build calls the directory it writes to, as a step of a path. */
-    private static final String WHERE_A_BUILD_WRITES = "target";
-
-    /** Reaching a class file: parsing one, and asking the shared reading for an output by path. */
-    private static final Set<String> READS_A_CLASS_FILE = Set.of(
-            "java/lang/classfile/ClassFile.of",
+    /** Naming an output: the two ways the shared reading is handed one. */
+    private static final Set<String> NAMES_AN_OUTPUT = Set.of(
+            "souther/test/CompiledClasses.ofModule",
             "souther/test/CompiledClasses.at");
 
+    /** The one place this module's outputs are named, which is what the rule is that there is one. */
+    private static final String THE_ONE_PLACE = WhatWasCompiled.class.getName();
+
     @Test
-    void nothingThatReachesAClassFileSaysWhereABuildWrites() {
-        List<ClassModel> reaching = new ArrayList<>();
-        for (ClassModel each : CompiledClasses.ofModule(
-                NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.class).all()) {
-            if (reachesAClassFile(each)) {
-                reaching.add(each);
-            }
-        }
-        assertFalse(reaching.isEmpty(), "no check of this module reaches a class file at all, so"
-                + " this rule is asked of nothing and passes by having nobody to ask");
-
-        Set<String> looking = new TreeSet<>();
-        for (ClassModel each : reaching) {
-            String said = whereABuildWritesAsSaidBy(each);
-            if (said != null) {
-                looking.add(each.thisClass().asInternalName().replace('/', '.') + " says `" + said
-                        + "`");
-            }
-        }
-
-        assertEquals(Set.of(), looking,
-                "a check works out where this module's compiled output is instead of asking for it,"
-                        + " so it answers about wherever the build was invoked from and reads files"
-                        + " a check beside it has already read");
-    }
-
-    /** What the class says that names the directory a build writes to, where it says one. */
-    private static String whereABuildWritesAsSaidBy(ClassModel model) {
-        for (String said : constantsOf(model)) {
-            for (String step : said.split("[/\\\\]")) {
-                if (step.equals(WHERE_A_BUILD_WRITES)) {
-                    return said;
+    void oneCheckNamesThisModulesOutputsAndTheRestAskIt() {
+        Set<String> naming = new TreeSet<>();
+        for (ClassModel each : checks()) {
+            for (MethodModel method : each.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
+                    continue;
+                }
+                for (var element : code) {
+                    if (element instanceof InvokeInstruction call && NAMES_AN_OUTPUT.contains(
+                            call.owner().asInternalName() + "." + call.name().stringValue())) {
+                        naming.add(named(each));
+                    }
                 }
             }
         }
-        return null;
+
+        assertEquals(Set.of(THE_ONE_PLACE), naming,
+                "a check of this module works out which output to read instead of asking, so where"
+                        + " this module's classes are is said in more than one place and a module"
+                        + " that moves is as many edits as there are checks");
     }
 
-    private static boolean reachesAClassFile(ClassModel model) {
-        for (MethodModel method : model.methods()) {
-            CodeModel code = method.code().orElse(null);
-            if (code == null) {
-                continue;
-            }
-            for (var element : code) {
-                if (element instanceof InvokeInstruction call && READS_A_CLASS_FILE.contains(
-                        call.owner().asInternalName() + "." + call.name().stringValue())) {
-                    return true;
+    @Test
+    void andNothingWritesDownWhereABuildPutsWhatItMade() {
+        String said = RepositoryLayout.whereABuildWrites();
+        Set<String> writing = new TreeSet<>();
+        List<ClassModel> checks = checks();
+        assertFalse(checks.isEmpty(), "no check of this module was read at all, so this rule is"
+                + " asked of nothing and passes by having nobody to ask");
+
+        for (ClassModel each : checks) {
+            for (String constant : constantsOf(each)) {
+                for (String step : constant.split("[/\\\\]")) {
+                    if (step.equals(said)) {
+                        writing.add(named(each) + " says `" + constant + "`");
+                    }
                 }
             }
         }
-        return false;
+
+        assertEquals(Set.of(), writing,
+                "a check of this module writes down where a build puts what it made, which is the"
+                        + " half of finding the files for itself that nothing else needs: what is"
+                        + " under a build's output is the repository's to say");
+    }
+
+    private static List<ClassModel> checks() {
+        return WhatWasCompiled.checksCompiledBesideIt().all();
     }
 
     private static List<String> constantsOf(ClassModel model) {
@@ -117,5 +114,9 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
             }
         }
         return said;
+    }
+
+    private static String named(ClassModel of) {
+        return of.thisClass().asInternalName().replace('/', '.');
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -1,0 +1,110 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.test.CompiledClasses;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A check of this module asks for the compiled output; it does not go and find one.
+ *
+ * <p>Where the classes a rule reads are is one question and what they hold is another, and a check
+ * that answers the first for itself has taken on a fact about the build. What it takes on is the
+ * directory the build happened to be invoked from — so the same check answers differently under a
+ * build invoked elsewhere — and, having found the files, it opens them: the same files the check
+ * beside it opened, for the fork to read again.
+ *
+ * <p><b>What is refused is going to look, and not reading a class file.</b> A test handed bytes to
+ * read is doing something else entirely: this module compiles Souther models and asks what came out
+ * of them, and what came out is a value in the test rather than a file anybody went looking for. A
+ * rule written over parsing would refuse those as well, and there are many of them.
+ *
+ * <p>So what is refused is the pair: a check that says where a build writes <em>and</em> reaches a
+ * class file. Either alone is somebody else's business — a walk over the repository's own sources
+ * says where a build writes in order to leave it out, and a test handed bytes reads a class file
+ * without going anywhere — and it is holding both that makes a second way into the compiled output.
+ */
+class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
+
+    /** What a build calls the directory it writes to, as a step of a path. */
+    private static final String WHERE_A_BUILD_WRITES = "target";
+
+    /** Reaching a class file: parsing one, and asking the shared reading for an output by path. */
+    private static final Set<String> READS_A_CLASS_FILE = Set.of(
+            "java/lang/classfile/ClassFile.of",
+            "souther/test/CompiledClasses.at");
+
+    @Test
+    void nothingSaysWhereABuildWritesAndReachesAClassFileAsWell() {
+        Set<String> both = new TreeSet<>();
+        List<ClassModel> checks = CompiledClasses.ofModule(
+                NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.class).all();
+        for (ClassModel each : checks) {
+            String said = whereABuildWritesAsSaidBy(each);
+            if (said != null && reachesAClassFile(each)) {
+                both.add(each.thisClass().asInternalName().replace('/', '.') + " says `" + said
+                        + "`");
+            }
+        }
+
+        assertEquals(Set.of(), both,
+                "a check works out where this module's compiled output is instead of asking for it,"
+                        + " so it answers about wherever the build was invoked from and reads files"
+                        + " a check beside it has already read");
+    }
+
+    /** What the class says that names the directory a build writes to, where it says one. */
+    private static String whereABuildWritesAsSaidBy(ClassModel model) {
+        for (String said : constantsOf(model)) {
+            for (String step : said.split("[/\\\\]")) {
+                if (step.equals(WHERE_A_BUILD_WRITES)) {
+                    return said;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean reachesAClassFile(ClassModel model) {
+        for (MethodModel method : model.methods()) {
+            CodeModel code = method.code().orElse(null);
+            if (code == null) {
+                continue;
+            }
+            for (var element : code) {
+                if (element instanceof InvokeInstruction call && READS_A_CLASS_FILE.contains(
+                        call.owner().asInternalName() + "." + call.name().stringValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static List<String> constantsOf(ClassModel model) {
+        List<String> said = new ArrayList<>();
+        for (MethodModel method : model.methods()) {
+            CodeModel code = method.code().orElse(null);
+            if (code == null) {
+                continue;
+            }
+            for (var element : code) {
+                if (element instanceof ConstantInstruction loaded
+                        && loaded.constantValue() instanceof String text) {
+                    said.add(text);
+                }
+            }
+        }
+        return said;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -33,6 +33,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * co-occurrence. Naming an output is asked of the call that names one, and finding the files is
  * asked of the word a build's output goes by, which nothing here has any business writing down.
  *
+ * <p><b>Which leaves what hands the location out, and nothing does.</b> A rule against writing the
+ * word is worth nothing while something answers with it, and two things did: a reading said which
+ * output it was, and the repository said what a build calls its directory. Both are kept where they
+ * are worked out, so what is left of the second way in is writing the word — which is what this
+ * asks. Reaching an output any other way needs the repository root and then the word, and that is
+ * the same question again.
+ *
  * <p>What is not refused is reading a class file. This module compiles Souther models and asks what
  * came out of them, and what came out is a value in the test rather than a file anybody went looking
  * for; a rule written over parsing would refuse those as well, and there are many of them.
@@ -73,7 +80,6 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
 
     @Test
     void andNothingWritesDownWhereABuildPutsWhatItMade() {
-        String said = RepositoryLayout.whereABuildWrites();
         Set<String> writing = new TreeSet<>();
         List<ClassModel> checks = checks();
         assertFalse(checks.isEmpty(), "no check of this module was read at all, so this rule is"
@@ -81,10 +87,8 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
 
         for (ClassModel each : checks) {
             for (String constant : constantsOf(each)) {
-                for (String step : constant.split("[/\\\\]")) {
-                    if (step.equals(said)) {
-                        writing.add(named(each) + " says `" + constant + "`");
-                    }
+                if (RepositoryLayout.namesBuildOutput(constant)) {
+                    writing.add(named(each) + " says `" + constant + "`");
                 }
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
@@ -39,6 +39,17 @@ public final class WhatWasCompiled {
     }
 
     /**
+     * The checks compiled beside it, which is the other output this module has.
+     *
+     * <p>Here for the same reason the one above is: a rule about the checks themselves is a rule
+     * about an output of this module, and naming it somewhere else would be a second place saying
+     * where this module's classes are.
+     */
+    public static CompiledClasses checksCompiledBesideIt() {
+        return BESIDE;
+    }
+
+    /**
      * Which output this module compiled to, worked out once.
      *
      * <p>Not the classes, which the fork holds: this is the view of them, and working one out asks
@@ -48,13 +59,11 @@ public final class WhatWasCompiled {
      */
     private static final CompiledClasses COMPILED = CompiledClasses.ofModule(Compiler.class);
 
-    /** Every class this module compiled, by binary name. */
+    private static final CompiledClasses BESIDE = CompiledClasses.ofModule(WhatWasCompiled.class);
+
+    /** Every class this module compiled, by binary name and without reading any of them. */
     public static List<String> classes() {
-        List<String> found = new ArrayList<>();
-        for (ClassModel each : compiled().all()) {
-            found.add(named(each));
-        }
-        return found;
+        return compiled().names();
     }
 
     private static String named(ClassModel of) {

--- a/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
@@ -35,8 +35,18 @@ public final class WhatWasCompiled {
      * itself would be one more place to get it wrong when a module moves.
      */
     public static CompiledClasses compiled() {
-        return CompiledClasses.ofModule(Compiler.class);
+        return COMPILED;
     }
+
+    /**
+     * Which output this module compiled to, worked out once.
+     *
+     * <p>Not the classes, which the fork holds: this is the view of them, and working one out asks
+     * the file system what the path it was handed really is. A rule that walks the supertypes of
+     * every class asks for the view once per name it follows, so working it out per ask is a system
+     * call per lookup for an answer that was the same every time.
+     */
+    private static final CompiledClasses COMPILED = CompiledClasses.ofModule(Compiler.class);
 
     /** Every class this module compiled, by binary name. */
     public static List<String> classes() {

--- a/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
@@ -1,23 +1,17 @@
 package souther.compiler;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import souther.test.CompiledClasses;
+
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.MethodTypeEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.constant.ClassDesc;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * What this module compiled to, for a rule about who may depend on what.
@@ -28,31 +22,33 @@ import java.util.stream.Stream;
  * not. So the set is taken from what javac made of the module, where an anonymous body, a class and
  * a lambda are all present and all say what they are.
  *
- * <p>Read from {@code target/classes}, which is what surefire was handed and what the tests using
- * this were compiled against. A walk finding nothing is a walk of the wrong directory, so
- * {@link #classes} says so rather than reporting an empty set as a clean one.
+ * <p>Read from what this module compiled to, which is what surefire was handed and what the tests
+ * using this were compiled against. Which output that is, and how many times its files are opened,
+ * are {@link CompiledClasses}'s to answer; what is here is what this module's rules ask of it.
  */
 public final class WhatWasCompiled {
 
-    private static final Path CLASSES = Path.of("target/classes");
+    /**
+     * What this module compiled, named in one place.
+     *
+     * <p>A check of this module asks about this module, and a check that named the output for
+     * itself would be one more place to get it wrong when a module moves.
+     */
+    public static CompiledClasses compiled() {
+        return CompiledClasses.ofModule(Compiler.class);
+    }
 
     /** Every class this module compiled, by binary name. */
     public static List<String> classes() {
         List<String> found = new ArrayList<>();
-        try (Stream<Path> written = Files.walk(CLASSES)) {
-            for (Path each : written.filter(p -> p.toString().endsWith(".class")).sorted().toList()) {
-                found.add(CLASSES.relativize(each).toString()
-                        .replace(java.io.File.separatorChar, '.')
-                        .replaceAll("\\.class$", ""));
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        if (found.isEmpty()) {
-            throw new IllegalStateException(CLASSES.toAbsolutePath()
-                    + " holds no classes, so a rule read from it holds nothing");
+        for (ClassModel each : compiled().all()) {
+            found.add(named(each));
         }
         return found;
+    }
+
+    private static String named(ClassModel of) {
+        return of.thisClass().asInternalName().replace('/', '.');
     }
 
     /**
@@ -66,10 +62,9 @@ public final class WhatWasCompiled {
     public static Set<String> answering(Class<?> answered) {
         ClassDesc asked = answered.describeConstable().orElseThrow();
         Set<String> found = new LinkedHashSet<>();
-        for (String each : classes()) {
-            ClassModel model = parse(each);
-            if (reaches(model, asked, new LinkedHashSet<>()) || lambdaOf(model, asked)) {
-                found.add(each);
+        for (ClassModel each : compiled().all()) {
+            if (reaches(each, asked, new LinkedHashSet<>()) || lambdaOf(each, asked)) {
+                found.add(named(each));
             }
         }
         return found;
@@ -90,9 +85,9 @@ public final class WhatWasCompiled {
     public static Set<String> implementing(Class<?> answered) {
         ClassDesc asked = answered.describeConstable().orElseThrow();
         Set<String> found = new LinkedHashSet<>();
-        for (String each : classes()) {
-            if (reaches(parse(each), asked, new LinkedHashSet<>())) {
-                found.add(each);
+        for (ClassModel each : compiled().all()) {
+            if (reaches(each, asked, new LinkedHashSet<>())) {
+                found.add(named(each));
             }
         }
         return found;
@@ -116,9 +111,9 @@ public final class WhatWasCompiled {
             if (!seen.add(each)) {
                 continue;
             }
-            ClassModel further = parsedOrNull(each.packageName().isEmpty()
+            ClassModel further = compiled().find(each.packageName().isEmpty()
                     ? each.displayName()
-                    : each.packageName() + "." + each.displayName());
+                    : each.packageName() + "." + each.displayName()).orElse(null);
             if (further != null && reaches(further, asked, seen)) {
                 return true;
             }
@@ -175,8 +170,8 @@ public final class WhatWasCompiled {
             owners.add(ClassDesc.of(each));
         }
         Set<String> found = new LinkedHashSet<>();
-        for (String each : classes()) {
-            ConstantPool pool = parse(each).constantPool();
+        for (ClassModel model : compiled().all()) {
+            ConstantPool pool = model.constantPool();
             for (int i = 1; i < pool.size(); i++) {
                 PoolEntry entry;
                 try {
@@ -187,7 +182,7 @@ public final class WhatWasCompiled {
                 if (entry instanceof java.lang.classfile.constantpool.MemberRefEntry asCall
                         && owners.contains(asCall.owner().asSymbol())
                         && asCall.name().stringValue().equals(method)) {
-                    found.add(each);
+                    found.add(named(model));
                 }
             }
         }
@@ -197,7 +192,10 @@ public final class WhatWasCompiled {
     /** Every type {@code name} names — what it implements, calls, holds, catches or hands over. */
     public static Set<String> typesNamedBy(String name) {
         Set<String> named = new LinkedHashSet<>();
-        ConstantPool pool = parse(name).constantPool();
+        ConstantPool pool = compiled().find(name)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        name + " is not a class this module compiled"))
+                .constantPool();
         for (int i = 1; i < pool.size(); i++) {
             PoolEntry entry;
             try {
@@ -232,47 +230,6 @@ public final class WhatWasCompiled {
             }
         }
         return named;
-    }
-
-    /**
-     * What each class file holds, read once for however many rules ask about it.
-     *
-     * <p>A rule asks about every class this module compiled, and a suite holds many rules. Read per
-     * question, the same files are parsed again for each of them — which is what a rule about who
-     * calls what does twice over, once for the callers and once for the types the call could be
-     * named through. What is read cannot change while the tests run, since it is what surefire was
-     * handed.
-     */
-    private static final Map<String, ClassModel> READ = new HashMap<>();
-
-    /** {@code name} as this module compiled it, or nothing where it is not this module's — the JDK's
-     *  own types and anything on the class path, which a rule about this module does not read. */
-    private static ClassModel parsedOrNull(String name) {
-        if (READ.containsKey(name)) {
-            return READ.get(name);
-        }
-        Path at = CLASSES.resolve(name.replace('.', '/') + ".class");
-        ClassModel read = Files.exists(at) ? parsed(at) : null;
-        READ.put(name, read);
-        return read;
-    }
-
-    private static ClassModel parse(String name) {
-        ClassModel read = parsedOrNull(name);
-        if (read == null) {
-            throw new UncheckedIOException(new IOException(
-                    CLASSES.resolve(name.replace('.', '/') + ".class") + " is not a class this"
-                            + " module compiled"));
-        }
-        return read;
-    }
-
-    private static ClassModel parsed(Path at) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(at));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     private WhatWasCompiled() {

--- a/souther-compiler/src/test/java/souther/compiler/ast/TheParsedTreeHoldsOnlyWhatTheFrontendWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/TheParsedTreeHoldsOnlyWhatTheFrontendWritesTest.java
@@ -1,20 +1,16 @@
 package souther.compiler.ast;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,8 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TheParsedTreeHoldsOnlyWhatTheFrontendWritesTest {
 
-    private static final Path FRONTEND =
-            Path.of("target", "classes", "souther", "compiler", "frontend");
+    private static final String FRONTEND = "souther.compiler.frontend";
 
     @Test
     void everyFormOfTheParsedTreeIsNamedByTheFrontendThatWritesIt() {
@@ -92,16 +87,12 @@ class TheParsedTreeHoldsOnlyWhatTheFrontendWritesTest {
     /** Every name the frontend's classes hold, descriptors and signatures included. */
     private static Set<String> whatTheFrontendNames() {
         Set<String> named = new HashSet<>();
-        try (Stream<Path> found = Files.walk(FRONTEND)) {
-            for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
-                for (PoolEntry entry : ClassFile.of().parse(Files.readAllBytes(each)).constantPool()) {
-                    if (entry instanceof Utf8Entry text) {
-                        named.add(text.stringValue());
-                    }
+        for (ClassModel each : WhatWasCompiled.compiled().inPackage(FRONTEND)) {
+            for (PoolEntry entry : each.constantPool()) {
+                if (entry instanceof Utf8Entry text) {
+                    named.add(text.stringValue());
                 }
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         return named;
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APublishedDeclarationSaysEverythingAndPlacesNothingTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.WhatWasCompiled;
 import souther.compiler.ast.Hir;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.diag.Region;
@@ -7,14 +8,10 @@ import souther.compiler.diag.SourcePos;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.reflect.RecordComponent;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -53,6 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * class file says, and reading the source would be answering the same question a second way.
  */
 class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
+
+    /** The producer whose calls this is about. */
+    private static final String THE_PRODUCER = "souther.compiler.check.DeclarationMeaning";
 
     /** What a component of this type says is where the declaration stands, and not what it says. */
     private static final Set<Class<?>> WHERE_IT_STANDS = Set.of(SourcePos.class, Region.class);
@@ -110,7 +110,7 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
     }
 
     @Test
-    void everythingADeclarationSaysIsRead() throws IOException {
+    void everythingADeclarationSaysIsRead() {
         Set<String> called = componentsReadByTheProducer();
         Set<String> unread = new TreeSet<>();
         for (Class<?> kind : walked()) {
@@ -131,7 +131,7 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
     }
 
     @Test
-    void andNothingOfWhereItStandsIs() throws IOException {
+    void andNothingOfWhereItStandsIs() {
         Set<String> called = componentsReadByTheProducer();
         Set<String> read = new TreeSet<>();
         for (Class<?> kind : walked()) {
@@ -155,7 +155,7 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
      * holds the spelling out of the answer is which of its own components the producer asks for.
      */
     @Test
-    void andOfANameOnlyWhatItIsCalledIsAsked() throws IOException {
+    void andOfANameOnlyWhatItIsCalledIsAsked() {
         Set<String> asked = new TreeSet<>(methodsCalledOn("souther/compiler/ast/WrittenName"));
         asked.removeAll(WHAT_A_NAME_MAY_BE_ASKED);
 
@@ -194,7 +194,7 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
      * <p>A call made on {@link Hir.Def} is a call on every kind of one: the sealed parent declares
      * what all of them hold, and which arm it lands in is settled after the call.
      */
-    private static Set<String> componentsReadByTheProducer() throws IOException {
+    private static Set<String> componentsReadByTheProducer() {
         Set<String> read = new LinkedHashSet<>();
         for (Call call : callsMadeByTheProducer()) {
             if (!call.owner().startsWith("souther/compiler/ast/Hir")) {
@@ -214,7 +214,7 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
     }
 
     /** What the producer asks of {@code owner}, by method name. */
-    private static Set<String> methodsCalledOn(String owner) throws IOException {
+    private static Set<String> methodsCalledOn(String owner) {
         Set<String> asked = new LinkedHashSet<>();
         for (Call call : callsMadeByTheProducer()) {
             if (call.owner().equals(owner)) {
@@ -234,8 +234,10 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
      * and a call it makes into another class is answered by whatever that class was written to do.
      * The two it delegates to are named in {@link #READ_ELSEWHERE}.
      */
-    private static List<Call> callsMadeByTheProducer() throws IOException {
-        ClassModel model = ClassFile.of().parse(Files.readAllBytes(compiledProducer()));
+    private static List<Call> callsMadeByTheProducer() {
+        ClassModel model = WhatWasCompiled.compiled().find(THE_PRODUCER)
+                .orElseThrow(() -> new IllegalStateException(
+                        THE_PRODUCER + " is not a class this module compiled"));
         List<Call> calls = new ArrayList<>();
         Set<String> walked = new LinkedHashSet<>();
         Deque<MethodModel> pending = new ArrayDeque<>();
@@ -272,8 +274,4 @@ class APublishedDeclarationSaysEverythingAndPlacesNothingTest {
         return calls;
     }
 
-    private static Path compiledProducer() {
-        return Path.of("target", "classes", "souther", "compiler", "check",
-                "DeclarationMeaning.class").toAbsolutePath();
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.WhatWasCompiled;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ApplicationOrigin;
@@ -8,14 +9,10 @@ import souther.compiler.types.ReferenceOrigin;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.reflect.RecordComponent;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -51,6 +48,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
 
+    /** The reading whose identity this is about. */
+    private static final String THE_READING = "souther.compiler.check.TermMeaning";
+
     /** What a component of this type says is where the node stands, and not what it says. */
     private static final Set<Class<?>> WHERE_IT_STANDS = Set.of(
             SourcePos.class,
@@ -77,7 +77,7 @@ class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
     }
 
     @Test
-    void everythingATermSaysIsRead() throws IOException {
+    void everythingATermSaysIsRead() {
         Set<String> unread = new TreeSet<>();
         Set<String> called = componentsReadByTheIdentity();
         for (Class<?> kind : walked()) {
@@ -95,7 +95,7 @@ class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
     }
 
     @Test
-    void andNothingOfWhereItStandsIs() throws IOException {
+    void andNothingOfWhereItStandsIs() {
         Set<String> read = new TreeSet<>();
         Set<String> called = componentsReadByTheIdentity();
         for (Class<?> kind : walked()) {
@@ -122,7 +122,7 @@ class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
      * comparison stands while nothing above sees a place component being read.
      */
     @Test
-    void andWhatItReadsOfATermAreItsComponents() throws IOException {
+    void andWhatItReadsOfATermAreItsComponents() {
         Set<String> components = new TreeSet<>();
         for (Class<?> kind : walked()) {
             for (RecordComponent component : kind.getRecordComponents()) {
@@ -167,8 +167,10 @@ class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
      * component the identity leaves out is exactly the one that makes two readings the store called
      * one answer differently, whoever else reads it.
      */
-    private static Set<String> componentsReadByTheIdentity() throws IOException {
-        ClassModel model = ClassFile.of().parse(Files.readAllBytes(compiledReading()));
+    private static Set<String> componentsReadByTheIdentity() {
+        ClassModel model = WhatWasCompiled.compiled().find(THE_READING)
+                .orElseThrow(() -> new IllegalStateException(
+                        THE_READING + " is not a class this module compiled"));
         Set<String> read = new LinkedHashSet<>();
         Set<String> walked = new LinkedHashSet<>();
         Deque<MethodModel> pending = new ArrayDeque<>();
@@ -208,8 +210,4 @@ class AReadingReadsEverythingATermSaysAndNothingOfWhereItStandsTest {
         return read;
     }
 
-    private static Path compiledReading() {
-        return Path.of("target", "classes", "souther", "compiler", "check", "TermMeaning.class")
-                .toAbsolutePath();
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
@@ -1,15 +1,12 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -18,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,6 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class AnAnswersIdentityCoversEverythingItAnswersWithTest {
 
+    /** The package whose states the store compares, which is what this rule is about. */
+    private static final String THE_CHECK = "souther.compiler.check";
+
     /** Where a state's identity may leave a field out, and why. Nothing else may. */
     private static final Map<String, String> ALLOWED = Map.of(
             "souther.compiler.check.Term.hash",
@@ -66,11 +65,16 @@ class AnAnswersIdentityCoversEverythingItAnswersWithTest {
                     + " identity");
 
     @Test
-    void everyHandWrittenIdentityReadsEveryFieldItsStateHolds() throws IOException {
+    void everyHandWrittenIdentityReadsEveryFieldItsStateHolds() {
         Map<String, String> uncovered = new TreeMap<>();
         int asked = 0;
-        for (Path each : classesOfTheCheck()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().inPackage(THE_CHECK)) {
+            if (model.superclass().isPresent()
+                    && model.superclass().get().asInternalName().equals("java/lang/Record")) {
+                // A record's identity is written for it out of its components, and what such a one
+                // covers is not a question about what anybody wrote.
+                continue;
+            }
             MethodModel equals = declaredEquals(model);
             if (equals == null) {
                 continue;
@@ -166,25 +170,4 @@ class AnAnswersIdentityCoversEverythingItAnswersWithTest {
         return fields;
     }
 
-    /**
-     * The compiled classes of the check, records left out.
-     *
-     * <p>Read from the build and not from the sources: which fields a class has and which of them a
-     * method loads are what the class file says, and a reading of the text would be answering the
-     * same question a second way.
-     */
-    private static List<Path> classesOfTheCheck() throws IOException {
-        Path root = Path.of("target", "classes", "souther", "compiler", "check").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            List<Path> out = new ArrayList<>();
-            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
-                ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-                if (model.superclass().isEmpty()
-                        || !model.superclass().get().asInternalName().equals("java/lang/Record")) {
-                    out.add(each);
-                }
-            }
-            return out;
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -1,23 +1,17 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who reads an operator for what it places, and how often.
@@ -68,7 +62,7 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                             + " the fold answers and is handed to nobody"));
 
     @Test
-    void onlyARecognitionReadsAnOperatorForWhatItPlaces() throws IOException {
+    void onlyARecognitionReadsAnOperatorForWhatItPlaces() {
         assertEquals(declared(MAY_ASK), callsTo(PLACEMENT, "of"),
                 "a reader below a recognised comparison that asks the operator again holds the"
                         + " wide answer, and has a case to invent an answer for; a second call in a"
@@ -89,12 +83,9 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
     }
 
     /** How many times each method of the compiler calls {@code owner.name}. */
-    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+    private static Map<String, Integer> callsTo(String owner, String name) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -106,14 +97,6 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OnePlaceMakesThePartIdEverybodyElseHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnePlaceMakesThePartIdEverybodyElseHoldsTest.java
@@ -1,22 +1,16 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who may make a {@link PartId}, and how often.
@@ -47,7 +41,7 @@ class OnePlaceMakesThePartIdEverybodyElseHoldsTest {
                             + " assigned"));
 
     @Test
-    void onlyTheSplitThatNumberedThePartsNamesOne() throws IOException {
+    void onlyTheSplitThatNumberedThePartsNamesOne() {
         assertEquals(declared(MAY_MAKE), callsTo(PART_ID, "<init>"),
                 "a part named anywhere else is a number somebody counted for themselves put beside"
                         + " whichever rule they were holding. What may make one, and why: "
@@ -67,12 +61,9 @@ class OnePlaceMakesThePartIdEverybodyElseHoldsTest {
     }
 
     /** How many times each method of the compiler calls {@code owner.name}. */
-    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+    private static Map<String, Integer> callsTo(String owner, String name) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -84,14 +75,6 @@ class OnePlaceMakesThePartIdEverybodyElseHoldsTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest.java
@@ -1,25 +1,19 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.constantpool.LoadableConstantEntry;
 import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * What a branch nobody can be in leaves is said once, and every account of a choice is that rule
@@ -96,7 +90,7 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
                     "the account of a rule, asking each alternative of a choice what became of it"));
 
     @Test
-    void theRuleForABranchNobodyCanBeInIsAppliedDownOneRoad() throws IOException {
+    void theRuleForABranchNobodyCanBeInIsAppliedDownOneRoad() {
         assertEquals(declared(DEADENING_AN_ADOPTION), callsTo(ADOPTION, "inADeadBranch"),
                 "a second caller states the rule for a language a second time, and the two are free"
                         + " to disagree: " + why(DEADENING_AN_ADOPTION));
@@ -109,7 +103,7 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
     }
 
     @Test
-    void andAFateIsSpentOnOneBranchInOnePlace() throws IOException {
+    void andAFateIsSpentOnOneBranchInOnePlace() {
         assertEquals(declared(SPENDING_A_FATE_ON_A_BRANCH), callsTo(TAKEN, "under"),
                 "a second caller of this is a second place deciding what a fate does to an account,"
                         + " and what a branch left would be back to turning on the pair: "
@@ -129,12 +123,9 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
     }
 
     /** How many times each method of the compiler names {@code owner.name}. */
-    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+    private static Map<String, Integer> callsTo(String owner, String name) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 String where = from + "." + method.methodName().stringValue();
@@ -145,7 +136,6 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
     }
 
@@ -173,12 +163,5 @@ class OnePlaceSaysWhatABranchNobodyCanBeInLeavesTest {
             }
         }
         return false;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
@@ -1,22 +1,17 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -119,7 +114,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      * grows.
      */
     @Test
-    void everyWayToComeByACanonicalComparisonIsWrittenDown() throws IOException {
+    void everyWayToComeByACanonicalComparisonIsWrittenDown() {
         assertEquals(declared(WAYS_IN), shown(producers()),
                 "a method handing back a canonical comparison is a way to come by one, and what"
                         + " may call it is decided below. What each of these is for: "
@@ -138,7 +133,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      * What they are is said above.
      */
     @Test
-    void nothingMakesOneExceptTheWaysInToMakingOne() throws IOException {
+    void nothingMakesOneExceptTheWaysInToMakingOne() {
         assertEquals(shown(assembling()),
                 callers(Set.of(new Producer(CANONICAL, "<init>"))),
                 "a canonical comparison made anywhere else is one whose making nothing decided,"
@@ -154,7 +149,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      * not.
      */
     @Test
-    void onlyTheTwoClaimsPutACanonicalComparisonTogether() throws IOException {
+    void onlyTheTwoClaimsPutACanonicalComparisonTogether() {
         assertEquals(declared(MAY_ASSEMBLE), callersOf(Producer::assembles),
                 "what a comparison states is derived where what it placed is held, and nowhere"
                         + " else. What each of these assembles: " + why(MAY_ASSEMBLE));
@@ -168,7 +163,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      * writes has to be a comparison of this compiler's own rather than one the source never wrote.
      */
     @Test
-    void onlyAReaderWritingAComparisonDownAsksForOne() throws IOException {
+    void onlyAReaderWritingAComparisonDownAsksForOne() {
         assertEquals(declared(MAY_ASK), callersOf(producer -> !producer.assembles()),
                 "asking a claim what it states is asking to write the comparison down somewhere,"
                         + " through the interface or through the arm that declares the answer."
@@ -194,9 +189,9 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
     }
 
     /** Everything the compiler declares that hands one back. */
-    private static Set<Producer> producers() throws IOException {
+    private static Set<Producer> producers() {
         Set<Producer> out = new TreeSet<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String owner = model.thisClass().asInternalName();
             for (MethodModel method : model.methods()) {
                 if (method.methodTypeSymbol().returnType().descriptorString()
@@ -210,22 +205,22 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
     }
 
     /** The ways in that are declared on the value itself, which is how one is made. */
-    private static Set<Producer> assembling() throws IOException {
+    private static Set<Producer> assembling() {
         return new TreeSet<>(producers().stream().filter(Producer::assembles).toList());
     }
 
     /** Which methods call any producer {@code wanted} admits, whichever way its receiver is
      *  typed. */
     private static Map<String, String> callersOf(java.util.function.Predicate<Producer> wanted)
-            throws IOException {
+            {
         return callers(new TreeSet<>(producers().stream().filter(wanted).toList()));
     }
 
     /** Which methods call any of {@code watched}. */
-    private static Map<String, String> callers(Set<Producer> watched) throws IOException {
+    private static Map<String, String> callers(Set<Producer> watched) {
         assertFalse(watched.isEmpty(), "no producer was watched, so this says nothing");
         Map<String, String> calls = new TreeMap<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -240,15 +235,4 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
         return calls;
     }
 
-    private static List<ClassModel> compiled() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        List<ClassModel> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
-                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        }
-        assertFalse(out.isEmpty(), "no compiled class was read at all, so this says nothing");
-        return out;
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/TheBoundaryRepresentationIsHeldWhereItWasDerivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheBoundaryRepresentationIsHeldWhereItWasDerivedTest.java
@@ -1,22 +1,18 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
 import souther.compiler.ast.Hir;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.MethodRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -89,10 +85,9 @@ class TheBoundaryRepresentationIsHeldWhereItWasDerivedTest {
      * would go on passing after a second holder appeared.
      */
     @Test
-    void theOnlyWayToMakeOneIsToDeriveADeclaration() throws IOException {
+    void theOnlyWayToMakeOneIsToDeriveADeclaration() {
         Set<String> making = new LinkedHashSet<>();
-        for (Path each : classesOfTheCheck()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String owner = model.thisClass().asInternalName();
             for (PoolEntry entry : model.constantPool()) {
                 if (entry instanceof MethodRefEntry ref
@@ -136,10 +131,4 @@ class TheBoundaryRepresentationIsHeldWhereItWasDerivedTest {
         return false;
     }
 
-    private static List<Path> classesOfTheCheck() throws IOException {
-        Path root = Path.of("target", "classes", "souther", "compiler").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return walk.filter(p -> p.toString().endsWith(".class")).toList();
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
@@ -1,25 +1,20 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
 import souther.compiler.core.CompleteSignature;
 import souther.compiler.core.DeclaredOperation;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -115,7 +110,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
                             + " it answers"));
 
     @Test
-    void everyWayToComeByACompleteSignatureIsWrittenDown() throws IOException {
+    void everyWayToComeByACompleteSignatureIsWrittenDown() {
         assertEquals(declared(WAYS_IN), shown(producers()),
                 "a method handing back a complete signature is a way to come by one, and what may"
                         + " call it is decided below. What each of these is for: " + why(WAYS_IN));
@@ -130,7 +125,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
      * here, as a maker that is not one of the ways in.
      */
     @Test
-    void nothingMakesOneExceptTheWaysInToMakingOne() throws IOException {
+    void nothingMakesOneExceptTheWaysInToMakingOne() {
         assertEquals(shown(assembling()),
                 callers(Set.of(new Producer(SIGNATURE, "<init>"))),
                 "a complete signature made anywhere else is one whose making nothing decided");
@@ -138,7 +133,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
 
     /** Who reads a declaration into a signature. */
     @Test
-    void onlyAReaderOfADeclarationAssemblesOne() throws IOException {
+    void onlyAReaderOfADeclarationAssemblesOne() {
         assertEquals(declared(MAY_ASSEMBLE), callersOf(Producer::assembles),
                 "a signature is made where a declaration is being read and nowhere else. What each"
                         + " of these reads: " + why(MAY_ASSEMBLE));
@@ -152,14 +147,14 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
      * builds one" perfectly.
      */
     @Test
-    void onlyASignatureComingToBeMintsADeclaredOperation() throws IOException {
+    void onlyASignatureComingToBeMintsADeclaredOperation() {
         assertEquals(Set.of("souther.compiler.core.CompleteSignature.<init>"),
                 callers(Set.of(new Producer(DECLARED, "<init>"))).keySet(),
                 "a name said to have been read against a declaration, where no declaration was");
     }
 
     @Test
-    void andSomethingDoesMintOne() throws IOException {
+    void andSomethingDoesMintOne() {
         assertFalse(callers(Set.of(new Producer(DECLARED, "<init>"))).isEmpty(),
                 "nothing mints one, so the rule above saw no classes");
     }
@@ -183,9 +178,9 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
     }
 
     /** Everything the compiler declares that hands one back. */
-    private static Set<Producer> producers() throws IOException {
+    private static Set<Producer> producers() {
         Set<Producer> out = new TreeSet<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String owner = model.thisClass().asInternalName();
             for (MethodModel method : model.methods()) {
                 if (method.methodTypeSymbol().returnType().descriptorString()
@@ -199,22 +194,22 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
     }
 
     /** The ways in declared on the signature itself, which is how one is made. */
-    private static Set<Producer> assembling() throws IOException {
+    private static Set<Producer> assembling() {
         return new TreeSet<>(producers().stream().filter(Producer::assembles).toList());
     }
 
     /** Which methods call any producer {@code wanted} admits, whichever way its receiver is
      *  typed. */
     private static Map<String, String> callersOf(java.util.function.Predicate<Producer> wanted)
-            throws IOException {
+            {
         return callers(new TreeSet<>(producers().stream().filter(wanted).toList()));
     }
 
     /** Which methods call any of {@code watched}. */
-    private static Map<String, String> callers(Set<Producer> watched) throws IOException {
+    private static Map<String, String> callers(Set<Producer> watched) {
         assertFalse(watched.isEmpty(), "no producer was watched, so this says nothing");
         Map<String, String> calls = new TreeMap<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -229,15 +224,4 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
         return calls;
     }
 
-    private static List<ClassModel> compiled() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        List<ClassModel> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
-                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        }
-        assertFalse(out.isEmpty(), "no compiled class was read at all, so this says nothing");
-        return out;
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -1,9 +1,8 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.FieldModel;
@@ -34,17 +33,13 @@ import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.classfile.instruction.NewObjectInstruction;
 import java.lang.classfile.instruction.NewReferenceArrayInstruction;
 import java.lang.classfile.instruction.TypeCheckInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Everywhere an operator can be, and what each of them wants one for.
@@ -500,36 +495,22 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
     }
 
     private static void forEachClass(EachClass each) {
-        int read = 0;
-        try {
-            for (Path path : classes()) {
-                ClassModel model = ClassFile.of().parse(Files.readAllBytes(path));
-                String owner = model.thisClass().asInternalName()
-                        .replace('/', '.').replace('$', '.');
-                if (owner.equals("souther.compiler.types.BinOp")) {
-                    // The operator itself, whose own members are what an enum is made of.
-                    continue;
-                }
-                if (model.flags().has(java.lang.reflect.AccessFlag.SYNTHETIC)) {
-                    // A class the compiler wrote, not a place anybody reads an operator: what
-                    // javac emits to switch over an enum holds one, on behalf of the method that
-                    // does the switching — and that method is in the list under its own name. An
-                    // anonymous class is not one of these; it holds what somebody wrote.
-                    continue;
-                }
-                read++;
-                each.read(owner, model);
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
+            String owner = model.thisClass().asInternalName()
+                    .replace('/', '.').replace('$', '.');
+            if (owner.equals("souther.compiler.types.BinOp")) {
+                // The operator itself, whose own members are what an enum is made of.
+                continue;
             }
-        } catch (IOException e) {
-            throw new java.io.UncheckedIOException(e);
+            if (model.flags().has(java.lang.reflect.AccessFlag.SYNTHETIC)) {
+                // A class the compiler wrote, not a place anybody reads an operator: what
+                // javac emits to switch over an enum holds one, on behalf of the method that
+                // does the switching — and that method is in the list under its own name. An
+                // anonymous class is not one of these; it holds what somebody wrote.
+                continue;
+            }
+            each.read(owner, model);
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMayCarryTheNumberOfAPartIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMayCarryTheNumberOfAPartIsWrittenDownTest.java
@@ -1,21 +1,15 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who carries the number of a part beside the rule it is a part of, rather than the name that was
@@ -50,7 +44,7 @@ class WhoMayCarryTheNumberOfAPartIsWrittenDownTest {
                             + " the one place the two stand together"));
 
     @Test
-    void aNumberBesideARuleIsWrittenDownWithWhatItCounts() throws IOException {
+    void aNumberBesideARuleIsWrittenDownWithWhatItCounts() {
         assertEquals(declared(MAY_HOLD), numbersHeldBesideARule(),
                 "a type downstream of the split that numbers a clause's parts holds the name that"
                         + " split issued, not a number of its own. What still holds one, and what"
@@ -76,12 +70,9 @@ class WhoMayCarryTheNumberOfAPartIsWrittenDownTest {
      * the pair whatever it is named, and a check that looked for the word would be satisfied by
      * renaming the field.
      */
-    private static Map<String, String> numbersHeldBesideARule() throws IOException {
+    private static Map<String, String> numbersHeldBesideARule() {
         Map<String, String> found = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             boolean holdsARule = false;
             for (FieldModel field : model.fields()) {
@@ -97,14 +88,6 @@ class WhoMayCarryTheNumberOfAPartIsWrittenDownTest {
                 }
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return found;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
@@ -1,22 +1,17 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -127,7 +122,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
                     "reads which of a plan's comparisons the walk settled nothing about"));
 
     @Test
-    void everyMethodThatHandsBackALimitIsWrittenDownAsOneOfTheTwo() throws IOException {
+    void everyMethodThatHandsBackALimitIsWrittenDownAsOneOfTheTwo() {
         assertEquals(declared(WAYS_IN, HANDS_ON), shown(producers()),
                 "a method handing back a limit either makes one or hands on one that was made, and"
                         + " which it is has to be said before anything asks who may call it. What"
@@ -136,7 +131,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
 
     /** And that a limit is made only on the limit itself, so the ways in are all of them. */
     @Test
-    void nothingMakesOneExceptTheWaysIn() throws IOException {
+    void nothingMakesOneExceptTheWaysIn() {
         assertEquals(declared(WAYS_IN), shown(assembling()),
                 "a limit made anywhere else is one whose making nothing decided");
     }
@@ -160,9 +155,9 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
             "Lsouther/compiler/diag/SourcePos;");
 
     @Test
-    void aWayInTakesWhatThisReadingMetAndNothingItWasHanded() throws IOException {
+    void aWayInTakesWhatThisReadingMetAndNothingItWasHanded() {
         Map<String, String> taking = new TreeMap<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             if (!model.thisClass().asInternalName().equals(LIMIT)) {
                 continue;
             }
@@ -183,7 +178,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
     }
 
     @Test
-    void onlyAReaderThatMetOneSaysThisCheckMetALimit() throws IOException {
+    void onlyAReaderThatMetOneSaysThisCheckMetALimit() {
         assertEquals(declared(MAY_SAY), callers(assembling()),
                 "a limit is made where one was met and nowhere else. What each of these met: "
                         + why(MAY_SAY));
@@ -191,7 +186,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
 
     /** And that something does make one, so the rule above is not read over no classes at all. */
     @Test
-    void andSomethingDoesSaySo() throws IOException {
+    void andSomethingDoesSaySo() {
         assertFalse(callers(assembling()).isEmpty(),
                 "nothing makes a limit, so the rule above saw nothing");
     }
@@ -206,7 +201,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
     }
 
     /** The ways in, which are the methods declared on the limit itself. */
-    private static Set<Producer> assembling() throws IOException {
+    private static Set<Producer> assembling() {
         return new TreeSet<>(producers().stream()
                 .filter(each -> each.owner().equals(LIMIT)).toList());
     }
@@ -227,9 +222,9 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
     }
 
     /** Everything the compiler declares that hands one back. */
-    private static Set<Producer> producers() throws IOException {
+    private static Set<Producer> producers() {
         Set<Producer> out = new TreeSet<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String owner = model.thisClass().asInternalName();
             for (MethodModel method : model.methods()) {
                 if (method.methodTypeSymbol().returnType().descriptorString()
@@ -244,10 +239,10 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
     }
 
     /** Which methods call any of {@code watched}. */
-    private static Map<String, String> callers(Set<Producer> watched) throws IOException {
+    private static Map<String, String> callers(Set<Producer> watched) {
         assertFalse(watched.isEmpty(), "no producer was watched, so this says nothing");
         Map<String, String> calls = new TreeMap<>();
-        for (ClassModel model : compiled()) {
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -275,15 +270,4 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
         return out.append(')').toString();
     }
 
-    private static List<ClassModel> compiled() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        List<ClassModel> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
-                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        }
-        assertFalse(out.isEmpty(), "no compiled class was read at all, so this says nothing");
-        return out;
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest.java
@@ -1,22 +1,16 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who splits a clause into the parts its author wrote, and where such a split may happen.
@@ -58,7 +52,7 @@ class WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest {
                             + " which splits the written tree and expands one part at a time"));
 
     @Test
-    void onlyAnExpansionSplitsAClauseIntoTheParts() throws IOException {
+    void onlyAnExpansionSplitsAClauseIntoTheParts() {
         assertEquals(declared(MAY_SPLIT), callsTo(HELPERS, "shapeOf"),
                 "a clause split anywhere else is a second answer to which parts it has, and the"
                         + " tree such a reader holds is one an expansion has been over. What may"
@@ -81,12 +75,9 @@ class WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest {
     }
 
     /** How many times each method of the compiler calls {@code owner.name}. */
-    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+    private static Map<String, Integer> callsTo(String owner, String name) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -98,14 +89,6 @@ class WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/TheBackendEmitsAgainstTheLanguageItWasHandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/TheBackendEmitsAgainstTheLanguageItWasHandedTest.java
@@ -1,17 +1,13 @@
 package souther.compiler.codegen;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,8 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TheBackendEmitsAgainstTheLanguageItWasHandedTest {
 
-    private static final Path COMPILED = Path.of("target", "classes", "souther", "compiler",
-            "codegen");
+    private static final String THE_BACKEND = "souther.compiler.codegen";
 
     /** What the backend may not name, as the constant pool spells it. */
     private static final String THE_LIBRARY = "souther/compiler/stdlib/";
@@ -45,17 +40,17 @@ class TheBackendEmitsAgainstTheLanguageItWasHandedTest {
     @Test
     void nothingInTheBackendNamesTheStandardLibrary() {
         List<String> reaching = new ArrayList<>();
-        List<Path> classes = compiledClasses();
+        List<ClassModel> classes = WhatWasCompiled.compiled().inPackage(THE_BACKEND);
 
-        // A walk that found nothing because it read nothing answers the same as one that read
-        // everything and found nothing.
+        // A walk that found nothing because it read next to nothing answers the same as one that
+        // read everything and found nothing.
         assertTrue(classes.size() > 10,
-                () -> "read only " + classes.size() + " compiled classes under " + COMPILED);
+                () -> "read only " + classes.size() + " compiled classes of " + THE_BACKEND);
 
-        for (Path each : classes) {
-            for (PoolEntry entry : constantPoolOf(each)) {
+        for (ClassModel each : classes) {
+            for (PoolEntry entry : each.constantPool()) {
                 if (entry instanceof Utf8Entry utf8 && utf8.stringValue().contains(THE_LIBRARY)) {
-                    reaching.add(each.getFileName() + " names " + utf8.stringValue());
+                    reaching.add(each.thisClass().asInternalName() + " names " + utf8.stringValue());
                     break;
                 }
             }
@@ -64,21 +59,5 @@ class TheBackendEmitsAgainstTheLanguageItWasHandedTest {
         assertEquals(List.of(), reaching,
                 "the backend emits against the kernel declarations it is handed; these reach the"
                         + " library for an answer of their own");
-    }
-
-    private static List<Path> compiledClasses() {
-        try (Stream<Path> found = Files.walk(COMPILED)) {
-            return found.filter(each -> each.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException("the backend's classes are not compiled at " + COMPILED, e);
-        }
-    }
-
-    private static Iterable<PoolEntry> constantPoolOf(Path each) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(each)).constantPool();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AModuleHasOnePlanAndOneMakerOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AModuleHasOnePlanAndOneMakerOfItTest.java
@@ -1,9 +1,8 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
@@ -11,10 +10,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -22,7 +17,6 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A module's places are walked once, by the answer that holds its bodies.
@@ -72,7 +66,7 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
                     + " is refused");
 
     @Test
-    void onlyTheCheckThatHoldsTheBodiesWalksThemForAPlan() throws IOException {
+    void onlyTheCheckThatHoldsTheBodiesWalksThemForAPlan() {
         assertEquals(once(MAY_WALK), calling(SITES, "of"),
                 () -> "a second walk of one module's bodies makes a second plan of it, addressing"
                         + " objects the first plan does not — and a second walk written where the"
@@ -81,7 +75,7 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
     }
 
     @Test
-    void andOnlyTheEndOfThatWalkPutsOneTogether() throws IOException {
+    void andOnlyTheEndOfThatWalkPutsOneTogether() {
         assertEquals(once(MAY_CONSTRUCT), calling(A_PLAN, "<init>"),
                 () -> "a plan assembled out of parts is an index into a graph its assembler does"
                         + " not own. What builds one today, and what makes it the one that may: "
@@ -194,12 +188,12 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
      * read and every instruction of it decoded, which is not what a run somebody is waiting on
      * should do twice to answer two questions about the same compiled code.
      */
-    private static Map<String, Integer> calling(String owner, String name) throws IOException {
+    private static Map<String, Integer> calling(String owner, String name) {
         return counted().getOrDefault(owner + "." + name, Map.of());
     }
 
     /** What each door is called by, read once. */
-    private static Map<String, Map<String, Integer>> counted() throws IOException {
+    private static Map<String, Map<String, Integer>> counted() {
         if (COUNTED == null) {
             COUNTED = count();
         }
@@ -208,12 +202,9 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
 
     private static Map<String, Map<String, Integer>> COUNTED;
 
-    private static Map<String, Map<String, Integer>> count() throws IOException {
+    private static Map<String, Map<String, Integer>> count() {
         Map<String, Map<String, Integer>> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -229,17 +220,9 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
     }
 
     /** The two ways to a plan, as an invocation names them. */
     private static final Set<String> DOORS = Set.of(SITES + ".of", A_PLAN + ".<init>");
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
@@ -1,24 +1,18 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A place is asked for its number where a number is what has to be written, and nowhere else.
@@ -72,7 +66,7 @@ class OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest {
                             + " asked in the same words"));
 
     @Test
-    void onlyTheEmitterTakesTheNumberOutOfAPlace() throws IOException {
+    void onlyTheEmitterTakesTheNumberOutOfAPlace() {
         assertEquals(declared(), asked(),
                 "a number taken out anywhere else is a number a caller can pair with a place it"
                         + " was not issued for, and nothing downstream can tell that from a right"
@@ -92,12 +86,9 @@ class OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest {
     }
 
     /** How many times each method of the compiler asks a place for its number. */
-    private static Map<String, Integer> asked() throws IOException {
+    private static Map<String, Integer> asked() {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -109,14 +100,6 @@ class OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatARunSaysAboutAPlaceIsAskedOfTheRunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatARunSaysAboutAPlaceIsAskedOfTheRunTest.java
@@ -1,24 +1,18 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Whether a run was at a place is asked of the run, and not of the set it holds.
@@ -62,7 +56,7 @@ class WhatARunSaysAboutAPlaceIsAskedOfTheRunTest {
                             + " wrong about"));
 
     @Test
-    void whatTakesThePlacesWholeIsGatheringThemAndSaysSo() throws IOException {
+    void whatTakesThePlacesWholeIsGatheringThemAndSaysSo() {
         assertEquals(declared(), taken(),
                 "a reader that takes the set to ask whether one place is in it has gone round the"
                         + " refusal that makes an aligned run mean anything, and gets an ordinary"
@@ -83,12 +77,9 @@ class WhatARunSaysAboutAPlaceIsAskedOfTheRunTest {
     }
 
     /** How many times each method of the compiler takes a run's places whole. */
-    private static Map<String, Integer> taken() throws IOException {
+    private static Map<String, Integer> taken() {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -101,14 +92,6 @@ class WhatARunSaysAboutAPlaceIsAskedOfTheRunTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatDerivesANumberingIsWhatHoldsTheBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatDerivesANumberingIsWhatHoldsTheBodiesTest.java
@@ -1,23 +1,17 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A module's numbering is derived where its bodies are held, and nowhere else in the compiler.
@@ -105,7 +99,7 @@ class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
                             + " in for one"));
 
     @Test
-    void onlyTheCheckThatHoldsThemDerivesAModulesNumbering() throws IOException {
+    void onlyTheCheckThatHoldsThemDerivesAModulesNumbering() {
         assertEquals(declared(MAY_DERIVE), derivations(),
                 "a numbering derived anywhere else is a second answer about one module's arms, and"
                         + " a reader holding it is reading a run against numbers nothing wrote."
@@ -129,7 +123,7 @@ class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
      * {@code souther-cli} or {@code souther-lsp} is outside what this can answer for.
      */
     @Test
-    void nothingElseInTheCompilerMakesANumbering() throws IOException {
+    void nothingElseInTheCompilerMakesANumbering() {
         Map<String, Map<String, Integer>> declared = new TreeMap<>();
         Map<String, String> why = new LinkedHashMap<>();
         for (Door each : DOORS) {
@@ -163,14 +157,14 @@ class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
     /** How many times each method of the compiler decides a numbering from bodies. Only the call
      *  that decides one: a walk taking a numbering already issued asks for it by another name, and
      *  hands out addresses of what it was given. */
-    private static Map<String, Integer> derivations() throws IOException {
+    private static Map<String, Integer> derivations() {
         return calls(call -> call.owner().asInternalName().equals(SITES)
                 && call.name().stringValue().equals("of"));
     }
 
     /** How many times each method of the compiler goes through {@code door}, which is written the
      *  way the classes name a method: the owning class, then the method. */
-    private static Map<String, Integer> callersOf(String door) throws IOException {
+    private static Map<String, Integer> callersOf(String door) {
         int split = door.lastIndexOf('.');
         String owner = door.substring(0, split).replace('.', '/');
         String method = door.substring(split + 1);
@@ -179,12 +173,9 @@ class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
     }
 
     private static Map<String, Integer> calls(java.util.function.Predicate<InvokeInstruction> what)
-            throws IOException {
+            {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -194,14 +185,6 @@ class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatMakesAPlanIsWhatNumberedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatMakesAPlanIsWhatNumberedItTest.java
@@ -1,23 +1,17 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A plan is made where its bodies are numbered, and nowhere else in the compiler.
@@ -65,7 +59,7 @@ class WhatMakesAPlanIsWhatNumberedItTest {
                             + " there being none of them"));
 
     @Test
-    void onlyTheWalkThatNumberedThemMakesAPlanOfABodysArms() throws IOException {
+    void onlyTheWalkThatNumberedThemMakesAPlanOfABodysArms() {
         assertEquals(declared(), made(),
                 "a plan put together anywhere else is parts a caller believed went together, and"
                         + " the agreements between them are what a reader of a run rests on."
@@ -85,12 +79,9 @@ class WhatMakesAPlanIsWhatNumberedItTest {
     }
 
     /** How many times each method of the compiler makes one. */
-    private static Map<String, Integer> made() throws IOException {
+    private static Map<String, Integer> made() {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -102,14 +93,6 @@ class WhatMakesAPlanIsWhatNumberedItTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
@@ -1,23 +1,17 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Which comparison a reading is talking about, and where a run through one is written down, are
@@ -117,7 +111,7 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
                             + " numbered it"));
 
     @Test
-    void onlyACheckPairsAModuleWithItsBodies() throws IOException {
+    void onlyACheckPairsAModuleWithItsBodies() {
         assertEquals(declared(MAY_PAIR), callsToConstructor(BODIES),
                 "a module's name beside another module's trees has the catalog issue names true of"
                         + " nothing, and no later check can refuse them. What may pair them, and"
@@ -125,28 +119,28 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
     }
 
     @Test
-    void onlyTheWalkPutsACataloguedComparisonTogether() throws IOException {
+    void onlyTheWalkPutsACataloguedComparisonTogether() {
         assertEquals(declared(MAY_CATALOGUE), callsToConstructor(CATALOGUED),
                 "a name, a recognition and a place are true together or not at all. What may put"
                         + " them together, and why: " + why(MAY_CATALOGUE));
     }
 
     @Test
-    void onlyOnePlaceSaysWhichComparisonARuleIsReadOff() throws IOException {
+    void onlyOnePlaceSaysWhichComparisonARuleIsReadOff() {
         assertEquals(declared(MAY_READ), callsToConstructor(READ),
                 "an occurrence of one plan beside the emission site of another is a rule pointing"
                         + " at two places. What may pair them, and why: " + why(MAY_READ));
     }
 
     @Test
-    void onlyTheCatalogNamesAComparisonOfABody() throws IOException {
+    void onlyTheCatalogNamesAComparisonOfABody() {
         assertEquals(declared(MAY_NAME), callsToConstructor(OCCURRENCE),
                 "a second place naming an occurrence is a second answer to which comparison a"
                         + " reading means. What may name one, and why: " + why(MAY_NAME));
     }
 
     @Test
-    void onlyTheNumberingAddressesAComparisonOfARun() throws IOException {
+    void onlyTheNumberingAddressesAComparisonOfARun() {
         assertEquals(declared(MAY_ADDRESS), callsToConstructor(SITE),
                 "an address made anywhere else is a place no run was recorded at. What may make"
                         + " one, and why: " + why(MAY_ADDRESS));
@@ -160,7 +154,7 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
      * paired with a numbering that never handed them out.
      */
     @Test
-    void onlyTheNumberingAddressesAnArmOfARun() throws IOException {
+    void onlyTheNumberingAddressesAnArmOfARun() {
         assertEquals(declared(MAY_ADDRESS_AN_ARM), callsToConstructor(ARM),
                 "an address made anywhere else is a place no run was recorded at. What may make"
                         + " one, and why: " + why(MAY_ADDRESS_AN_ARM));
@@ -179,12 +173,9 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
     }
 
     /** How many times each method of the compiler makes one of {@code owner}. */
-    private static Map<String, Integer> callsToConstructor(String owner) throws IOException {
+    private static Map<String, Integer> callsToConstructor(String owner) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -196,14 +187,6 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
@@ -1,24 +1,18 @@
 package souther.compiler.coverage;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who takes a plan's numbering, written down with what makes it safe where it stands.
@@ -72,7 +66,7 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
                             + " beside the one the probes were written from"));
 
     @Test
-    void everyReaderOfAPlansNumberingIsWrittenDownWithWhatMakesItSafe() throws IOException {
+    void everyReaderOfAPlansNumberingIsWrittenDownWithWhatMakesItSafe() {
         assertEquals(declared(), taken(),
                 "a numbering taken off a plan that stands in for absent bodies is nobody's, and a"
                         + " reader aligning a recording against it is told the run was of somewhere"
@@ -94,12 +88,9 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
     }
 
     /** How many times each method of the compiler takes a plan's numbering. */
-    private static Map<String, Integer> taken() throws IOException {
+    private static Map<String, Integer> taken() {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -112,14 +103,6 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/frontend/WhatIsWrittenBesideADefinitionDoesNotNumberItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/frontend/WhatIsWrittenBesideADefinitionDoesNotNumberItTest.java
@@ -300,12 +300,13 @@ class WhatIsWrittenBesideADefinitionDoesNotNumberItTest {
     /** Every {@code .sou} file the repository carries, by where it is written: the corpora, the
      *  models written to be worked with, and the library the language ships. */
     private static Map<String, String> everySourceTheRepositoryCarries() {
-        Path root = RepositoryLayout.ofWorkingDirectory().root();
+        RepositoryLayout repository = RepositoryLayout.ofWorkingDirectory();
+        Path root = repository.root();
         Map<String, String> sources = new LinkedHashMap<>();
         try (Stream<Path> walk = Files.walk(root)) {
             for (Path each : walk.filter(Files::isRegularFile)
                     .filter(it -> it.getFileName().toString().endsWith(".sou"))
-                    .filter(it -> !it.toString().contains("/target/"))
+                    .filter(it -> !repository.isUnderBuildOutput(it))
                     .sorted().toList()) {
                 sources.put(root.relativize(each).toString(), Files.readString(each));
             }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NothingTakesANumberAndAnotherNumbersOrdersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NothingTakesANumberAndAnotherNumbersOrdersTest.java
@@ -1,22 +1,16 @@
 package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.constant.ClassDesc;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,10 +60,9 @@ class NothingTakesANumberAndAnotherNumbersOrdersTest {
     private static final String MOVES = "movedTo";
 
     @Test
-    void nothingTakesBothWithoutProvingTheyAgree() throws IOException {
+    void nothingTakesBothWithoutProvingTheyAgree() {
         Set<String> takesBoth = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.');
             if (from.equals(ORDERS)) {
                 continue;   // what the pair says about itself is its own business
@@ -96,10 +89,9 @@ class NothingTakesANumberAndAnotherNumbersOrdersTest {
      * the one name this does not report.
      */
     @Test
-    void movingAQuantityIsAskedOneNumberAndHandedOneAnswer() throws IOException {
+    void movingAQuantityIsAskedOneNumberAndHandedOneAnswer() {
         Set<String> shapes = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             for (MethodModel method : model.methods()) {
                 // The declared move, not the lambdas inside one: a lambda's parameters are what it
                 // captured, which is not a shape anybody wrote.
@@ -122,10 +114,9 @@ class NothingTakesANumberAndAnotherNumbersOrdersTest {
 
     /** That the scan is reading methods at all, so an empty answer means what it says. */
     @Test
-    void theScanReadsTheMethodsItIsAbout() throws IOException {
+    void theScanReadsTheMethodsItIsAbout() {
         int found = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             for (MethodModel method : model.methods()) {
                 if (mentions(method, ORDERS)) {
                     found++;
@@ -174,11 +165,4 @@ class NothingTakesANumberAndAnotherNumbersOrdersTest {
         return false;
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(new LinkedHashSet<>(
-                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -1,20 +1,14 @@
 package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,10 +47,9 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
      * own. What the class files carry is the call, whatever it was written as.
      */
     @Test
-    void oneProductionPlaceDerivesATermsOrders() throws IOException {
+    void oneProductionPlaceDerivesATermsOrders() {
         Set<String> derives = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = nestOf(model.thisClass().asInternalName().replace('/', '.'));
             if (from.equals(DERIVES)) {
                 continue;   // what the derivation does with itself is its own business
@@ -96,11 +89,10 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
      * held to here rather than left to be noticed.
      */
     @Test
-    void oneProductionPlaceMakesAPair() throws IOException {
+    void oneProductionPlaceMakesAPair() {
         Set<String> built = new TreeSet<>();
         Set<String> named = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = nestOf(model.thisClass().asInternalName().replace('/', '.'));
             if (from.equals(MADE)) {
                 continue;   // what the pair does with itself is its own business
@@ -137,13 +129,6 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
         return nested < 0 ? binaryName : binaryName.substring(0, nested);
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(new LinkedHashSet<>(
-                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
-        }
-    }
 
     /**
      * And the way in stays shut, which is what makes the count above the whole of the rule.

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
@@ -1,20 +1,13 @@
 package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -61,10 +54,9 @@ class WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest {
             "souther.compiler.partition.Generator");
 
     @Test
-    void nothingElseSettlesAPositionOfAValuesRules() throws IOException {
+    void nothingElseSettlesAPositionOfAValuesRules() {
         Set<String> found = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = nestOf(model.thisClass().asInternalName().replace('/', '.'));
             if (from.equals(CONDITIONS)) {
                 continue;   // what the reading does with itself is its own business
@@ -111,11 +103,4 @@ class WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest {
         return nested < 0 ? binaryName : binaryName.substring(0, nested);
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(new LinkedHashSet<>(
-                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/meta/OnlyARendererTakesAProofApartTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/OnlyARendererTakesAProofApartTest.java
@@ -1,22 +1,18 @@
 package souther.compiler.meta;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.classfile.instruction.NewObjectInstruction;
 import java.lang.constant.DirectMethodHandleDesc;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -84,7 +80,7 @@ class OnlyARendererTakesAProofApartTest {
     private record Use(String from, String owner, String member, boolean isStatic) {}
 
     @Test
-    void onlyItsOwnWordsAskAPayloadWhatItSays() throws IOException {
+    void onlyItsOwnWordsAskAPayloadWhatItSays() {
         Map<String, List<String>> asked = new LinkedHashMap<>();
         for (Use use : uses()) {
             if (WRITES_THE_WORDS_OF.containsKey(use.owner()) && use.member().equals("said")) {
@@ -99,10 +95,9 @@ class OnlyARendererTakesAProofApartTest {
     }
 
     @Test
-    void andOnlyThoseWordsAreWritten() throws IOException {
+    void andOnlyThoseWordsAreWritten() {
         Map<String, List<String>> implementors = new LinkedHashMap<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             for (var face : model.interfaces()) {
                 String name = face.asInternalName().replace('/', '.');
                 WRITES_THE_WORDS_OF.forEach((payload, words) -> {
@@ -121,7 +116,7 @@ class OnlyARendererTakesAProofApartTest {
     }
 
     @Test
-    void andNothingButTheReadingMakesAnAnswer() throws IOException {
+    void andNothingButTheReadingMakesAnAnswer() {
         List<String> outside = new ArrayList<>();
         List<Use> made = new ArrayList<>();
         boolean sawAConstructor = false;
@@ -170,10 +165,9 @@ class OnlyARendererTakesAProofApartTest {
     }
 
     /** Every call and construction the compiled classes hold, the answers' own aside. */
-    private static List<Use> uses() throws IOException {
+    private static List<Use> uses() {
         List<Use> found = new ArrayList<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.');
             if (from.startsWith(REACH)) {
                 continue;   // what the answers do among themselves is their own business
@@ -210,12 +204,4 @@ class OnlyARendererTakesAProofApartTest {
         return found;
     }
 
-    /** The compiled main classes of this module. Read from the build rather than from the sources,
-     *  because what a call is, is what the compiler made of it. */
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return walk.filter(each -> each.toString().endsWith(".class")).toList();
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OnePlaceTurnsAPlacementIntoAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OnePlaceTurnsAPlacementIntoAnAnswerTest.java
@@ -1,19 +1,14 @@
 package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.instruction.NewObjectInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -62,10 +57,9 @@ class OnePlaceTurnsAPlacementIntoAnAnswerTest {
                     "souther.compiler.partition.CandidateDomain.filling"));
 
     @Test
-    void nothingElseTurnsAPlacementIntoAnAnswer() throws IOException {
+    void nothingElseTurnsAPlacementIntoAnAnswer() {
         Map<String, Set<String>> made = new java.util.TreeMap<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.');
             for (var method : model.methods()) {
                 CodeModel code = method.code().orElse(null);
@@ -90,10 +84,4 @@ class OnePlaceTurnsAPlacementIntoAnAnswerTest {
                 "who hands back a " + what));
     }
 
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return walk.filter(each -> each.toString().endsWith(".class")).toList();
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
@@ -1,23 +1,16 @@
 package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.constant.ConstantDesc;
 import java.lang.constant.DirectMethodHandleDesc;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -73,7 +66,7 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      * written, one relation standing in for the other again.
      */
     @Test
-    void oneMethodAsksWhereAWrittenValueHasItsParts() throws IOException {
+    void oneMethodAsksWhereAWrittenValueHasItsParts() {
         Set<String> asks = callersOf(ANSWERS);
 
         assertFalse(asks.isEmpty(),
@@ -100,7 +93,7 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      * error one call further out.
      */
     @Test
-    void theWalkIsAskedWhereAValueIsComposed() throws IOException {
+    void theWalkIsAskedWhereAValueIsComposed() {
         Set<String> asks = callersOf(WALKS);
 
         assertFalse(asks.isEmpty(),
@@ -117,10 +110,9 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
     }
 
     /** Every production method that reaches {@code answer} on the owner, however it spelled it. */
-    private static Set<String> callersOf(String answer) throws IOException {
+    private static Set<String> callersOf(String answer) {
         Set<String> asks = new TreeSet<>();
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.');
             for (var method : model.methods()) {
                 CodeModel code = method.code().orElse(null);
@@ -146,9 +138,9 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      * would be settled by the types it happened to hold.
      */
     @Test
-    void thereIsOneAnswerUnderThatName() throws IOException {
+    void thereIsOneAnswerUnderThatName() {
         Set<String> declared = new TreeSet<>();
-        ClassModel model = ClassFile.of().parse(Files.readAllBytes(fileOf(OWNER)));
+        ClassModel model = compiled(OWNER);
         for (var method : model.methods()) {
             if (method.methodName().stringValue().equals(ANSWERS)) {
                 declared.add(method.methodType().stringValue());
@@ -193,18 +185,9 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
         return (owner.equals(OWNER) || owner.equals(SHORT)) && method.equals(answer);
     }
 
-    private static Path fileOf(String binaryName) {
-        return root().resolve(binaryName.replace('.', '/') + ".class");
-    }
-
-    private static List<Path> classes() throws IOException {
-        try (Stream<Path> walk = Files.walk(root())) {
-            return new ArrayList<>(new LinkedHashSet<>(
-                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
-        }
-    }
-
-    private static Path root() {
-        return Path.of("target", "classes").toAbsolutePath();
+    private static ClassModel compiled(String binaryName) {
+        return WhatWasCompiled.compiled().find(binaryName)
+                .orElseThrow(() -> new IllegalStateException(
+                        binaryName + " is not a class this module compiled"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
@@ -3,23 +3,17 @@ package souther.compiler.partition;
 import souther.compiler.check.PartId;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who carries the number of a statement beside the part it is a statement of, and who may make one.
@@ -66,7 +60,7 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
      * statement is, which is the number being counted by whoever was holding the part.
      */
     @Test
-    void onlyTheReadingThatTookThePartApartNamesOne() throws IOException {
+    void onlyTheReadingThatTookThePartApartNamesOne() {
         assertEquals(named(MAY_MAKE), callsTo(STATEMENT_ID, "<init>"),
                 "a statement named anywhere else is a number somebody counted for themselves put"
                         + " beside whichever part they were holding. What may make one, and why: "
@@ -75,7 +69,7 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
 
     /** And nothing downstream of that reading holds the number instead of the name. */
     @Test
-    void aNumberBesideAPartIsWrittenDownWithWhatItCounts() throws IOException {
+    void aNumberBesideAPartIsWrittenDownWithWhatItCounts() {
         assertEquals(named(MAY_HOLD), numbersHeldBesideAPart(),
                 "a type downstream of the reading that numbers a part's statements holds the name"
                         + " that reading issued, not a number of its own. What still holds one, and"
@@ -101,11 +95,9 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
      * the pair whatever it is named, and a check that looked for the word would be satisfied by
      * renaming the field.
      */
-    private static Map<String, String> numbersHeldBesideAPart() throws IOException {
+    private static Map<String, String> numbersHeldBesideAPart() {
         Map<String, String> found = new TreeMap<>();
-        int read = 0;
-        for (ClassModel model : compiled()) {
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             boolean holdsAPart = false;
             for (FieldModel field : model.fields()) {
@@ -121,16 +113,13 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
                 }
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return found;
     }
 
     /** Which methods of the compiler call {@code owner.name}. */
-    private static Map<String, String> callsTo(String owner, String name) throws IOException {
+    private static Map<String, String> callsTo(String owner, String name) {
         Map<String, String> calls = new TreeMap<>();
-        int read = 0;
-        for (ClassModel model : compiled()) {
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 String where = from + "." + method.methodName().stringValue();
@@ -143,30 +132,9 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
     }
 
-    /**
-     * Every compiled class, parsed once for both questions.
-     *
-     * <p>The two ask different things of the same classes, and reading the tree twice is reading
-     * every class file of the compiler twice for an answer that does not change between them.
-     */
-    private static List<ClassModel> compiled() throws IOException {
-        if (COMPILED != null) {
-            return COMPILED;
-        }
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        List<ClassModel> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
-                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        }
-        COMPILED = List.copyOf(out);
-        return COMPILED;
-    }
 
     private static List<ClassModel> COMPILED;
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
@@ -134,7 +134,4 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
         }
         return calls;
     }
-
-
-    private static List<ClassModel> COMPILED;
 }

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -1,23 +1,17 @@
 package souther.compiler.semantics;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Who reads an operator for what a connective composes, and how often.
@@ -72,7 +66,7 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
                             + " second place the same `&&` is recognised in"));
 
     @Test
-    void onlyARecognitionReadsAnOperatorForWhatItComposes() throws IOException {
+    void onlyARecognitionReadsAnOperatorForWhatItComposes() {
         assertEquals(declared(MAY_ASK), callsTo(JOIN, "of"),
                 "a reader that has recognised a connective and asks the operator again has"
                         + " somewhere in it that could disagree with itself, and a second call in a"
@@ -93,12 +87,9 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
     }
 
     /** How many times each method of the compiler calls {@code owner.name}. */
-    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+    private static Map<String, Integer> callsTo(String owner, String name) {
         Map<String, Integer> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
@@ -110,14 +101,6 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
-    }
-
-    private static List<Path> classes() throws IOException {
-        Path root = Path.of("target", "classes").toAbsolutePath();
-        try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
-        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/stdlib/NobodyOutsideTheLibrarySpellsWhatItPublishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/stdlib/NobodyOutsideTheLibrarySpellsWhatItPublishesTest.java
@@ -1,20 +1,16 @@
 package souther.compiler.stdlib;
 
 import souther.compiler.DefaultStdlib;
+import souther.compiler.WhatWasCompiled;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,8 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class NobodyOutsideTheLibrarySpellsWhatItPublishesTest {
 
-    private static final Path COMPILED = Path.of("target", "classes", "souther", "compiler");
-
     /** Where a published name may be written: the library itself, which is what publishes them.
      *  Nothing else does, so nothing else is named here. */
     private static final Set<String> MAY_SPELL_THEM = Set.of(
@@ -52,15 +46,15 @@ class NobodyOutsideTheLibrarySpellsWhatItPublishesTest {
         assertTrue(published.size() > 20, () -> "read only " + published.size() + " published names");
 
         List<String> spelling = new ArrayList<>();
-        List<Path> classes = compiledClasses();
+        List<ClassModel> classes = WhatWasCompiled.compiled().all();
         assertTrue(classes.size() > 100, () -> "read only " + classes.size() + " compiled classes");
 
-        for (Path each : classes) {
+        for (ClassModel each : classes) {
             String owner = ownerOf(each);
             if (MAY_SPELL_THEM.stream().anyMatch(owner::startsWith)) {
                 continue;
             }
-            for (PoolEntry entry : constantPoolOf(each)) {
+            for (PoolEntry entry : each.constantPool()) {
                 if (entry instanceof Utf8Entry utf8 && published.contains(utf8.stringValue())) {
                     spelling.add(owner + " writes `" + utf8.stringValue() + "`");
                 }
@@ -72,26 +66,8 @@ class NobodyOutsideTheLibrarySpellsWhatItPublishesTest {
                         + " mean, or ask the call which kernel it reaches");
     }
 
-    private static String ownerOf(Path each) {
-        return COMPILED.getParent().getParent().relativize(each).toString()
-                .replace(java.io.File.separatorChar, '.')
-                .replaceFirst("\\.class$", "")
-                .replaceFirst("\\$.*$", "");
-    }
-
-    private static List<Path> compiledClasses() {
-        try (Stream<Path> found = Files.walk(COMPILED)) {
-            return found.filter(p -> p.toString().endsWith(".class")).sorted().toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private static Iterable<PoolEntry> constantPoolOf(Path each) {
-        try {
-            return ClassFile.of().parse(each).constantPool();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    /** The class a name is written in, which for a nested one is the class it is nested in. */
+    private static String ownerOf(ClassModel each) {
+        return each.thisClass().asInternalName().replace('/', '.').replaceFirst("\\$.*$", "");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/types/WhatCarriesADeclarationSaysSoInItsTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/WhatCarriesADeclarationSaysSoInItsTypeTest.java
@@ -1,18 +1,14 @@
 package souther.compiler.types;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,8 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * where the frontier is; this does, so the next one is a failing test rather than a reading.
  */
 class WhatCarriesADeclarationSaysSoInItsTypeTest {
-
-    private static final Path COMPILED = Path.of("target", "classes", "souther", "compiler");
 
     /**
      * The positions that carry any route, and why each of them does.
@@ -101,22 +95,15 @@ class WhatCarriesADeclarationSaysSoInItsTypeTest {
     }
 
     private static List<Class<?>> compiled() {
-        try (Stream<Path> found = Files.walk(COMPILED)) {
-            List<Class<?>> classes = new ArrayList<>();
-            for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
-                String name = COMPILED.getParent().getParent().relativize(each).toString()
-                        .replace(java.io.File.separatorChar, '.')
-                        .replaceFirst("\\.class$", "");
-                try {
-                    classes.add(Class.forName(name, false,
-                            WhatCarriesADeclarationSaysSoInItsTypeTest.class.getClassLoader()));
-                } catch (ClassNotFoundException | NoClassDefFoundError _) {
-                    // A class the test classpath cannot load says nothing about what it holds.
-                }
+        List<Class<?>> classes = new ArrayList<>();
+        for (String name : WhatWasCompiled.classes()) {
+            try {
+                classes.add(Class.forName(name, false,
+                        WhatCarriesADeclarationSaysSoInItsTypeTest.class.getClassLoader()));
+            } catch (ClassNotFoundException | NoClassDefFoundError _) {
+                // A class the test classpath cannot load says nothing about what it holds.
             }
-            return classes;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
+        return classes;
     }
 }

--- a/souther-test-support/src/main/java/souther/test/CompiledClasses.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClasses.java
@@ -1,5 +1,6 @@
 package souther.test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.classfile.ClassModel;
@@ -19,11 +20,12 @@ import java.util.Optional;
  * question. What each check does with them differs, so what is answered here is the classes and
  * never a verdict about them.
  *
- * <p><b>Three ways of asking, and each pays for what it asks.</b> A rule about a whole module walks
+ * <p><b>Four ways of asking, and each pays for what it asks.</b> A rule about a whole module walks
  * {@link #all}; a rule about one class asks {@link #find}, which reaches that file and no other; a
  * rule about a package asks {@link #inPackage}, which settles which files are in it before any of
- * them is parsed. A rule that could only have the whole module would make the narrow questions pay
- * for the wide one, and the narrowest of them reads eight classes of four thousand.
+ * them is parsed; a rule that wants only what there is asks {@link #names}, which reads none of
+ * them. A rule that could only have the whole module would make the narrow questions pay for the
+ * wide one, and the narrowest of them reads eight classes of four thousand.
  *
  * <p><b>Which output is asked is the caller's to name, and so is what to do with two of them.</b> A
  * rule about what this repository publishes and a rule about what a test compiled beside it are
@@ -106,6 +108,27 @@ public final class CompiledClasses {
      */
     public List<ClassModel> all() {
         List<ClassModel> found = read(readings.listing(root));
+        if (found.isEmpty()) {
+            throw new IllegalStateException(root + " holds no classes, so a rule read from it holds"
+                    + " nothing");
+        }
+        return found;
+    }
+
+    /**
+     * What the output holds, by binary name, without reading any of it.
+     *
+     * <p>Which classes there are is a question the listing answers, and a rule that only wants the
+     * names — to load them, or to say which packages there are — would otherwise pay for parsing
+     * every one of them to be told what the file names already said.
+     */
+    public List<String> names() {
+        List<String> found = new ArrayList<>();
+        for (Path each : readings.listing(root)) {
+            found.add(root.relativize(each).toString()
+                    .replace(File.separatorChar, '.')
+                    .replaceAll("\\.class$", ""));
+        }
         if (found.isEmpty()) {
             throw new IllegalStateException(root + " holds no classes, so a rule read from it holds"
                     + " nothing");

--- a/souther-test-support/src/main/java/souther/test/CompiledClasses.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClasses.java
@@ -95,8 +95,15 @@ public final class CompiledClasses {
         }
     }
 
-    /** Which output this is, settled. */
-    public Path root() {
+    /**
+     * Which output this is, settled.
+     *
+     * <p>Not handed out. What a caller can do with an output root is walk it, and a caller that
+     * walks one reads the files this exists to read once — so a reading that answered where it is
+     * would be handing back the way round itself. What the output holds is asked for above; where
+     * it is stays here.
+     */
+    Path root() {
         return root;
     }
 

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -116,6 +116,35 @@ public final class RepositoryLayout {
     }
 
     /**
+     * What a build calls the directory it writes into.
+     *
+     * <p>Where a build puts what it made is a fact about how this repository is laid out, and it
+     * belongs beside the rest of them. Written out wherever it is wanted, it is a fact each writer
+     * has taken on: a check that says it is one that would go on looking in the old place, and a
+     * walk that says it in order to leave it out is one more copy to find when it moves.
+     */
+    public static String whereABuildWrites() {
+        return "target";
+    }
+
+    /**
+     * Whether {@code file} is something a build wrote rather than something somebody did.
+     *
+     * <p>Asked of a walk that means to read what the repository holds: what a build wrote is a copy
+     * of something already counted, or output derived from it, and a walk that took both would
+     * report the same source twice and call the second one somebody's work.
+     */
+    public boolean isUnderBuildOutput(Path file) {
+        Path absolute = file.toAbsolutePath().normalize();
+        for (Path module : modules) {
+            if (absolute.startsWith(module.resolve(whereABuildWrites()))) {
+                return true;
+            }
+        }
+        return absolute.startsWith(root.resolve(whereABuildWrites()));
+    }
+
+    /**
      * The {@code src} of every module that has one.
      *
      * <p>A source tree and not a source root: {@code src/main/java} and {@code src/test/resources}

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -122,9 +122,30 @@ public final class RepositoryLayout {
      * belongs beside the rest of them. Written out wherever it is wanted, it is a fact each writer
      * has taken on: a check that says it is one that would go on looking in the old place, and a
      * walk that says it in order to leave it out is one more copy to find when it moves.
+     *
+     * <p>Kept here rather than answered. A caller handed this can build the path to a build's
+     * output, which is the thing not writing it down was for, so what is answered is whether
+     * something is under one ({@link #isUnderBuildOutput}) or names one
+     * ({@link #namesBuildOutput}), and never the name itself.
      */
-    public static String whereABuildWrites() {
+    private static String whereABuildWrites() {
         return "target";
+    }
+
+    /**
+     * Whether {@code said} names the directory a build writes into, at any step of a path.
+     *
+     * <p>For a rule about what is written down rather than about what is on disk: a check that
+     * works out where compiled output is has said this somewhere, and saying it is what such a
+     * check has in common however it then goes looking.
+     */
+    public static boolean namesBuildOutput(String said) {
+        for (String step : said.split("[/\\\\]")) {
+            if (step.equals(whereABuildWrites())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
+++ b/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
@@ -115,6 +115,17 @@ class WhatIsReadOfACompiledOutputIsReadOnceTest {
     }
 
     @Test
+    void says_what_the_output_holds_without_reading_any_of_it() {
+        List<String> named = at(PUBLISHED).names();
+
+        assertTrue(named.contains(RepositoryLayout.class.getName()));
+        assertEquals(0, counting.reads.get(),
+                "being told which classes there are opened them, so a rule that wants no more than"
+                        + " the names pays for parsing every one of them");
+        assertEquals(1, counting.listings.get());
+    }
+
+    @Test
     void reaches_one_class_without_listing_the_output_it_is_in() {
         Optional<ClassModel> found = at(PUBLISHED).find(RepositoryLayout.class.getName());
 


### PR DESCRIPTION
Every check in this module that reads what a method does walked the compiled output for itself,
parsed each class file and decoded the methods with bodies. What they read is the same for all of
them and does not change while the run happens — the classes were written by the compile the run is
testing, before any test started — so each walk was the reading beside it done again, and a check
declaring more than one question mostly walked again per question.

## What closes it

They ask the shared reading now. Which output this module compiled to is said in one place: a check
that named it had worked out where a build put things, which is a fact about the directory the build
was invoked from rather than about this module, and a module that moves is now one edit rather than
as many edits as there are checks.

Three things go with the walks. A check that kept its own list of parsed classes has none, since the
fork holds one. A check that guarded against having read nothing has no such guard, because an
output that holds no classes is refused where an output is read, and a population of none cannot
reach a rule in order to pass it. And the local vocabulary for reading one class by name is gone:
what one class holds is asked for by name, and what a package holds is asked for as a package, which
reads the files of that package and no others rather than the module round it.

Two questions were narrower than the walk that answered them and stay narrower: the frontend's
classes and the backend's are read as packages. One check reads the package whose states a store
compares, together with the records it leaves out, which is what it read before.

## How it is held

What is refused from here on is the pair, and neither half alone: a check that says where a build
writes and reaches a class file as well. A walk over the repository's own sources says where a build
writes in order to leave it out, and the many tests here that are handed bytes to read reach a class
file without going anywhere to find one — a rule written over either alone would refuse work that is
doing something else. Holding both is what makes a second way into the compiled output, and putting
a walk back is a failing test rather than a reading.

The migration itself was mechanical enough to script, and one thing that cost is worth writing down:
a scripted rewrite widened a population without failing anything. The check whose subject is one
package was rewritten to read the module, and the records it excludes came back in with it. Both are
restored, and the deletions were then swept for every condition that went with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
