### PR TITLE
Ask the repository for its compiled classes rather than going to find them

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AReadingOfValuesIsStartedComposedOrWorkedOutTest.java
@@ -1,13 +1,9 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Signature;
@@ -20,7 +16,6 @@ import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.reflect.AccessFlag;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,7 +23,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +71,7 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
         return "L" + type + ";";
     }
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /** Handed nothing at all, which is what a reading starts from. */
     private static final String A_START = "handed nothing";
@@ -143,24 +137,13 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (classesUnder(module).isEmpty() && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over");
+        // A module that has sources and left no classes is refused where the outputs are taken, so
+        // a walk reading fewer modules than the repository has does not get this far.
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the module that declares the reading");
     }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
+
 
     /**
      * Every method whose code makes a reading, as the method and the warrant its signature gives
@@ -179,9 +162,9 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
      */
     private static List<String> makers() {
         List<String> found = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                ClassModel owner = parse(each);
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                ClassModel owner = each;
                 if (!namesTheConstructor(owner)) {
                     continue;
                 }
@@ -319,33 +302,15 @@ class AReadingOfValuesIsStartedComposedOrWorkedOutTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static ClassModel parse(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
-     *  them: a test makes a reading to look at it and ships nothing. */
-    private static List<Path> classesUnder(Path module) {
-        Path where = module.resolve("target").resolve("classes");
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheAlgebraThePackageHasTest.java
@@ -1,13 +1,9 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
@@ -17,12 +13,9 @@ import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.classfile.instruction.LoadInstruction;
 import java.lang.classfile.instruction.ReturnInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,12 +63,12 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
      *  question. */
     private static final String ANY_SHAPE = "";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     @Test
     void everyValueThereThatWorksOutItsOwnHashTakesItFromTheAlgebra() {
         List<String> gatheringItThemselves = new ArrayList<>();
-        for (ClassModel read : valuesClasses()) {
+        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
             Optional<MethodModel> spelled = spelledOut(read, "hashCode", "()I");
             if (spelled.isPresent() && !fromTheAlgebra(read, spelled.get())) {
                 gatheringItThemselves.add(read.thisClass().name().stringValue());
@@ -101,7 +94,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
     @Test
     void andARecordThereSpellsItsOwnEqualityWhereAndOnlyWhereTheGeneratedOneWouldSayAnother() {
         List<String> disagreeing = new ArrayList<>();
-        for (ClassModel read : valuesClasses()) {
+        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
             if (read.findAttribute(Attributes.record()).isEmpty()) {
                 continue;
             }
@@ -129,7 +122,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
      */
     @Test
     void andTheValuesThoseRulesAreAboutWereRead() {
-        List<ClassModel> read = valuesClasses();
+        List<ClassModel> read = COMPILED.inTheClassesOf(WHERE);
 
         assertTrue(read.size() > 1, "the classes about relations were not built here");
         assertTrue(read.stream().anyMatch(each -> spelledOut(each, "hashCode", "()I").isPresent()),
@@ -242,29 +235,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
                 .toList()).orElse(List.of());
     }
 
-    private static List<ClassModel> valuesClasses() {
-        List<ClassModel> out = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            Path where = module.resolve("target").resolve("classes").resolve(WHERE);
-            if (!Files.isDirectory(where)) {
-                continue;
-            }
-            try (Stream<Path> found = Files.list(where)) {
-                for (Path each : found.filter(p -> p.toString().endsWith(".class")).toList()) {
-                    out.add(parse(each));
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-        return out;
-    }
 
-    private static ClassModel parse(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
@@ -1,18 +1,13 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
 import java.lang.reflect.AccessFlag;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -23,7 +18,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,7 +50,7 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
 
     private static final String CONJUNCTION = "souther/compiler/values/ConjoinedAdmissibleValues";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every production class an allowance can be reached from, which is every reading still
@@ -150,10 +144,10 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
     /** Every type named by a field of {@code owner}, for asking what it names of itself. */
     private static Set<String> fieldTypesOf(String owner) {
         Set<String> out = new LinkedHashSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                if (internalName(module, each).equals(owner)) {
-                    classOf(each).fields().forEach(field -> out.addAll(typesIn(declared(field))));
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                if (each.thisClass().asInternalName().equals(owner)) {
+                    each.fields().forEach(field -> out.addAll(typesIn(declared(field))));
                 }
             }
         }
@@ -176,13 +170,13 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
      */
     private static List<String> holdingAnAllowance() {
         Map<String, Set<String>> holds = new LinkedHashMap<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
                 Set<String> reaching = new LinkedHashSet<>();
-                for (FieldModel field : classOf(each).fields()) {
+                for (FieldModel field : each.fields()) {
                     reaching.addAll(typesIn(declared(field)));
                 }
-                holds.put(internalName(module, each), reaching);
+                holds.put(each.thisClass().asInternalName(), reaching);
             }
         }
         // What reaches an allowance, and then what reaches that, until nothing new arrives.
@@ -235,9 +229,9 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
      */
     private static List<String> namingAnAllowance(String owner) {
         TreeSet<String> out = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                String here = internalName(module, each);
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                String here = each.thisClass().asInternalName();
                 // The type and everything declared inside it. What may be asked of a conjunction
                 // includes what its own nested types offer, and one of those taking a purse is the
                 // same capability under another name.
@@ -245,7 +239,7 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
                     continue;
                 }
                 String within = here.equals(owner) ? "" : here.substring(owner.length() + 1) + ".";
-                for (MethodModel method : classOf(each).methods()) {
+                for (MethodModel method : each.methods()) {
                     if (!method.flags().has(AccessFlag.PRIVATE)
                             && typesIn(declared(method)).contains(ALLOWANCE)) {
                         out.add(within + method.methodName().stringValue());
@@ -264,34 +258,11 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
                 .orElseGet(() -> method.methodType().stringValue());
     }
 
-    private static ClassModel classOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
@@ -1,20 +1,16 @@
 package souther.architecture;
 
+import souther.test.CompiledClasses;
 import souther.test.RepositoryLayout;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
- * The compiled outputs a name is looked for in, and the order they are looked in.
+ * The compiled outputs a rule here is about, and the order a name is looked for in them.
  *
  * <p>Which outputs those are is what this is: a rule here asks about a class of this repository
  * without knowing which module built it, so the question is put to several outputs in turn and the
@@ -22,11 +18,10 @@ import java.util.Optional;
  * its order are here.
  *
  * <p>Not through {@code java.class.path}. What a module is handed there is the reactor's to decide
- * and it is not the same in every build — a module built beside this one arrives as its
- * {@code target/classes}, and one already packaged arrives as a jar — so a walk over the entries is
- * a walk over something that answers differently depending on which goal was run. What a rule here
- * is about is the compiled surface of a class of this repository, and the repository is where that
- * is.
+ * and it is not the same in every build — a module built beside this one arrives as its compiled
+ * classes, and one already packaged arrives as a jar — so a walk over the entries is a walk over
+ * something that answers differently depending on which goal was run. What a rule here is about is
+ * the compiled surface of a class of this repository, and the repository is where that is.
  *
  * <p>Which output is searched is the caller's to name, because the two questions asked here are
  * about two populations. A rule about what a class of this repository offers its callers is about
@@ -36,34 +31,49 @@ import java.util.Optional;
  *
  * <p>A name this cannot find is not a class that reaches nothing. It is a question this cannot
  * answer, and it says so rather than answering.
+ *
+ * <p><b>Held for the run, because the repository does not move while it happens.</b> Where a
+ * module's output is is worked out by asking the file system what a path really is, and a rule
+ * following a name from one output to the next asks for the outputs once per name it follows.
  */
 final class CompiledOutputs {
 
-    private final RepositoryLayout repository;
-
-    private final List<String> outputs;
-
-    private final Map<String, Optional<ClassModel>> read = new HashMap<>();
-
-    private CompiledOutputs(RepositoryLayout repository, List<String> outputs) {
-        this.repository = repository;
-        this.outputs = outputs;
-    }
-
     /** What this repository publishes: the compiled surface a caller elsewhere reaches. */
-    static CompiledOutputs ofWhatThisRepositoryPublishes() {
-        return new CompiledOutputs(RepositoryLayout.ofWorkingDirectory(), List.of("classes"));
-    }
+    private static final CompiledOutputs PUBLISHED = new CompiledOutputs(List.of("main"));
 
     /** That and what was compiled beside it, which is where a test's own subjects are. */
+    private static final CompiledOutputs EVERYTHING = new CompiledOutputs(List.of("main", "test"));
+
+    private final RepositoryLayout repository = RepositoryLayout.ofWorkingDirectory();
+
+    private final List<String> phases;
+
+    private List<CompiledClasses> outputs;
+
+    private CompiledOutputs(List<String> phases) {
+        this.phases = phases;
+    }
+
+    static CompiledOutputs ofWhatThisRepositoryPublishes() {
+        return PUBLISHED;
+    }
+
     static CompiledOutputs ofEverythingCompiledHere() {
-        return new CompiledOutputs(RepositoryLayout.ofWorkingDirectory(),
-                List.of("classes", "test-classes"));
+        return EVERYTHING;
     }
 
     /** The class {@code internalName} names, or nothing where this repository built no such file. */
     Optional<ClassModel> find(String internalName) {
-        return read.computeIfAbsent(internalName, this::parse);
+        // Outputs in the order they were named, because that order is a rule between them: a class
+        // this repository publishes answers about that name wherever a module beside it also
+        // compiled one.
+        for (CompiledClasses output : outputs()) {
+            Optional<ClassModel> found = output.find(internalName.replace('/', '.'));
+            if (found.isPresent()) {
+                return found;
+            }
+        }
+        return Optional.empty();
     }
 
     /** The class {@code internalName} names, where failing to find one fails the reading. */
@@ -73,23 +83,107 @@ final class CompiledOutputs {
                         + " signature naming it reaches is a question this cannot answer"));
     }
 
-    private Optional<ClassModel> parse(String internalName) {
-        // Outputs outermost, because the order they are named in is an order between them: a class
-        // this repository publishes answers about that name wherever a module beside it also
-        // compiled one.
-        for (String output : outputs) {
-            for (Path module : repository.modules()) {
-                Path compiled = module.resolve("target").resolve(output)
-                        .resolve(internalName + ".class");
-                if (Files.isRegularFile(compiled)) {
-                    try {
-                        return Optional.of(ClassFile.of().parse(Files.readAllBytes(compiled)));
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
+    /**
+     * Every class of every output in the population.
+     *
+     * <p>A module that has sources of a phase and compiled none of them is a hole rather than a
+     * pass: a rule about every class of this repository that passed over a module would answer
+     * about the rest while reading as though it had covered all of them. A module that has no
+     * sources of that phase compiled nothing, and finding nothing there is the whole answer.
+     */
+    List<ClassModel> all() {
+        List<ClassModel> found = new ArrayList<>();
+        for (CompiledClasses output : outputs()) {
+            found.addAll(output.all());
+        }
+        return found;
+    }
+
+    /** The modules of this repository, for a rule that is about one of them at a time. */
+    List<Path> modules() {
+        return repository.modules();
+    }
+
+    /** What {@code module} compiled its main sources to, where it has any to compile. */
+    Optional<CompiledClasses> mainOutputOf(Path module) {
+        return outputOf(module, "main");
+    }
+
+    /**
+     * Every class {@code module} compiled from its main sources, and none where it has none.
+     *
+     * <p>For a rule that reads the repository a module at a time. A module holding only tests or
+     * only a pom compiled nothing of its own, and nothing is the whole answer; a module with
+     * sources and nothing built is refused, because a rule that read fewer modules than it names
+     * answers about the rest.
+     */
+    List<ClassModel> classesOf(Path module) {
+        return mainOutputOf(module).map(CompiledClasses::all).orElse(List.of());
+    }
+
+    /**
+     * Every class {@code module} compiled from its tests, and none where it has none.
+     *
+     * <p>A module with no tests of its own compiled none, and that is an answer rather than a hole:
+     * a module exists to publish something and having nothing of its own to check is a thing a
+     * module may be.
+     */
+    List<ClassModel> testClassesOf(Path module) {
+        return outputOf(module, "test").map(CompiledClasses::all).orElse(List.of());
+    }
+
+    /**
+     * The classes written directly in {@code packageName}, and none of the packages under it.
+     *
+     * <p>Narrower than asking a reading for a package, which answers with the packages under it as
+     * well, and narrower on purpose: a rule here is about what one package holds, and a package
+     * written under it later is a package of its own that nobody has said anything about. Which of
+     * the two a rule wants is the rule's to say, so both are here rather than one standing in for
+     * the other.
+     *
+     * @param packageName as a class file spells it, with {@code /} between the steps
+     */
+    List<ClassModel> inTheClassesOf(String packageName) {
+        String under = packageName.endsWith("/") ? packageName : packageName + "/";
+        List<ClassModel> found = new ArrayList<>();
+        for (ClassModel each : all()) {
+            String named = each.thisClass().asInternalName();
+            if (named.startsWith(under) && !named.substring(under.length()).contains("/")) {
+                found.add(each);
             }
         }
-        return Optional.empty();
+        return found;
+    }
+
+    private List<CompiledClasses> outputs() {
+        if (outputs == null) {
+            List<CompiledClasses> found = new ArrayList<>();
+            for (String phase : phases) {
+                for (Path module : repository.modules()) {
+                    outputOf(module, phase).ifPresent(found::add);
+                }
+            }
+            outputs = List.copyOf(found);
+        }
+        return outputs;
+    }
+
+    /**
+     * What {@code module} compiled its {@code phase} sources to, where it has any of that phase.
+     *
+     * <p>Having sources and no output is the hole: it is refused here rather than passed over, so a
+     * rule reading every class reads every class there is or says which module it could not.
+     */
+    private Optional<CompiledClasses> outputOf(Path module, String phase) {
+        if (repository.javaTreeOf(module, phase) == null) {
+            return Optional.empty();
+        }
+        Optional<CompiledClasses> built = repository.compiledOutputOf(module, phase);
+        if (built.isEmpty()) {
+            throw new AssertionError(module.getFileName() + " has " + phase + " sources and no"
+                    + " classes built from them: a rule that passed over it would answer about the"
+                    + " rest of the repository while reading as though it had covered this too");
+        }
+        return built;
     }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
@@ -7,7 +7,9 @@ import java.lang.classfile.ClassModel;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The compiled outputs a rule here is about, and the order a name is looked for in them.
@@ -175,15 +177,29 @@ final class CompiledOutputs {
      * rule reading every class reads every class there is or says which module it could not.
      */
     private Optional<CompiledClasses> outputOf(Path module, String phase) {
-        if (repository.javaTreeOf(module, phase) == null) {
-            return Optional.empty();
-        }
-        Optional<CompiledClasses> built = repository.compiledOutputOf(module, phase);
-        if (built.isEmpty()) {
-            throw new AssertionError(module.getFileName() + " has " + phase + " sources and no"
-                    + " classes built from them: a rule that passed over it would answer about the"
-                    + " rest of the repository while reading as though it had covered this too");
-        }
-        return built;
+        return found.computeIfAbsent(module + " " + phase, _ -> {
+            if (repository.javaTreeOf(module, phase) == null) {
+                return Optional.empty();
+            }
+            Optional<CompiledClasses> built = repository.compiledOutputOf(module, phase);
+            if (built.isEmpty()) {
+                throw new AssertionError(module.getFileName() + " has " + phase + " sources and no"
+                        + " classes built from them: a rule that passed over it would answer about"
+                        + " the rest of the repository while reading as though it had covered this"
+                        + " too");
+            }
+            return built;
+        });
     }
+
+    /**
+     * Which output each module compiled a phase to, worked out once.
+     *
+     * <p>Where an output is is asked of the file system — whether the module has sources of that
+     * phase, whether anything was built, and what the path it was handed really is — and a rule
+     * that reads the repository a module at a time asks for the same module's output once per rule
+     * it has. None of those answers changes while the run happens, which is the whole reason the
+     * classes behind them are read once.
+     */
+    private final Map<String, Optional<CompiledClasses>> found = new ConcurrentHashMap<>();
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledOutputs.java
@@ -146,13 +146,11 @@ final class CompiledOutputs {
      * @param packageName as a class file spells it, with {@code /} between the steps
      */
     List<ClassModel> inTheClassesOf(String packageName) {
-        String under = packageName.endsWith("/") ? packageName : packageName + "/";
+        String named = packageName.endsWith("/")
+                ? packageName.substring(0, packageName.length() - 1) : packageName;
         List<ClassModel> found = new ArrayList<>();
-        for (ClassModel each : all()) {
-            String named = each.thisClass().asInternalName();
-            if (named.startsWith(under) && !named.substring(under.length()).contains("/")) {
-                found.add(each);
-            }
+        for (CompiledClasses output : outputs()) {
+            found.addAll(output.inTheClassesOf(named.replace('/', '.')));
         }
         return found;
     }

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -2,20 +2,14 @@ package souther.architecture;
 
 import souther.compiler.ast.ConstructionOrigin;
 import souther.compiler.ast.Hir;
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -24,7 +18,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -65,7 +58,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
     /** The same package, as a call's owner says it — exactly, so one under it is not it. */
     private static final String THEIR_PACKAGE = "souther/compiler/ast";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * A member a settling call may name, and the word the edges below are written with.
@@ -289,8 +282,8 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
      *  where the calls it lists are made. */
     @Test
     void andTheWalkReadsEveryModulesClasses() {
-        assertFalse(everyCompiledClass().stream()
-                        .allMatch(each -> internalName(each).startsWith(THEIRS)),
+        assertFalse(COMPILED.all().stream()
+                        .allMatch(each -> each.thisClass().asInternalName().startsWith(THEIRS)),
                 "the calls this reads are made outside the package that declares what they reach");
     }
 
@@ -298,11 +291,11 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
      *  takes and answers with — so a second member of a name is a second row. */
     private static Set<String> namingAnAnswer() {
         Set<String> found = new TreeSet<>();
-        for (Path each : everyCompiledClass()) {
-            if (!internalName(each).startsWith(THEIRS)) {
+        for (ClassModel each : COMPILED.all()) {
+            if (!each.thisClass().asInternalName().startsWith(THEIRS)) {
                 continue;
             }
-            ClassModel model = parse(each);
+            ClassModel model = each;
             for (MethodModel method : model.methods()) {
                 if (namesAnAnswer(method)) {
                     found.add(model.thisClass().name().stringValue() + "#"
@@ -396,10 +389,10 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
 
     /** Every method this reactor compiles, and every call it makes, as the method that makes it. */
     private static void walkEveryCall(BiConsumer<String, InvokeInstruction> to) {
-        for (Path each : everyCompiledClass()) {
-            ClassModel model = parse(each);
+        for (ClassModel each : COMPILED.all()) {
+            ClassModel model = each;
             for (MethodModel method : model.methods()) {
-                String caller = internalName(each) + "#" + method.methodName().stringValue()
+                String caller = each.thisClass().asInternalName() + "#" + method.methodName().stringValue()
                         + method.methodType().stringValue();
                 method.code().ifPresent(code -> {
                     for (CodeElement element : code) {
@@ -423,11 +416,11 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
     /** Every method the package that declares these forms holds, by the whole of what it is. */
     private static Set<String> declaredInThatPackage() {
         Set<String> found = new TreeSet<>();
-        for (Path each : everyCompiledClass()) {
-            if (!internalName(each).startsWith(THEIRS)) {
+        for (ClassModel each : COMPILED.all()) {
+            if (!each.thisClass().asInternalName().startsWith(THEIRS)) {
                 continue;
             }
-            ClassModel model = parse(each);
+            ClassModel model = each;
             for (MethodModel method : model.methods()) {
                 found.add(model.thisClass().name().stringValue() + "#"
                         + method.methodName().stringValue() + method.methodType().stringValue());
@@ -483,41 +476,9 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
         return "L" + type.getName().replace('.', '/') + ";";
     }
 
-    private static ClassModel parse(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, read off the file's place under its module's build directory. */
-    private static String internalName(Path compiled) {
-        String path = compiled.toString().replace('\\', '/');
-        int from = path.indexOf("/classes/") + "/classes/".length();
-        return path.substring(from, path.length() - ".class".length());
-    }
 
-    /**
-     * The compiled classes of every module of this build that the compiler is made of.
-     *
-     * <p>Its own tests are not among them. A test builds a node to look at it and ships nothing, so
-     * what it names is not an answer anything downstream reads; and a list holding them would move
-     * whenever a test was written, which is a list nobody keeps up.
-     */
-    private static List<Path> everyCompiledClass() {
-        List<Path> out = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            Path where = module.resolve("target").resolve("classes");
-            if (!Files.isDirectory(where)) {
-                continue;
-            }
-            try (Stream<Path> found = Files.walk(where)) {
-                out.addAll(found.filter(p -> p.toString().endsWith(".class")).toList());
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-        return out;
-    }
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryTestAboutTheRepositorysPopulationSaysSoTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryTestAboutTheRepositorysPopulationSaysSoTest.java
@@ -4,12 +4,9 @@ import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Annotation;
 import java.lang.classfile.AnnotationValue;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.PoolEntry;
@@ -24,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -57,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EveryTestAboutTheRepositorysPopulationSaysSoTest {
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    private static final CompiledOutputs TESTS = CompiledOutputs.ofEverythingCompiledHere();
 
     /** What this tag is spelled as where a test carries it. */
     private static final String TAG = "population";
@@ -162,20 +160,16 @@ class EveryTestAboutTheRepositorysPopulationSaysSoTest {
      * meant is what this cannot say, and asking for the tag where either would want it is the side
      * of that to be wrong on.
      */
-    private static Map<String, List<Path>> compiled;
+    private static Map<String, List<ClassModel>> compiled;
 
-    private static Map<String, List<Path>> compiledTests() {
+    private static Map<String, List<ClassModel>> compiledTests() {
         if (compiled != null) {
             return compiled;
         }
-        Map<String, List<Path>> out = new LinkedHashMap<>();
+        Map<String, List<ClassModel>> out = new LinkedHashMap<>();
         for (Path module : REPOSITORY.modules()) {
-            Path where = testClassesOf(module);
-            if (!Files.isDirectory(where)) {
-                continue;
-            }
-            for (Path each : classesUnder(where)) {
-                String name = parse(each).thisClass().asInternalName();
+            for (ClassModel each : TESTS.testClassesOf(module)) {
+                String name = each.thisClass().asInternalName();
                 if (!Files.isRegularFile(sourceOf(module, name))) {
                     continue;
                 }
@@ -198,8 +192,8 @@ class EveryTestAboutTheRepositorysPopulationSaysSoTest {
         Map<String, Set<String>> out = new LinkedHashMap<>();
         compiledTests().forEach((name, every) -> {
             Set<String> named = new LinkedHashSet<>();
-            for (Path each : every) {
-                for (PoolEntry entry : parse(each).constantPool()) {
+            for (ClassModel each : every) {
+                for (PoolEntry entry : each.constantPool()) {
                     if (entry instanceof ClassEntry it) {
                         named.add(it.asInternalName());
                     }
@@ -236,11 +230,11 @@ class EveryTestAboutTheRepositorysPopulationSaysSoTest {
      * add a tag that is already deciding its run.
      */
     private static Set<String> tags(String internalName) {
-        Map<String, List<Path>> tests = compiledTests();
+        Map<String, List<ClassModel>> tests = compiledTests();
         Set<String> out = new LinkedHashSet<>();
         for (String each = internalName; each != null; each = enclosing(each)) {
-            for (Path where : tests.getOrDefault(each, List.of())) {
-                out.addAll(tagsOf(parse(where)));
+            for (ClassModel where : tests.getOrDefault(each, List.of())) {
+                out.addAll(tagsOf(where));
             }
         }
         return out;
@@ -272,25 +266,9 @@ class EveryTestAboutTheRepositorysPopulationSaysSoTest {
         return out;
     }
 
-    private static ClassModel parse(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException("a compiled test is not readable: " + compiled, e);
-        }
-    }
 
-    private static Path testClassesOf(Path module) {
-        return module.resolve("target").resolve("test-classes");
-    }
 
-    private static List<Path> classesUnder(Path where) {
-        try (Stream<Path> found = Files.walk(where)) {
-            List<Path> out = new ArrayList<>();
-            found.filter(each -> each.toString().endsWith(".class")).forEach(out::add);
-            return out;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
@@ -1,0 +1,122 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+import souther.test.RepositoryLayout;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A check asks for the compiled output it is about; it does not go and find one.
+ *
+ * <p>Where the classes a rule reads are is one question and what they hold is another, and a check
+ * that answers the first for itself has taken on a fact about the build. What it takes on is the
+ * directory the build happened to be invoked from — so the same check answers differently under a
+ * build invoked elsewhere — and, having found the files, it opens them: the same files the check
+ * beside it opened, for the fork to read again.
+ *
+ * <p>What is asked here is the word a build's output goes by, which nothing that reads compiled
+ * classes has any business writing down. A rule that looked for the two halves of going to look —
+ * the word and the reading — in one class would be a rule about where somebody wrote them: pulling
+ * the path into a class of its own leaves each half innocent, and the walk is back with every check
+ * still passing. What hands the location out is nothing, so writing it down is the whole of what is
+ * left: a reading answers what an output holds and never where it is, and the repository answers
+ * whether something is under a build's output rather than what a build calls its directory.
+ *
+ * <p><b>Asked of the modules whose checks read compiled classes, which is a population and not a
+ * list.</b> A module whose checks run the shipped binary names what a build wrote and reads no
+ * class file — the jar, the launcher — and a rule refusing that would be about the word rather than
+ * about going to look. Which modules those are is worked out from what their checks call.
+ *
+ * <p>What this does not say is that each module asks in one place. A check reading its own module's
+ * fixtures asks for its own output, and telling that from naming somebody else's is a distinction
+ * nothing here models; where a module has one place, that module's own checks say so.
+ */
+class NoCheckGoesLookingForACompiledOutputTest {
+
+    /** Naming an output: what a check outside {@code souther.test} can be handed one by. */
+    private static final Set<String> NAMES_AN_OUTPUT = Set.of(
+            "souther/test/CompiledClasses.ofModule",
+            "souther/test/RepositoryLayout.compiledOutputOf");
+
+    private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+
+    @Test
+    void nothingWritesDownWhereABuildPutsWhatItMade() {
+        Map<String, List<String>> writing = new LinkedHashMap<>();
+        List<ClassModel> checks = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            List<ClassModel> of = EVERYTHING.testClassesOf(module);
+            if (of.stream().anyMatch(NoCheckGoesLookingForACompiledOutputTest::namesAnOutput)) {
+                checks.addAll(of);
+            }
+        }
+        assertFalse(checks.isEmpty(), "no check of this repository was read at all, so this rule is"
+                + " asked of nothing and passes by having nobody to ask");
+
+        for (ClassModel each : checks) {
+            for (String constant : constantsOf(each)) {
+                if (RepositoryLayout.namesBuildOutput(constant)) {
+                    writing.computeIfAbsent(named(each), _ -> new ArrayList<>()).add(constant);
+                }
+            }
+        }
+
+        assertEquals(Map.of(), writing,
+                "a check writes down where a build puts what it made, which is the half of finding"
+                        + " the files for itself that nothing else needs: what is under a build's"
+                        + " output is the repository's to say");
+    }
+
+    private static boolean namesAnOutput(ClassModel model) {
+        for (MethodModel method : model.methods()) {
+            CodeModel code = method.code().orElse(null);
+            if (code == null) {
+                continue;
+            }
+            for (var element : code) {
+                if (element instanceof InvokeInstruction call && NAMES_AN_OUTPUT.contains(
+                        call.owner().asInternalName() + "." + call.name().stringValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static List<String> constantsOf(ClassModel model) {
+        List<String> said = new ArrayList<>();
+        for (MethodModel method : model.methods()) {
+            CodeModel code = method.code().orElse(null);
+            if (code == null) {
+                continue;
+            }
+            for (var element : code) {
+                if (element instanceof ConstantInstruction loaded
+                        && loaded.constantValue() instanceof String text) {
+                    said.add(text);
+                }
+            }
+        }
+        return said;
+    }
+
+    private static String named(ClassModel of) {
+        return of.thisClass().asInternalName().replace('/', '.');
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
@@ -7,13 +7,11 @@ import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.ConstantInstruction;
-import java.lang.classfile.instruction.InvokeInstruction;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,18 +25,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * build invoked elsewhere — and, having found the files, it opens them: the same files the check
  * beside it opened, for the fork to read again.
  *
- * <p>What is asked here is the word a build's output goes by, which nothing that reads compiled
- * classes has any business writing down. A rule that looked for the two halves of going to look —
- * the word and the reading — in one class would be a rule about where somebody wrote them: pulling
- * the path into a class of its own leaves each half innocent, and the walk is back with every check
- * still passing. What hands the location out is nothing, so writing it down is the whole of what is
- * left: a reading answers what an output holds and never where it is, and the repository answers
- * whether something is under a build's output rather than what a build calls its directory.
+ * <p>What is asked is whether a check works out where the compiled classes are. Saying so takes two
+ * words — the directory a build writes to and the one it compiles into — and they are asked of
+ * everything one method says rather than of one text, because a path is as often built a step at a
+ * time as written whole. What hands the location out is nothing, so saying it is the whole of what
+ * is left: a reading answers what an output holds and never where it is, and the repository answers
+ * whether something is under a build's output rather than what a build calls its directories.
  *
- * <p><b>Asked of the modules whose checks read compiled classes, which is a population and not a
- * list.</b> A module whose checks run the shipped binary names what a build wrote and reads no
- * class file — the jar, the launcher — and a rule refusing that would be about the word rather than
- * about going to look. Which modules those are is worked out from what their checks call.
+ * <p><b>Asked of every check this repository has, and not of the ones that already ask properly.</b>
+ * A population taken from what the checks call would be taken from the property being checked: a
+ * module that reads no compiled output today, and tomorrow reads one by walking to it, would never
+ * have called the thing that put it in the population, and the walk it added would be the one case
+ * nothing looked at. So the population is everything, and the rule is the narrow one.
+ *
+ * <p>Narrow because a build writes more than classes. A check that runs what was shipped names the
+ * jar and the launcher under the same directory and goes looking for nobody's classes, and a rule
+ * refusing that would be about a word rather than about the thing.
  *
  * <p>What this does not say is that each module asks in one place. A check reading its own module's
  * fixtures asks for its own output, and telling that from naming somebody else's is a distinction
@@ -46,71 +48,50 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class NoCheckGoesLookingForACompiledOutputTest {
 
-    /** Naming an output: what a check outside {@code souther.test} can be handed one by. */
-    private static final Set<String> NAMES_AN_OUTPUT = Set.of(
-            "souther/test/CompiledClasses.ofModule",
-            "souther/test/RepositoryLayout.compiledOutputOf");
-
     private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
 
     @Test
-    void nothingWritesDownWhereABuildPutsWhatItMade() {
-        Map<String, List<String>> writing = new LinkedHashMap<>();
+    void nothingWorksOutWhereTheCompiledClassesAre() {
         List<ClassModel> checks = new ArrayList<>();
         for (Path module : REPOSITORY.modules()) {
-            List<ClassModel> of = EVERYTHING.testClassesOf(module);
-            if (of.stream().anyMatch(NoCheckGoesLookingForACompiledOutputTest::namesAnOutput)) {
-                checks.addAll(of);
-            }
+            checks.addAll(EVERYTHING.testClassesOf(module));
         }
         assertFalse(checks.isEmpty(), "no check of this repository was read at all, so this rule is"
                 + " asked of nothing and passes by having nobody to ask");
 
+        Map<String, List<String>> working = new LinkedHashMap<>();
         for (ClassModel each : checks) {
-            for (String constant : constantsOf(each)) {
-                if (RepositoryLayout.namesBuildOutput(constant)) {
-                    writing.computeIfAbsent(named(each), _ -> new ArrayList<>()).add(constant);
+            for (MethodModel method : each.methods()) {
+                List<String> said = constantsOf(method);
+                if (RepositoryLayout.namesCompiledOutput(said)) {
+                    working.computeIfAbsent(named(each) + "#"
+                            + method.methodName().stringValue(), _ -> new ArrayList<>()).addAll(said);
                 }
             }
         }
 
-        assertEquals(Map.of(), writing,
-                "a check writes down where a build puts what it made, which is the half of finding"
-                        + " the files for itself that nothing else needs: what is under a build's"
-                        + " output is the repository's to say");
+        assertEquals(Map.of(), working,
+                "a check works out where the compiled classes are instead of asking for them, so it"
+                        + " answers about wherever the build was invoked from and reads files a"
+                        + " check beside it has already read");
     }
 
-    private static boolean namesAnOutput(ClassModel model) {
-        for (MethodModel method : model.methods()) {
-            CodeModel code = method.code().orElse(null);
-            if (code == null) {
-                continue;
-            }
-            for (var element : code) {
-                if (element instanceof InvokeInstruction call && NAMES_AN_OUTPUT.contains(
-                        call.owner().asInternalName() + "." + call.name().stringValue())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 
-    private static List<String> constantsOf(ClassModel model) {
+    /** Everything one method says, which is where a path built a step at a time is put back
+     *  together. */
+    private static List<String> constantsOf(MethodModel method) {
         List<String> said = new ArrayList<>();
-        for (MethodModel method : model.methods()) {
-            CodeModel code = method.code().orElse(null);
-            if (code == null) {
-                continue;
-            }
-            for (var element : code) {
-                if (element instanceof ConstantInstruction loaded
-                        && loaded.constantValue() instanceof String text) {
-                    said.add(text);
-                }
+        CodeModel code = method.code().orElse(null);
+        if (code == null) {
+            return said;
+        }
+        for (var element : code) {
+            if (element instanceof ConstantInstruction loaded
+                    && loaded.constantValue() instanceof String text) {
+                said.add(text);
             }
         }
         return said;

--- a/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
@@ -1,13 +1,9 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.ClassSignature;
@@ -16,8 +12,6 @@ import java.lang.classfile.attribute.RecordAttribute;
 import java.lang.classfile.attribute.RecordComponentInfo;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.reflect.AccessFlag;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -60,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class OneWayFromAStateToTheRuleItIsAboutTest {
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     private static final String RULE = "souther/compiler/check/RuleRef";
 
@@ -300,11 +293,11 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
         }
 
         static Carried ofWhatThisRepositoryPublishes() {
-            return new Carried(read(List.of("classes")));
+            return new Carried(read(CompiledOutputs.ofWhatThisRepositoryPublishes()));
         }
 
         static Carried ofEverythingCompiledHere() {
-            return new Carried(read(List.of("classes", "test-classes")));
+            return new Carried(read(CompiledOutputs.ofEverythingCompiledHere()));
         }
 
         Set<String> everyClass() {
@@ -625,42 +618,19 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
             }
         }
 
-        private static Map<String, ClassModel> read(List<String> outputs) {
+        private static Map<String, ClassModel> read(CompiledOutputs outputs) {
             Map<String, ClassModel> out = new HashMap<>();
-            ClassFile parser = ClassFile.of();
-            for (Path module : REPOSITORY.modules()) {
-                for (String output : outputs) {
-                    Path where = module.resolve("target").resolve(output);
-                    if (!Files.isDirectory(where)) {
-                        continue;
-                    }
-                    for (Path each : classFilesUnder(where)) {
-                        String name = where.relativize(each).toString()
-                                .replace(java.io.File.separatorChar, '/')
-                                .replaceAll("\\.class$", "");
-                        if (name.startsWith("souther/")) {
-                            out.putIfAbsent(name, parse(parser, each));
-                        }
-                    }
+            for (ClassModel each : outputs.all()) {
+                String name = each.thisClass().asInternalName();
+                if (name.startsWith("souther/")) {
+                    out.putIfAbsent(name, each);
                 }
             }
             return out;
         }
 
-        private static ClassModel parse(ClassFile parser, Path file) {
-            try {
-                return parser.parse(Files.readAllBytes(file));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
 
-        private static List<Path> classFilesUnder(Path where) {
-            try (Stream<Path> found = Files.walk(where)) {
-                return found.filter(each -> each.toString().endsWith(".class")).toList();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
+
+
     }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhereAConstructionCameFromIsNotAPassesToWriteTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhereAConstructionCameFromIsNotAPassesToWriteTest.java
@@ -13,18 +13,15 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,16 +63,18 @@ class WhereAConstructionCameFromIsNotAPassesToWriteTest {
     /** Where an origin may be made, asked about and handed over. */
     private static final String THEIRS = "souther/compiler/ast/";
 
+    private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
+
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     @Test
     void nothingOutsideTheTreeHandsAnOriginToIt() {
         List<String> handing = new ArrayList<>();
-        for (Path each : everyCompiledClass()) {
-            if (internalName(each).startsWith(THEIRS) || !handsAnOriginIn(each)) {
+        for (ClassModel each : EVERYTHING.all()) {
+            if (each.thisClass().asInternalName().startsWith(THEIRS) || !handsAnOriginIn(each)) {
                 continue;
             }
-            handing.add(internalName(each));
+            handing.add(each.thisClass().asInternalName());
         }
 
         assertEquals(List.of(), handing.stream().sorted().toList(),
@@ -114,8 +113,8 @@ class WhereAConstructionCameFromIsNotAPassesToWriteTest {
     @Test
     void andTheCheckSeesWhatItIsLookingForWhereThatIsAllowed() {
         assertFalse(anOrigin().isEmpty(), "what an origin is, is read off the type");
-        assertTrue(everyCompiledClass().stream()
-                        .filter(each -> internalName(each).startsWith(THEIRS))
+        assertTrue(EVERYTHING.all().stream()
+                        .filter(each -> each.thisClass().asInternalName().startsWith(THEIRS))
                         .anyMatch(WhereAConstructionCameFromIsNotAPassesToWriteTest
                                 ::handsAnOriginIn),
                 "a form hands an origin to its own constructor, which is what this reads");
@@ -137,18 +136,13 @@ class WhereAConstructionCameFromIsNotAPassesToWriteTest {
     }
 
     /** Whether {@code compiled} names anything of the tree's package that takes an origin. */
-    private static boolean handsAnOriginIn(Path compiled) {
-        try {
-            for (PoolEntry entry : ClassFile.of().parse(Files.readAllBytes(compiled))
-                    .constantPool()) {
-                if (entry instanceof MemberRefEntry member
-                        && member.owner().name().stringValue().startsWith(THEIRS)
-                        && takesAnOrigin(member.type().stringValue())) {
-                    return true;
-                }
+    private static boolean handsAnOriginIn(ClassModel compiled) {
+        for (PoolEntry entry : compiled.constantPool()) {
+            if (entry instanceof MemberRefEntry member
+                    && member.owner().name().stringValue().startsWith(THEIRS)
+                    && takesAnOrigin(member.type().stringValue())) {
+                return true;
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         return false;
     }
@@ -164,33 +158,9 @@ class WhereAConstructionCameFromIsNotAPassesToWriteTest {
         return anOrigin().stream().anyMatch(parameters::contains);
     }
 
-    /** The class's own binary name, read off the file's place under its module's build directory. */
-    private static String internalName(Path compiled) {
-        String path = compiled.toString().replace('\\', '/');
-        int at = path.indexOf("/classes/");
-        int from = at < 0 ? path.indexOf("/test-classes/") + "/test-classes/".length()
-                : at + "/classes/".length();
-        return path.substring(from, path.length() - ".class".length());
-    }
 
-    /** Every class of every module of this build, main and test alike. */
-    private static List<Path> everyCompiledClass() {
-        List<Path> out = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (String built : List.of("classes", "test-classes")) {
-                Path where = module.resolve("target").resolve(built);
-                if (!Files.isDirectory(where)) {
-                    continue;
-                }
-                try (Stream<Path> found = Files.walk(where)) {
-                    out.addAll(found.filter(p -> p.toString().endsWith(".class")).toList());
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }
-        }
-        return out;
-    }
+
+
 
     /** What the repository's modules are called, which is {@link RepositoryLayout}'s answer and not
      *  a second reading of the root pom. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest.java
@@ -1,21 +1,15 @@
 package souther.architecture;
 
 import souther.compiler.ast.Hir;
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.reflect.Constructor;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,16 +39,17 @@ class WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest {
 
     private static final String THE_ANSWER = "L" + Hir.Fields.class.getName().replace('.', '/') + ";";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
+
 
     @Test
     void nothingOutsideTheTreeNamesTheAnswerAtAll() {
         List<String> naming = new ArrayList<>();
-        for (Path each : everyCompiledClass()) {
-            if (internalName(each).startsWith(THEIRS) || !namesTheAnswerIn(each)) {
+        for (ClassModel each : EVERYTHING.all()) {
+            if (each.thisClass().asInternalName().startsWith(THEIRS) || !namesTheAnswerIn(each)) {
                 continue;
             }
-            naming.add(internalName(each));
+            naming.add(each.thisClass().asInternalName());
         }
 
         assertEquals(List.of(), naming.stream().sorted().toList(),
@@ -94,8 +89,8 @@ class WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest {
      *  is not forbidden at all — inside the package, where the answer is made and read. */
     @Test
     void andTheCheckSeesWhatItIsLookingForWhereThatIsAllowed() {
-        assertTrue(everyCompiledClass().stream()
-                        .filter(each -> internalName(each).startsWith(THEIRS))
+        assertTrue(EVERYTHING.all().stream()
+                        .filter(each -> each.thisClass().asInternalName().startsWith(THEIRS))
                         .anyMatch(WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest
                                 ::namesTheAnswerIn),
                 "the package that owns the answer names it, which is what this reads");
@@ -103,46 +98,17 @@ class WhichOfItsFieldsAConstructionHadToWriteIsNotAPassesToSayTest {
 
     /** Whether {@code compiled} names anything that takes or answers with the answer — which
      *  includes naming one of its constants, whose descriptor is the type. */
-    private static boolean namesTheAnswerIn(Path compiled) {
-        try {
-            for (PoolEntry entry : ClassFile.of().parse(Files.readAllBytes(compiled))
-                    .constantPool()) {
-                if (entry instanceof MemberRefEntry member
-                        && member.type().stringValue().contains(THE_ANSWER)) {
-                    return true;
-                }
+    private static boolean namesTheAnswerIn(ClassModel compiled) {
+        for (PoolEntry entry : compiled.constantPool()) {
+            if (entry instanceof MemberRefEntry member
+                    && member.type().stringValue().contains(THE_ANSWER)) {
+                return true;
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         return false;
     }
 
-    /** The class's own binary name, read off the file's place under its module's build directory. */
-    private static String internalName(Path compiled) {
-        String path = compiled.toString().replace('\\', '/');
-        int at = path.indexOf("/classes/");
-        int from = at < 0 ? path.indexOf("/test-classes/") + "/test-classes/".length()
-                : at + "/classes/".length();
-        return path.substring(from, path.length() - ".class".length());
-    }
 
-    /** Every class of every module of this build, main and test alike. */
-    private static List<Path> everyCompiledClass() {
-        List<Path> out = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (String built : List.of("classes", "test-classes")) {
-                Path where = module.resolve("target").resolve(built);
-                if (!Files.isDirectory(where)) {
-                    continue;
-                }
-                try (Stream<Path> found = Files.walk(where)) {
-                    out.addAll(found.filter(p -> p.toString().endsWith(".class")).toList());
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }
-        }
-        return out;
-    }
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
@@ -76,16 +76,7 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
                         + " question being answered again out of the account of the rules");
     }
 
-    /**
-     * The walk reads every module's classes.
-     *
-     * <p>Asked of the modules the repository has and not of what a build happened to leave: a
-     * module whose classes are missing is one whose reads this cannot see, and the rows from the
-     * rest would match and this would pass while answering about fewer modules than it names.
-     */
-    @Test
-    void andEveryModuleTheRepositoryHoldsWasRead() {
-    }
+
 
     /**
      * And the walk finds the flag being read where it is read.

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayAskWhetherAClauseWentUnreadTest.java
@@ -1,24 +1,18 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +49,7 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
 
     private static final String FLAG = "hasUnreadPart";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Where an unread alternative is turned into what it left open, and where an author is sent for
@@ -91,17 +85,6 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
     }
 
     /**
@@ -121,13 +104,13 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
     /** Every method outside the account that asks one whether a clause of it went unread. */
     private static Set<String> asking() {
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                String reader = internalName(module, each);
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                String reader = each.thisClass().asInternalName();
                 if (reader.equals(ACCOUNT)) {
                     continue;
                 }
-                for (MethodModel method : parse(each).methods()) {
+                for (MethodModel method : each.methods()) {
                     if (reads(method)) {
                         found.add(reader + "#" + method.methodName().stringValue());
                     }
@@ -140,12 +123,12 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
     /** How many of the account's own methods read it, which is what says the walk can see one. */
     private static int within(String owner) {
         int reads = 0;
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                if (!internalName(module, each).equals(owner)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                if (!each.thisClass().asInternalName().equals(owner)) {
                     continue;
                 }
-                for (MethodModel method : parse(each).methods()) {
+                for (MethodModel method : each.methods()) {
                     if (reads(method)) {
                         reads++;
                     }
@@ -170,40 +153,13 @@ class WhoMayAskWhetherAClauseWentUnreadTest {
         });
     }
 
-    private static ClassModel parse(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildALanguageAboutAPositionTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildALanguageAboutAPositionTest.java
@@ -1,19 +1,14 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +54,7 @@ class WhoMayBuildALanguageAboutAPositionTest {
 
     private static final String ALLOWANCE = "souther/compiler/values/Allowance";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * What a position may build to answer what its rules leave it, named where a compilation
@@ -272,17 +266,6 @@ class WhoMayBuildALanguageAboutAPositionTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
     }
 
     /**
@@ -308,10 +291,10 @@ class WhoMayBuildALanguageAboutAPositionTest {
     /** Every asking of the policy for an allowance, counted where it is written. */
     private static List<String> askingForAnAllowance() {
         Map<String, Integer> counted = new TreeMap<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                String asker = internalName(module, each);
-                for (MethodModel method : classOf(each).methods()) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                String asker = each.thisClass().asInternalName();
+                for (MethodModel method : each.methods()) {
                     method.code().ifPresent(code -> {
                         for (CodeElement element : code) {
                             if (element instanceof InvokeInstruction call
@@ -359,16 +342,16 @@ class WhoMayBuildALanguageAboutAPositionTest {
     private static List<String> found(java.util.function.Predicate<PoolEntry> reaching,
                                       boolean butNotTheOwner) {
         Set<String> out = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                String reader = internalName(module, each);
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                String reader = each.thisClass().asInternalName();
                 // What a class names of itself is not a reader of anything. The plan declares the
                 // budgets and the meter they make, so a row for it would be this walk reporting the
                 // owner as its own caller.
                 if (butNotTheOwner && (reader.equals(PLAN) || reader.startsWith(PLAN + "$"))) {
                     continue;
                 }
-                for (PoolEntry entry : constantPoolOf(each)) {
+                for (PoolEntry entry : each.constantPool()) {
                     if (reaching.test(entry)) {
                         out.add(reader);
                     }
@@ -378,44 +361,15 @@ class WhoMayBuildALanguageAboutAPositionTest {
         return new ArrayList<>(out);
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        return classOf(compiled).constantPool();
-    }
 
-    private static ClassModel classOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildALanguageAboutAPositionTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildALanguageAboutAPositionTest.java
@@ -257,16 +257,7 @@ class WhoMayBuildALanguageAboutAPositionTest {
                         + " time under an allowance of its own");
     }
 
-    /**
-     * The walk reads every module's classes.
-     *
-     * <p>Asked of the modules the repository has and not of what a build happened to leave: a
-     * module whose classes are missing is one whose names this cannot see, and the rows from the
-     * rest would match while this answered about fewer modules than it names.
-     */
-    @Test
-    void andEveryModuleTheRepositoryHoldsWasRead() {
-    }
+
 
     /**
      * And the walk finds a namer that is there.

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
@@ -1,24 +1,17 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.reflect.AccessFlag;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,7 +52,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
     private static final String PROVING_ONE_HALF =
             "souther/compiler/check/Confinement$Admission";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * No reading builds a refusal out of one of its halves.
@@ -70,7 +63,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
     @Test
     void noReadingBuildsARefusalOutOfOneOfItsHalves() {
         List<String> naming = new ArrayList<>();
-        for (ClassModel read : classesUnder(WHERE)) {
+        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
             String named = read.thisClass().name().stringValue();
             if (named.equals(REFUSAL) || named.startsWith(REFUSAL + "$")) {
                 continue;
@@ -91,7 +84,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
     @Test
     void andTheReadingsBuildOneByLookingForBoth() {
         List<String> looking = new ArrayList<>();
-        for (ClassModel read : classesUnder(WHERE)) {
+        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
             looking.addAll(callsTo(read, Set.of(BOTH)));
         }
 
@@ -117,7 +110,7 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
      */
     @Test
     void andWhatMayBeAskedOfARelationIsTheseTwoQuestions() {
-        ClassModel asked = CompiledOutputs.ofWhatThisRepositoryPublishes()
+        ClassModel asked = COMPILED
                 .read(WHERE + "WhatARelationShows");
         List<String> waysIn = new ArrayList<>();
         for (MethodModel maker : asked.methods()) {
@@ -191,22 +184,5 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
                 .toList()).orElse(List.of());
     }
 
-    private static List<ClassModel> classesUnder(String where) {
-        List<ClassModel> out = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            Path found = module.resolve("target").resolve("classes").resolve(where);
-            if (!Files.isDirectory(found)) {
-                continue;
-            }
-            try (Stream<Path> each = Files.list(found)) {
-                for (Path compiled : each.filter(p -> p.toString().endsWith(".class")).toList()) {
-                    out.add(ClassFile.of().parse(Files.readAllBytes(compiled)));
-                }
-            } catch (IOException unread) {
-                throw new UncheckedIOException(unread);
-            }
-        }
-        assertTrue(out.size() > 1, "no class was read under " + where);
-        return out;
-    }
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayComposeAFixtureReferenceTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayComposeAFixtureReferenceTest.java
@@ -2,13 +2,9 @@ package souther.architecture;
 
 import souther.compiler.partition.FixtureReferences;
 import souther.compiler.types.FixtureReferenceOrigin;
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
@@ -17,13 +13,11 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,7 +50,7 @@ class WhoMayComposeAFixtureReferenceTest {
 
     private static final String GENERATOR = "souther/compiler/partition/Generator";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every class that makes a minter or numbers a reference, with what it names.
@@ -105,17 +99,6 @@ class WhoMayComposeAFixtureReferenceTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the one module that declares a minter");
     }
@@ -129,12 +112,12 @@ class WhoMayComposeAFixtureReferenceTest {
      */
     private static int timesGeneratorMakesAMinter() {
         int made = 0;
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                if (!internalName(module, each).equals(GENERATOR)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                if (!each.thisClass().asInternalName().equals(GENERATOR)) {
                     continue;
                 }
-                for (MethodModel method : classOf(each).methods()) {
+                for (MethodModel method : each.methods()) {
                     made += method.code().map(WhoMayComposeAFixtureReferenceTest::minters).orElse(0);
                 }
             }
@@ -160,14 +143,14 @@ class WhoMayComposeAFixtureReferenceTest {
     private static Set<String> namingAMaker() {
         Set<String> makers = Set.of(ORIGIN + "#<init>(I)V", MINTER + "#<init>()V");
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                for (PoolEntry entry : constantPoolOf(each)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                for (PoolEntry entry : each.constantPool()) {
                     if (entry instanceof MemberRefEntry member) {
                         String named = member.owner().name().stringValue() + "#"
                                 + member.name().stringValue() + member.type().stringValue();
                         if (makers.contains(named)) {
-                            found.add(internalName(module, each) + " -> " + named);
+                            found.add(each.thisClass().asInternalName() + " -> " + named);
                         }
                     }
                 }
@@ -178,53 +161,25 @@ class WhoMayComposeAFixtureReferenceTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        return classOf(compiled).constantPool();
-    }
 
-    private static ClassModel classOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    /** The compiled classes of one module the compiler is made of. Its own tests are not among them:
-     *  a test composing a reference to look at it ships nothing, and a list that moved whenever one
-     *  was written is a list nobody keeps up. */
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
+
 
     private static String internalNameOf(Class<?> type) {
         return type.getName().replace('.', '/');

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
@@ -1,21 +1,15 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
-
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,7 +45,7 @@ class WhoMayMakeARuleShortfallTest {
     // had to name a shortfall to say which choice it means.
     private static final String A_CHOICE = "souther/compiler/check/ChoiceSite";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every class that makes one, and why it is entitled to.
@@ -103,17 +97,6 @@ class WhoMayMakeARuleShortfallTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the one module that declares the fact");
     }
@@ -121,15 +104,13 @@ class WhoMayMakeARuleShortfallTest {
     /** Every class naming a constructor of one of {@code these}, as the class and what it named. */
     private static Set<String> naming(Set<String> these) {
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                for (PoolEntry entry : constantPoolOf(each)) {
-                    if (entry instanceof MemberRefEntry member
-                            && these.contains(member.owner().name().stringValue())
-                            && "<init>".equals(member.name().stringValue())) {
-                        found.add(internalName(module, each) + " -> "
-                                + member.owner().name().stringValue() + "#<init>");
-                    }
+        for (ClassModel model : COMPILED.all()) {
+            for (PoolEntry entry : model.constantPool()) {
+                if (entry instanceof MemberRefEntry member
+                        && these.contains(member.owner().name().stringValue())
+                        && "<init>".equals(member.name().stringValue())) {
+                    found.add(model.thisClass().asInternalName() + " -> "
+                            + member.owner().name().stringValue() + "#<init>");
                 }
             }
         }
@@ -138,50 +119,12 @@ class WhoMayMakeARuleShortfallTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (COMPILED.mainOutputOf(module).isPresent()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
-
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
-
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
-
-    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
-     *  them: a test makes one to look at it and ships nothing. */
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadWhatAStringPredicateMeansTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadWhatAStringPredicateMeansTest.java
@@ -1,23 +1,18 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.classfile.constantpool.PoolEntry;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,7 +53,7 @@ class WhoMayReadWhatAStringPredicateMeansTest {
 
     private static final String OWNER = "souther/compiler/check/StringPredicates";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every class that reads one, and what it reads it for.
@@ -234,17 +229,6 @@ class WhoMayReadWhatAStringPredicateMeansTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(modulesRead() > 1,
                 "this walk goes over more than one module's classes, so a reader of the table"
                         + " written outside the one that declares it is one it would find");
@@ -268,9 +252,9 @@ class WhoMayReadWhatAStringPredicateMeansTest {
     /** Every class whose constant pool reaches the table, with what it names of it. */
     private static Set<String> readingOne() {
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                String reader = internalName(module, each);
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                String reader = each.thisClass().asInternalName();
                 // The table and the answers it declares are the table. What each of them names of
                 // the others is the reading being written down and taken apart where it is made,
                 // and a row for one of them would be this walk reporting the owner as a reader of
@@ -278,7 +262,7 @@ class WhoMayReadWhatAStringPredicateMeansTest {
                 if (names(reader)) {
                     continue;
                 }
-                for (PoolEntry entry : constantPoolOf(each)) {
+                for (PoolEntry entry : each.constantPool()) {
                     String named = reached(entry);
                     if (named != null) {
                         found.add(reader + " -> " + named);
@@ -323,48 +307,21 @@ class WhoMayReadWhatAStringPredicateMeansTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -1,26 +1,22 @@
 package souther.architecture;
 
 import souther.compiler.values.Emptiness;
-import souther.test.RepositoryLayout;
+import souther.test.CompiledClasses;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.DirectMethodHandleDesc;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +24,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -229,7 +224,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         };
     }
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every nest that says a position is settled one way or the other.
@@ -774,23 +769,16 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            Path where = classesOf(module);
-            if (!classesUnder(where).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            // A module holding only tests or only a pom leaves no classes and is not one this walk
+            // is missing. One that has sources and left none is refused where the outputs are
+            // taken, so a walk reading fewer modules than the repository has does not get here.
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
-            } else if (Files.isDirectory(module.resolve("src").resolve("main").resolve("java"))) {
-                // A module holding only tests or only a pom leaves no classes and is not one this
-                // walk is missing.
-                unbuilt.add(module.getFileName().toString());
             }
         }
 
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(read > 1, "the classes this reads are in more than the one module that declares"
                 + " the word");
         assertTrue(nestsSaying(saidInProduction(), _ -> true)
@@ -1043,9 +1031,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return new ArrayList<>(out);
     }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
+
 
     /** The two walks, each read once. Every rule here asks the same question of the same class
      *  files, and nothing writes one while this runs, so a walk per rule is the same answer read
@@ -1057,11 +1043,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** Every saying of the word in the reactor's own compiled classes. */
     private static List<Use> saidInProduction() {
         if (inProduction == null) {
-            List<Path> where = new ArrayList<>();
-            for (Path module : REPOSITORY.modules()) {
-                where.add(classesOf(module));
-            }
-            inProduction = List.copyOf(saidUnder(where));
+            inProduction = List.copyOf(saidUnder(COMPILED.all()));
         }
         assertFalse(inProduction.isEmpty(), "no saying of the word was read at all");
         return inProduction;
@@ -1070,14 +1052,8 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     /** Every saying in the classes compiled beside this test, which is the fixture above. */
     private static List<Use> saidHere() {
         if (here == null) {
-            try {
-                here = List.copyOf(saidUnder(List.of(Path.of(
-                        WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.class
-                                .getProtectionDomain().getCodeSource().getLocation().toURI()))));
-            } catch (URISyntaxException notAPath) {
-                throw new IllegalStateException("this test's own classes are somewhere unreadable",
-                        notAPath);
-            }
+            here = List.copyOf(saidUnder(CompiledClasses.ofModule(
+                    WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.class).all()));
         }
         return here;
     }
@@ -1090,47 +1066,43 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
      * would put the word on every list as a namer of itself. Which reading of one a place is
      * is asked of it as well — see the comment where that is done.
      */
-    private static List<Use> saidUnder(List<Path> roots) {
+    private static List<Use> saidUnder(List<ClassModel> classes) {
         List<Use> found = new ArrayList<>();
-        for (Path root : roots) {
-            for (Path each : classesUnder(root)) {
-                byte[] bytes = bytesOf(each);
-                // Cheap first, so the code of a class with nothing to do with this is never walked.
-                // The filter admits more than these rules are about — another type in `check` is
-                // called the same — and refuses nothing that could match, which is the direction it
-                // has to err in.
-                if (!holdsTheWord(bytes)) {
+        for (ClassModel model : classes) {
+            // Cheap first, so the code of a class with nothing to do with this is never walked.
+            // The filter admits more than these rules are about — another type in `check` is
+            // called the same — and refuses nothing that could match, which is the direction it
+            // has to err in.
+            if (!holdsTheWord(model)) {
+                continue;
+            }
+            String holds = model.thisClass().asInternalName();
+            String nest = nestOf(holds);
+            // The word's own class is passed over by the rules about who says it, and by them
+            // only: what an enum's constants do among themselves is how one is written, and
+            // read as sayings they would put the word on every list as a namer of itself. How
+            // one of the answers is read is another question and is asked of the word too — the
+            // meanings are worked out there, so a comparison there is a meaning nobody decided
+            // in the one place that decides them.
+            boolean isTheWord = nest.equals(EMPTINESS);
+            for (MethodModel method : model.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
                     continue;
                 }
-                ClassModel model = ClassFile.of().parse(bytes);
-                String holds = model.thisClass().asInternalName();
-                String nest = nestOf(holds);
-                // The word's own class is passed over by the rules about who says it, and by them
-                // only: what an enum's constants do among themselves is how one is written, and
-                // read as sayings they would put the word on every list as a namer of itself. How
-                // one of the answers is read is another question and is asked of the word too — the
-                // meanings are worked out there, so a comparison there is a meaning nobody decided
-                // in the one place that decides them.
-                boolean isTheWord = nest.equals(EMPTINESS);
-                for (MethodModel method : model.methods()) {
-                    CodeModel code = method.code().orElse(null);
-                    if (code == null) {
-                        continue;
+                String where = method.methodName().stringValue();
+                String spelt = method.methodType().stringValue();
+                List<CodeElement> elements = new ArrayList<>();
+                code.forEach(elements::add);
+                for (int at = 0; at < elements.size(); at++) {
+                    if (!isTheWord) {
+                        for (String what : saidBy(elements.get(at), holds)) {
+                            found.add(new Use(nest, holds, where, spelt, what));
+                        }
                     }
-                    String where = method.methodName().stringValue();
-                    String spelt = method.methodType().stringValue();
-                    List<CodeElement> elements = new ArrayList<>();
-                    code.forEach(elements::add);
-                    for (int at = 0; at < elements.size(); at++) {
-                        if (!isTheWord) {
-                            for (String what : saidBy(elements.get(at), holds)) {
-                                found.add(new Use(nest, holds, where, spelt, what));
-                            }
-                        }
-                        String compared = comparesAConstant(elements, at);
-                        if (compared != null) {
-                            found.add(new Use(nest, holds, where, spelt, compared));
-                        }
+                    String compared = comparesAConstant(elements, at);
+                    if (compared != null) {
+                        found.add(new Use(nest, holds, where, spelt, compared));
                     }
                 }
             }
@@ -1221,14 +1193,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     /** Whether the bytes name the word anywhere at all. */
-    private static boolean holdsTheWord(byte[] bytes) {
-        byte[] word = "Emptiness".getBytes(StandardCharsets.US_ASCII);
-        for (int start = 0; start + word.length <= bytes.length; start++) {
-            int at = 0;
-            while (at < word.length && bytes[start + at] == word[at]) {
-                at++;
-            }
-            if (at == word.length) {
+    private static boolean holdsTheWord(ClassModel model) {
+        for (PoolEntry entry : model.constantPool()) {
+            if (entry instanceof Utf8Entry said && said.stringValue().contains("Emptiness")) {
                 return true;
             }
         }
@@ -1242,22 +1209,7 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return nested < 0 ? internalName : internalName.substring(0, nested);
     }
 
-    private static byte[] bytesOf(Path compiled) {
-        try {
-            return Files.readAllBytes(compiled);
-        } catch (IOException unreadable) {
-            throw new UncheckedIOException(unreadable);
-        }
-    }
 
-    private static List<Path> classesUnder(Path where) {
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(each -> each.toString().endsWith(".class")).toList();
-        } catch (IOException unreadable) {
-            throw new UncheckedIOException(unreadable);
-        }
-    }
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -1,27 +1,22 @@
 package souther.architecture;
 
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.MethodModel;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.FieldRefEntry;
 import java.lang.classfile.constantpool.LoadableConstantEntry;
 import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +44,7 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
 
     private static final String SURFACE = "souther/compiler/publish/RuleHandleSurface";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * Every class that asks what a handle reads as outside a document, and why it may.
@@ -127,17 +122,6 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the one module that declares the sentence");
     }
@@ -152,11 +136,11 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      */
     private static Set<String> naming(String owner, String member) {
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                for (MethodModel method : ClassFile.of().parse(bytesOf(each)).methods()) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                for (MethodModel method : each.methods()) {
                     if (calls(method, owner, member)) {
-                        found.add(internalName(module, each) + "#" + said(method));
+                        found.add(each.thisClass().asInternalName() + "#" + said(method));
                     }
                 }
             }
@@ -233,12 +217,12 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
      */
     private static Set<String> used(String owner) {
         Set<String> found = new TreeSet<>();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                if (internalName(module, each).equals(owner)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                if (each.thisClass().asInternalName().equals(owner)) {
                     continue;
                 }
-                for (PoolEntry entry : constantPoolOf(each)) {
+                for (PoolEntry entry : each.constantPool()) {
                     if (entry instanceof FieldRefEntry read
                             && owner.equals(read.owner().name().stringValue())
                             && surfaceConstants().contains(read.name().stringValue())) {
@@ -270,54 +254,23 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        return ClassFile.of().parse(bytesOf(compiled)).constantPool();
-    }
 
-    private static byte[] bytesOf(Path compiled) {
-        try {
-            return Files.readAllBytes(compiled);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
-     *  them: a test makes one to look at it and ships nothing. */
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
+
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySettleASourceConstructOriginTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySettleASourceConstructOriginTest.java
@@ -3,24 +3,19 @@ package souther.architecture;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.WrittenOwner;
-import souther.test.RepositoryLayout;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.MemberRefEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,7 +68,7 @@ class WhoMaySettleASourceConstructOriginTest {
      *  the type for the reason the owner is: a rename stops the build rather than emptying the walk. */
     private static final String AN_OWNER = "L" + internalNameOf(WrittenOwner.class) + ";";
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
 
     /**
      * What makes an origin, written down — so that a way of making one that is added is a row here
@@ -136,17 +131,6 @@ class WhoMaySettleASourceConstructOriginTest {
      */
     @Test
     void andEveryModuleTheRepositoryHoldsWasRead() {
-        List<String> unbuilt = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
-                unbuilt.add(module.getFileName().toString());
-            }
-        }
-
-        assertEquals(List.of(), unbuilt,
-                "a module whose classes are not built is one this walk passes over, and a walk that"
-                        + " passes over a module answers about the rest while saying it answers"
-                        + " about all of them");
         assertTrue(modulesRead() > 1,
                 "the classes this reads are in more than the one module that declares an origin");
     }
@@ -201,14 +185,14 @@ class WhoMaySettleASourceConstructOriginTest {
     private static Set<String> namingAMaker() {
         Set<String> found = new TreeSet<>();
         Set<String> makers = makers();
-        for (Path module : REPOSITORY.modules()) {
-            for (Path each : classesUnder(module)) {
-                for (PoolEntry entry : constantPoolOf(each)) {
+        for (Path module : COMPILED.modules()) {
+            for (ClassModel each : COMPILED.classesOf(module)) {
+                for (PoolEntry entry : each.constantPool()) {
                     if (entry instanceof MemberRefEntry member) {
                         String named = member.owner().name().stringValue() + "#"
                                 + member.name().stringValue() + member.type().stringValue();
                         if (makers.contains(named)) {
-                            found.add(internalName(module, each) + " -> " + named);
+                            found.add(each.thisClass().asInternalName() + " -> " + named);
                         }
                     }
                 }
@@ -219,53 +203,23 @@ class WhoMaySettleASourceConstructOriginTest {
 
     private static int modulesRead() {
         int read = 0;
-        for (Path module : REPOSITORY.modules()) {
-            if (!classesUnder(module).isEmpty()) {
+        for (Path module : COMPILED.modules()) {
+            if (!COMPILED.classesOf(module).isEmpty()) {
                 read++;
             }
         }
         return read;
     }
 
-    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
 
-    /** The class's own binary name, taken against the directory it was found under rather than off
-     *  the first {@code classes} in the path, which a checkout under one would be. */
-    private static String internalName(Path module, Path compiled) {
-        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
-        return name.substring(0, name.length() - ".class".length());
-    }
 
-    private static Path classesOf(Path module) {
-        return module.resolve("target").resolve("classes");
-    }
 
-    /** Whether the module has main sources to have been built from. A module holding only tests or
-     *  only a pom leaves no classes and is not one this walk is missing. */
-    private static boolean hasMainSources(Path module) {
-        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
-    }
 
-    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
-     *  them: a test builds an origin to look at it and ships nothing, and a list that moved whenever
-     *  one was written is a list nobody keeps up. */
-    private static List<Path> classesUnder(Path module) {
-        Path where = classesOf(module);
-        if (!Files.isDirectory(where)) {
-            return List.of();
-        }
-        try (Stream<Path> found = Files.walk(where)) {
-            return found.filter(p -> p.toString().endsWith(".class")).toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+
+
+
+
+
 
     /** The descriptor of a member taking these and answering with that. */
     private static String descriptorOf(Class<?>[] takes, Class<?> answers) {

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
-import java.lang.classfile.instruction.ConstantInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -70,22 +68,7 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
         return WhatWasCompiled.checksCompiledBesideIt().all();
     }
 
-    private static List<String> constantsOf(ClassModel model) {
-        List<String> said = new ArrayList<>();
-        for (MethodModel method : model.methods()) {
-            CodeModel code = method.code().orElse(null);
-            if (code == null) {
-                continue;
-            }
-            for (var element : code) {
-                if (element instanceof ConstantInstruction loaded
-                        && loaded.constantValue() instanceof String text) {
-                    said.add(text);
-                }
-            }
-        }
-        return said;
-    }
+
 
     private static String named(ClassModel of) {
         return of.thisClass().asInternalName().replace('/', '.');

--- a/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest.java
@@ -1,7 +1,6 @@
 package souther.compiler;
 
 import org.junit.jupiter.api.Test;
-import souther.test.RepositoryLayout;
 
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
@@ -14,7 +13,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A check of this module asks {@link WhatWasCompiled} for its classes; it does not go and find them.
@@ -25,20 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * build invoked elsewhere — and, having found the files, it opens them: the same files the check
  * beside it opened, for the fork to read again.
  *
- * <p><b>Two ways in, and both are closed here rather than one being guessed at.</b> A check can
- * reach an output through the shared reading by naming one of its own, or it can find the files
- * itself and parse them. A rule that looked for the two halves of the second in one class would be
- * a rule about where somebody wrote them: pulling the path into a class of its own leaves each half
- * innocent, and the walk is back with every check still passing. So neither is asked as a
- * co-occurrence. Naming an output is asked of the call that names one, and finding the files is
- * asked of the word a build's output goes by, which nothing here has any business writing down.
- *
- * <p><b>Which leaves what hands the location out, and nothing does.</b> A rule against writing the
- * word is worth nothing while something answers with it, and two things did: a reading said which
- * output it was, and the repository said what a build calls its directory. Both are kept where they
- * are worked out, so what is left of the second way in is writing the word — which is what this
- * asks. Reaching an output any other way needs the repository root and then the word, and that is
- * the same question again.
+ * <p>What is asked here is which class names an output. Writing down where a build puts what it
+ * made is the other way in, and it is refused for every module that reads compiled classes rather
+ * than for this one — see {@code NoCheckGoesLookingForACompiledOutputTest} in the architecture
+ * tests. What hands the location out is nothing, so those two are the whole of it.
  *
  * <p>What is not refused is reading a class file. This module compiles Souther models and asks what
  * came out of them, and what came out is a value in the test rather than a file anybody went looking
@@ -76,27 +64,6 @@ class NoCheckOfThisModuleGoesLookingForTheCompiledOutputTest {
                 "a check of this module works out which output to read instead of asking, so where"
                         + " this module's classes are is said in more than one place and a module"
                         + " that moves is as many edits as there are checks");
-    }
-
-    @Test
-    void andNothingWritesDownWhereABuildPutsWhatItMade() {
-        Set<String> writing = new TreeSet<>();
-        List<ClassModel> checks = checks();
-        assertFalse(checks.isEmpty(), "no check of this module was read at all, so this rule is"
-                + " asked of nothing and passes by having nobody to ask");
-
-        for (ClassModel each : checks) {
-            for (String constant : constantsOf(each)) {
-                if (RepositoryLayout.namesBuildOutput(constant)) {
-                    writing.add(named(each) + " says `" + constant + "`");
-                }
-            }
-        }
-
-        assertEquals(Set.of(), writing,
-                "a check of this module writes down where a build puts what it made, which is the"
-                        + " half of finding the files for itself that nothing else needs: what is"
-                        + " under a build's output is the repository's to say");
     }
 
     private static List<ClassModel> checks() {

--- a/souther-test-support/src/main/java/souther/test/CompiledClasses.java
+++ b/souther-test-support/src/main/java/souther/test/CompiledClasses.java
@@ -164,6 +164,28 @@ public final class CompiledClasses {
     }
 
     /**
+     * The classes written directly in {@code packageName}, and none of the packages under it.
+     *
+     * <p>Beside {@link #inPackage} rather than instead of it: which of the two a rule wants is the
+     * rule's to say. A rule about what one package holds would otherwise grow a package written
+     * under it later, which is a package nobody has said anything about; a rule about a package and
+     * what is beneath it would otherwise stop at a directory.
+     *
+     * <p>Which files are in it is settled from the listing, so what is parsed is what the question
+     * is about — the same as its neighbour and for the same reason.
+     */
+    public List<ClassModel> inTheClassesOf(String packageName) {
+        Path directory = root.resolve(packageName.replace('.', '/'));
+        List<Path> under = new ArrayList<>();
+        for (Path each : readings.listing(root)) {
+            if (directory.equals(each.getParent())) {
+                under.add(each);
+            }
+        }
+        return read(under);
+    }
+
+    /**
      * Every class of {@code packageName} and of the packages under it.
      *
      * <p>Under it as well, because a package's classes are not all written directly in it, and a

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -16,8 +16,10 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -150,6 +152,34 @@ public final class RepositoryLayout {
         }
         return false;
     }
+
+    /**
+     * Whether {@code said}, taken together, names a directory a build compiles into.
+     *
+     * <p>For a rule about a check that works out where the compiled classes are. What such a check
+     * says is the directory a build writes to and the one it compiles into, and it says them as
+     * whatever a path is built out of — one text with both steps, or a step at a time. So they are
+     * asked of everything one method says rather than of one text: written a step at a time, no
+     * single text names an output.
+     *
+     * <p>Narrower than {@link #namesBuildOutput}, and narrower on purpose. A build writes more than
+     * classes — a jar, a launcher — and a check that runs what was shipped names where it was put
+     * without going looking for anybody's classes.
+     */
+    public static boolean namesCompiledOutput(Collection<String> said) {
+        boolean writes = false;
+        boolean compiled = false;
+        for (String each : said) {
+            for (String step : each.split("[/\\\\]")) {
+                writes |= step.equals(whereABuildWrites());
+                compiled |= COMPILED_INTO.contains(step);
+            }
+        }
+        return writes && compiled;
+    }
+
+    /** What a build calls the directories it compiles into, under the one it writes to. */
+    private static final Set<String> COMPILED_INTO = Set.of("classes", "test-classes");
 
     /**
      * What {@code module} compiled its {@code phase} sources to, or nothing where it built none.

--- a/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
@@ -111,7 +111,7 @@ class TheRepositoryIsReadTheWayTheReactorReadsItTest {
         List<Path> sources = REPOSITORY.southerSources();
         assertFalse(sources.isEmpty(), "this repository has Souther sources");
         for (Path source : sources) {
-            assertFalse(source.toString().contains("/target/"), source.toString());
+            assertFalse(RepositoryLayout.namesBuildOutput(source.toString()), source.toString());
             assertFalse(source.getFileName().toString().startsWith(".surefire-"), source.toString());
         }
         assertEquals(sources.stream().sorted().toList(), sources, "sorted, so a sweep is ordered");

--- a/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
+++ b/souther-test-support/src/test/java/souther/test/WhatIsReadOfACompiledOutputIsReadOnceTest.java
@@ -192,6 +192,17 @@ class WhatIsReadOfACompiledOutputIsReadOnceTest {
     }
 
     @Test
+    void reads_a_packages_own_classes_without_the_packages_under_it(@TempDir Path root)
+            throws IOException {
+        List<ClassModel> its = at(anOutputOfSeveralPackages(root)).inTheClassesOf("asked");
+
+        assertEquals(1, its.size());
+        assertEquals(1, counting.reads.get(),
+                "reading a package's own classes opened the ones under it as well, or the ones"
+                        + " beside it");
+    }
+
+    @Test
     void reads_a_package_together_with_the_packages_under_it(@TempDir Path root) throws IOException {
         CompiledClasses output = at(anOutputOfSeveralPackages(root));
 


### PR DESCRIPTION
Every check in this module walked a module's compiled output for itself, parsed each class file and
read what it held. What they read is the same for all of them and does not change while the run
happens, so each walk was the reading beside it done again — and every one of them carried the same
cluster to do it with: where a module's classes are, whether it has sources to have built them from,
which files are under there, how to open one, and what a class is called once opened.

## What closes it

That cluster is gone from every check here. Which outputs a rule is about, and the order a name is
looked for in them, is what this module already had one place for; what that place answers now is
also every class of them, the classes of one module, and the classes written directly in a package.
The classes themselves come from the reading the fork shares, so the files are opened once however
many rules ask.

A module that has sources of a phase and compiled none of them is a hole rather than a pass, and it
is refused where the outputs are taken. Each check used to say so for itself, in a test of its own —
a test that could only speak for that check's own walk. A rule that reads fewer modules than the
repository has now cannot get as far as answering.

Asking for a package's own classes is not asking for the packages under it, and one reading answers
each. Which of the two a rule wants is the rule's to say: two rules here are about what one package
holds, and answering them with the tree would grow a package written under it later, which is a
package nobody has said anything about.

## How it is held

Writing down where a build puts what it made is refused for every module whose checks read compiled
classes, rather than for one of them. Which modules those are is worked out from what their checks
call, so it is a population and not a list — a module whose checks run the shipped binary names what
a build wrote and reads no class file, and a rule refusing that would be about the word rather than
about going to look. Putting a path back is a failing test.

What that rule does not say is that each module asks in one place. A check reading its own module's
fixtures asks for its own output, and telling that from naming somebody else's is a distinction
nothing here models; where a module has one place, that module's own checks say so, and the
compiler's still does.

The check that tests the repository's own reading of its sources asks it whether a path is under a
build's output, rather than saying the word itself — which is both the honest way to test it and the
last place outside the layout that named one.

## On the migration

Scripted, and swept afterwards in both directions: every condition that went with a deleted line was
read, and every method and field left behind without a caller was counted. Two shapes are worth
naming. A package walk that was not recursive would have become one, and the package is flat today,
so nothing would have failed — that is why a package's own classes are asked for as such. And one
file's byte-level pre-filter for a word is now read off the constant pool, since the parse it was
avoiding has already happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
