### PR TITLE
Read the reactor once for the fork, and decode it once for this module

### DIFF
--- a/souther-bench/src/test/java/souther/bench/Compiled.java
+++ b/souther-bench/src/test/java/souther/bench/Compiled.java
@@ -1,7 +1,5 @@
 package souther.bench;
 
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
@@ -14,8 +12,6 @@ import java.lang.classfile.instruction.NewObjectInstruction;
 import java.lang.classfile.instruction.TypeCheckInstruction;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.DirectMethodHandleDesc;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -139,9 +135,38 @@ final class Compiled {
      */
     record Invocation(Site site, List<String> said) {}
 
-    /** Every call of every compiled class, with the text read at it. */
-    static List<Invocation> invocations() throws IOException {
-        return invocationsIn(Reactor.classes());
+    /**
+     * Every call of every compiled class, with the text read at it, worked out once.
+     *
+     * <p>Beside the parsed classes, which the fork shares, and not the same thing: this is what
+     * <em>this</em> module makes of them. Every check here walks the whole reactor's code, and the
+     * walk allocates one of these for every call there is, so sharing the files and then decoding
+     * them again per check would leave the reading shared and the work not.
+     */
+    static List<Invocation> invocations() {
+        if (EVERY_INVOCATION == null) {
+            EVERY_INVOCATION = invocationsIn(Reactor.classes());
+            WORKED_OUT.merge("invocations", 1, Integer::sum);
+        }
+        return EVERY_INVOCATION;
+    }
+
+    private static List<Invocation> EVERY_INVOCATION;
+
+    private static List<Site> EVERY_SITE;
+
+    /**
+     * How many times each of the two was worked out, for the check that says once.
+     *
+     * <p>Counted rather than compared: what these hold is a site for every call the reactor's code
+     * makes, and a check asking whether it was handed the same list twice would say so by printing
+     * both of them.
+     */
+    private static final java.util.Map<String, Integer> WORKED_OUT = new java.util.TreeMap<>();
+
+    /** How many times {@code named} has been worked out in this fork. */
+    static int timesWorkedOut(String named) {
+        return WORKED_OUT.getOrDefault(named, 0);
     }
 
     /**
@@ -152,10 +177,9 @@ final class Compiled {
      * this does to a particular shape would otherwise write the walk again, and then what it
      * measured would be its own copy rather than the thing every rule here is built on.
      */
-    static List<Invocation> invocationsIn(List<Path> classes) throws IOException {
+    static List<Invocation> invocationsIn(List<ClassModel> classes) {
         List<Invocation> found = new ArrayList<>();
-        for (Path each : classes) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : classes) {
             String from = named(model.thisClass().asInternalName());
             for (var method : model.methods()) {
                 CodeModel code = method.code().orElse(null);
@@ -193,9 +217,14 @@ final class Compiled {
         return found;
     }
 
-    /** Everything every compiled class of every module does. */
-    static List<Site> sites() throws IOException {
-        return sitesIn(Reactor.classes());
+    /** Everything every compiled class of every module does, worked out once and beside
+     *  {@link #invocations} for the same reason. */
+    static List<Site> sites() {
+        if (EVERY_SITE == null) {
+            EVERY_SITE = sitesIn(Reactor.classes());
+            WORKED_OUT.merge("sites", 1, Integer::sum);
+        }
+        return EVERY_SITE;
     }
 
     /**
@@ -207,10 +236,9 @@ final class Compiled {
      * its cases — has to be able to hand it code written to be read, and a copy of the walk written
      * for that would be a check of the copy.
      */
-    static List<Site> sitesIn(List<Path> classes) throws IOException {
+    static List<Site> sitesIn(List<ClassModel> classes) {
         List<Site> found = new ArrayList<>();
-        for (Path each : classes) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : classes) {
             String from = named(model.thisClass().asInternalName());
             for (var method : model.methods()) {
                 CodeModel code = method.code().orElse(null);

--- a/souther-bench/src/test/java/souther/bench/Compiled.java
+++ b/souther-bench/src/test/java/souther/bench/Compiled.java
@@ -179,24 +179,29 @@ final class Compiled {
     private static Reading theReactor() {
         if (EVERY == null) {
             EVERY = read(Reactor.classes());
-            DECODINGS++;
+            BUILDS++;
         }
         return EVERY;
     }
 
     /**
-     * How many times the reactor's code has been decoded in this fork, for the check that says
-     * once.
+     * How many times the reading the fork shares has been built, for the check that says once.
      *
-     * <p>Counted rather than compared. What a reading holds is a site for every call the reactor's
+     * <p>Counted rather than compared: what a reading holds is a site for every call the reactor's
      * code makes, and a check asking whether it was handed the same lists twice says so by printing
-     * all of them; and a count kept per answer would say one of each while the walk ran twice.
+     * all of them.
+     *
+     * <p><b>About the store and not about the walk.</b> A walk started anywhere else is not counted
+     * here — {@link #read} is a walk over whatever it is handed, and a caller handing it the
+     * reactor's classes is decoding them without filling this. What is true of one walk rather than
+     * two is asked of the answers themselves, where the site an invocation carries is the site the
+     * other answer holds.
      */
-    private static int DECODINGS;
+    private static int BUILDS;
 
-    /** How many times the reactor's code has been decoded in this fork. */
-    static int decodings() {
-        return DECODINGS;
+    /** How many times the reading the fork shares has been built in this fork. */
+    static int timesTheSharedReadingWasBuilt() {
+        return BUILDS;
     }
 
     /** The invocations of the classes named, so that what this reads can be asked of code written
@@ -289,8 +294,10 @@ final class Compiled {
                 }
             }
         }
-        assertFalse(sites.isEmpty(), "no compiled call was read at all");
-        assertFalse(invocations.isEmpty(), "no compiled call was read at all");
+        assertFalse(sites.isEmpty(), "these classes do nothing at all, so a rule read off what they"
+                + " do holds nothing");
+        assertFalse(invocations.isEmpty(), "these classes make no call at all, so a rule read off"
+                + " the text at a call holds nothing");
         return new Reading(sites, invocations);
     }
 

--- a/souther-bench/src/test/java/souther/bench/Compiled.java
+++ b/souther-bench/src/test/java/souther/bench/Compiled.java
@@ -144,41 +144,84 @@ final class Compiled {
      * them again per check would leave the reading shared and the work not.
      */
     static List<Invocation> invocations() {
-        if (EVERY_INVOCATION == null) {
-            EVERY_INVOCATION = invocationsIn(Reactor.classes());
-            WORKED_OUT.merge("invocations", 1, Integer::sum);
-        }
-        return EVERY_INVOCATION;
+        return theReactor().invocations();
     }
 
-    private static List<Invocation> EVERY_INVOCATION;
-
-    private static List<Site> EVERY_SITE;
+    /** Everything every compiled class of every module does, beside {@link #invocations} and out of
+     *  the same walk. */
+    static List<Site> sites() {
+        return theReactor().sites();
+    }
 
     /**
-     * How many times each of the two was worked out, for the check that says once.
+     * What one walk over some classes came to.
      *
-     * <p>Counted rather than compared: what these hold is a site for every call the reactor's code
-     * makes, and a check asking whether it was handed the same list twice would say so by printing
-     * both of them.
+     * <p>Both of them, because they are two projections of one decoding and not two readings. What
+     * a call is appears in each — a site saying that a call was made, and the same site with the
+     * text this could read at it — so a reading that answered them separately would walk the code
+     * twice, decode every method twice, and build two of the site for every call there is. Which is
+     * what it did, while the count for each of them said one.
+     *
+     * <p>Handed out as it stands, and so held as what it is: a caller of a reading the whole fork
+     * shares can empty a list everything after it reads. Made per ask, that was the caller's own
+     * copy to spoil; shared, the lifetime is shared and the way to change it has to go.
      */
-    private static final java.util.Map<String, Integer> WORKED_OUT = new java.util.TreeMap<>();
+    record Reading(List<Site> sites, List<Invocation> invocations) {
 
-    /** How many times {@code named} has been worked out in this fork. */
-    static int timesWorkedOut(String named) {
-        return WORKED_OUT.getOrDefault(named, 0);
+        Reading {
+            sites = List.copyOf(sites);
+            invocations = List.copyOf(invocations);
+        }
+    }
+
+    private static Reading EVERY;
+
+    private static Reading theReactor() {
+        if (EVERY == null) {
+            EVERY = read(Reactor.classes());
+            DECODINGS++;
+        }
+        return EVERY;
     }
 
     /**
-     * The same of the classes named, so that what this reads can be asked of code written to be
-     * read.
+     * How many times the reactor's code has been decoded in this fork, for the check that says
+     * once.
+     *
+     * <p>Counted rather than compared. What a reading holds is a site for every call the reactor's
+     * code makes, and a check asking whether it was handed the same lists twice says so by printing
+     * all of them; and a count kept per answer would say one of each while the walk ran twice.
+     */
+    private static int DECODINGS;
+
+    /** How many times the reactor's code has been decoded in this fork. */
+    static int decodings() {
+        return DECODINGS;
+    }
+
+    /** The invocations of the classes named, so that what this reads can be asked of code written
+     *  to be read. */
+    static List<Invocation> invocationsIn(List<ClassModel> classes) {
+        return read(classes).invocations();
+    }
+
+    /** The sites of the same, beside {@link #invocationsIn} and for the same reason. */
+    static List<Site> sitesIn(List<ClassModel> classes) {
+        return read(classes).sites();
+    }
+
+    /**
+     * One walk over {@code classes}, which is where everything this answers comes from.
      *
      * <p>The population is the argument and the reading is not: a check that wanted to know what
      * this does to a particular shape would otherwise write the walk again, and then what it
-     * measured would be its own copy rather than the thing every rule here is built on.
+     * measured would be its own copy rather than the thing every rule here is built on. Which
+     * classes are read and what is read of them are two things, and a rule that fixed both could
+     * only ever be asked about the repository as it stands.
      */
-    static List<Invocation> invocationsIn(List<ClassModel> classes) {
-        List<Invocation> found = new ArrayList<>();
+    static Reading read(List<ClassModel> classes) {
+        List<Site> sites = new ArrayList<>();
+        List<Invocation> invocations = new ArrayList<>();
         for (ClassModel model : classes) {
             String from = named(model.thisClass().asInternalName());
             for (var method : model.methods()) {
@@ -200,11 +243,44 @@ final class Compiled {
                                 loaded = constant.constantValue() instanceof String text
                                         ? text : null;
                         case InvokeInstruction call -> {
-                            found.add(new Invocation(new Site(from, name, descriptor, How.CALLS,
+                            Site site = new Site(from, name, descriptor, How.CALLS,
                                     named(call.owner().asInternalName()),
                                     call.name().stringValue(),
-                                    call.opcode() == Opcode.INVOKESTATIC),
+                                    call.opcode() == Opcode.INVOKESTATIC);
+                            sites.add(site);
+                            invocations.add(new Invocation(site,
                                     loaded == null ? List.of() : List.of(loaded)));
+                            loaded = null;
+                        }
+                        case NewObjectInstruction made -> {
+                            sites.add(new Site(from, name, descriptor, How.MAKES,
+                                    named(made.className().asInternalName()), "<init>", false));
+                            loaded = null;
+                        }
+                        case TypeCheckInstruction asked
+                                when asked.opcode() == Opcode.INSTANCEOF -> {
+                            sites.add(new Site(from, name, descriptor, How.ASKS,
+                                    named(asked.type().asInternalName()), "instanceof", false));
+                            loaded = null;
+                        }
+                        case FieldInstruction field -> {
+                            sites.add(new Site(from, name, descriptor, How.READS,
+                                    named(field.owner().asInternalName()),
+                                    field.name().stringValue(),
+                                    field.opcode() == Opcode.GETSTATIC
+                                            || field.opcode() == Opcode.PUTSTATIC));
+                            loaded = null;
+                        }
+                        case InvokeDynamicInstruction reference -> {
+                            boolean switching = isATypeSwitch(reference);
+                            for (var argument : reference.bootstrapArgs()) {
+                                if (argument instanceof DirectMethodHandleDesc handle) {
+                                    sites.add(referred(from, name, descriptor, handle));
+                                } else if (switching && argument instanceof ClassDesc labelled) {
+                                    sites.add(new Site(from, name, descriptor, How.NAMES,
+                                            describedBy(labelled), "case", false));
+                                }
+                            }
                             loaded = null;
                         }
                         case Instruction _ -> loaded = null;
@@ -213,75 +289,9 @@ final class Compiled {
                 }
             }
         }
-        assertFalse(found.isEmpty(), "no compiled call was read at all");
-        return found;
-    }
-
-    /** Everything every compiled class of every module does, worked out once and beside
-     *  {@link #invocations} for the same reason. */
-    static List<Site> sites() {
-        if (EVERY_SITE == null) {
-            EVERY_SITE = sitesIn(Reactor.classes());
-            WORKED_OUT.merge("sites", 1, Integer::sum);
-        }
-        return EVERY_SITE;
-    }
-
-    /**
-     * The same of the classes named, beside {@link #invocationsIn} and for the same reason.
-     *
-     * <p>Which classes are read and what is read of them are two things, and a rule that fixed both
-     * could only ever be asked about the repository as it stands. A check of what this reading
-     * <em>does</em> — that a call two methods away is still a call, that a switch over a sum names
-     * its cases — has to be able to hand it code written to be read, and a copy of the walk written
-     * for that would be a check of the copy.
-     */
-    static List<Site> sitesIn(List<ClassModel> classes) {
-        List<Site> found = new ArrayList<>();
-        for (ClassModel model : classes) {
-            String from = named(model.thisClass().asInternalName());
-            for (var method : model.methods()) {
-                CodeModel code = method.code().orElse(null);
-                if (code == null) {
-                    continue;
-                }
-                String name = method.methodName().stringValue();
-                String descriptor = method.methodType().stringValue();
-                for (var element : code) {
-                    switch (element) {
-                        case InvokeInstruction call -> found.add(new Site(from, name, descriptor,
-                                How.CALLS, named(call.owner().asInternalName()),
-                                call.name().stringValue(), call.opcode() == Opcode.INVOKESTATIC));
-                        case NewObjectInstruction made -> found.add(new Site(from, name, descriptor,
-                                How.MAKES, named(made.className().asInternalName()), "<init>",
-                                false));
-                        case TypeCheckInstruction asked
-                                when asked.opcode() == Opcode.INSTANCEOF ->
-                                found.add(new Site(from, name, descriptor, How.ASKS,
-                                        named(asked.type().asInternalName()), "instanceof", false));
-                        case FieldInstruction field -> found.add(new Site(from, name, descriptor,
-                                How.READS, named(field.owner().asInternalName()),
-                                field.name().stringValue(),
-                                field.opcode() == Opcode.GETSTATIC
-                                        || field.opcode() == Opcode.PUTSTATIC));
-                        case InvokeDynamicInstruction reference -> {
-                            boolean switching = isATypeSwitch(reference);
-                            for (var argument : reference.bootstrapArgs()) {
-                                if (argument instanceof DirectMethodHandleDesc handle) {
-                                    found.add(referred(from, name, descriptor, handle));
-                                } else if (switching && argument instanceof ClassDesc labelled) {
-                                    found.add(new Site(from, name, descriptor, How.NAMES,
-                                            describedBy(labelled), "case", false));
-                                }
-                            }
-                        }
-                        default -> { }
-                    }
-                }
-            }
-        }
-        assertFalse(found.isEmpty(), "no compiled call was read at all");
-        return found;
+        assertFalse(sites.isEmpty(), "no compiled call was read at all");
+        assertFalse(invocations.isEmpty(), "no compiled call was read at all");
+        return new Reading(sites, invocations);
     }
 
     /** Whether this {@code invokedynamic} is a {@code switch} over what a value is. Asked of the

--- a/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
@@ -3,10 +3,7 @@ package souther.bench;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -90,8 +87,7 @@ class EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest {
     @Test
     void aFigureIsThisCompilersBudgetOrIsSaidToBeSomethingElse() throws IOException {
         List<String> written = new ArrayList<>();
-        for (Path each : Reactor.classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : Reactor.classes()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             if (!from.startsWith(COMPOSING) || from.equals(COMPOSING + "CompositionBudget")) {
                 continue;

--- a/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
@@ -2,7 +2,6 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.lang.classfile.ClassModel;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -85,7 +84,7 @@ class EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest {
      * that is not there.
      */
     @Test
-    void aFigureIsThisCompilersBudgetOrIsSaidToBeSomethingElse() throws IOException {
+    void aFigureIsThisCompilersBudgetOrIsSaidToBeSomethingElse() {
         List<String> written = new ArrayList<>();
         for (ClassModel model : Reactor.classes()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');

--- a/souther-bench/src/test/java/souther/bench/OnlyARendererTakesAProofApartTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyARendererTakesAProofApartTest.java
@@ -3,10 +3,7 @@ package souther.bench;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -89,8 +86,7 @@ class OnlyARendererTakesAProofApartTest {
     @Test
     void andOnlyThoseWordsAreWritten() throws IOException {
         Map<String, List<String>> implementors = new LinkedHashMap<>();
-        for (Path each : Reactor.classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : Reactor.classes()) {
             for (var face : model.interfaces()) {
                 String name = face.asInternalName().replace('/', '.');
                 WRITES_THE_WORDS_OF.forEach((payload, words) -> {

--- a/souther-bench/src/test/java/souther/bench/OnlyARendererTakesAProofApartTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyARendererTakesAProofApartTest.java
@@ -2,7 +2,6 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.lang.classfile.ClassModel;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -69,7 +68,7 @@ class OnlyARendererTakesAProofApartTest {
             REACH + "Reachability$Unsettled");
 
     @Test
-    void onlyItsOwnWordsAskAPayloadWhatItSays() throws IOException {
+    void onlyItsOwnWordsAskAPayloadWhatItSays() {
         Map<String, List<String>> asked = new LinkedHashMap<>();
         for (Compiled.Site use : uses()) {
             if (WRITES_THE_WORDS_OF.containsKey(use.owner()) && use.member().equals("said")) {
@@ -84,7 +83,7 @@ class OnlyARendererTakesAProofApartTest {
     }
 
     @Test
-    void andOnlyThoseWordsAreWritten() throws IOException {
+    void andOnlyThoseWordsAreWritten() {
         Map<String, List<String>> implementors = new LinkedHashMap<>();
         for (ClassModel model : Reactor.classes()) {
             for (var face : model.interfaces()) {
@@ -105,7 +104,7 @@ class OnlyARendererTakesAProofApartTest {
     }
 
     @Test
-    void andNothingButTheReadingMakesAnAnswer() throws IOException {
+    void andNothingButTheReadingMakesAnAnswer() {
         List<String> outside = new ArrayList<>();
         boolean sawAFactory = false;
         boolean sawAConstructor = false;
@@ -144,7 +143,7 @@ class OnlyARendererTakesAProofApartTest {
      * that out first and the next one copied the module walk instead, so the reading is one place
      * now and both ask it.
      */
-    private static List<Compiled.Site> uses() throws IOException {
+    private static List<Compiled.Site> uses() {
         // What the answers do among themselves is their own business.
         return Compiled.sites().stream().filter(use -> !use.from().startsWith(REACH)).toList();
     }

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -1,6 +1,5 @@
 package souther.bench;
 
-import java.io.IOException;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
 import java.util.ArrayDeque;
@@ -130,7 +129,7 @@ final class PositionReadings {
         }
     }
 
-    static Reading of(Over over) throws IOException {
+    static Reading of(Over over) {
         Map<String, ClassModel> models = new LinkedHashMap<>();
         for (ClassModel model : over.classes()) {
             models.put(model.thisClass().asInternalName().replace('/', '.'), model);

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -2,10 +2,7 @@ package souther.bench;
 
 import java.io.IOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -97,7 +94,7 @@ final class PositionReadings {
      *                    made of them is told from one that is not
      * @param authorities what answers for a reading, and what a walk does at each
      */
-    record Over(List<Path> classes, String stage, String declaration, String lookup,
+    record Over(List<ClassModel> classes, String stage, String declaration, String lookup,
                 String compound, String held, List<Authority> authorities) {}
 
     /**
@@ -135,8 +132,7 @@ final class PositionReadings {
 
     static Reading of(Over over) throws IOException {
         Map<String, ClassModel> models = new LinkedHashMap<>();
-        for (Path each : over.classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+        for (ClassModel model : over.classes()) {
             models.put(model.thisClass().asInternalName().replace('/', '.'), model);
         }
         Set<String> declarations = descendantsOf(models, over.declaration());

--- a/souther-bench/src/test/java/souther/bench/Reactor.java
+++ b/souther-bench/src/test/java/souther/bench/Reactor.java
@@ -1,15 +1,14 @@
 package souther.bench;
 
+import souther.test.CompiledClasses;
 import souther.test.RepositoryLayout;
 
-import java.io.IOException;
+import java.lang.classfile.ClassModel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Optional;
 
 /**
  * What the reactor builds, asked once.
@@ -61,22 +60,36 @@ final class Reactor {
         return REPOSITORY.mainJavaSources();
     }
 
-    /** Every compiled class of every one of them. */
-    static List<Path> classes() throws IOException {
-        List<Path> found = new ArrayList<>();
+    /** Every compiled class of every one of them, read once for the fork rather than per check. */
+    static List<ClassModel> classes() {
+        List<ClassModel> found = new ArrayList<>();
         for (Path module : modules()) {
             if (!hasMainSources(module)) {
                 continue;
             }
-            Path built = module.resolve("target/classes");
-            assertTrue(Files.isDirectory(built),
-                    name(module) + " has no built classes: this check covers what has been built, so a"
-                            + " module that has not been is a hole rather than a pass");
-            try (Stream<Path> walk = Files.walk(built)) {
-                walk.filter(each -> each.toString().endsWith(".class")).forEach(found::add);
-            }
+            found.addAll(mainOutputOf(module).all());
         }
         return found;
+    }
+
+    /**
+     * What {@code module} compiled its main sources to.
+     *
+     * <p>A module that has sources and no output is a hole and not a pass, so this refuses rather
+     * than passing over it — which is what a check covering every module needs, and is also what
+     * makes naming every module a dependency of this one the thing that keeps such a check honest
+     * under {@code -am}.
+     */
+    static CompiledClasses mainOutputOf(Path module) {
+        return REPOSITORY.compiledOutputOf(module, "main").orElseGet(() -> {
+            throw new AssertionError(name(module) + " has no built classes: this check covers what"
+                    + " has been built, so a module that has not been is a hole rather than a pass");
+        });
+    }
+
+    /** The same of what its tests compiled to, or nothing where it has none. */
+    static Optional<CompiledClasses> testOutputOf(Path module) {
+        return REPOSITORY.compiledOutputOf(module, "test");
     }
 
     /** The repository, from the module this runs in. */

--- a/souther-bench/src/test/java/souther/bench/Reactor.java
+++ b/souther-bench/src/test/java/souther/bench/Reactor.java
@@ -81,10 +81,9 @@ final class Reactor {
      * under {@code -am}.
      */
     static CompiledClasses mainOutputOf(Path module) {
-        return REPOSITORY.compiledOutputOf(module, "main").orElseGet(() -> {
-            throw new AssertionError(name(module) + " has no built classes: this check covers what"
-                    + " has been built, so a module that has not been is a hole rather than a pass");
-        });
+        return REPOSITORY.compiledOutputOf(module, "main").orElseThrow(() -> new AssertionError(
+                name(module) + " has no built classes: this check covers what has been built, so a"
+                        + " module that has not been is a hole rather than a pass"));
     }
 
     /** The same of what its tests compiled to, or nothing where it has none. */

--- a/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
@@ -7,19 +7,15 @@ import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeSymbol;
+import souther.test.CompiledClasses;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.constantpool.StringEntry;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -79,20 +75,11 @@ class TheAbiIsSpelledInOnePlaceTest {
         List<Path> scanned = new ArrayList<>();
         List<Path> modules = Reactor.modules();
         for (Path module : modules) {
-            for (String where : List.of("target/classes", "target/test-classes")) {
-                Path classes = module.resolve(where);
-                if (where.endsWith("test-classes") && !Files.isDirectory(classes)) {
-                    continue;   // a module with no tests of its own
-                }
-                if (where.endsWith("target/classes") && !Reactor.hasMainSources(module)) {
-                    continue;   // a module with no main sources of its own
-                }
-                assertTrue(Files.isDirectory(classes),
-                        Reactor.name(module) + " has no built classes: this test covers what has been"
-                                + " built, so a"
-                                + " module that has not been is a hole rather than a pass");
-                walk(classes, violations, spellings);
+            if (Reactor.hasMainSources(module)) {
+                walk(Reactor.mainOutputOf(module), violations, spellings);
             }
+            // A module with no tests of its own compiled none, and there is nothing to read.
+            Reactor.testOutputOf(module).ifPresent(built -> walk(built, violations, spellings));
             scanned.add(module);
         }
         assertEquals(modules, scanned, "every module the reactor builds was read");
@@ -140,9 +127,7 @@ class TheAbiIsSpelledInOnePlaceTest {
             if (!Reactor.hasMainSources(module)) {
                 continue;   // a module with no main sources of its own
             }
-            Path classes = module.resolve("target/classes");
-            assertTrue(Files.isDirectory(classes), Reactor.name(module) + " has no built classes");
-            walkFor(classes, callers, TheAbiIsSpelledInOnePlaceTest::capitalizes);
+            walkFor(Reactor.mainOutputOf(module), callers, TheAbiIsSpelledInOnePlaceTest::capitalizes);
         }
         assertEquals(List.of(), callers,
                 "the rule a behavior's class name follows is stated somewhere else too");
@@ -160,25 +145,14 @@ class TheAbiIsSpelledInOnePlaceTest {
         return false;
     }
 
-    private static void walkFor(Path classes, List<String> found,
+    private static void walkFor(CompiledClasses classes, List<String> found,
                                 java.util.function.Predicate<java.lang.classfile.ClassModel> offending) {
-        try (Stream<Path> files = Files.walk(classes)) {
-            files.filter(p -> p.toString().endsWith(".class")).forEach(p -> {
-                byte[] bytes;
-                try {
-                    bytes = Files.readAllBytes(p);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-                var model = ClassFile.of().parse(bytes);
-                String owner = model.thisClass().asInternalName().replace('/', '.');
-                if (!owner.startsWith(ABI_PACKAGE) && offending.test(model)) {
-                    found.add(owner);
-                }
-            });
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        classes.all().forEach(model -> {
+            String owner = model.thisClass().asInternalName().replace('/', '.');
+            if (!owner.startsWith(ABI_PACKAGE) && offending.test(model)) {
+                found.add(owner);
+            }
+        });
     }
 
     /**
@@ -250,22 +224,13 @@ class TheAbiIsSpelledInOnePlaceTest {
         return false;
     }
 
-    private static void walk(Path classes, List<String> violations, Set<String> spellings) {
-        try (Stream<Path> files = Files.walk(classes)) {
-            files.filter(p -> p.toString().endsWith(".class")).forEach(p -> read(p, violations, spellings));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    private static void walk(CompiledClasses classes, List<String> violations,
+                             Set<String> spellings) {
+        classes.all().forEach(model -> read(model, violations, spellings));
     }
 
-    private static void read(Path file, List<String> violations, Set<String> spellings) {
-        byte[] bytes;
-        try {
-            bytes = Files.readAllBytes(file);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        var model = ClassFile.of().parse(bytes);
+    private static void read(java.lang.classfile.ClassModel model, List<String> violations,
+                             Set<String> spellings) {
         String owner = model.thisClass().asInternalName().replace('/', '.');
         if (owner.startsWith(ABI_PACKAGE) || owner.equals(THE_CONTRACT_TEST)
                 || owner.startsWith(THE_CONTRACT_TEST + "$")) {

--- a/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
@@ -6,9 +6,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
@@ -24,7 +21,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The modules an ordinary build runs NullAway over are the modules that declare {@code @NullMarked}.
@@ -99,24 +95,11 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
         if (!Reactor.hasMainSources(module)) {
             return false;   // nothing of its own to annotate
         }
-        Path classes = module.resolve("target/classes");
-        assertTrue(Files.isDirectory(classes),
-                Reactor.name(module) + " has no built classes: this reads what has been built, so a module that has"
-                        + " not been is a hole rather than a pass");
-        try (Stream<Path> walk = Files.walk(classes)) {
-            return walk.filter(p -> p.toString().endsWith(".class")).anyMatch(TheNullnessGateRunsWhereItIsDeclaredTest::carriesNullMarked);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return Reactor.mainOutputOf(module).all().stream()
+                .anyMatch(TheNullnessGateRunsWhereItIsDeclaredTest::carriesNullMarked);
     }
 
-    private static boolean carriesNullMarked(Path classFile) {
-        ClassModel model;
-        try {
-            model = ClassFile.of().parse(Files.readAllBytes(classFile));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    private static boolean carriesNullMarked(ClassModel model) {
         // Both retentions, because which one JSpecify uses is JSpecify's to change.
         Stream<java.lang.classfile.Annotation> annotations = Stream.concat(
                 model.findAttribute(java.lang.classfile.Attributes.runtimeVisibleAnnotations())

--- a/souther-bench/src/test/java/souther/bench/TheTextReadAtACallIsTheOneWrittenThereTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheTextReadAtACallIsTheOneWrittenThereTest.java
@@ -1,6 +1,7 @@
 package souther.bench;
 
 import org.junit.jupiter.api.Test;
+import souther.test.CompiledClasses;
 
 import java.util.List;
 
@@ -61,15 +62,10 @@ class TheTextReadAtACallIsTheOneWrittenThereTest {
 
     /** This class as it was compiled, which is where the two calls above are. */
     private static List<Compiled.Invocation> read() {
-        try {
-            java.nio.file.Path root = java.nio.file.Path.of(
-                    TheTextReadAtACallIsTheOneWrittenThereTest.class.getProtectionDomain()
-                            .getCodeSource().getLocation().toURI());
-            return Compiled.invocationsIn(List.of(root.resolve(
-                    TheTextReadAtACallIsTheOneWrittenThereTest.class.getName()
-                            .replace('.', '/') + ".class")));
-        } catch (Exception opaque) {
-            throw new AssertionError("this class could not be read", opaque);
-        }
+        String named = TheTextReadAtACallIsTheOneWrittenThereTest.class.getName();
+        return Compiled.invocationsIn(List.of(CompiledClasses
+                .ofModule(TheTextReadAtACallIsTheOneWrittenThereTest.class)
+                .find(named)
+                .orElseThrow(() -> new AssertionError(named + " was not read back"))));
     }
 }

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -4,14 +4,13 @@ import org.junit.jupiter.api.Test;
 
 import souther.bench.PositionReadings.Authority;
 import souther.bench.PositionReadings.Traversal;
+import souther.test.CompiledClasses;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.lang.classfile.ClassModel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -56,20 +55,14 @@ class ThisReadingSeesAReadingOfRawStructureTest {
     /**
      * The compiled model, which is what this is a reading of.
      *
-     * <p>Found from the repository, the way everything else here finds what a build produced. Read
-     * from wherever this happens to have been started instead, the model would be missing whenever
-     * that was somewhere else — and a walk over no classes finds no reading and says nothing.
+     * <p>Found through the output this test was compiled into, the way everything else here finds
+     * what a build produced. Read from wherever this happens to have been started instead, the
+     * model would be missing whenever that was somewhere else — and a walk over no classes finds no
+     * reading and says nothing, which is why a package holding none is refused where it is read.
      */
-    private static List<Path> written() throws IOException {
-        Path built = Reactor.root().resolve("souther-bench/target/test-classes/souther/bench/readings");
-        assertTrue(Files.isDirectory(built),
-                "the model was not compiled, so this would assert nothing: " + built);
-        try (Stream<Path> walk = Files.walk(built)) {
-            List<Path> out = new ArrayList<>(
-                    walk.filter(each -> each.toString().endsWith(".class")).toList());
-            assertFalse(out.isEmpty(), "the model compiled to no classes");
-            return out;
-        }
+    private static List<ClassModel> written() {
+        return CompiledClasses.ofModule(ThisReadingSeesAReadingOfRawStructureTest.class)
+                .inPackage("souther.bench.readings");
     }
 
     private static List<String> bypassing() throws IOException {

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -6,7 +6,6 @@ import souther.bench.PositionReadings.Authority;
 import souther.bench.PositionReadings.Traversal;
 import souther.test.CompiledClasses;
 
-import java.io.IOException;
 import java.lang.classfile.ClassModel;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +44,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
             new Authority("what a name comes to on the way",
                     "souther.bench.readings.Transparent", Traversal.TRANSPARENT));
 
-    private static PositionReadings.Over model() throws IOException {
+    private static PositionReadings.Over model() {
         return new PositionReadings.Over(written(), STAGE,
                 "souther.bench.readings.Written$Declared", "souther.bench.readings.Written$Names#declaredNode",
                 "souther.bench.readings.Written$Position$Built",
@@ -65,7 +64,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
                 .inPackage("souther.bench.readings");
     }
 
-    private static List<String> bypassing() throws IOException {
+    private static List<String> bypassing() {
         return PositionReadings.of(model()).named();
     }
 
@@ -77,7 +76,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * the whole of what this is about.
      */
     @Test
-    void everyReaderThatReachesRawStructureIsSeenAndNoOtherIs() throws IOException {
+    void everyReaderThatReachesRawStructureIsSeenAndNoOtherIs() {
         assertEquals(List.of(
                         // Its own code reaches a declaration, and its own code takes a compound
                         // apart. The two plainest readings there are.
@@ -112,7 +111,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * and the walk stops at a boundary that was never about what it is standing in front of.
      */
     @Test
-    void namingTheOperationCatchesTheQuestionBesideItAndNamingTheClassDoesNot() throws IOException {
+    void namingTheOperationCatchesTheQuestionBesideItAndNamingTheClassDoesNot() {
         assertFalse(bypassing().contains("asksTheQuestionBesideIt"),
                 "named by its class, the entry about one question answers for the other too");
 
@@ -140,7 +139,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * nothing wrong — which is how a rule stops being read.
      */
     @Test
-    void touchingTheModelWithoutReadingItIsNotOne() throws IOException {
+    void touchingTheModelWithoutReadingItIsNotOne() {
         List<String> seen = bypassing();
         for (String each : List.of("asksAnAuthority", "readsANameOffALeaf", "makesACompound",
                 "readsAComponentHoldingNoPosition")) {
@@ -158,7 +157,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * and the model says so. What is met is recorded; what answers is the table's to say.
      */
     @Test
-    void everyBoundaryOfTheModelIsMetAndAHelperIsNotOne() throws IOException {
+    void everyBoundaryOfTheModelIsMetAndAHelperIsNotOne() {
         PositionReadings.Reading read = PositionReadings.of(model());
 
         assertEquals(List.of("souther.bench.readings.Opaque",
@@ -177,7 +176,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * helper an owner. What is on the way is walked through; what answers is met at the end of it.
      */
     @Test
-    void aHelperBetweenTheStageAndAnAuthorityChangesNothing() throws IOException {
+    void aHelperBetweenTheStageAndAnAuthorityChangesNothing() {
         PositionReadings.Reading read = PositionReadings.of(model());
 
         assertFalse(read.named().contains("asksAnAuthorityThroughAHelper"),
@@ -193,7 +192,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * to say so. Named by an operation nothing is written under, this stands nowhere.
      */
     @Test
-    void anAuthorityStandingNowhereIsNotMet() throws IOException {
+    void anAuthorityStandingNowhereIsNotMet() {
         assertFalse(alsoNaming("souther.bench.readings.Opaque#spellingAsItWasCalled")
                         .contains("souther.bench.readings.Opaque#spellingAsItWasCalled"),
                 "nothing of that name is there to be met");
@@ -209,7 +208,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * being made.
      */
     @Test
-    void anAuthorityOnAWayTheStageIsNotOnIsNotStanding() throws IOException {
+    void anAuthorityOnAWayTheStageIsNotOnIsNotStanding() {
         assertFalse(alsoNaming("souther.bench.readings.Elsewhere").contains(
                         "souther.bench.readings.Elsewhere"),
                 "it answers for a reader of its own, and the stage reaches neither");
@@ -219,7 +218,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
     }
 
     /** What the walk records as standing, with one more entry named. */
-    private static Set<String> alsoNaming(String owns) throws IOException {
+    private static Set<String> alsoNaming(String owns) {
         PositionReadings.Over over = model();
         List<Authority> withOneMore = new ArrayList<>(over.authorities());
         withOneMore.add(new Authority("a question nothing on a way from the stage asks", owns,
@@ -237,7 +236,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * far as this refuses, which is why the refusal is asked of a model that has one.
      */
     @Test
-    void aCaseBuiltOutOfTypesThatIsNotARecordIsRefused() throws IOException {
+    void aCaseBuiltOutOfTypesThatIsNotARecordIsRefused() {
         assertEquals(List.of("souther.bench.readings.Written$Position$Built$Awkward"),
                 PositionReadings.of(model()).madeOfNonRecords(),
                 "the arm of the model written as a class rather than a record: what it holds is"
@@ -254,7 +253,7 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      * compiler.
      */
     @Test
-    void anOpaqueBoundaryIsWhatStopsTheWalk() throws IOException {
+    void anOpaqueBoundaryIsWhatStopsTheWalk() {
         assertFalse(bypassing().contains("asksAnAuthority"),
                 "the authority answers, so its caller reaches nothing raw");
 

--- a/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
@@ -27,13 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest {
 
     @Test
-    void theReactorsCodeIsDecodedOnceHoweverManyTimesItIsAsked() {
+    void theReadingTheForkSharesIsBuiltOnceHoweverManyTimesItIsAsked() {
         Compiled.sites();
         Compiled.sites();
 
-        assertEquals(1, Compiled.decodings(),
-                "the reactor's code was decoded more than once, so every check here decodes it for"
-                        + " itself and sharing the files bought nothing");
+        assertEquals(1, Compiled.timesTheSharedReadingWasBuilt(),
+                "the shared reading was built more than once, so every check here decodes the"
+                        + " reactor's code for itself and sharing the files bought nothing");
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
@@ -1,0 +1,43 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The reading of the class files is shared with the whole fork; what this module makes of it is
+ * shared here.
+ *
+ * <p>They are two things and only the first is somebody else's. Sharing the files and then decoding
+ * them again per check would leave the reading shared and the work not: every check here walks the
+ * code of every class the reactor built, and the walk allocates a site for every call, field access
+ * and case there is. Read per check, that is the same decoding over and over on classes that were
+ * already parsed.
+ *
+ * <p>Counted rather than compared. What these hold is a site for every call the reactor's code
+ * makes, and a check asking whether it was handed the same list twice says so by printing both of
+ * them. How many times one was worked out is the same fact in a number.
+ */
+class WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest {
+
+    @Test
+    void everythingTheCompiledClassesDoIsWorkedOutOnce() {
+        Compiled.sites();
+        Compiled.sites();
+
+        assertEquals(1, Compiled.timesWorkedOut("sites"),
+                "what the compiled classes do was worked out more than once, so every check here"
+                        + " decodes the reactor's code for itself and sharing the files bought"
+                        + " nothing");
+    }
+
+    @Test
+    void andSoIsTheTextReadAtEachCall() {
+        Compiled.invocations();
+        Compiled.invocations();
+
+        assertEquals(1, Compiled.timesWorkedOut("invocations"),
+                "the text read at each call was worked out more than once, beside the sites and for"
+                        + " the same walk over the same classes");
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest.java
@@ -2,7 +2,13 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The reading of the class files is shared with the whole fork; what this module makes of it is
@@ -21,23 +27,51 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WhatThisModuleMakesOfTheCompiledClassesIsMadeOnceTest {
 
     @Test
-    void everythingTheCompiledClassesDoIsWorkedOutOnce() {
+    void theReactorsCodeIsDecodedOnceHoweverManyTimesItIsAsked() {
         Compiled.sites();
         Compiled.sites();
 
-        assertEquals(1, Compiled.timesWorkedOut("sites"),
-                "what the compiled classes do was worked out more than once, so every check here"
-                        + " decodes the reactor's code for itself and sharing the files bought"
-                        + " nothing");
+        assertEquals(1, Compiled.decodings(),
+                "the reactor's code was decoded more than once, so every check here decodes it for"
+                        + " itself and sharing the files bought nothing");
     }
 
+    /**
+     * And both of what it comes to are that one walk.
+     *
+     * <p>Asked of the sites themselves rather than of a count. A count says how many times something
+     * filled a store, which is a fact about the store: a second walk written beside it fills nothing
+     * and is counted nowhere, and the count goes on saying one. What cannot be true of two walks is
+     * that the site an invocation carries <em>is</em> the site the other answer holds — two walks
+     * build two of it, equal and not the same.
+     */
     @Test
-    void andSoIsTheTextReadAtEachCall() {
-        Compiled.invocations();
-        Compiled.invocations();
+    void andBothOfWhatItComesToAreThatOneWalk() {
+        Set<Compiled.Site> byIdentity = Collections.newSetFromMap(new IdentityHashMap<>());
+        byIdentity.addAll(Compiled.sites());
 
-        assertEquals(1, Compiled.timesWorkedOut("invocations"),
-                "the text read at each call was worked out more than once, beside the sites and for"
-                        + " the same walk over the same classes");
+        Compiled.Site carried = Compiled.invocations().getFirst().site();
+
+        assertTrue(byIdentity.contains(carried),
+                "what a call is was worked out twice: once as a site saying a call was made and"
+                        + " once as the same site with the text read at it. They are two projections"
+                        + " of one walk, and answered apart they are two walks");
+    }
+
+    /**
+     * And what is shared cannot be changed by whoever asked for it first.
+     *
+     * <p>Made per ask, a list was the caller's own to spoil. Shared for the length of the fork, the
+     * lifetime is shared and so is every way of changing it: one check emptying what it was handed
+     * would answer for every check after it, and each of those would be reading the reactor's code
+     * as somebody else left it.
+     */
+    @Test
+    void andWhatIsSharedIsNotOneCallersToChange() {
+        int held = Compiled.sites().size();
+
+        assertThrows(UnsupportedOperationException.class, () -> Compiled.sites().clear());
+        assertEquals(held, Compiled.sites().size(),
+                "a caller changed what the rest of this fork reads");
     }
 }

--- a/souther-bench/src/test/java/souther/bench/WhoseARowIsIsDecidedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhoseARowIsIsDecidedInOnePlaceTest.java
@@ -2,7 +2,6 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -100,17 +99,13 @@ class WhoseARowIsIsDecidedInOnePlaceTest {
      */
     private static java.util.SortedMap<String, List<String>> reachesFromOutside() {
         java.util.SortedMap<String, java.util.SortedSet<String>> found = new java.util.TreeMap<>();
-        try {
-            for (Compiled.Site site : Compiled.sites()) {
-                if (!site.owner().startsWith(ATTRIBUTION) || site.from().startsWith(ATTRIBUTION)) {
-                    continue;
-                }
-                found.computeIfAbsent(site.owner() + "#" + site.member() + " " + site.how(),
-                                _ -> new java.util.TreeSet<>())
-                        .add(site.from() + "#" + written(site.method()));
+        for (Compiled.Site site : Compiled.sites()) {
+            if (!site.owner().startsWith(ATTRIBUTION) || site.from().startsWith(ATTRIBUTION)) {
+                continue;
             }
-        } catch (IOException e) {
-            throw new AssertionError("the compiled classes were not readable", e);
+            found.computeIfAbsent(site.owner() + "#" + site.member() + " " + site.how(),
+                            _ -> new java.util.TreeSet<>())
+                    .add(site.from() + "#" + written(site.method()));
         }
         java.util.SortedMap<String, List<String>> out = new java.util.TreeMap<>();
         found.forEach((what, where) -> out.put(what, List.copyOf(where)));

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -46,10 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
 
-    /** Naming an output: the two ways the shared reading is handed one. */
+    /** Naming an output: what a check outside {@code souther.test} can be handed one by. */
     private static final Set<String> NAMES_AN_OUTPUT = Set.of(
             "souther/test/CompiledClasses.ofModule",
-            "souther/test/CompiledClasses.at");
+            "souther/test/RepositoryLayout.compiledOutputOf");
 
     /** The one place this module's outputs are named, which is what the rule is that there is one. */
     private static final String THE_ONE_PLACE = WhatWasCompiled.class.getName();

--- a/souther-test-support/src/main/java/souther/test/CompiledClasses.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClasses.java
@@ -49,8 +49,15 @@ public final class CompiledClasses {
         this.readings = readings;
     }
 
-    /** The output at {@code root}, read by the fork this runs in. */
-    public static CompiledClasses at(Path root) {
+    /**
+     * The output at {@code root}, read by the fork this runs in.
+     *
+     * <p>Not handed out either. Where a module's output is is worked out by
+     * {@link RepositoryLayout}, which knows how this repository is laid out; a caller that could
+     * make one of these from a path of its own would be working that out for itself, and would have
+     * had to say where a build writes to do it.
+     */
+    static CompiledClasses at(Path root) {
         return at(root, CompiledClassReadings.forThisFork());
     }
 

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -146,6 +147,30 @@ public final class RepositoryLayout {
             }
         }
         return false;
+    }
+
+    /**
+     * What {@code module} compiled its {@code phase} sources to, or nothing where it built none.
+     *
+     * <p>A reading and not a place. What a caller does with a compiled output is ask what it holds,
+     * and what it would do with the path is walk it — which reads once more the files the reading
+     * exists to read once. So where a module's output is stays worked out here, beside the rest of
+     * what this knows about how the repository is laid out.
+     *
+     * <p>Nothing where the module built none, because that is two different things to two callers.
+     * A check about every module is entitled to treat a module that has sources and no output as a
+     * hole; a check about whichever module holds a name is entitled to look in the next one.
+     *
+     * @param phase {@code main} or {@code test}, as {@link #javaTreeOf} takes it
+     */
+    public Optional<CompiledClasses> compiledOutputOf(Path module, String phase) {
+        Path at = module.resolve(whereABuildWrites()).resolve(switch (phase) {
+            case "main" -> "classes";
+            case "test" -> "test-classes";
+            default -> throw new IllegalArgumentException(
+                    phase + " is not a phase a module compiles: main and test are");
+        });
+        return Files.isDirectory(at) ? Optional.of(CompiledClasses.at(at)) : Optional.empty();
     }
 
     /**

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -12,7 +12,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -170,7 +172,27 @@ public final class RepositoryLayout {
             default -> throw new IllegalArgumentException(
                     phase + " is not a phase a module compiles: main and test are");
         });
-        return Files.isDirectory(at) ? Optional.of(CompiledClasses.at(at)) : Optional.empty();
+        return isThere(at) ? Optional.of(CompiledClasses.at(at)) : Optional.empty();
+    }
+
+    /**
+     * Whether {@code at} is a directory, where not being able to tell is not the same as no.
+     *
+     * <p>Nothing where a module built none is a fact a caller acts on — a check reads the next
+     * output, or passes over a module with no tests of its own. That this process could not look is
+     * not that fact, and answering both with the same no hands a caller the one it asked for
+     * whichever it met. What is not there is an answer; anything else that stops the look is a
+     * failure and says so.
+     */
+    private static boolean isThere(Path at) {
+        try {
+            return Files.readAttributes(at, BasicFileAttributes.class).isDirectory();
+        } catch (NoSuchFileException e) {
+            return false;
+        } catch (IOException e) {
+            throw new UncheckedIOException(at + " cannot be looked at, so whether a build wrote"
+                    + " anything there is a question this cannot answer", e);
+        }
     }
 
     /**
@@ -236,10 +258,12 @@ public final class RepositoryLayout {
         return treeOf(module, phase, "java");
     }
 
-    /** Where a module keeps one kind of source, or null where it keeps none of that kind. */
+    /** Where a module keeps one kind of source, or null where it keeps none of that kind. Beside
+     *  {@link #isThere} and for its reason: a tree this cannot look at is not a tree that is not
+     *  there. */
     private static Path treeOf(Path module, String phase, String kind) {
         Path tree = module.resolve("src").resolve(phase).resolve(kind);
-        return Files.isDirectory(tree) ? tree : null;
+        return isThere(tree) ? tree : null;
     }
 
     /**


### PR DESCRIPTION
Every check in this module is about the repository rather than about one build, so each walked every
class the reactor compiled, parsed it and decoded the methods with bodies. The files are the same for
all of them and do not change while the run happens — and so is what this module makes of them: a
site for every call, field access, reference and case the reactor's code holds.

## What closes it

Two things, and only the first was somebody else's. The files come from the reading the fork shares.
What this module makes of them is worked out here, once, because sharing the files and then decoding
them again per check would leave the reading shared and the work not. That is a derived index and it
belongs here rather than under the shared reading: what a check of this module asks of the compiled
classes is not what a check elsewhere asks, and the classes are what they have in common.

What a check is handed is the classes rather than where to find them. The walk over the reactor
answers with what it read, the reading of code written to be read takes the same, and a check that
wanted one class of its own module asks for that class by name. Nothing here says where a build
writes any more.

Where a module's output is is answered by the repository, as a reading and not as a path: what a
caller does with a compiled output is ask what it holds, and what it would do with the root is walk
it. With that answered there, making a reading from a path of one's own is closed as well — a caller
that could would have had to say where a build writes to get the path, which is the question that was
already closed.

A module that has main sources and no output is still a hole rather than a pass, and that policy
stays in this module: it is what a check covering every module needs, and it is what keeps one honest
under `-am`.

## How it is held

That the decoding happens once is counted rather than compared. What these hold is a site for every
call the reactor's code makes, and a check asking whether it was handed the same list twice says so
by printing both of them — the failure message ran to megabytes before it was written the other way.
Worked out per ask instead, the count goes up and the check fails.

The rest is held by the checks that were already here: they read the same classes, in the same
vocabulary, and answer the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
