### PR TITLE
Let a world say which parts it leaves out by where they stand

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -1,11 +1,10 @@
 package souther.compiler.check;
 
-import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,12 +42,12 @@ final class ClauseView {
     private final List<Clauses.StatedPart> authored;
     /** The parts this world holds, in the order they were written. */
     private final List<Clauses.StatedPart> present;
-    /** And the roots of the ones it does not, by identity: two conjuncts spelled alike are two
-     *  parts, and a set comparing them by what they say would leave out both. */
-    private final Set<Core> omitted;
+    /** And where in the clause the ones it does not are: two conjuncts spelled alike stand at two
+     *  places, and a set comparing them by what they say would leave out both. */
+    private final Set<ClauseExpr.Occurrence> omitted;
 
     private ClauseView(List<Clauses.StatedPart> authored, List<Clauses.StatedPart> present,
-                       Set<Core> omitted) {
+                       Set<ClauseExpr.Occurrence> omitted) {
         this.authored = authored;
         this.present = present;
         this.omitted = omitted;
@@ -88,17 +87,19 @@ final class ClauseView {
      * holds it.
      *
      * <p>Told which parts by their names and never by their trees, which is what a world is asked
-     * with ({@link PartsLeftOut}); the roots are worked out here so that what the walk matches on is
-     * the very node this clause holds. Handed a set of nodes instead, a caller could build one that
-     * tells two conjuncts spelled alike apart by what they say, and both would go.
+     * with ({@link PartsLeftOut}); where each of them stands is worked out here, off the shape the
+     * clause was read into, so that what the walk matches on is a place in the clause. Handed a set
+     * of nodes instead, a caller could build one that tells two conjuncts spelled alike apart by
+     * what they say, and both would go — and a walk over a tree built for it by a substitution
+     * would match none of them, which is a world holding rules the caller took away.
      */
     static ClauseView without(List<Clauses.StatedPart> authored,
                               Set<PartId<RuleRef.Invariant>> left) {
         List<Clauses.StatedPart> here = new ArrayList<>(authored.size());
-        Set<Core> omitted = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<ClauseExpr.Occurrence> omitted = new LinkedHashSet<>();
         for (Clauses.StatedPart each : authored) {
             if (left.contains(each.id())) {
-                omitted.add(each.expr());
+                omitted.add(each.of().at());
             } else {
                 here.add(each);
             }
@@ -152,10 +153,8 @@ final class ClauseView {
         if (omitted.isEmpty()) {
             return false;
         }
-        for (Core each : shape.spelled()) {
-            if (omitted.contains(each)) {
-                return true;
-            }
+        if (omitted.contains(shape.at())) {
+            return true;
         }
         return switch (shape) {
             case ClauseExpr.Scoped it -> omits(it.body());

--- a/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
@@ -15,7 +15,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Which rules a world has is settled before a reading says how far into them it goes.
@@ -83,6 +85,47 @@ class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
         assertEquals(List.of("right"), whatReached(again, withoutTheLeft()),
                 "the left conjunct is no rule of this world, whichever of the two trees saying so"
                         + " the reading is walking");
+    }
+
+    /**
+     * And two parts that say the same thing stand at two places.
+     *
+     * <p>The other half of what a place is for. An author may write one conjunct twice, and the two
+     * are two rules of the model: a world told to leave the first out holds the second, which says
+     * exactly what the first said. Told which parts it holds by what they say, such a world would
+     * leave out both — and a reading of it would answer about a declaration holding neither.
+     *
+     * <p>Asked of the world directly, because the fold never puts the question that way: it takes
+     * the first side that is out and reads the other, so a world that had lost the second would
+     * hand back the same reading as one that had not.
+     */
+    @Test
+    void andTwoPartsThatSayTheSameThingStandAtTwoPlaces() {
+        ClauseExpr.Joined shape = (ClauseExpr.Joined) ClauseExpr.of(twice(), true);
+        assertEquals(shape.left().written(), shape.right().written(),
+                "one conjunct written twice, which is two rules saying one thing");
+        PartId<RuleRef.Invariant> left = new PartId<>(rule(), 0);
+        ClauseView view = PartsLeftOut.without(Set.of(left)).viewOf(
+                List.of(new Clauses.StatedPart(left, shape.left()),
+                        new Clauses.StatedPart(new PartId<>(rule(), 1), shape.right())));
+
+        ClauseExpr.Joined again = (ClauseExpr.Joined) ClauseExpr.of(twice(), true);
+        assertTrue(view.omits(again.left()),
+                "the first conjunct is the one this world was told to leave out");
+        assertFalse(view.omits(again.right()),
+                "and the second is not out for saying what the first said");
+    }
+
+    /** {@code same && same}, built afresh each time this is called. */
+    private static Core twice() {
+        return new Core.Binary(BinOp.AND, leaf("same"), leaf("same"),
+                ConstructOccurrence.unwritten(), Type.BOOL, POS);
+    }
+
+    private static RuleRef.Invariant rule() {
+        return new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("demo", "R")), 0),
+                Optional.empty()));
     }
 
     /** What a reading that stops at every connective was handed, in the order it reached them. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Which rules a world has is settled before a reading says how far into them it goes.
@@ -64,8 +65,32 @@ class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
                 "both conjuncts are rules here, so what the reading stops at is the conjunction");
     }
 
+    /**
+     * And it holds over whatever tree the reading is walking.
+     *
+     * <p>A clause reaches a value through the tree the step that brought it there built, and a
+     * world is told which parts it holds by their names. Matched against the trees instead, a world
+     * built from one of them leaves nothing out of a walk over another — and a reading that was
+     * asked what one conjunct was holding reads the conjunct it was told to leave out.
+     */
+    @Test
+    void andTheWorldHoldsWhateverTreeTheReadingIsOver() {
+        Core again = new Core.Binary(BinOp.AND, leaf("left"), leaf("right"),
+                ConstructOccurrence.unwritten(), Type.BOOL, POS);
+        assertNotSame(BOTH, again, "the same clause, built again, which is what a step downstream"
+                + " hands on");
+        assertEquals(BOTH, again, "and it is the same clause");
+        assertEquals(List.of("right"), whatReached(again, withoutTheLeft()),
+                "the left conjunct is no rule of this world, whichever of the two trees saying so"
+                        + " the reading is walking");
+    }
+
     /** What a reading that stops at every connective was handed, in the order it reached them. */
     private static List<String> whatReached(ClauseView view) {
+        return whatReached(BOTH, view);
+    }
+
+    private static List<String> whatReached(Core clause, ClauseView view) {
         List<String> reached = new java.util.ArrayList<>();
         ClauseReading<String, Void> stopping = new ClauseReading<>() {
 
@@ -82,7 +107,7 @@ class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
                 return new Descent.Whole<>();
             }
         };
-        stopping.read(BOTH, true, null, ClauseScope.unchanged(), null, view);
+        stopping.read(clause, true, null, ClauseScope.unchanged(), null, view);
         return List.copyOf(reached);
     }
 
@@ -93,20 +118,26 @@ class AWorldSaysWhichRulesThereAreBeforeAReadingSaysHowFarItGoesTest {
                 Optional.empty()));
         PartId<RuleRef.Invariant> left = new PartId<>(rule, 0);
         PartId<RuleRef.Invariant> right = new PartId<>(rule, 1);
+        // The parts as subtrees of the one shape the clause was read into, which is the only way
+        // one is made: read apart, the two would each be the first occurrence of a clause of their
+        // own, and a world told to leave one out would be told a place both of them stand at.
+        ClauseExpr.Joined shape = (ClauseExpr.Joined) ClauseExpr.of(BOTH, true);
         return PartsLeftOut.without(Set.of(left)).viewOf(
-                List.of(new Clauses.StatedPart(left, ClauseExpr.of(LEFT, true)),
-                        new Clauses.StatedPart(right, ClauseExpr.of(RIGHT, true))));
+                List.of(new Clauses.StatedPart(left, shape.left()),
+                        new Clauses.StatedPart(right, shape.right())));
     }
 
     /** What a node reads as here, which is enough to tell the two conjuncts and the whole apart. */
     private static String spelled(Core node) {
-        if (node == LEFT) {
+        // What the node says and not which object it is: a clause built a second time is the same
+        // clause, and a reading walking that one is reaching the same rules.
+        if (LEFT.equals(node)) {
             return "left";
         }
-        if (node == RIGHT) {
+        if (RIGHT.equals(node)) {
             return "right";
         }
-        return node == BOTH ? "left && right" : "something else";
+        return BOTH.equals(node) ? "left && right" : "something else";
     }
 
     /** A clause of no connective, named by which of them it is. */


### PR DESCRIPTION
A reading asked what one conjunct of a rule was holding is a reading of the
declaration in a world the author did not write. That world kept the roots of
the parts it leaves out and matched them against the nodes the walk was over.

A clause reaches a value through the tree the step that brought it there built,
and a substitution that changes anything builds afresh. So a world built from
one tree left nothing out of a walk over another: the reading was handed the
conjunct it had been told to leave out, the end that conjunct and its neighbour
placed came back owed to both of them, and the same line was written twice.

Which parts a world holds is now said by where in the clause they stand. The
occurrences are the clause's own, handed out once where the shape is read out of
the tree, so they name the same places whatever tree says them.

Found by reading every clause over a structurally equal tree rebuilt for it:
that leaves the whole suite green now and left two reports of a line drawn twice
before. The regression is stated where the world is asked — a world built from
one tree, a walk over another — and the mechanism it replaces turns it red.

The fixture that read each part into a shape of its own is read the way parts
are made instead. Apart, each of them is the first occurrence of a clause of its
own, and a world told to leave one out is told a place both of them stand at;
the one thing that makes parts descends a single shape.

Part of #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)