### PR TITLE
Hand the default library over from one place, and refuse a corpus that is not there

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckGoesLookingForACompiledOutputTest.java
@@ -4,9 +4,6 @@ import org.junit.jupiter.api.Test;
 import souther.test.RepositoryLayout;
 
 import java.lang.classfile.ClassModel;
-import java.lang.classfile.CodeModel;
-import java.lang.classfile.MethodModel;
-import java.lang.classfile.instruction.ConstantInstruction;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -27,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * <p>What is asked is whether a check works out where the compiled classes are. Saying so takes two
  * words — the directory a build writes to and the one it compiles into — and they are asked of
- * everything one method says rather than of one text, because a path is as often built a step at a
- * time as written whole. What hands the location out is nothing, so saying it is the whole of what
+ * everything one place says rather than of one text, because a path is as often built a step at a
+ * time as written whole. {@link WhatACheckSays} is what a place is and what one says. What hands the location out is nothing, so saying it is the whole of what
  * is left: a reading answers what an output holds and never where it is, and the repository answers
  * whether something is under a build's output rather than what a build calls its directories.
  *
@@ -64,13 +61,11 @@ class NoCheckGoesLookingForACompiledOutputTest {
 
         Map<String, List<String>> working = new LinkedHashMap<>();
         for (ClassModel each : checks) {
-            for (MethodModel method : each.methods()) {
-                List<String> said = constantsOf(method);
+            WhatACheckSays.of(each).forEach((where, said) -> {
                 if (RepositoryLayout.namesCompiledOutput(said)) {
-                    working.computeIfAbsent(named(each) + "#"
-                            + method.methodName().stringValue(), _ -> new ArrayList<>()).addAll(said);
+                    working.put(where, said);
                 }
-            }
+            });
         }
 
         assertEquals(Map.of(), working,
@@ -80,24 +75,4 @@ class NoCheckGoesLookingForACompiledOutputTest {
     }
 
 
-    /** Everything one method says, which is where a path built a step at a time is put back
-     *  together. */
-    private static List<String> constantsOf(MethodModel method) {
-        List<String> said = new ArrayList<>();
-        CodeModel code = method.code().orElse(null);
-        if (code == null) {
-            return said;
-        }
-        for (var element : code) {
-            if (element instanceof ConstantInstruction loaded
-                    && loaded.constantValue() instanceof String text) {
-                said.add(text);
-            }
-        }
-        return said;
-    }
-
-    private static String named(ClassModel of) {
-        return of.thisClass().asInternalName().replace('/', '.');
-    }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest.java
@@ -1,0 +1,121 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+import souther.test.RepositoryLayout;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A check names the module whose files it wants; it does not work out which way that module is.
+ *
+ * <p>Which module a check reads is the check's own subject — this module's fixtures, that module's
+ * corpus — and it stays written where the check is. Where that module is, is not a subject: a check
+ * stepping out of its own directory to land in another has answered it from wherever the build was
+ * invoked, so the same check reads different files under a build started elsewhere. Started
+ * somewhere the step does not land, the three checks that spelled the default library this way
+ * answered three different ways, and one of them swept no sources and reported a pass over all of
+ * them.
+ *
+ * <p>What is asked is whether a check works out which way another module is. Saying so takes two
+ * words — a step out of where it stands and the name of the module it means to reach — and they are
+ * asked of everything one method says rather than of one text, because a path is as often built a
+ * step at a time as written whole.
+ *
+ * <p>The module's name is not what this refuses, and a rule that refused it would be a rule against
+ * naming a subject. What it refuses is the {@code ..} beside the name:
+ * {@link RepositoryLayout#moduleNamed} answers where a module is, and a check that asks it says
+ * which module and nothing about where anything is.
+ *
+ * <p><b>Asked of every check this repository has, and not of the ones that reach another module
+ * today.</b> A population taken from the checks that read across modules would be taken from the
+ * property being checked: a check reading only its own module now, and reaching for another
+ * tomorrow by stepping out of its directory, would be the one case nothing looked at.
+ */
+class NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest {
+
+    private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    @Test
+    void nothingWorksOutWhichWayAnotherModuleIs() {
+        List<ClassModel> checks = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            checks.addAll(EVERYTHING.testClassesOf(module));
+        }
+        assertFalse(checks.isEmpty(), "no check of this repository was read at all, so this rule is"
+                + " asked of nothing and passes by having nobody to ask");
+
+        Map<String, List<String>> walking = new LinkedHashMap<>();
+        for (ClassModel each : checks) {
+            for (MethodModel method : each.methods()) {
+                List<String> said = constantsOf(method);
+                if (REPOSITORY.reachesAModuleThroughAParent(said)) {
+                    walking.computeIfAbsent(named(each) + "#"
+                            + method.methodName().stringValue(), _ -> new ArrayList<>()).addAll(said);
+                }
+            }
+        }
+
+        assertEquals(Map.of(), walking,
+                "a check works out which way another module is instead of naming it, so what it"
+                        + " reads is decided by the directory the build was invoked from, and a step"
+                        + " that lands nowhere leaves it sweeping whatever it found");
+    }
+
+    /**
+     * And the rule sees the shape it is about.
+     *
+     * <p>A rule reading a repository that no longer writes what it refuses passes because there is
+     * nothing to find, and so does one whose reading has stopped answering. The module's name is
+     * taken from the repository rather than written here, so that this says nothing the rule above
+     * would have to leave itself out of.
+     */
+    @Test
+    void andTheRuleSeesTheShapeItIsAbout() {
+        String module = REPOSITORY.modules().getFirst().getFileName().toString();
+        String out = "..";
+        assertTrue(REPOSITORY.reachesAModuleThroughAParent(List.of(out, module, "src", "main")),
+                "a path built a step at a time");
+        assertTrue(REPOSITORY.reachesAModuleThroughAParent(
+                        List.of(out + "/" + module + "/src/main/resources")),
+                "and one written whole");
+        assertFalse(REPOSITORY.reachesAModuleThroughAParent(List.of(out)),
+                "a step out that lands nowhere in particular is the repository's own business");
+        assertFalse(REPOSITORY.reachesAModuleThroughAParent(List.of(module + "/src/main")),
+                "and naming a module is naming a subject");
+    }
+
+    /** Everything one method says, which is where a path built a step at a time is put back
+     *  together. */
+    private static List<String> constantsOf(MethodModel method) {
+        List<String> said = new ArrayList<>();
+        CodeModel code = method.code().orElse(null);
+        if (code == null) {
+            return said;
+        }
+        for (var element : code) {
+            if (element instanceof ConstantInstruction loaded
+                    && loaded.constantValue() instanceof String text) {
+                said.add(text);
+            }
+        }
+        return said;
+    }
+
+    private static String named(ClassModel of) {
+        return of.thisClass().asInternalName().replace('/', '.');
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest.java
@@ -1,12 +1,10 @@
 package souther.architecture;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.ValueSource;
 import souther.test.RepositoryLayout;
 
 import java.lang.classfile.ClassModel;
-import java.lang.classfile.CodeModel;
-import java.lang.classfile.MethodModel;
-import java.lang.classfile.instruction.ConstantInstruction;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -30,8 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>What is asked is whether a check works out which way another module is. Saying so takes two
  * words — a step out of where it stands and the name of the module it means to reach — and they are
- * asked of everything one method says rather than of one text, because a path is as often built a
- * step at a time as written whole.
+ * asked of everything one place says rather than of one text, because a path is as often built a
+ * step at a time as written whole. A parameterized case says where its subjects are in an
+ * annotation, so that is one of the places: {@link WhatACheckSays} is what they are.
  *
  * <p>The module's name is not what this refuses, and a rule that refused it would be a rule against
  * naming a subject. What it refuses is the {@code ..} beside the name:
@@ -60,13 +59,11 @@ class NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest {
 
         Map<String, List<String>> walking = new LinkedHashMap<>();
         for (ClassModel each : checks) {
-            for (MethodModel method : each.methods()) {
-                List<String> said = constantsOf(method);
+            WhatACheckSays.of(each).forEach((where, said) -> {
                 if (REPOSITORY.reachesAModuleThroughAParent(said)) {
-                    walking.computeIfAbsent(named(each) + "#"
-                            + method.methodName().stringValue(), _ -> new ArrayList<>()).addAll(said);
+                    walking.put(where, said);
                 }
-            }
+            });
         }
 
         assertEquals(Map.of(), walking,
@@ -76,7 +73,7 @@ class NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest {
     }
 
     /**
-     * And the rule sees the shape it is about.
+     * And the words the rule looks for are words it would recognise.
      *
      * <p>A rule reading a repository that no longer writes what it refuses passes because there is
      * nothing to find, and so does one whose reading has stopped answering. The module's name is
@@ -84,7 +81,7 @@ class NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest {
      * would have to leave itself out of.
      */
     @Test
-    void andTheRuleSeesTheShapeItIsAbout() {
+    void andTheWordsItLooksForAreWordsItWouldRecognise() {
         String module = REPOSITORY.modules().getFirst().getFileName().toString();
         String out = "..";
         assertTrue(REPOSITORY.reachesAModuleThroughAParent(List.of(out, module, "src", "main")),
@@ -98,24 +95,40 @@ class NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest {
                 "and naming a module is naming a subject");
     }
 
-    /** Everything one method says, which is where a path built a step at a time is put back
-     *  together. */
-    private static List<String> constantsOf(MethodModel method) {
-        List<String> said = new ArrayList<>();
-        CodeModel code = method.code().orElse(null);
-        if (code == null) {
-            return said;
-        }
-        for (var element : code) {
-            if (element instanceof ConstantInstruction loaded
-                    && loaded.constantValue() instanceof String text) {
-                said.add(text);
-            }
-        }
-        return said;
+    /**
+     * And what a check writes in an annotation is something it said.
+     *
+     * <p>The half the rule above cannot show. A parameterized case takes its subjects from an
+     * annotation, so a corpus named there is named as plainly as one named in the body — and it is
+     * an element value, which never reaches the code the class holds. Read through the class file,
+     * the way the rule reads it, because a reading that answered nothing would leave the rule
+     * passing over every check in the repository with nothing to say why.
+     */
+    @Test
+    void andWhatACheckWritesInAnAnnotationIsSomethingItSaid() {
+        Map<String, List<String>> said = WhatACheckSays.of(EVERYTHING.read(
+                "souther/architecture/NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest"
+                        + "$SaidOnlyInAnAnnotation"));
+        assertEquals(List.of(SENTINEL, SENTINEL + "/and-another"),
+                said.get("souther.architecture.NoCheckReachesAModuleByWalkingOutOfWhereItStands"
+                        + "Test$SaidOnlyInAnAnnotation#takesItsSubjectsFromAnAnnotation"),
+                "what the annotation says, in the order it says it: " + said);
     }
 
-    private static String named(ClassModel of) {
-        return of.thisClass().asInternalName().replace('/', '.');
+    /** A word nothing else writes, so that finding it is finding this one. */
+    private static final String SENTINEL = "a-corpus-named-where-only-an-annotation-can-see-it";
+
+    /**
+     * A check whose subjects are written in an annotation and nowhere else.
+     *
+     * <p>Here to be read as a class file rather than to be run, so it carries the source of the
+     * subjects without the annotation that would ask for them. What it names is a sentinel rather
+     * than a real corpus: a class here naming one would be a check reaching another module, which is
+     * what the rule above refuses, and an exemption for this one would be the hole it is for.
+     */
+    static final class SaidOnlyInAnAnnotation {
+        @ValueSource(strings = {SENTINEL, SENTINEL + "/and-another"})
+        void takesItsSubjectsFromAnAnnotation(String corpus) {
+        }
     }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatACheckSays.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatACheckSays.java
@@ -1,0 +1,120 @@
+package souther.architecture;
+
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationElement;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.AttributedElement;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.StringEntry;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The text a check has written down, by where it wrote it.
+ *
+ * <p>What a rule about what a check <em>says</em> reads. Such a rule asks whether two words stand
+ * together in one thing somebody wrote — a directory a build writes to beside the one it compiles
+ * into, a step out of a module beside the name of another — so the text has to come back grouped by
+ * the thing that was written, and not as one bag for the class.
+ *
+ * <p><b>What a check says is not only what its code loads.</b> A parameterized case takes its
+ * subjects from {@code @ValueSource} or {@code @CsvSource}, and a corpus named there is named as
+ * plainly as one named in the body. That text is an annotation's element value and never reaches
+ * the code, so a reading that walked the instructions saw the same check as saying nothing. Both
+ * rules here had that reading, written out twice, and a rule is only as wide as what it is given to
+ * read.
+ *
+ * <p>Grouped by method for what a method's code and its own annotations say, and by class for what
+ * the class and its fields say. A field or a class annotation is written by the class rather than by
+ * any one of its methods, and putting it in every method's row would report a method that says
+ * nothing of the kind.
+ */
+final class WhatACheckSays {
+
+    private WhatACheckSays() {}
+
+    /**
+     * Everything {@code check} says, by where it says it.
+     *
+     * <p>The key is what a rule names when it reports: {@code class#method} for a method's own, and
+     * the class's name for what is written outside one.
+     */
+    static Map<String, List<String>> of(ClassModel check) {
+        String named = check.thisClass().asInternalName().replace('/', '.');
+        Map<String, List<String>> said = new LinkedHashMap<>();
+
+        List<String> outsideAMethod = new ArrayList<>();
+        annotationsOn(check, outsideAMethod);
+        for (FieldModel field : check.fields()) {
+            annotationsOn(field, outsideAMethod);
+            field.findAttribute(Attributes.constantValue()).ifPresent(held -> {
+                if (held.constant() instanceof StringEntry text) {
+                    outsideAMethod.add(text.stringValue());
+                }
+            });
+        }
+        if (!outsideAMethod.isEmpty()) {
+            said.put(named, outsideAMethod);
+        }
+
+        for (MethodModel method : check.methods()) {
+            List<String> here = new ArrayList<>();
+            CodeModel code = method.code().orElse(null);
+            if (code != null) {
+                for (var element : code) {
+                    if (element instanceof ConstantInstruction loaded
+                            && loaded.constantValue() instanceof String text) {
+                        here.add(text);
+                    }
+                }
+            }
+            annotationsOn(method, here);
+            method.findAttribute(Attributes.runtimeVisibleParameterAnnotations())
+                    .ifPresent(taken -> taken.parameterAnnotations()
+                            .forEach(each -> each.forEach(one -> valuesOf(one, here))));
+            method.findAttribute(Attributes.runtimeInvisibleParameterAnnotations())
+                    .ifPresent(taken -> taken.parameterAnnotations()
+                            .forEach(each -> each.forEach(one -> valuesOf(one, here))));
+            if (!here.isEmpty()) {
+                said.put(named + "#" + method.methodName().stringValue(), here);
+            }
+        }
+        return said;
+    }
+
+    /**
+     * What the annotations on one declaration say.
+     *
+     * <p>Both retentions, because which one an annotation has is the annotation's business and not
+     * the business of a rule about what somebody wrote down.
+     */
+    private static void annotationsOn(AttributedElement declaration, List<String> into) {
+        declaration.findAttribute(Attributes.runtimeVisibleAnnotations())
+                .ifPresent(taken -> taken.annotations().forEach(one -> valuesOf(one, into)));
+        declaration.findAttribute(Attributes.runtimeInvisibleAnnotations())
+                .ifPresent(taken -> taken.annotations().forEach(one -> valuesOf(one, into)));
+    }
+
+    /** What one annotation says, through the arrays and the annotations written inside it. */
+    private static void valuesOf(Annotation annotation, List<String> into) {
+        for (AnnotationElement element : annotation.elements()) {
+            valuesOf(element.value(), into);
+        }
+    }
+
+    private static void valuesOf(AnnotationValue value, List<String> into) {
+        switch (value) {
+            case AnnotationValue.OfString text -> into.add(text.stringValue());
+            case AnnotationValue.OfArray many -> many.values().forEach(one -> valuesOf(one, into));
+            case AnnotationValue.OfAnnotation inside -> valuesOf(inside.annotation(), into);
+            default -> { }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.meta.ModulePath;
+import souther.test.RepositoryLayout;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -416,16 +419,22 @@ class WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest {
      * from was taken over these, so a check over fewer would be answering about a different set
      * than the one somebody measured.
      */
-    private static final List<String> THE_MODELS = List.of(
-            "src/test/resources/souther/compiler/conformance/catalog",
-            "src/test/resources/souther/compiler/conformance/staffing",
-            "../souther-bench/src/main/resources/souther/bench/corpus/crm",
-            "../souther-bench/src/main/resources/souther/bench/corpus/issuetracker");
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    private static final List<Path> THE_MODELS = List.of(
+            REPOSITORY.moduleNamed("souther-compiler")
+                    .resolve("src/test/resources/souther/compiler/conformance/catalog"),
+            REPOSITORY.moduleNamed("souther-compiler")
+                    .resolve("src/test/resources/souther/compiler/conformance/staffing"),
+            REPOSITORY.moduleNamed("souther-bench")
+                    .resolve("src/main/resources/souther/bench/corpus/crm"),
+            REPOSITORY.moduleNamed("souther-bench")
+                    .resolve("src/main/resources/souther/bench/corpus/issuetracker"));
 
     /** Every instance of a registered carrier the models reach, by carrier. */
     private static Map<String, List<Object>> carriersInTheModels() {
         Map<String, List<Object>> out = new LinkedHashMap<>();
-        for (String model : THE_MODELS) {
+        for (Path model : THE_MODELS) {
             carriersIn(compiled(model)).forEach((carrier, held) ->
                     out.computeIfAbsent(carrier, _ -> new ArrayList<>()).addAll(held));
         }
@@ -433,15 +442,14 @@ class WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest {
     }
 
     /** A compile of one model, with its findings asked for. */
-    private static Db compiled(String model) {
+    private static Db compiled(Path model) {
         Map<String, String> byId = new LinkedHashMap<>();
-        Path root = Path.of(model);
-        try (Stream<Path> files = Files.walk(root)) {
+        try (Stream<Path> files = Files.walk(model)) {
             for (Path each : files.filter(p -> p.toString().endsWith(".sou")).sorted().toList()) {
                 byId.put(each.getFileName().toString(), Files.readString(each));
             }
-        } catch (java.io.IOException unreadable) {
-            throw new java.io.UncheckedIOException(unreadable);
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
         }
         Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
         c.answerEverything();

--- a/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -31,10 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class FormatterTest {
 
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** The bundled prelude, asked for rather than found: a corpus that is not there refuses where
      *  it is handed out, and does so the same way for every check that sweeps it. */
     static Stream<Path> corpus() {
-        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
+        return REPOSITORY.preludeSources().stream();
     }
 
     private static String read(Path p) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -7,6 +7,7 @@ import souther.compiler.cst.SyntaxKind;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import souther.test.RepositoryLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,22 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class FormatterTest {
 
-    static Stream<Path> corpus() throws IOException {
-        // The bundled prelude, named where the compiler keeps it rather than where this module
-        // happens to stand. A root that is skipped for not being there takes its sources out of the
-        // sweep and leaves the rows that remain passing, so a missing one is said instead.
-        List<Path> roots = List.of(
-                Path.of("..", "souther-compiler", "src", "main", "resources", "souther"));
-        List<Path> sources = new ArrayList<>();
-        for (Path root : roots) {
-            if (!Files.isDirectory(root)) {
-                throw new IOException("the corpus root " + root.toAbsolutePath() + " is not there");
-            }
-            try (Stream<Path> walk = Files.walk(root)) {
-                walk.filter(p -> p.toString().endsWith(".sou")).forEach(sources::add);
-            }
-        }
-        return sources.stream();
+    /** The bundled prelude, asked for rather than found: a corpus that is not there refuses where
+     *  it is handed out, and does so the same way for every check that sweeps it. */
+    static Stream<Path> corpus() {
+        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
     }
 
     private static String read(Path p) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
@@ -11,6 +11,7 @@ import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxKind;
 import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
+import souther.test.RepositoryLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -276,19 +277,17 @@ class WhatGoesBetweenTwoTokensOnALineTest {
             """);
 
     /**
-     * One bundled standard-library source, read from where the compiler keeps it.
+     * One bundled standard-library source, asked for by the name the library gives it.
      *
-     * <p>Named by path rather than looked up on the class path. The formatter depends on the syntax
-     * and not on the compiler, so the sources the compiler bundles are not on this module's class
-     * path — and a corpus that quietly came up short would leave every rule below holding over less
-     * text than it says it does.
+     * <p>Read from the repository rather than looked up on the class path. The formatter depends on
+     * the syntax and not on the compiler, so the sources the compiler bundles are not on this
+     * module's class path — and a corpus that quietly came up short would leave every rule below
+     * holding over less text than it says it does. A name the library does not have is refused
+     * where the library is handed out.
      */
     private static String stdlib(String module) {
-        Path source = Path.of("..", "souther-compiler", "src", "main", "resources", "souther",
-                module + ".sou");
+        Path source = RepositoryLayout.ofWorkingDirectory().preludeSourceOf(module);
         try {
-            assertTrue(Files.isRegularFile(source),
-                    "missing bundled source " + source.toAbsolutePath());
             return Files.readString(source, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
@@ -276,6 +276,10 @@ class WhatGoesBetweenTwoTokensOnALineTest {
                 | _ -> 0
             """);
 
+    /** Read once, because the repository does not move while a run happens: reading it is a pom to
+     *  parse and a walk, and {@link #corpus} is asked for by every rule this module holds. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /**
      * One bundled standard-library source, asked for by the name the library gives it.
      *
@@ -286,7 +290,7 @@ class WhatGoesBetweenTwoTokensOnALineTest {
      * where the library is handed out.
      */
     private static String stdlib(String module) {
-        Path source = RepositoryLayout.ofWorkingDirectory().preludeSourceOf(module);
+        Path source = REPOSITORY.preludeSourceOf(module);
         try {
             return Files.readString(source, StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/souther-syntax/src/test/java/souther/compiler/cst/CstLexerRoundTripTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/CstLexerRoundTripTest.java
@@ -55,8 +55,10 @@ class CstLexerRoundTripTest {
         assertEquals(source, relex(source));
     }
 
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     static Stream<Path> preludeSources() {
-        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
+        return REPOSITORY.preludeSources().stream();
     }
 
     @ParameterizedTest

--- a/souther-syntax/src/test/java/souther/compiler/cst/CstLexerRoundTripTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/CstLexerRoundTripTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import souther.test.RepositoryLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -54,11 +55,8 @@ class CstLexerRoundTripTest {
         assertEquals(source, relex(source));
     }
 
-    static Stream<Path> preludeSources() throws IOException {
-        Path prelude = Path.of("..", "souther-compiler", "src", "main", "resources", "souther");
-        try (Stream<Path> walk = Files.walk(prelude)) {
-            return walk.filter(p -> p.toString().endsWith(".sou")).toList().stream();
-        }
+    static Stream<Path> preludeSources() {
+        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
     }
 
     @ParameterizedTest

--- a/souther-syntax/src/test/java/souther/compiler/cst/CstParserRoundTripTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/CstParserRoundTripTest.java
@@ -22,11 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CstParserRoundTripTest {
 
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** The bundled prelude — the hardest corpus, and asked for rather than gone looking for, so a
      *  source added to it is swept here without this being edited and a corpus that is not there
      *  refuses rather than leaving a sweep of nothing to pass. */
     static Stream<Path> exampleSources() {
-        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
+        return REPOSITORY.preludeSources().stream();
     }
 
     private static String read(Path p) {

--- a/souther-syntax/src/test/java/souther/compiler/cst/CstParserRoundTripTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/CstParserRoundTripTest.java
@@ -3,14 +3,13 @@ package souther.compiler.cst;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import souther.test.RepositoryLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,22 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CstParserRoundTripTest {
 
-    static Stream<Path> exampleSources() throws IOException {
-        // The bundled prelude — the hardest corpus. It is the compiler's resource, named where it
-        // is rather than where this module happens to stand, so the sweep is over the same sources
-        // wherever the check that reads them is written.
-        List<Path> roots = List.of(
-                Path.of("..", "souther-compiler", "src", "main", "resources", "souther"));
-        List<Path> sources = new ArrayList<>();
-        for (Path root : roots) {
-            if (!Files.isDirectory(root)) {
-                continue;
-            }
-            try (Stream<Path> walk = Files.walk(root)) {
-                walk.filter(p -> p.toString().endsWith(".sou")).forEach(sources::add);
-            }
-        }
-        return sources.stream();
+    /** The bundled prelude — the hardest corpus, and asked for rather than gone looking for, so a
+     *  source added to it is swept here without this being edited and a corpus that is not there
+     *  refuses rather than leaving a sweep of nothing to pass. */
+    static Stream<Path> exampleSources() {
+        return RepositoryLayout.ofWorkingDirectory().preludeSources().stream();
     }
 
     private static String read(Path p) {

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -121,6 +121,29 @@ public final class RepositoryLayout {
     }
 
     /**
+     * The directory of the module called {@code named}.
+     *
+     * <p>What a check reaching another module's files wants, and the whole of what it should have
+     * to say. Naming the module is naming a subject — which module's fixtures, which module's
+     * corpus — and it stays written where the check is. Where that module is, is not a subject: a
+     * check working it out from where it happens to be standing answers about whatever directory
+     * the build was invoked from, and that is what this takes off it.
+     *
+     * <p>Refused rather than resolved where the root pom names no such module, so a module renamed
+     * out from under a check stops that check rather than handing it a directory that is not there.
+     */
+    public Path moduleNamed(String named) {
+        for (Path module : modules) {
+            if (module.getFileName().toString().equals(named)) {
+                return module;
+            }
+        }
+        throw new IllegalArgumentException("the root pom names no module called " + named
+                + ": it names " + modules.stream().map(each -> each.getFileName().toString())
+                        .toList());
+    }
+
+    /**
      * What a build calls the directory it writes into.
      *
      * <p>Where a build puts what it made is a fact about how this repository is laid out, and it
@@ -325,6 +348,103 @@ public final class RepositoryLayout {
     /** Every {@code .sou} in a source tree, sorted. */
     public List<Path> southerSources() {
         return filesUnderSourceTrees(".sou");
+    }
+
+    /** The module that ships the default library, and where under its resources it keeps it. */
+    private static final String SHIPS_THE_PRELUDE = "souther-compiler";
+    private static final String THE_PRELUDE_IS_UNDER = "souther";
+
+    /**
+     * The Souther sources this repository ships as its default library, sorted.
+     *
+     * <p>A population and not a directory. Three checks swept it and each had worked out where it
+     * was, so a source added to it reached whichever of them had been edited and the rest went on
+     * reporting a pass over the sources they knew about. Asked here, they sweep the same population
+     * or none of them does.
+     *
+     * <p>Narrower than {@link #southerSources}, which is every Souther source the repository holds:
+     * the models written to ask one question are sources too, and a check about the library is not
+     * about those. Filtering the wider answer down would be a second account of which of them are
+     * the library, kept beside the one the compiler ships by.
+     *
+     * <p>A corpus that is not there is refused rather than swept over. A sweep of no sources is a
+     * sweep every row of which holds, and a round trip over nothing reproduces everything it was
+     * given: the check reports a pass. That refusal belongs with the answer, because the place that
+     * hands the sources over is the only one that can tell a missing corpus from an empty one.
+     */
+    public List<Path> preludeSources() {
+        Path at = moduleNamed(SHIPS_THE_PRELUDE)
+                .resolve("src").resolve("main").resolve("resources").resolve(THE_PRELUDE_IS_UNDER);
+        if (!isThere(at)) {
+            throw new IllegalStateException(at + " is not there, so a sweep of the default library"
+                    + " would be a sweep of no sources and would report a pass over all of them");
+        }
+        List<Path> found = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(at)) {
+            walk.filter(Files::isRegularFile)
+                    .filter(each -> each.getFileName().toString().endsWith(".sou"))
+                    .forEach(found::add);
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+        if (found.isEmpty()) {
+            throw new IllegalStateException(at + " holds no Souther source: the default library is"
+                    + " what the checks that sweep it are about, and there is none here");
+        }
+        found.sort(Path::compareTo);
+        return List.copyOf(found);
+    }
+
+    /**
+     * The one source of the default library that {@code module} names, without its suffix.
+     *
+     * <p>Looked for among {@link #preludeSources} rather than built from the same steps, so that
+     * what this hands back is one of the population above and not a path that would be one if it
+     * were there. A name the library does not have is refused with what it does have.
+     */
+    public Path preludeSourceOf(String module) {
+        List<Path> sources = preludeSources();
+        List<Path> named = sources.stream()
+                .filter(each -> each.getFileName().toString().equals(module + ".sou")).toList();
+        if (named.size() != 1) {
+            throw new IllegalArgumentException("the default library has " + named.size()
+                    + " sources called " + module + ".sou, among "
+                    + sources.stream().map(each -> each.getFileName().toString()).toList());
+        }
+        return named.getFirst();
+    }
+
+    /**
+     * Whether {@code said}, taken together, reaches a module by walking out of where it stands.
+     *
+     * <p>For a rule about a check that works out where another module's files are. What such a
+     * check says is a step out of its own directory and the name of the module it means to land in,
+     * and it says them as whatever a path is built out of — one text with both steps, or a step at
+     * a time — so they are asked of everything one method says rather than of one text.
+     *
+     * <p>The module's name is not what this refuses. Naming a module is naming a subject, and a
+     * check reaching for one asks {@link #moduleNamed} where it is; the {@code ..} beside it is the
+     * check answering that for itself, out of the directory the build was invoked from.
+     */
+    public boolean reachesAModuleThroughAParent(Collection<String> said) {
+        boolean walksOut = false;
+        boolean lands = false;
+        for (String each : said) {
+            for (String step : each.split("[/\\\\]")) {
+                walksOut |= step.equals("..");
+                lands |= isAModuleName(step);
+            }
+        }
+        return walksOut && lands;
+    }
+
+    private boolean isAModuleName(String step) {
+        for (Path module : modules) {
+            if (module.getFileName().toString().equals(step)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -371,8 +371,22 @@ public final class RepositoryLayout {
      * sweep every row of which holds, and a round trip over nothing reproduces everything it was
      * given: the check reports a pass. That refusal belongs with the answer, because the place that
      * hands the sources over is the only one that can tell a missing corpus from an empty one.
+     *
+     * <p>Walked once, because the repository does not move while a run happens. The checks that
+     * sweep the library ask for it once per property they hold over it, and the library is the same
+     * answer each time; only where the sources are is held, so what each check makes of them stays
+     * its own.
      */
     public List<Path> preludeSources() {
+        if (prelude == null) {
+            prelude = walkThePrelude();
+        }
+        return prelude;
+    }
+
+    private List<Path> prelude;
+
+    private List<Path> walkThePrelude() {
         Path at = moduleNamed(SHIPS_THE_PRELUDE)
                 .resolve("src").resolve("main").resolve("resources").resolve(THE_PRELUDE_IS_UNDER);
         if (!isThere(at)) {

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -17,7 +17,10 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -58,11 +61,14 @@ public final class RepositoryLayout {
 
     private final Path root;
     private final List<Path> modules;
+    private final Map<String, Path> byTheNameTheRootPomWrites;
     private final List<Path> sourceTrees;
 
-    private RepositoryLayout(Path root, List<Path> modules, List<Path> sourceTrees) {
+    private RepositoryLayout(Path root, LinkedHashMap<String, Path> named, List<Path> sourceTrees) {
         this.root = root;
-        this.modules = List.copyOf(modules);
+        this.byTheNameTheRootPomWrites =
+                Collections.unmodifiableMap(new LinkedHashMap<>(named));
+        this.modules = List.copyOf(named.values());
         this.sourceTrees = List.copyOf(sourceTrees);
     }
 
@@ -91,7 +97,7 @@ public final class RepositoryLayout {
      */
     public static RepositoryLayout of(Path start) {
         Path root = rootAbove(start.toAbsolutePath().normalize());
-        List<Path> modules = new ArrayList<>();
+        LinkedHashMap<String, Path> modules = new LinkedHashMap<>();
         List<Path> sourceTrees = new ArrayList<>();
         for (String named : modulesNamedBy(root.resolve("pom.xml"))) {
             Path module = root.resolve(named).normalize();
@@ -101,7 +107,11 @@ public final class RepositoryLayout {
                         + " repository, and a check that walked one module fewer would answer"
                         + " about the rest and say nothing about this one");
             }
-            modules.add(module);
+            // Two entries under one name would leave whoever asked for it holding whichever came
+            // first, which is the reading answering a question it cannot tell apart.
+            if (modules.put(named, module) != null) {
+                throw new IllegalStateException("the root pom names the module " + named + " twice");
+            }
             Path src = module.resolve("src");
             if (Files.isDirectory(src)) {
                 sourceTrees.add(src);
@@ -129,18 +139,23 @@ public final class RepositoryLayout {
      * check working it out from where it happens to be standing answers about whatever directory
      * the build was invoked from, and that is what this takes off it.
      *
+     * <p>{@code named} as the root pom writes it, which is what a module is called in this reactor.
+     * A directory's own name is not that: the pom may reach a module through a directory above it,
+     * and two modules under different ones can end in the same name — so a lookup on the last step
+     * of the path would answer a question it cannot tell apart, and would answer it with whichever
+     * the pom happened to name first. The pom's names are unique because this reads them into one
+     * answer per name and refuses a second.
+     *
      * <p>Refused rather than resolved where the root pom names no such module, so a module renamed
      * out from under a check stops that check rather than handing it a directory that is not there.
      */
     public Path moduleNamed(String named) {
-        for (Path module : modules) {
-            if (module.getFileName().toString().equals(named)) {
-                return module;
-            }
+        Path module = byTheNameTheRootPomWrites.get(named);
+        if (module == null) {
+            throw new IllegalArgumentException("the root pom names no module called " + named
+                    + ": it names " + byTheNameTheRootPomWrites.keySet());
         }
-        throw new IllegalArgumentException("the root pom names no module called " + named
-                + ": it names " + modules.stream().map(each -> each.getFileName().toString())
-                        .toList());
+        return module;
     }
 
     /**
@@ -446,13 +461,20 @@ public final class RepositoryLayout {
         for (String each : said) {
             for (String step : each.split("[/\\\\]")) {
                 walksOut |= step.equals("..");
-                lands |= isAModuleName(step);
+                lands |= isAModuleDirectory(step);
             }
         }
         return walksOut && lands;
     }
 
-    private boolean isAModuleName(String step) {
+    /**
+     * Whether {@code step} is what a module's directory is called.
+     *
+     * <p>The directory's own name and not the name the root pom writes, which is what
+     * {@link #moduleNamed} takes: this is asked of one step of a path, and a path reaches a module
+     * through the directory it is in whatever the pom calls the module.
+     */
+    private boolean isAModuleDirectory(String step) {
         for (Path module : modules) {
             if (module.getFileName().toString().equals(step)) {
                 return true;

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -64,7 +64,9 @@ public final class RepositoryLayout {
     private final Map<String, Path> byTheNameTheRootPomWrites;
     private final List<Path> sourceTrees;
 
-    private RepositoryLayout(Path root, LinkedHashMap<String, Path> named, List<Path> sourceTrees) {
+    /** {@code named} in the order the root pom names them, which is the order {@link #modules}
+     *  answers in: the pom is what that order is read from, and nothing here sorts it again. */
+    private RepositoryLayout(Path root, Map<String, Path> named, List<Path> sourceTrees) {
         this.root = root;
         this.byTheNameTheRootPomWrites =
                 Collections.unmodifiableMap(new LinkedHashMap<>(named));

--- a/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -91,6 +92,64 @@ class TheRepositoryIsReadTheWayTheReactorReadsItTest {
                 "the module is there");
         assertFalse(withMainJava.contains("souther-program-api-test"),
                 "and it contributes no main sources: " + withMainJava);
+    }
+
+    /**
+     * A module is reached by the name the root pom gives it, and by no other.
+     *
+     * <p>What a check reaching another module's files says. A name the reactor does not have is
+     * refused rather than resolved, so a module renamed out from under a check stops it instead of
+     * handing it a directory that is not there.
+     */
+    @Test
+    void aModuleIsFoundByTheNameTheRootPomGivesIt() {
+        for (Path module : REPOSITORY.modules()) {
+            assertEquals(module, REPOSITORY.moduleNamed(module.getFileName().toString()));
+        }
+        assertThrows(IllegalArgumentException.class,
+                () -> REPOSITORY.moduleNamed("souther-there-is-no-such-module"));
+    }
+
+    /**
+     * The default library is a population, and it is narrower than every source here.
+     *
+     * <p>Narrower is the whole of what makes it an answer: the models written to ask one question
+     * are Souther sources too, and a check about the library that swept those would be holding the
+     * library's properties over somebody's example.
+     */
+    @Test
+    void theDefaultLibraryIsWhatTheCompilerShips() {
+        List<Path> prelude = REPOSITORY.preludeSources();
+        assertFalse(prelude.isEmpty(), "this repository ships a default library");
+        assertEquals(prelude.stream().sorted().toList(), prelude, "sorted, so a sweep is ordered");
+        Path resources = REPOSITORY.moduleNamed("souther-compiler")
+                .resolve("src").resolve("main").resolve("resources");
+        for (Path source : prelude) {
+            assertTrue(source.isAbsolute(), source + " is where it is, not where somebody stands");
+            assertTrue(source.startsWith(resources), source + " is a resource the compiler ships");
+            assertTrue(source.getFileName().toString().endsWith(".sou"), source.toString());
+        }
+        List<Path> everySource = REPOSITORY.southerSources();
+        assertTrue(everySource.containsAll(prelude), "the library is among the sources held here");
+        assertTrue(everySource.size() > prelude.size(),
+                "and the sources written to ask one question are not the library");
+    }
+
+    /**
+     * And one of them is asked for by the name the library gives it.
+     *
+     * <p>Taken from the population rather than built from the same steps a second time, so what
+     * comes back is one of the sources swept above and not a path that would be one if it were
+     * there.
+     */
+    @Test
+    void andOneOfThemIsAskedForByName() {
+        for (Path source : REPOSITORY.preludeSources()) {
+            String name = source.getFileName().toString();
+            assertEquals(source, REPOSITORY.preludeSourceOf(name.substring(0, name.length() - 4)));
+        }
+        assertThrows(IllegalArgumentException.class,
+                () -> REPOSITORY.preludeSourceOf("there-is-no-such-module"));
     }
 
     /**

--- a/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
@@ -95,16 +95,23 @@ class TheRepositoryIsReadTheWayTheReactorReadsItTest {
     }
 
     /**
-     * A module is reached by the name the root pom gives it, and by no other.
+     * A module is reached by the name the root pom writes, and by no other.
      *
      * <p>What a check reaching another module's files says. A name the reactor does not have is
      * refused rather than resolved, so a module renamed out from under a check stops it instead of
      * handing it a directory that is not there.
+     *
+     * <p>Every module of this reactor is written as a bare directory name, which is why looking one
+     * up by the name of its directory is looking it up by the name the pom writes. Written through
+     * a directory above it, the pom's name would be the path it wrote and this would refuse the
+     * directory's own name — loudly, at every check that asked, rather than by handing back
+     * whichever module happened to end in it.
      */
     @Test
-    void aModuleIsFoundByTheNameTheRootPomGivesIt() {
+    void aModuleIsFoundByTheNameTheRootPomWrites() {
         for (Path module : REPOSITORY.modules()) {
-            assertEquals(module, REPOSITORY.moduleNamed(module.getFileName().toString()));
+            assertEquals(module, REPOSITORY.moduleNamed(module.getFileName().toString()),
+                    "each module of this reactor is written as its own directory name");
         }
         assertThrows(IllegalArgumentException.class,
                 () -> REPOSITORY.moduleNamed("souther-there-is-no-such-module"));

--- a/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
@@ -28,9 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * could be. It names what it caught, so the reply to it is to ask {@link RepositoryLayout} rather
  * than to spell the same derivation differently.
  *
- * <p>Deliberately not covered: a path that names one directory of another module, as four checks
- * spell the default library. That is a source this repository holds and not the shape of the
- * repository, so no answer here would be the one they want.
+ * <p>A path that steps out of a check's own directory to name another module is not covered here
+ * and is not allowed either. It is refused where it can be seen as one thing rather than as a
+ * spelling — over what a compiled method says, by
+ * {@code NoCheckReachesAModuleByWalkingOutOfWhereItStandsTest}.
  */
 class TheRepositorysShapeIsWorkedOutInOnePlaceTest {
 


### PR DESCRIPTION
The Souther sources this repository ships were swept by several checks, and each worked out where they were: a path out of its own directory into the module that keeps them. What such a path reaches is decided by the directory the build was invoked from rather than by where the repository keeps its sources.

The checks did not agree about a root that was not there. One let the walk fail, one refused with a message, and one passed over it and carried on — which leaves a round trip sweeping no sources, reproducing everything it was given, and reporting a pass.

`RepositoryLayout` now answers the default library as a population. A corpus that is not there is refused where the sources are handed out, because that is the only place that can tell a missing corpus from an empty one, and a source added to the library is in every sweep of it without a check being edited. One of them is asked for by the name the library gives it, and taken from the same population rather than built from the same steps a second time.

A check reaching another module now names it and asks where it is. Naming a module is naming a subject and stays written where the check is; the step out of its own directory was the check answering the other question for itself. A rule over what a compiled check says refuses that wherever it is written again — in its code and in the annotations a parameterized case takes its subjects from, which is a corpus named as plainly as one named in the body — and it is asked of every check here rather than of the ones that read across modules today — a check that starts reaching for another module tomorrow is the case a narrower population would not have looked at. Removing the spelling from the checks that had it left one more elsewhere, reaching the benchmark corpus, and that one is gone the same way.

Addresses #1534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
