### PR TITLE
Ask the shape what a connective composes where the shape is in hand

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -2145,9 +2145,11 @@ public final class FieldDomains {
                 // boundary beside it down with it.
                 // The rule as well as the place: a place is a coordinate of one clause and every
                 // clause has a first one, so an end another rule placed at its own opening would
-                // answer here for a conjunct that placed nothing.
-                if (directs.stream().anyMatch(d -> d.part().rule().equals(rule)
-                        && d.stands().equals(shape.at()))) {
+                // answer here for a conjunct that placed nothing. The place first, because it is
+                // a number and a rule is a declaration, a clause of it and a number of that.
+                ClauseExpr.Occurrence stands = shape.at();
+                if (directs.stream().anyMatch(d -> d.stands().equals(stands)
+                        && d.part().rule().equals(rule))) {
                     return;
                 }
                 // What this part is about, and not what the rule is. A conjunction is one rule the

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -19,9 +19,7 @@ import souther.compiler.values.ValueSet;
 
 import souther.compiler.numeric.Count;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import souther.compiler.types.ValueName;
@@ -111,7 +109,7 @@ public final class FieldDomains {
     private final Map<RuleRef.Invariant, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
      *  conjunct is about, and not what the conjunct written beside it raised. */
-    private final Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart;
+    private final Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart;
 
     /** What the reading answered for each boundary question it raised and left standing. */
     private final Map<BoundaryQuestion, BoundaryStanding> standing;
@@ -251,7 +249,7 @@ public final class FieldDomains {
                          List<WithoutAnEnd> withoutAnEnd, List<AboutOneCoordinate> aboutOneCoordinate,
                          PartsLeftOut withoutParts,
                          Map<RuleRef.Invariant, Required> raised,
-                         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
+                         Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
                          Map<BoundaryQuestion, BoundaryStanding> standing, ReadingEvidence took,
                          Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                          Map<RuleKey, Set<RulesMissed>> notGathered, Set<RuleKey> handedOn,
@@ -2108,26 +2106,33 @@ public final class FieldDomains {
         Map<RuleRef.Invariant, Set<RuleKey>> unrepresented = new LinkedHashMap<>();
         readings.forEach(reading -> {
             RuleRef.Invariant rule = reading.from();
-            // Every node the shapes this reading recorded were written as, which is what a
-            // conjunction below asks about its two halves.
-            Set<Core> recorded = Collections.newSetFromMap(new IdentityHashMap<>());
+            // Where in the clause this reading recorded a shape, which is what a conjunction below
+            // asks about its two halves.
+            Set<ClauseExpr.Occurrence> recorded = new LinkedHashSet<>();
             reading.constrained().values().forEach(byOccurrence ->
-                    byOccurrence.values().forEach(one -> recorded.addAll(one.of().spelled())));
+                    byOccurrence.values().forEach(one -> recorded.add(one.of().at())));
             // A part at a time, and any one of them is enough. A conjunct the bounds hold nothing of
             // leaves the range wider than the rule however well the conjunct written beside it went,
             // and a set unioned over the whole clause answers for the failing half with the other
             // one — which is the same shape as reading a clause's evidence for one of its parts.
             Set<RuleKey> said = unrepresented.computeIfAbsent(rule, _ -> new LinkedHashSet<>());
             reading.constrained().values().forEach(byOccurrence ->
-                    byOccurrence.values().forEach(one -> one.of().spelled().forEach(part -> {
+                    byOccurrence.values().forEach(one -> {
+                ClauseExpr shape = one.of();
                 InvariantChecker.PartRead read = one.said();
                 // A conjunction says what its conjuncts say, and they are here beside it. Asked of
                 // the conjunction as well, a rule whose halves are each held in a language of their
                 // own — a date bounded at both ends, read by the comparison rather than by the
                 // interval algebra — answers for neither half and fails on the node above them.
-                if (part instanceof Core.Binary b
-                        && ConditionJoin.of(b.op()).orElse(null) == ConditionJoin.BOTH
-                        && recorded.contains(b.left()) && recorded.contains(b.right())) {
+                //
+                // Which shapes are conjunctions is read off the shape and never off the operator
+                // it was written with: what a connective composes is settled where a clause is read
+                // out of the tree ({@link ClauseExpr}), and a denial written above one turns the
+                // conjunction its author wrote into a choice between the denials of its halves.
+                if (shape instanceof ClauseExpr.Joined it && it.how() == ConditionJoin.BOTH
+                        && it.positive()
+                        && recorded.contains(it.left().at())
+                        && recorded.contains(it.right().at())) {
                     return;
                 }
                 if (read.narrowable().stream().anyMatch(ranged::contains)) {
@@ -2138,7 +2143,11 @@ public final class FieldDomains {
                 // the comparison rather than from the interval algebra, and counting only the
                 // algebra calls a bounded `Date` a rule the bounds do not hold — and takes every
                 // boundary beside it down with it.
-                if (directs.stream().anyMatch(d -> d.read() == part)) {
+                // The rule as well as the place: a place is a coordinate of one clause and every
+                // clause has a first one, so an end another rule placed at its own opening would
+                // answer here for a conjunct that placed nothing.
+                if (directs.stream().anyMatch(d -> d.part().rule().equals(rule)
+                        && d.stands().equals(shape.at()))) {
                     return;
                 }
                 // What this part is about, and not what the rule is. A conjunction is one rule the
@@ -2146,8 +2155,8 @@ public final class FieldDomains {
                 // reaching for the rule's questions here would name the places of the conjunct
                 // written beside this one — the half the bounds do hold — among the ones they do
                 // not.
-                Map<Core, Required> byPartRaised = raisedByPart.get(rule);
-                Required required = byPartRaised == null ? null : byPartRaised.get(part);
+                Map<ClauseExpr.Occurrence, Required> byPartRaised = raisedByPart.get(rule);
+                Required required = byPartRaised == null ? null : byPartRaised.get(shape.at());
                 if (required != null) {
                     required.obligations().forEach(owed -> {
                         switch (owed) {
@@ -2161,7 +2170,7 @@ public final class FieldDomains {
                 if (required == null || required.obligations().isEmpty()) {
                     said.add(RuleKey.THE_VALUE);
                 }
-            })));
+            }));
         });
         // And said once per rule, after every reading of it has been met.
         unrepresented.forEach((rule, said) -> said.forEach(path ->

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -109,7 +109,7 @@ public final class FieldDomains {
     private final Map<RuleRef.Invariant, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
      *  conjunct is about, and not what the conjunct written beside it raised. */
-    private final Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart;
+    private final Map<InvariantChecker.ReadingPlace, Required> raisedByPart;
 
     /** What the reading answered for each boundary question it raised and left standing. */
     private final Map<BoundaryQuestion, BoundaryStanding> standing;
@@ -249,7 +249,7 @@ public final class FieldDomains {
                          List<WithoutAnEnd> withoutAnEnd, List<AboutOneCoordinate> aboutOneCoordinate,
                          PartsLeftOut withoutParts,
                          Map<RuleRef.Invariant, Required> raised,
-                         Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
+                         Map<InvariantChecker.ReadingPlace, Required> raisedByPart,
                          Map<BoundaryQuestion, BoundaryStanding> standing, ReadingEvidence took,
                          Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                          Map<RuleKey, Set<RulesMissed>> notGathered, Set<RuleKey> handedOn,
@@ -2143,13 +2143,13 @@ public final class FieldDomains {
                 // the comparison rather than from the interval algebra, and counting only the
                 // algebra calls a bounded `Date` a rule the bounds do not hold — and takes every
                 // boundary beside it down with it.
-                // The rule as well as the place: a place is a coordinate of one clause and every
-                // clause has a first one, so an end another rule placed at its own opening would
-                // answer here for a conjunct that placed nothing. The place first, because it is
-                // a number and a rule is a declaration, a clause of it and a number of that.
-                ClauseExpr.Occurrence stands = shape.at();
-                if (directs.stream().anyMatch(d -> d.stands().equals(stands)
-                        && d.part().rule().equals(rule))) {
+                // The place in this reading, which is what an end was filed under. A coordinate on
+                // its own would answer here with an end another reading of the same rule placed at
+                // the same conjunct — a rule held at two of a value's fields is read twice, and
+                // what each reading placed is about the field it was read at.
+                InvariantChecker.ReadingPlace stands =
+                        new InvariantChecker.ReadingPlace(reading.opened(), shape.at());
+                if (directs.stream().anyMatch(d -> d.stands().equals(stands))) {
                     return;
                 }
                 // What this part is about, and not what the rule is. A conjunction is one rule the
@@ -2157,8 +2157,7 @@ public final class FieldDomains {
                 // reaching for the rule's questions here would name the places of the conjunct
                 // written beside this one — the half the bounds do hold — among the ones they do
                 // not.
-                Map<ClauseExpr.Occurrence, Required> byPartRaised = raisedByPart.get(rule);
-                Required required = byPartRaised == null ? null : byPartRaised.get(shape.at());
+                Required required = raisedByPart.get(stands);
                 if (required != null) {
                     required.obligations().forEach(owed -> {
                         switch (owed) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1345,10 +1345,12 @@ public final class InvariantChecker {
      *                 declarations they came back as one. And the part and not the clause: one part
      *                 states as many rules as its author wrote into it, and each of them places its
      *                 own end
-     * @param read     the part itself, as the reading of the clause left it
+     * @param stands   where in the clause the part that placed it is. One part states as many rules
+     *                 as its author wrote into it and each of them stands somewhere, so what says
+     *                 which of them this end came of is the place and not the rule
      */
     record Direct(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part, InvariantBound bound,
-                  Core read) {
+                  ClauseExpr.Occurrence stands) {
 
         /** What the value's rules call where the end was placed. Never which end it is: one name
          *  carries more than one number and {@link #at} is what says which of them this is. */
@@ -1727,17 +1729,19 @@ public final class InvariantChecker {
      *                  Beside the ends rather than derived from them: a clause that placed no end
      *                  may have raised a question all the same, and a clause that placed one raised
      *                  more than the line. Nothing here says whether anything answered
-     * @param raisedByPart the same, kept per part of each rule. A conjunction is one rule the author
-     *                  wrote, and what it raises is what its conjuncts raise together — so a reader
-     *                  that found one conjunct wanting and reached for the rule's questions would
-     *                  name the positions of the conjunct written beside it as well
+     * @param raisedByPart the same, kept for each place in the rule's clause. A conjunction is one
+     *                  rule the author wrote, and what it raises is what its conjuncts raise
+     *                  together — so a reader that found one conjunct wanting and reached for the
+     *                  rule's questions would name the positions of the conjunct written beside it
+     *                  as well. Per place and not per part, because one part states as many rules
+     *                  as its author wrote into it and each of them raises its own questions
      */
     record Reading(List<Direct> directs, List<FieldDomains.NoLine> noLines,
                    List<FieldDomains.WithoutAnEnd> withoutAnEnd,
                    List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate,
                    Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                    Map<RuleRef.Invariant, Required> raised,
-                   Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
+                   Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
                    Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
     /**
@@ -1782,7 +1786,7 @@ public final class InvariantChecker {
         List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
-        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
         // The parts this world holds, which is the same list every other walk over these clauses
@@ -1827,13 +1831,13 @@ public final class InvariantChecker {
                         ClauseStates states, InvariantBound.Read placed,
                         Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
-                        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart) {
+                        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart) {
         raises(raised, rule, states);
         // And what this part of it raises, kept apart from what the rule raises. A reader that found
         // one conjunct wanting reaches for this: the questions of the conjunct written beside it are
         // not what that conjunct left standing.
-        raisedByPart.computeIfAbsent(rule, _ -> new java.util.IdentityHashMap<>())
-                .merge(part, Required.ofInvariant(states), Required::and);
+        raisedByPart.computeIfAbsent(rule, _ -> new LinkedHashMap<>())
+                .merge(at, Required.ofInvariant(states), Required::and);
         // A part the reading of ends took in is accounted for by that reading, whatever shape the
         // clause has. Asked of the reading and not of the shape: the two were one question while a
         // bound this could fold was the only clause that arrived here as a bound, and reading the
@@ -1915,7 +1919,7 @@ public final class InvariantChecker {
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         RulesRead rules,
-                        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
+                        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing) {
         // Which rule this is a part of, asked of the part. Carried beside it, a reading could be
@@ -2108,7 +2112,7 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(found.at(), part, placed.bound(), bin));
+            out.add(new Direct(found.at(), part, placed.bound(), saidAs.at()));
         }
     }
 
@@ -2832,7 +2836,7 @@ public final class InvariantChecker {
             // stop is undecided, which is not the same as its stating that they stop nowhere.
             switch (stated) {
                 case AdmittedStrings.Admitting it ->
-                        byPosition.put(position, placed(it.set(), value, part, clause, out));
+                        byPosition.put(position, placed(it.set(), value, part, at, out));
                 case AdmittedStrings.NotKnown it ->
                         byPosition.put(position, new Run.Undecided(it.why()));
                 // And a rule of a position that could not hand its sets on leaves the question
@@ -2861,7 +2865,7 @@ public final class InvariantChecker {
      * is why what is asked of it is which of its ends the rule placed.
      */
     private Run placed(ValueSet set, NumberAt<RuleKey> value, PartId<RuleRef.Invariant> part,
-                       Core clause, List<Direct> out) {
+                       ClauseExpr.Occurrence stands, List<Direct> out) {
         switch (extentOf(set)) {
             // A run holding one string is the rule naming a value rather than bounding a range, and
             // a value it names is a distinction of the position rather than an edge on it.
@@ -2873,12 +2877,12 @@ public final class InvariantChecker {
                 if (run.holdsFromAbove()) {
                     placed = true;
                     out.add(new Direct(value, part,
-                            new InvariantBound(true, Endpoint.inclusive(run.first())), clause));
+                            new InvariantBound(true, Endpoint.inclusive(run.first())), stands));
                 }
                 if (run.after() != null) {
                     placed = true;
                     out.add(new Direct(value, part,
-                            new InvariantBound(false, Endpoint.exclusive(run.after())), clause));
+                            new InvariantBound(false, Endpoint.exclusive(run.after())), stands));
                 }
                 return placed ? new Run.Bounding(value) : new Run.NotBounding();
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1345,12 +1345,14 @@ public final class InvariantChecker {
      *                 declarations they came back as one. And the part and not the clause: one part
      *                 states as many rules as its author wrote into it, and each of them places its
      *                 own end
-     * @param stands   where in the clause the part that placed it is. One part states as many rules
-     *                 as its author wrote into it and each of them stands somewhere, so what says
-     *                 which of them this end came of is the place and not the rule
+     * @param stands   where, and in which reading, the part that placed it is. One part states as
+     *                 many rules as its author wrote into it and each of them stands somewhere, so
+     *                 what says which of them this end came of is the place; and a rule is read
+     *                 once per place the walk opens a value at, so which reading placed it is the
+     *                 other half of the same answer
      */
     record Direct(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part, InvariantBound bound,
-                  ClauseExpr.Occurrence stands) {
+                  ReadingPlace stands) {
 
         /** What the value's rules call where the end was placed. Never which end it is: one name
          *  carries more than one number and {@link #at} is what says which of them this is. */
@@ -1383,6 +1385,33 @@ public final class InvariantChecker {
         @Override
         public String toString() {
             return "reading #" + ordinal;
+        }
+    }
+
+    /**
+     * One place in one reading of a clause, which is what an answer about a part is filed under.
+     *
+     * <p>An occurrence is a coordinate of a clause and every clause has a first one, so it says
+     * where without saying whose. A rule is read once per place the walk opens a value at, and what
+     * each of those readings made of the place it stands at is that reading's — the same rule read
+     * at {@code was} and at {@code now} raises the questions of {@code was} at one and of
+     * {@code now} at the other, and they are two answers about one written conjunct.
+     *
+     * <p>Which is what the node used to say and what saying only the coordinate leaves out. Each
+     * reading walked the tree a substitution built for it, so the node was where and whose at once;
+     * held apart, both halves have to be here.
+     */
+    record ReadingPlace(ReadingId reading, ClauseExpr.Occurrence at) {
+
+        ReadingPlace {
+            if (reading == null || at == null) {
+                throw new IllegalArgumentException("a place is somewhere, in some reading");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return reading + " " + at;
         }
     }
 
@@ -1741,7 +1770,7 @@ public final class InvariantChecker {
                    List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate,
                    Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                    Map<RuleRef.Invariant, Required> raised,
-                   Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
+                   Map<ReadingPlace, Required> raisedByPart,
                    Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
     /**
@@ -1786,7 +1815,7 @@ public final class InvariantChecker {
         List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
-        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart = new LinkedHashMap<>();
+        Map<ReadingPlace, Required> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
         // The parts this world holds, which is the same list every other walk over these clauses
@@ -1831,13 +1860,13 @@ public final class InvariantChecker {
                         ClauseStates states, InvariantBound.Read placed,
                         Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
-                        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart) {
+                        Map<ReadingPlace, Required> raisedByPart) {
         raises(raised, rule, states);
         // And what this part of it raises, kept apart from what the rule raises. A reader that found
         // one conjunct wanting reaches for this: the questions of the conjunct written beside it are
         // not what that conjunct left standing.
-        raisedByPart.computeIfAbsent(rule, _ -> new LinkedHashMap<>())
-                .merge(at, Required.ofInvariant(states), Required::and);
+        raisedByPart.merge(new ReadingPlace(of.opened(), at),
+                Required.ofInvariant(states), Required::and);
         // A part the reading of ends took in is accounted for by that reading, whatever shape the
         // clause has. Asked of the reading and not of the shape: the two were one question while a
         // bound this could fold was the only clause that arrived here as a bound, and reading the
@@ -1919,7 +1948,7 @@ public final class InvariantChecker {
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         RulesRead rules,
-                        Map<RuleRef.Invariant, Map<ClauseExpr.Occurrence, Required>> raisedByPart,
+                        Map<ReadingPlace, Required> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing) {
         // Which rule this is a part of, asked of the part. Carried beside it, a reading could be
@@ -1966,7 +1995,7 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(saidAs.at(), of, part, byName, out);
+        RunsRead runs = runsOf(new ReadingPlace(of.opened(), saidAs.at()), of, part, byName, out);
         restricting(clause, saidAs.at(), from, of, part, byName, rules, noLines, runs);
         aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
@@ -2112,7 +2141,8 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(found.at(), part, placed.bound(), saidAs.at()));
+            out.add(new Direct(found.at(), part, placed.bound(),
+                    new ReadingPlace(of.opened(), saidAs.at())));
         }
     }
 
@@ -2813,10 +2843,10 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private RunsRead runsOf(ClauseExpr.Occurrence at,
+    private RunsRead runsOf(ReadingPlace stands,
                         Written of, PartId<RuleRef.Invariant> part,
                         Map<FactSubject, Coordinate> byName, List<Direct> out) {
-        ReadByClauses.OfAPart account = of.adoptedAt(at);
+        ReadByClauses.OfAPart account = of.adoptedAt(stands.at());
         if (account == null) {
             return RunsRead.NOTHING;
         }
@@ -2836,7 +2866,7 @@ public final class InvariantChecker {
             // stop is undecided, which is not the same as its stating that they stop nowhere.
             switch (stated) {
                 case AdmittedStrings.Admitting it ->
-                        byPosition.put(position, placed(it.set(), value, part, at, out));
+                        byPosition.put(position, placed(it.set(), value, part, stands, out));
                 case AdmittedStrings.NotKnown it ->
                         byPosition.put(position, new Run.Undecided(it.why()));
                 // And a rule of a position that could not hand its sets on leaves the question
@@ -2865,7 +2895,7 @@ public final class InvariantChecker {
      * is why what is asked of it is which of its ends the rule placed.
      */
     private Run placed(ValueSet set, NumberAt<RuleKey> value, PartId<RuleRef.Invariant> part,
-                       ClauseExpr.Occurrence stands, List<Direct> out) {
+                       ReadingPlace stands, List<Direct> out) {
         switch (extentOf(set)) {
             // A run holding one string is the rule naming a value rather than bounding a range, and
             // a value it names is a distinction of the position rather than an edge on it.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1966,7 +1966,7 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(clause, saidAs.at(), of, part, byName, out);
+        RunsRead runs = runsOf(saidAs.at(), of, part, byName, out);
         restricting(clause, saidAs.at(), from, of, part, byName, rules, noLines, runs);
         aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
         if (!(clause instanceof Core.Binary bin)) {
@@ -2813,7 +2813,7 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private RunsRead runsOf(Core clause, ClauseExpr.Occurrence at,
+    private RunsRead runsOf(ClauseExpr.Occurrence at,
                         Written of, PartId<RuleRef.Invariant> part,
                         Map<FactSubject, Coordinate> byName, List<Direct> out) {
         ReadByClauses.OfAPart account = of.adoptedAt(at);

--- a/souther-compiler/src/test/java/souther/compiler/ADeniedConjunctionIsTheChoiceItMeansTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADeniedConjunctionIsTheChoiceItMeansTest.java
@@ -1,0 +1,79 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What a rule written as a denied conjunction states, which is a choice between its halves denied.
+ *
+ * <p>The mirror of what a denied disjunction states. One connective and one polarity say what a
+ * condition gives its reader, and the answer does not turn on which of the two ways round they
+ * arrive — so a rule written {@code Bool.not(a && b)} is owed exactly what the same rule written
+ * {@code !a || !b} is owed.
+ *
+ * <p>What the node underneath still spells is the conjunction. A reader that asks the operator what
+ * it composes is told a conjunction where the rule is a choice, and what that decides is what a
+ * half is answerable for: both halves of a conjunction hold, so a reading may take either as
+ * standing for the whole; one alternative of a choice holds, so neither does. The composition is
+ * settled where a clause is read out of the tree and nowhere else, which is what the licences over
+ * that reading hold; this is the same fact where an author can see it.
+ */
+class ADeniedConjunctionIsTheChoiceItMeansTest {
+
+    private static long warnings(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    /** A rule of a type, written as the choice it is. */
+    private static final String AS_A_CHOICE = """
+            module demo
+            data TooNear
+            data Away = Int
+                invariant value < 1 || value > 10
+            behavior toAway : (n: Int) -> Away | TooNear
+                constructs Away
+            let toAway (n) = {
+                guard n < 1
+                    else TooNear
+                Away(n)
+            }
+            """;
+
+    /** And the same rule written as the conjunction it denies. */
+    private static final String AS_A_DENIED_CONJUNCTION =
+            AS_A_CHOICE.replace("value < 1 || value > 10",
+                    "Bool.not(value >= 1 && value <= 10)");
+
+    /** The same model with a rule the guard settles outright, which is what a compiler that read
+     *  the rule says nothing about. */
+    private static final String SETTLED = AS_A_CHOICE
+            .replace("value < 1 || value > 10", "value <= 10")
+            .replace("guard n < 1", "guard n <= 10");
+
+    @Test
+    void aDeniedConjunctionIsOwedWhatTheChoiceItMeansIsOwed() {
+        assertEquals(warnings(AS_A_CHOICE), warnings(AS_A_DENIED_CONJUNCTION),
+                "a conjunction denied is the choice between its halves denied, so the two"
+                        + " spellings are one rule and neither owes what the other does not");
+    }
+
+    /**
+     * And the control: what the pair above agree on is not what every model says.
+     *
+     * <p>Without it they would agree on a compiler that reported nothing whatever it read, and the
+     * agreement would be about the reporting rather than about the rule.
+     */
+    @Test
+    void andWhatTheyAgreeOnIsNotWhatEveryModelSays() {
+        assertEquals(0, warnings(SETTLED),
+                "a rule the guard settles outright leaves nothing to say");
+        assertNotEquals(warnings(SETTLED), warnings(AS_A_CHOICE),
+                "and the rule above is not settled by its guard, so the agreement is about two"
+                        + " spellings of it and not about a compiler with nothing to say");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatOneReadingFiledAtAPlaceIsNotAnotherReadingsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatOneReadingFiledAtAPlaceIsNotAnotherReadingsAnswerTest.java
@@ -1,0 +1,102 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.ConstructOccurrence;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Two readings of one place in one clause are two answers, and neither is the other's.
+ *
+ * <p>A rule is read once per place the walk opens a value at. A record holding a bounded type at
+ * two of its fields is held to that type's clause at both, and each reading raises the questions of
+ * the field it was read at — so one written conjunct has as many answers as there were readings,
+ * and they are not the same answer.
+ *
+ * <p>Where in the clause a conjunct stands does not say which of them is speaking. Every clause has
+ * a first place and both readings walk the same one, so an answer filed under the coordinate alone
+ * lands where the other reading's answer already is — and what a reader takes out is the two of them
+ * put together, which is what neither reading said.
+ *
+ * <p>The node the answer used to be filed under said both things at once: each reading walked the
+ * tree a substitution built for it, so which object it was said which reading it was. Held apart,
+ * both halves have to be in the address.
+ *
+ * <p>The control is below: the two answers put together is a third answer, and it is what the wrong
+ * address hands back.
+ */
+class WhatOneReadingFiledAtAPlaceIsNotAnotherReadingsAnswerTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    /** {@code a == a && b == b}, read into the shape that hands out the places. */
+    private static final ClauseExpr.Joined CLAUSE = (ClauseExpr.Joined) ClauseExpr.of(
+            new Core.Binary(BinOp.AND, leaf("a"), leaf("b"),
+                    ConstructOccurrence.unwritten(), Type.BOOL, POS), true);
+
+    /** What one reading made of the left conjunct, and what another made of the same conjunct.
+     *  Two answers a reader can tell apart, so finding the wrong one is a failure. */
+    private static final Required RELATES =
+            Required.ofInvariant(new ClauseStates.ARelation());
+    private static final Required CONSTRAINS_NOTHING =
+            Required.ofInvariant(new ClauseStates.NoRestriction());
+
+    @Test
+    void twoReadingsOfOneConjunctFileTwoAnswers() {
+        InvariantChecker.ReadingPlace here = new InvariantChecker.ReadingPlace(
+                new InvariantChecker.ReadingId(0), CLAUSE.left().at());
+        InvariantChecker.ReadingPlace there = new InvariantChecker.ReadingPlace(
+                new InvariantChecker.ReadingId(1), CLAUSE.left().at());
+        assertEquals(here.at(), there.at(),
+                "the same conjunct of the same clause, which is what the two readings share");
+
+        Map<InvariantChecker.ReadingPlace, Required> raised = filed(here, there);
+
+        assertEquals(2, raised.size(),
+                "two readings of one conjunct are two answers about it");
+        assertEquals(RELATES, raised.get(here),
+                "what the first reading made of the conjunct, asked for where it filed it");
+        assertEquals(CONSTRAINS_NOTHING, raised.get(there),
+                "and what the second made of it, which is a different answer about one conjunct");
+    }
+
+    /**
+     * And the control: what an address short of the reading hands back.
+     *
+     * <p>The two are gathered the way a clause's conjuncts are, so an address the two readings
+     * share does not lose one of them — it answers with both, for a reading that said one.
+     */
+    @Test
+    void andTheTwoTogetherIsWhatNeitherReadingSaid() {
+        Required both = Required.and(RELATES, CONSTRAINS_NOTHING);
+        assertNotEquals(RELATES, both,
+                "the two put together is not what the first reading said");
+        assertNotEquals(CONSTRAINS_NOTHING, both,
+                "nor what the second did");
+    }
+
+    /** The two answers, filed as the walk files them. */
+    private static Map<InvariantChecker.ReadingPlace, Required> filed(
+            InvariantChecker.ReadingPlace here, InvariantChecker.ReadingPlace there) {
+        Map<InvariantChecker.ReadingPlace, Required> raised = new LinkedHashMap<>();
+        raised.merge(here, RELATES, Required::and);
+        raised.merge(there, CONSTRAINS_NOTHING, Required::and);
+        return raised;
+    }
+
+    /** A clause of no connective, named by which of them it is. */
+    private static Core leaf(String named) {
+        return new Core.Binary(BinOp.EQ, new Core.Str(named, Type.STRING, POS),
+                new Core.Str(named, Type.STRING, POS), ConstructOccurrence.unwritten(),
+                Type.BOOL, POS);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -253,8 +253,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "the shape an author wrote a clause in, which is walking into what composes"
                             + " both halves. The one walk that says what the parts are; everything"
                             + " else about them is read off the shape it leaves"),
-            new Held("souther.compiler.check.FieldDomains.lambda$projection$7",
-                    "walks into both halves for the clause that bounds a field"),
             new Held("souther.compiler.partition.Condition.of",
                     "the composition, which the shape it makes carries"),
             new Held("souther.compiler.partition.ClauseStatements.walk",

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -56,8 +56,6 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
                             + " parts there are, where each stands among them, the clause with each"
                             + " expanded where it stands, and which subtree of a reading each of"
                             + " them became are all answers over that one shape"),
-            new Licence("souther.compiler.check.FieldDomains.lambda$projection$7", 1,
-                    "the clause that bounds a field, whose halves are answered beside it"),
             new Licence("souther.compiler.partition.ClauseStatements.walk", 1,
                     "what a behavior's clause states outright: one recognition, and both of what a"
                             + " connective can compose read off it. The comparisons a clause draws"


### PR DESCRIPTION
The walk that says what a rule leaves unrepresented held the shape a clause was
read into and asked the operator underneath it what it composed. That is the
question the shape exists to have answered once. The two disagree where an
author wrote a denial above a conjunction: the shape says a choice between the
denials of the halves, and the operator underneath still spells the conjunction.

It walked the nodes rather than the shape because the two things it consults
were filed under nodes — what each place in the clause raised, and which of them
placed an end.

A node said two things at once. It said where in the clause a conjunct stands,
and it said which reading of that clause was speaking: a rule is read once per
place the walk opens a value at, and each reading walks the tree a substitution
built for it, so which object it was said which reading it was. An address made
of the coordinate alone keeps the first and loses the second — and a value
holding a bounded type at two of its fields is held to that type's clause at
both, so the two readings meet at one address and their questions are merged.

So a place says where in the clause it is and which reading it is in, and both
of the things filed under a node now say that. The ends are matched on the place
alone, the rule being the reading's to say.

Both ledgers that licensed this reader to ask an operator lose their entry. That
is what the change is: the readers left are the ones that make a shape, and
putting the question back turns those ledgers red.

Beside them, two tests. One says that two readings of one place are two answers
and that the two together is what neither reading said — collapsing the address
to the coordinate turns it red. The other says that a rule an author denied is
owed what the rule it means is owed, where an author can see it.

Part of #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)