### PR TITLE
Order the renderings of a block's positions, and not the positions

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -326,9 +326,11 @@ public final class AdmissibleValues<A> {
                 Set<Sameness.Block<A>> named = new LinkedHashSet<>();
                 boxes.forEach(box -> box.positions()
                         .forEach(position -> named.add(common.blockOf(position))));
+                Map<Alternative<A>, Refinement<A>> into = new LinkedHashMap<>();
+                boxes.forEach(box -> into.put(box, Refinement.of(common, box.sameness())));
                 for (Sameness.Block<A> block : named) {
-                    List<ValueSet> these = boxes.stream().map(box -> box.get(
-                            box.sameness().blockOf(block.members().iterator().next()))).toList();
+                    List<ValueSet> these = boxes.stream()
+                            .map(box -> box.get(into.get(box).coarseBlockOf(block))).toList();
                     // A block some alternative says nothing about is one a value satisfying that
                     // alternative may hold anything at, so the join is every value and is left out.
                     if (these.stream().anyMatch(ValueSet::isAny)) {
@@ -484,8 +486,8 @@ public final class AdmissibleValues<A> {
                                                       Allowance<A> sets,
                                                       Set<Sameness.Block<A>> gaveUp) {
             Map<Sameness.Block<A>, List<ValueSet>> parts = new LinkedHashMap<>();
-            gathering(at, heldAsOne, parts);
-            gathering(other.at, heldAsOne, parts);
+            gathering(at, Refinement.of(sameness(), heldAsOne), parts);
+            gathering(other.at, Refinement.of(other.sameness(), heldAsOne), parts);
             Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
             parts.forEach((block, these) -> {
                 if (these.size() == 1) {
@@ -503,11 +505,10 @@ public final class AdmissibleValues<A> {
 
         /** Every side of one box filed under the block it is part of once the two are conjoined. */
         private static <A> void gathering(Map<Sameness.Block<A>, ValueSet> these,
-                                          Sameness<A> heldAsOne,
+                                          Refinement<A> into,
                                           Map<Sameness.Block<A>, List<ValueSet>> parts) {
-            these.forEach((block, set) -> parts.computeIfAbsent(
-                            heldAsOne.blockOf(block.members().iterator().next()),
-                            _ -> new ArrayList<>())
+            these.forEach((block, set) -> parts
+                    .computeIfAbsent(into.coarseBlockOf(block), _ -> new ArrayList<>())
                     .add(set));
         }
 
@@ -621,7 +622,9 @@ public final class AdmissibleValues<A> {
                             Set<Sameness.Block<A>> gaveUp) {
             Sameness<A> heldAsOne = sameness().meet(other.sameness());
             return new Met<>(product.narrowedWith(other.product, heldAsOne, sets, gaveUp),
-                    apart.and(other.apart).filedIn(heldAsOne));
+                    apart.filedIn(Refinement.of(sameness(), heldAsOne))
+                            .and(other.apart.filedIn(
+                                    Refinement.of(other.sameness(), heldAsOne))));
         }
 
         /** What a conjunction of two alternatives came to, before anything asks whether a value
@@ -1070,10 +1073,15 @@ public final class AdmissibleValues<A> {
         // filed under a block is said in the answer's own before it is built.
         Sameness<A> heldAsOne = held instanceof Held.Alternatives<A> it
                 ? it.commonSameness() : Sameness.discrete();
+        // Carried only where something stands. A reading left holding nothing is a product over no
+        // blocks at all, so the described blocks are inside none of them and there is nowhere for a
+        // promise to be about.
         Map<Sameness.Block<A>, AdmittedPlan> promising = new LinkedHashMap<>();
-        of.guaranteed().forEach((block, plan) -> promising.merge(
-                heldAsOne.blockOf(block.members().iterator().next()), plan,
-                (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
+        if (held instanceof Held.Alternatives<A>) {
+            Refinement<A> into = Refinement.of(of.sameness(), heldAsOne);
+            of.guaranteed().forEach((block, plan) -> promising.merge(into.coarseBlockOf(block),
+                    plan, (one, other) -> AdmittedPlan.meeting(List.of(one, other))));
+        }
         return Realized.of(new Outcome<>(new AdmissibleValues<>(new Parts<>(held, perPosition,
                 gaveUp.beside(of.standing()),
                 promised(promising, by), promised(of.defaultGuaranteed(), by.elsewhere()),
@@ -1119,11 +1127,12 @@ public final class AdmissibleValues<A> {
         Set<Sameness.Block<A>> named = new LinkedHashSet<>();
         standing.forEach(box ->
                 box.positions().forEach(position -> named.add(common.blockOf(position))));
+        Map<PlannedHeld.Alternative<A>, Refinement<A>> into = new LinkedHashMap<>();
+        standing.forEach(box -> into.put(box, Refinement.of(common, box.sameness())));
         Map<Sameness.Block<A>, ValueSet> across = new LinkedHashMap<>();
         for (Sameness.Block<A> block : named) {
-            A member = block.members().iterator().next();
-            AdmittedPlan plan = AdmittedPlan.joining(
-                    standing.stream().map(box -> box.get(member)).toList());
+            AdmittedPlan plan = AdmittedPlan.joining(standing.stream()
+                    .map(box -> box.get(into.get(box).coarseBlockOf(block))).toList());
             Realization made = by.realizer(block).of(plan);
             gaveUp.note(block, made);
             if (!made.upperBound().isAny()) {
@@ -1561,7 +1570,12 @@ public final class AdmissibleValues<A> {
                 // conjunction never has to say it is not one. Two of them met is one — a value
                 // taken from each position of both stands in both readings — and nothing promised
                 // is one for want of anything to promise.
-                apart ? Map.of() : guaranteedBy(this, other, heldAsOne, sets::meetPromised),
+                //
+                // And nothing where nothing stands, which is not the same as promising nothing at
+                // the blocks: a conjunction holding nothing is a product over no blocks at all,
+                // and neither side's own are inside any of them.
+                apart || !(both instanceof Held.Alternatives<A>) ? Map.of()
+                        : guaranteedBy(this, other, heldAsOne, sets),
                 // Nothing is recorded where this could not be built exactly, because what comes
                 // back is nothing promised — and a reader short of a guarantee has been told no
                 // more than the truth. The reasons below are about {@link #at}, which is an upper
@@ -1713,10 +1727,10 @@ public final class AdmissibleValues<A> {
      * What both sides guarantee, at every block either of them holds a guarantee for, each side
      * missing one standing at its own default.
      *
-     * <p>Said in {@code blocks}, which is the coordinate the answer being built is in. Each side
-     * is asked what it promises there, and a side whose own blocks are coarser or finer answers
-     * all the same: a promise about the value two positions share is a promise about that value
-     * however the side that made it was holding those positions.
+     * <p>Said in the conjunction's own blocks, which is the coordinate the answer being built is
+     * in and is coarser than either side's. What a side promises there is what it promises at every
+     * one of its own blocks the positions fall in ({@link #promisedFor}), because they are one
+     * value here and a value standing in this reading stands in that side.
      *
      * <p>The keys are the footprint as well as the values — the blocks a rule of these readings
      * reached — so a block either side named is a key here whatever the promise came to. Dropped for coming to the default, which blocks a rule reached would turn
@@ -1724,22 +1738,39 @@ public final class AdmissibleValues<A> {
      */
     private static <A> Map<Sameness.Block<A>, ValueSet> guaranteedBy(
             AdmissibleValues<A> these, AdmissibleValues<A> those, Sameness<A> heldAsOne,
-            Allowance.Composing<A> both) {
+            Allowance<A> sets) {
+        Refinement<A> mine = Refinement.of(these.sameness(), heldAsOne);
+        Refinement<A> theirs = Refinement.of(those.sameness(), heldAsOne);
         Set<Sameness.Block<A>> named = mapped(these.guaranteed().keySet(), heldAsOne);
         named.addAll(mapped(those.guaranteed().keySet(), heldAsOne));
         Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
         // What could not be built exactly comes back as nothing promised, which is what a promise
         // widens to. Nothing is recorded: see {@link #meet}.
-        named.forEach(each -> out.put(each,
-                both.of(each, these.promisedFor(each), those.promisedFor(each)).set()));
+        named.forEach(each -> out.put(each, sets.meetPromised(each,
+                these.promisedFor(each, mine, sets), those.promisedFor(each, theirs, sets)).set()));
         return out;
     }
 
-    /** What this reading promises the value {@code block} stands for, whichever blocks of its own
-     *  it holds those positions in. */
-    private ValueSet promisedFor(Sameness.Block<A> block) {
-        return guaranteed().getOrDefault(blockOf(block.members().iterator().next()),
-                defaultGuaranteed());
+    /**
+     * What this reading promises the value {@code block} stands for, {@code block} being a block of
+     * a relation that holds as one everything this one does.
+     *
+     * <p>What it promises at every one of its own blocks those positions fall in, met. Read off one
+     * of them, the answer would be about the positions that block happens to hold: a reading
+     * stating {@code p == q} and promising {@code S} there, asked about a conjunction's
+     * {@code p == q == r}, promises {@code S} of {@code p} and {@code q} and its default of
+     * {@code r} — and a value at the three of them is a value at each, so what is promised is what
+     * both of those say and not whichever was reached first.
+     *
+     * <p>Met under the allowance, because these are sets and putting two of them together is
+     * building a third — and handed over at once rather than folded, so what it costs is not the
+     * order this reading's positions were walked in ({@link Allowance#meetingPromised}).
+     */
+    private ValueSet promisedFor(Sameness.Block<A> block, Refinement<A> into, Allowance<A> sets) {
+        List<ValueSet> mine = new ArrayList<>();
+        into.fineBlocksWithin(block)
+                .forEach(each -> mine.add(guaranteed().getOrDefault(each, defaultGuaranteed())));
+        return mine.size() == 1 ? mine.getFirst() : sets.meetingPromised(block, mine).set();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1728,9 +1728,15 @@ public final class AdmissibleValues<A> {
      * missing one standing at its own default.
      *
      * <p>Said in the conjunction's own blocks, which is the coordinate the answer being built is
-     * in and is coarser than either side's. What a side promises there is what it promises at every
-     * one of its own blocks the positions fall in ({@link #promisedFor}), because they are one
-     * value here and a value standing in this reading stands in that side.
+     * in and is coarser than either side's. One of those blocks covers several of a side's own, and
+     * what that side promises there is what it promises at every one of them — a value at the block
+     * is a value at each of the positions in it, and each of those stands in that side.
+     *
+     * <p><b>So what a block is promised is one meet over every promise either side made about it,
+     * and one thing built.</b> The promises are gathered ({@link #promisesFor}) and the set is made
+     * where they are all in hand: a side's own met first would build a set nobody asked about, and
+     * what the block cost would be how many blocks each side happened to hold its positions in
+     * rather than what was asked of it.
      *
      * <p>The keys are the footprint as well as the values — the blocks a rule of these readings
      * reached — so a block either side named is a key here whatever the promise came to. Dropped for coming to the default, which blocks a rule reached would turn
@@ -1746,36 +1752,33 @@ public final class AdmissibleValues<A> {
         Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
         // What could not be built exactly comes back as nothing promised, which is what a promise
         // widens to. Nothing is recorded: see {@link #meet}.
-        named.forEach(each -> out.put(each, sets.meetPromised(each,
-                these.promisedFor(each, mine, sets), those.promisedFor(each, theirs, sets)).set()));
+        named.forEach(each -> {
+            List<ValueSet> promised = these.promisesFor(each, mine);
+            promised.addAll(those.promisesFor(each, theirs));
+            out.put(each, sets.meetingPromised(each, promised).set());
+        });
         return out;
     }
 
     /**
-     * What this reading promises the value {@code block} stands for, {@code block} being a block of
-     * a relation that holds as one everything this one does.
+     * Every promise this reading made about the value {@code block} stands for, {@code block} being
+     * a block of a relation that holds as one everything this one does.
      *
-     * <p>What it promises at every one of its own blocks those positions fall in, met. Read off one
-     * of them, the answer would be about the positions that block happens to hold: a reading
-     * stating {@code p == q} and promising {@code S} there, asked about a conjunction's
-     * {@code p == q == r}, promises {@code S} of {@code p} and {@code q} and its default of
-     * {@code r} — and a value at the three of them is a value at each, so what is promised is what
-     * both of those say and not whichever was reached first.
+     * <p>One per block of its own those positions fall in, since a value at {@code block} is a
+     * value at each of them: a reading stating {@code p == q} and promising {@code S} there, asked
+     * about a conjunction's {@code p == q == r}, promises {@code S} of {@code p} and {@code q} and
+     * its default of {@code r}, and what stands at the three is what both of those admit.
      *
-     * <p>Met under the allowance, because these are sets and putting two of them together is
-     * building a third — and handed over at once rather than folded, so what it costs is not the
-     * order this reading's positions were walked in ({@link Allowance#meetingPromised}).
+     * <p><b>The promises and not what they come to.</b> They are met with the other side's, and a
+     * set built here would be one nobody asked for — charged to the block, and then charged again
+     * where the answer that was wanted is built. What a block is promised is one question, so it is
+     * one thing built ({@link Allowance#meetingPromised}).
      */
-    private ValueSet promisedFor(Sameness.Block<A> block, Refinement<A> into, Allowance<A> sets) {
-        Set<Sameness.Block<A>> own = into.fineBlocksWithin(block);
-        // Where the coarser relation states no equality this one does not, the block is one of
-        // this reading's own and what it promises there is the whole answer.
-        if (own.size() == 1) {
-            return guaranteed().getOrDefault(own.iterator().next(), defaultGuaranteed());
-        }
-        List<ValueSet> mine = new ArrayList<>();
-        own.forEach(each -> mine.add(guaranteed().getOrDefault(each, defaultGuaranteed())));
-        return sets.meetingPromised(block, mine).set();
+    private List<ValueSet> promisesFor(Sameness.Block<A> block, Refinement<A> into) {
+        List<ValueSet> out = new ArrayList<>();
+        into.fineBlocksWithin(block)
+                .forEach(each -> out.add(guaranteed().getOrDefault(each, defaultGuaranteed())));
+        return out;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1767,10 +1767,15 @@ public final class AdmissibleValues<A> {
      * order this reading's positions were walked in ({@link Allowance#meetingPromised}).
      */
     private ValueSet promisedFor(Sameness.Block<A> block, Refinement<A> into, Allowance<A> sets) {
+        Set<Sameness.Block<A>> own = into.fineBlocksWithin(block);
+        // Where the coarser relation states no equality this one does not, the block is one of
+        // this reading's own and what it promises there is the whole answer.
+        if (own.size() == 1) {
+            return guaranteed().getOrDefault(own.iterator().next(), defaultGuaranteed());
+        }
         List<ValueSet> mine = new ArrayList<>();
-        into.fineBlocksWithin(block)
-                .forEach(each -> mine.add(guaranteed().getOrDefault(each, defaultGuaranteed())));
-        return mine.size() == 1 ? mine.getFirst() : sets.meetingPromised(block, mine).set();
+        own.forEach(each -> mine.add(guaranteed().getOrDefault(each, defaultGuaranteed())));
+        return sets.meetingPromised(block, mine).set();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
@@ -235,6 +235,19 @@ public final class Allowance<A> {
         return promised(meet(block, one, other));
     }
 
+    /**
+     * The same, of several at once, which is what one reading promises a block a coarser relation
+     * holds as one value.
+     *
+     * <p>{@link #meeting} for a promise, and n-ary for its reason. A block of a coarser relation
+     * covers several of this reading's own, and what it promises there is what it promises at every
+     * one of them — so they are handed over together and cost one number, where a caller folding
+     * them two at a time would pay for the order it happened to walk that block's positions in.
+     */
+    public Composed meetingPromised(Sameness.Block<A> block, List<ValueSet> these) {
+        return promised(meeting(block, these));
+    }
+
     private static Composed promised(Composed made) {
         return made.gaveUp() ? new Composed(ValueSet.NONE, true) : made;
     }

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -274,22 +274,26 @@ public final class Apartness<A> {
     }
 
     /**
-     * Both alternatives' denials, filed under the blocks {@code heldAsOne} holds.
+     * These denials, filed under the blocks the coarser relation of {@code into} holds.
      *
-     * <p>The union pushed forward and not the union. A conjunction leaves a coarser relation — an
-     * equality read beside these puts two blocks together — so a pair stated of the blocks either
-     * side was a product over is a pair of whatever those blocks are part of here. Left where they
-     * were, a denial would name a block this alternative does not answer in, which is what
+     * <p>Pushed forward and not left. A conjunction leaves a coarser relation — an equality read
+     * beside these puts two blocks together — so a pair stated of the blocks this alternative was
+     * a product over is a pair of whatever those blocks are part of there. Left where they were, a
+     * denial would name a block the conjunction does not answer in, which is what
      * {@link Sameness#filing} refuses.
+     *
+     * <p>Of one alternative's denials and not of two put together, because the step is read
+     * against the relation the denials were stated in and two alternatives state two. Both sides'
+     * pairs are one relation once each of them is filed here.
      *
      * <p>A pair both of whose ends land on one block is kept and not dropped. What it says is that
      * a value differs from itself, which nothing satisfies — read as a pair to discard, the
      * alternative would go on standing and the rules that emptied it would be gone.
      */
-    public Apartness<A> filedIn(Sameness<A> heldAsOne) {
+    public Apartness<A> filedIn(Refinement<A> into) {
         Set<Edge<A>> out = new LinkedHashSet<>();
         for (Edge<A> edge : edges) {
-            out.add(new Edge<>(under(edge.one(), heldAsOne), under(edge.other(), heldAsOne)));
+            out.add(new Edge<>(into.coarseBlockOf(edge.one()), into.coarseBlockOf(edge.other())));
         }
         return new Apartness<>(out);
     }
@@ -393,12 +397,6 @@ public final class Apartness<A> {
         Set<Edge<B>> out = new LinkedHashSet<>();
         edges.forEach(edge -> out.add(edge.renamed(naming)));
         return new Apartness<>(out);
-    }
-
-    /** The block {@code block} is part of here, asked of any of its positions: a block is inside
-     *  one block of a coarser relation, so which member is asked does not decide the answer. */
-    private static <A> Sameness.Block<A> under(Sameness.Block<A> block, Sameness<A> heldAsOne) {
-        return heldAsOne.blockOf(block.members().iterator().next());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -119,7 +119,9 @@ sealed interface PlannedHeld<A> {
         Alternative<A> meet(Alternative<A> other) {
             Sameness<A> heldAsOne = sameness().meet(other.sameness());
             return new Alternative<>(product.meet(other.product, heldAsOne),
-                    apart.and(other.apart).filedIn(heldAsOne));
+                    apart.filedIn(Refinement.of(sameness(), heldAsOne))
+                            .and(other.apart.filedIn(
+                                    Refinement.of(other.sameness(), heldAsOne))));
         }
 
         @Override
@@ -194,8 +196,8 @@ sealed interface PlannedHeld<A> {
          */
         Box<A> meet(Box<A> other, Sameness<A> heldAsOne) {
             Map<Sameness.Block<A>, List<AdmittedPlan>> parts = new LinkedHashMap<>();
-            gathering(at, heldAsOne, parts);
-            gathering(other.at, heldAsOne, parts);
+            gathering(at, Refinement.of(sameness(), heldAsOne), parts);
+            gathering(other.at, Refinement.of(other.sameness(), heldAsOne), parts);
             Map<Sameness.Block<A>, AdmittedPlan> out = new LinkedHashMap<>();
             parts.forEach((block, these) -> out.put(block,
                     these.size() == 1 ? these.getFirst() : AdmittedPlan.meeting(these)));
@@ -203,11 +205,10 @@ sealed interface PlannedHeld<A> {
         }
 
         private static <A> void gathering(Map<Sameness.Block<A>, AdmittedPlan> these,
-                                          Sameness<A> heldAsOne,
+                                          Refinement<A> into,
                                           Map<Sameness.Block<A>, List<AdmittedPlan>> parts) {
-            these.forEach((block, plan) -> parts.computeIfAbsent(
-                            heldAsOne.blockOf(block.members().iterator().next()),
-                            _ -> new ArrayList<>())
+            these.forEach((block, plan) -> parts
+                    .computeIfAbsent(into.coarseBlockOf(block), _ -> new ArrayList<>())
                     .add(plan));
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -580,7 +580,7 @@ public sealed interface PlannedValues<A> {
      * guarantee for — see {@link AdmissibleValues#guaranteedBy}.
      *
      * <p>A conjunction leaves a coarser relation, so a block here covers several of a side's own
-     * and what that side promises is what it promises at all of them ({@link #promisedAcross}).
+     * and what that side promises is what it promises at all of them ({@link #promisesFor}).
      */
     private static <A> Map<Sameness.Block<A>, AdmittedPlan> guaranteedMet(
             Settled<A> here, Settled<A> there, Sameness<A> heldAsOne) {

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -587,9 +587,11 @@ public sealed interface PlannedValues<A> {
         Refinement<A> mine = Refinement.of(here.sameness(), heldAsOne);
         Refinement<A> theirs = Refinement.of(there.sameness(), heldAsOne);
         Map<Sameness.Block<A>, AdmittedPlan> out = new LinkedHashMap<>();
-        named(here, there, heldAsOne).forEach(each -> out.put(each, AdmittedPlan.meeting(
-                List.of(promisedAcross(here, mine.fineBlocksWithin(each)),
-                        promisedAcross(there, theirs.fineBlocksWithin(each))))));
+        named(here, there, heldAsOne).forEach(each -> {
+            List<AdmittedPlan> promised = promisesFor(here, mine, each);
+            promised.addAll(promisesFor(there, theirs, each));
+            out.put(each, AdmittedPlan.meeting(promised));
+        });
         return out;
     }
 
@@ -626,18 +628,19 @@ public sealed interface PlannedValues<A> {
         return of.guaranteed().getOrDefault(own, of.defaultGuaranteed());
     }
 
-    /** What one reading promises at all of {@code own} at once, which is a description and costs
-     *  nothing to say. Handed over together rather than folded, so what it comes to does not
-     *  follow the order the blocks were walked in. */
-    private static <A> AdmittedPlan promisedAcross(Settled<A> of, Set<Sameness.Block<A>> own) {
-        // Where the coarser relation states no equality this one does not, the block is one of
-        // this reading's own and what it promises there is the whole answer.
-        if (own.size() == 1) {
-            return promisedAt(of, own.iterator().next());
-        }
-        List<AdmittedPlan> these = new ArrayList<>();
-        own.forEach(each -> these.add(promisedAt(of, each)));
-        return AdmittedPlan.meeting(these);
+    /**
+     * Every promise one reading made about the value {@code block} stands for — see
+     * {@link AdmissibleValues#promisesFor}, whose reasoning this is.
+     *
+     * <p>The promises and not what they come to, though a description costs nothing to say. What a
+     * block is promised is one meet over both sides, and one written here would be a bracket the
+     * meet below has to be relied on to take out again.
+     */
+    private static <A> List<AdmittedPlan> promisesFor(Settled<A> of, Refinement<A> into,
+                                                      Sameness.Block<A> block) {
+        List<AdmittedPlan> out = new ArrayList<>();
+        into.fineBlocksWithin(block).forEach(each -> out.add(promisedAt(of, each)));
+        return out;
     }
 
     /** What each position holds across the alternatives, which a description makes free. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -1,5 +1,6 @@
 package souther.compiler.values;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -527,7 +528,9 @@ public sealed interface PlannedValues<A> {
         return new Settled<>(new Settled.Parts<>(both,
                 narrowed(here.perPosition(), there.perPosition()),
                 here.standing().and(there.standing()),
-                apart ? Map.of() : guaranteedBy(here, there, heldAsOne, true),
+                // And nothing where nothing stands — see {@link AdmissibleValues#meet}.
+                apart || !(both instanceof PlannedHeld.Alternatives<A>) ? Map.of()
+                        : guaranteedMet(here, there, heldAsOne),
                 apart ? AdmittedPlan.NONE
                         : AdmittedPlan.meeting(List.of(here.defaultGuaranteed(),
                                 there.defaultGuaranteed())),
@@ -572,25 +575,64 @@ public sealed interface PlannedValues<A> {
         return out;
     }
 
-    /** What both sides guarantee, at every block either holds a guarantee for, each side
-     *  missing one standing at its own default — see {@link AdmissibleValues#guaranteedBy}. */
-    private static <A> Map<Sameness.Block<A>, AdmittedPlan> guaranteedBy(
-            Settled<A> here, Settled<A> there, Sameness<A> heldAsOne, boolean met) {
-        Set<Sameness.Block<A>> named = mapped(here.guaranteed().keySet(), heldAsOne);
-        named.addAll(mapped(there.guaranteed().keySet(), heldAsOne));
+    /**
+     * What both sides guarantee where the two are stated together, at every block either holds a
+     * guarantee for — see {@link AdmissibleValues#guaranteedBy}.
+     *
+     * <p>A conjunction leaves a coarser relation, so a block here covers several of a side's own
+     * and what that side promises is what it promises at all of them ({@link #promisedAcross}).
+     */
+    private static <A> Map<Sameness.Block<A>, AdmittedPlan> guaranteedMet(
+            Settled<A> here, Settled<A> there, Sameness<A> heldAsOne) {
+        Refinement<A> mine = Refinement.of(here.sameness(), heldAsOne);
+        Refinement<A> theirs = Refinement.of(there.sameness(), heldAsOne);
         Map<Sameness.Block<A>, AdmittedPlan> out = new LinkedHashMap<>();
-        named.forEach(each -> {
-            List<AdmittedPlan> two = List.of(promisedFor(here, each), promisedFor(there, each));
-            out.put(each, met ? AdmittedPlan.meeting(two) : AdmittedPlan.joining(two));
-        });
+        named(here, there, heldAsOne).forEach(each -> out.put(each, AdmittedPlan.meeting(
+                List.of(promisedAcross(here, mine.fineBlocksWithin(each)),
+                        promisedAcross(there, theirs.fineBlocksWithin(each))))));
         return out;
     }
 
-    /** What one reading promises the value {@code block} stands for, whichever blocks of its own
-     *  it holds those positions in. */
-    private static <A> AdmittedPlan promisedFor(Settled<A> of, Sameness.Block<A> block) {
-        return of.guaranteed().getOrDefault(
-                of.sameness().blockOf(block.members().iterator().next()), of.defaultGuaranteed());
+    /**
+     * What either side guarantees where one of the two holds, at every block either holds a
+     * guarantee for.
+     *
+     * <p>A choice leaves a finer relation, so a block here is inside one block of a side's own and
+     * what that side promises there is promised of it: whoever satisfies that alternative holds a
+     * value from it at every position the block covers.
+     */
+    private static <A> Map<Sameness.Block<A>, AdmittedPlan> guaranteedJoined(
+            Settled<A> here, Settled<A> there, Sameness<A> heldAsOne) {
+        Refinement<A> mine = Refinement.of(heldAsOne, here.sameness());
+        Refinement<A> theirs = Refinement.of(heldAsOne, there.sameness());
+        Map<Sameness.Block<A>, AdmittedPlan> out = new LinkedHashMap<>();
+        named(here, there, heldAsOne).forEach(each -> out.put(each, AdmittedPlan.joining(
+                List.of(promisedAt(here, mine.coarseBlockOf(each)),
+                        promisedAt(there, theirs.coarseBlockOf(each))))));
+        return out;
+    }
+
+    /** The blocks of the relation being answered in that either side holds a guarantee for. */
+    private static <A> Set<Sameness.Block<A>> named(Settled<A> here, Settled<A> there,
+                                                    Sameness<A> heldAsOne) {
+        Set<Sameness.Block<A>> out = mapped(here.guaranteed().keySet(), heldAsOne);
+        out.addAll(mapped(there.guaranteed().keySet(), heldAsOne));
+        return out;
+    }
+
+    /** What one reading promises at one of its own blocks, which is its default where it promised
+     *  nothing there. */
+    private static <A> AdmittedPlan promisedAt(Settled<A> of, Sameness.Block<A> own) {
+        return of.guaranteed().getOrDefault(own, of.defaultGuaranteed());
+    }
+
+    /** What one reading promises at all of {@code own} at once, which is a description and costs
+     *  nothing to say. Handed over together rather than folded, so what it comes to does not
+     *  follow the order the blocks were walked in. */
+    private static <A> AdmittedPlan promisedAcross(Settled<A> of, Set<Sameness.Block<A>> own) {
+        List<AdmittedPlan> these = new ArrayList<>();
+        own.forEach(each -> these.add(promisedAt(of, each)));
+        return AdmittedPlan.meeting(these);
     }
 
     /** What each position holds across the alternatives, which a description makes free. */
@@ -609,6 +651,7 @@ public sealed interface PlannedValues<A> {
                     boxes.boxes().stream().map(box -> box.get(atom)).toList());
         };
     }
+
 
     /**
      * Either reading holding, the alternatives merged back into one product.
@@ -709,7 +752,7 @@ public sealed interface PlannedValues<A> {
         PlannedHeld<A> held = apart ? apart(here, there) : merged(here, there);
         Sameness<A> heldAsOne = held instanceof PlannedHeld.Alternatives<A> it
                 ? it.commonSameness() : Sameness.discrete();
-        Map<Sameness.Block<A>, AdmittedPlan> covered = guaranteedBy(here, there, heldAsOne, false);
+        Map<Sameness.Block<A>, AdmittedPlan> covered = guaranteedJoined(here, there, heldAsOne);
         AdmittedPlan coveredElsewhere = AdmittedPlan.joining(
                 List.of(here.defaultGuaranteed(), there.defaultGuaranteed()));
         // What an alternative nothing could read left open is not said here — see
@@ -758,9 +801,10 @@ public sealed interface PlannedValues<A> {
         Map<Sameness.Block<A>, AdmittedPlan> out = new LinkedHashMap<>();
         Set<Sameness.Block<A>> named = new LinkedHashSet<>();
         adopted(here).forEach(atom -> named.add(heldAsOne.blockOf(atom)));
+        Reached<A> mine = Reached.of(here, heldAsOne);
+        Reached<A> yours = Reached.of(there, heldAsOne);
         for (Sameness.Block<A> block : named) {
-            A member = block.members().iterator().next();
-            AdmittedPlan theirs = across(there, member);
+            AdmittedPlan theirs = yours.at(block);
             // A block one side says nothing about is one the choice says nothing about, since a
             // value satisfying that side may hold anything there. The block is kept where it is
             // more than one position: what those positions being one value says stands whatever
@@ -771,7 +815,7 @@ public sealed interface PlannedValues<A> {
                 }
                 continue;
             }
-            out.put(block, AdmittedPlan.joining(List.of(across(here, member), theirs)));
+            out.put(block, AdmittedPlan.joining(List.of(mine.at(block), theirs)));
         }
         // And what every alternative of both states to differ, which the choice states as well.
         // Merging a union into the smallest product containing it widens what the blocks hold; it

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -630,6 +630,11 @@ public sealed interface PlannedValues<A> {
      *  nothing to say. Handed over together rather than folded, so what it comes to does not
      *  follow the order the blocks were walked in. */
     private static <A> AdmittedPlan promisedAcross(Settled<A> of, Set<Sameness.Block<A>> own) {
+        // Where the coarser relation states no equality this one does not, the block is one of
+        // this reading's own and what it promises there is the whole answer.
+        if (own.size() == 1) {
+            return promisedAt(of, own.iterator().next());
+        }
         List<AdmittedPlan> these = new ArrayList<>();
         own.forEach(each -> these.add(promisedAt(of, each)));
         return AdmittedPlan.meeting(these);

--- a/souther-compiler/src/main/java/souther/compiler/values/Reached.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Reached.java
@@ -24,10 +24,11 @@ record Reached<A>(PlannedValues.Settled<A> of,
 
     /** {@code of} read against {@code finer}, whose blocks the asks below are in. */
     static <A> Reached<A> of(PlannedValues.Settled<A> of, Sameness<A> finer) {
-        Map<PlannedHeld.Alternative<A>, Refinement<A>> out = new LinkedHashMap<>();
-        if (of.held() instanceof PlannedHeld.Alternatives<A> boxes) {
-            boxes.boxes().forEach(box -> out.put(box, Refinement.of(finer, box.sameness())));
+        if (!(of.held() instanceof PlannedHeld.Alternatives<A> boxes)) {
+            return new Reached<>(of, Map.of());
         }
+        Map<PlannedHeld.Alternative<A>, Refinement<A>> out = new LinkedHashMap<>();
+        boxes.boxes().forEach(box -> out.put(box, Refinement.of(finer, box.sameness())));
         return new Reached<>(of, out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Reached.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Reached.java
@@ -13,10 +13,6 @@ import java.util.Map;
  * alternative is worked out once and kept, because it is taken again for every block the choice
  * names.
  *
- * <p>Read through a position before, one taken out of the block. Which is this same step where the
- * block is one an alternative holds whole, and a different question where it is not — and nothing
- * in the spelling said which of the two it was.
- *
  * @param <A> what a position is called
  */
 record Reached<A>(PlannedValues.Settled<A> of,

--- a/souther-compiler/src/main/java/souther/compiler/values/Reached.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Reached.java
@@ -1,0 +1,47 @@
+package souther.compiler.values;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * One reading read against a relation finer than its own, so that a block of that relation reaches
+ * what the reading describes.
+ *
+ * <p>What a choice between two readings is worked out in is finer than either of them — each side's
+ * equalities hold only where both state them — so a block of it is inside one block of every
+ * alternative, and what an alternative describes there is described of it. The step to each
+ * alternative is worked out once and kept, because it is taken again for every block the choice
+ * names.
+ *
+ * <p>Read through a position before, one taken out of the block. Which is this same step where the
+ * block is one an alternative holds whole, and a different question where it is not — and nothing
+ * in the spelling said which of the two it was.
+ *
+ * @param <A> what a position is called
+ */
+record Reached<A>(PlannedValues.Settled<A> of,
+                  Map<PlannedHeld.Alternative<A>, Refinement<A>> alternatives) {
+
+    /** {@code of} read against {@code finer}, whose blocks the asks below are in. */
+    static <A> Reached<A> of(PlannedValues.Settled<A> of, Sameness<A> finer) {
+        Map<PlannedHeld.Alternative<A>, Refinement<A>> out = new LinkedHashMap<>();
+        if (of.held() instanceof PlannedHeld.Alternatives<A> boxes) {
+            boxes.boxes().forEach(box -> out.put(box, Refinement.of(finer, box.sameness())));
+        }
+        return new Reached<>(of, out);
+    }
+
+    /** What this reading describes at {@code block}, every one of its alternatives being asked at
+     *  the block of its own that holds those positions. */
+    AdmittedPlan at(Sameness.Block<A> block) {
+        return switch (of.held()) {
+            // A reading with no alternatives holds its positions apart, so a block of anything
+            // finer than it is one position — and the meet is over that one, said this way rather
+            // than by taking it out.
+            case PlannedHeld.Nothing<A> _ -> AdmittedPlan.meeting(block.members().stream()
+                    .map(each -> of.perPosition().getOrDefault(each, AdmittedPlan.ANY)).toList());
+            case PlannedHeld.Alternatives<A> boxes -> AdmittedPlan.joining(boxes.boxes().stream()
+                    .map(box -> box.get(alternatives.get(box).coarseBlockOf(block))).toList());
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
@@ -13,17 +13,16 @@ import java.util.Set;
  * one block — a total function up. A block of the coarser relation is made of several of the finer,
  * so what the finer says about it is what it says about every one of them — a set, and not a block.
  *
- * <p><b>Which is why the two are named apart.</b> Both were written as a member handed to
- * {@link Sameness#blockOf}: one position taken out of the block, the relation asked about that
- * one. Up, that is an answer any member gives and the pick is only a pick. Down, the members answer
- * differently and the pick decides — so one spelling stood for a lookup that is warranted and for
- * one that is not, and which of the two a line was doing could not be read off it. Named apart, a
- * caller asking down cannot spell a block coming back.
+ * <p><b>Named apart, because a caller may take one of the steps and not the other.</b> Up is a
+ * block; down is a set, and no caller of it can spell a block coming back. A pair of names that
+ * differed only in which relation was asked would let a caller holding the wrong end read the
+ * positions it happened to be given as though they were one value.
  *
  * <p>The warrant is here and not at each ask. Every block of the finer relation is walked when this
  * is made, and one whose positions the coarser relation holds in more than one block is refused —
  * so holding one of these is holding the fact that {@link #coarseBlockOf} answers, rather than a
- * rule each of its callers keeps.
+ * rule each of its callers keeps. Each of the two asks for its own end besides: a block neither
+ * relation has is a set of positions this says nothing about.
  *
  * @param <A> what a position is called
  */
@@ -84,12 +83,25 @@ public final class Refinement<A> {
     /**
      * The one block of the coarser relation holding every position of {@code block}.
      *
-     * <p>Total over the blocks the finer relation has, which is what making this proved. A block
-     * it does not have is one position on its own, and one position is in one block of anything.
+     * <p>Total over the blocks the finer relation has, and over those only. What was proved when
+     * this was made is where each of those lands; a set of positions the finer relation does not
+     * hold together is outside it, and an answer for one would be worked out from whichever
+     * position was read first — which is the question this type exists to stop being asked.
+     *
+     * <p>A block of one position is a block of every relation that holds it with nothing, so it
+     * lands without anything having been written down for it.
      */
     public Sameness.Block<A> coarseBlockOf(Sameness.Block<A> block) {
         Sameness.Block<A> there = up.get(block);
-        return there != null ? there : coarser.blockOf(block.members().iterator().next());
+        if (there != null) {
+            return there;
+        }
+        if (!finer.has(block)) {
+            throw new IllegalArgumentException("the relation these positions are read from does"
+                    + " not hold them as one value: " + block + ", which it holds as "
+                    + InOneOrder.of(finer.holding(block)));
+        }
+        return coarser.blockOf(block.members().iterator().next());
     }
 
     /**
@@ -100,8 +112,16 @@ public final class Refinement<A> {
      * all three as one value, and a side that stated only the first holds them in two blocks. What
      * that side says about the three is what it says about both of those blocks together, and
      * asking one of them would be answering about the positions it happens to hold.
+     *
+     * <p>Of the blocks the coarser relation has, and of those only. Any other set of positions has
+     * blocks under it too, and they would be an answer about a value nothing holds together.
      */
     public Set<Sameness.Block<A>> fineBlocksWithin(Sameness.Block<A> block) {
+        if (!coarser.has(block)) {
+            throw new IllegalArgumentException("the relation these positions are read against does"
+                    + " not hold them as one value: " + block + ", which it holds as "
+                    + InOneOrder.of(coarser.holding(block)));
+        }
         return finer.holding(block);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
@@ -40,7 +40,7 @@ public final class Refinement<A> {
                        Map<Sameness.Block<A>, Sameness.Block<A>> up) {
         this.finer = finer;
         this.coarser = coarser;
-        this.up = Collections.unmodifiableMap(up);
+        this.up = up;
     }
 
     /**
@@ -53,6 +53,12 @@ public final class Refinement<A> {
      * holding them the other way round is asking {@link #fineBlocksWithin}.
      */
     public static <A> Refinement<A> of(Sameness<A> finer, Sameness<A> coarser) {
+        // A relation holding no two positions as one has no block to walk and none to write down:
+        // every position is its own block, and one position is inside one block of anything. Which
+        // is what almost every step taken is between, so it is answered before anything is built.
+        if (finer.isDiscrete()) {
+            return new Refinement<>(finer, coarser, Map.of());
+        }
         Map<Sameness.Block<A>, Sameness.Block<A>> up = new LinkedHashMap<>();
         for (Sameness.Block<A> block : finer.joined()) {
             Set<Sameness.Block<A>> there = coarser.holding(block);
@@ -67,7 +73,7 @@ public final class Refinement<A> {
             }
             up.put(block, there.iterator().next());
         }
-        return new Refinement<>(finer, coarser, up);
+        return new Refinement<>(finer, coarser, Collections.unmodifiableMap(up));
     }
 
     /** The relation the blocks below are read against. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refinement.java
@@ -1,0 +1,106 @@
+package souther.compiler.values;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * One relation holding as one everything a second one does, said as the way between their blocks.
+ *
+ * <p>Two questions are asked across that step and they are not the same question. A block of the
+ * finer relation is inside one block of the coarser, so what was said about it is said about that
+ * one block — a total function up. A block of the coarser relation is made of several of the finer,
+ * so what the finer says about it is what it says about every one of them — a set, and not a block.
+ *
+ * <p><b>Which is why the two are named apart.</b> Both were written as a member handed to
+ * {@link Sameness#blockOf}: one position taken out of the block, the relation asked about that
+ * one. Up, that is an answer any member gives and the pick is only a pick. Down, the members answer
+ * differently and the pick decides — so one spelling stood for a lookup that is warranted and for
+ * one that is not, and which of the two a line was doing could not be read off it. Named apart, a
+ * caller asking down cannot spell a block coming back.
+ *
+ * <p>The warrant is here and not at each ask. Every block of the finer relation is walked when this
+ * is made, and one whose positions the coarser relation holds in more than one block is refused —
+ * so holding one of these is holding the fact that {@link #coarseBlockOf} answers, rather than a
+ * rule each of its callers keeps.
+ *
+ * @param <A> what a position is called
+ */
+public final class Refinement<A> {
+
+    private final Sameness<A> finer;
+    private final Sameness<A> coarser;
+
+    /** Where each block of the finer relation lands, worked out where this is made. A block of one
+     *  is absent: it is inside one block of anything, so the coarser relation answers for it. */
+    private final Map<Sameness.Block<A>, Sameness.Block<A>> up;
+
+    private Refinement(Sameness<A> finer, Sameness<A> coarser,
+                       Map<Sameness.Block<A>, Sameness.Block<A>> up) {
+        this.finer = finer;
+        this.coarser = coarser;
+        this.up = Collections.unmodifiableMap(up);
+    }
+
+    /**
+     * {@code coarser} read as what it does to {@code finer}'s blocks.
+     *
+     * <p>Refused where it holds some block's positions apart, which is not a coarsening at all:
+     * {@code finer} states an equality {@code coarser} does not, and there is no block up there for
+     * what that equality named. A conjunction leaves a coarser relation and a choice a finer one,
+     * so the two are in hand this way round wherever one is asked of the other — and a caller
+     * holding them the other way round is asking {@link #fineBlocksWithin}.
+     */
+    public static <A> Refinement<A> of(Sameness<A> finer, Sameness<A> coarser) {
+        Map<Sameness.Block<A>, Sameness.Block<A>> up = new LinkedHashMap<>();
+        for (Sameness.Block<A> block : finer.joined()) {
+            Set<Sameness.Block<A>> there = coarser.holding(block);
+            if (there.size() != 1) {
+                // Said as where each position landed, because the blocks alone are two renderings
+                // beside each other and one block of those positions is written the same way.
+                Map<A, Sameness.Block<A>> each = new LinkedHashMap<>();
+                block.members().forEach(member -> each.put(member, coarser.blockOf(member)));
+                throw new IllegalArgumentException("positions held as one at " + block
+                        + " are held apart by the relation they are read against, which holds "
+                        + InOneOrder.of(each));
+            }
+            up.put(block, there.iterator().next());
+        }
+        return new Refinement<>(finer, coarser, up);
+    }
+
+    /** The relation the blocks below are read against. */
+    public Sameness<A> coarser() {
+        return coarser;
+    }
+
+    /**
+     * The one block of the coarser relation holding every position of {@code block}.
+     *
+     * <p>Total over the blocks the finer relation has, which is what making this proved. A block
+     * it does not have is one position on its own, and one position is in one block of anything.
+     */
+    public Sameness.Block<A> coarseBlockOf(Sameness.Block<A> block) {
+        Sameness.Block<A> there = up.get(block);
+        return there != null ? there : coarser.blockOf(block.members().iterator().next());
+    }
+
+    /**
+     * The blocks of the finer relation holding {@code block}'s positions.
+     *
+     * <p>More than one where the coarser relation states an equality the finer one does not, which
+     * is what a conjunction of two readings leaves: {@code p == q} met with {@code q == r} holds
+     * all three as one value, and a side that stated only the first holds them in two blocks. What
+     * that side says about the three is what it says about both of those blocks together, and
+     * asking one of them would be answering about the positions it happens to hold.
+     */
+    public Set<Sameness.Block<A>> fineBlocksWithin(Sameness.Block<A> block) {
+        return finer.holding(block);
+    }
+
+    @Override
+    public String toString() {
+        return finer + " read against " + coarser;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -3,7 +3,6 @@ package souther.compiler.values;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -115,14 +114,22 @@ public final class Sameness<A> {
     public final void filing(Set<Block<A>>... these) {
         for (Set<Block<A>> filed : these) {
             for (Block<A> block : filed) {
-                Block<A> here = blockOf(block.members().iterator().next());
-                if (!block.equals(here)) {
+                Set<Block<A>> here = holding(block);
+                if (here.size() != 1 || !here.contains(block)) {
                     throw new IllegalArgumentException("an answer at " + block
                             + " is filed under a coordinate this reading does not answer in,"
-                            + " which holds those positions as " + here);
+                            + " which holds those positions as " + InOneOrder.of(here));
                 }
             }
         }
+    }
+
+    /** The blocks this holds {@code block}'s positions in, which is one block where it holds them
+     *  as {@code block} does and several where it cuts them apart. */
+    Set<Block<A>> holding(Block<A> block) {
+        Set<Block<A>> out = new LinkedHashSet<>();
+        block.members().forEach(each -> out.add(blockOf(each)));
+        return out;
     }
 
     /**
@@ -246,9 +253,11 @@ public final class Sameness<A> {
         return ValueHash.ofWhatItHolds(Sameness.class, blocks.hashCode(), blocks.size());
     }
 
+    /** The blocks written in one order whichever order they were made in — see
+     *  {@link InOneOrder}. */
     @Override
     public String toString() {
-        return joined().toString();
+        return InOneOrder.of(joined());
     }
 
     /**
@@ -259,12 +268,18 @@ public final class Sameness<A> {
      * coordinate: {@code p == q && q == r} and {@code q == r && p == q} name one block, hold one
      * set, and spend from one purse.
      *
-     * <p>Its members are read in the order they are spelled in, so that where their spellings tell
-     * them apart, what is written out of a reading — a proof naming the positions that must hold
-     * one value among them — does not read differently for the order the equalities behind it were
-     * written in. Where two of them are spelled alike it says nothing: those two keep the order
-     * they arrived in, which is the order it was there to keep out. Nothing is filed, compared or
-     * hashed under any of it.
+     * <p><b>A set, and no order over it.</b> Its members are held in whatever order they arrived
+     * in, and that order is a fact about how one block was built rather than about which block it
+     * is — two that are equal were built two ways. So nothing is filed, compared, hashed, chosen or
+     * written under it, and a reader wanting positions in an order takes one it has: a proof names
+     * them in the order the value declares them ({@code ProofOfEmptiness}), and a rendering puts
+     * the renderings in order ({@link InOneOrder}).
+     *
+     * <p>Ordered by their spellings before, so that a proof would not read differently for the
+     * order the equalities behind it were written in. What a spelling gives is an order over
+     * renderings, and putting the members in it made an order over positions — which two positions
+     * rendering alike leave in the order a closure reached them, and which the reader that owed the
+     * promise never read.
      */
     public static final class Block<A> {
 
@@ -295,19 +310,17 @@ public final class Sameness<A> {
             this.hash = ValueHash.ofWhatItHolds(Block.class, members.hashCode(), members.size());
         }
 
-        /**
-         * The block one position is on its own.
-         *
-         * <p>Built without ordering anything. One member is in one order, and the order below is
-         * what several of them are read in.
-         */
+        /** The block one position is on its own. */
         public static <A> Block<A> of(A position) {
             return new Block<>(Set.of(position));
         }
 
         /** The block these positions are held as one in. */
         public static <A> Block<A> of(Set<A> members) {
-            return new Block<>(ordered(members));
+            if (members.isEmpty()) {
+                throw new IllegalArgumentException("an answer is about at least one position");
+            }
+            return new Block<>(Collections.unmodifiableSet(new LinkedHashSet<>(members)));
         }
 
         /** The positions this answer is about. */
@@ -358,28 +371,11 @@ public final class Sameness<A> {
             return hash;
         }
 
+        /** The positions written in one order whichever order they are held in — see
+         *  {@link InOneOrder}. */
         @Override
         public String toString() {
-            return isOne() ? String.valueOf(members.iterator().next()) : members.toString();
-        }
-
-        /**
-         * The members in the order they are spelled in, which is the order a block reads them in.
-         *
-         * <p>How they are spelled is all a position of any kind can be ordered by here, since what
-         * a position is is the caller's. One of them is in one order already, which is what the
-         * block of a single position is built by.
-         */
-        private static <A> Set<A> ordered(Set<A> members) {
-            if (members.isEmpty()) {
-                throw new IllegalArgumentException("an answer is about at least one position");
-            }
-            if (members.size() == 1) {
-                return Set.of(members.iterator().next());
-            }
-            List<A> sorted = new ArrayList<>(members);
-            sorted.sort(Comparator.comparing(String::valueOf));
-            return Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
+            return isOne() ? String.valueOf(members.iterator().next()) : InOneOrder.of(members);
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -114,26 +114,39 @@ public final class Sameness<A> {
     public final void filing(Set<Block<A>>... these) {
         for (Set<Block<A>> filed : these) {
             for (Block<A> block : filed) {
-                // Asked of each position rather than of the blocks they land in. The two say the
-                // same thing — a block every position of it lands on is the block they are all in
-                // — and this one reads nothing but the map, where gathering the blocks first is a
-                // set built for every answer a reading files.
-                for (A member : block.members()) {
-                    if (!block.equals(blockOf(member))) {
-                        throw new IllegalArgumentException("an answer at " + block
-                                + " is filed under a coordinate this reading does not answer in,"
-                                + " which holds those positions as " + InOneOrder.of(holding(block)));
-                    }
+                if (!has(block)) {
+                    throw new IllegalArgumentException("an answer at " + block
+                            + " is filed under a coordinate this reading does not answer in,"
+                            + " which holds those positions as " + InOneOrder.of(holding(block)));
                 }
             }
         }
     }
 
+    /**
+     * Whether this is one of the blocks this relation has.
+     *
+     * <p>Asked of every position rather than of one, because one position of a block says which
+     * block it is on and says nothing about where the rest are. A block some of whose positions
+     * this holds elsewhere is not a block of it, and neither is one holding fewer positions than
+     * this holds together.
+     *
+     * <p>What a question about a block may be asked of. A relation answers about the blocks it
+     * has; asked about any other set of positions it has no answer, and one worked out from a
+     * position taken out of the set would be an answer about that position's block.
+     */
+    boolean has(Block<A> block) {
+        for (A member : block.members()) {
+            if (!block.equals(blockOf(member))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /** The blocks this holds {@code block}'s positions in, which is one block where it holds them
      *  as {@code block} does and several where it cuts them apart. */
     Set<Block<A>> holding(Block<A> block) {
-        // One position is in one block, so there is nothing to gather and nothing two of them
-        // could disagree about. Which is what nearly every block asked about is.
         if (block.isOne()) {
             return Set.of(blockOf(block.members().iterator().next()));
         }
@@ -285,11 +298,6 @@ public final class Sameness<A> {
      * them in the order the value declares them ({@code ProofOfEmptiness}), and a rendering puts
      * the renderings in order ({@link InOneOrder}).
      *
-     * <p>Ordered by their spellings before, so that a proof would not read differently for the
-     * order the equalities behind it were written in. What a spelling gives is an order over
-     * renderings, and putting the members in it made an order over positions — which two positions
-     * rendering alike leave in the order a closure reached them, and which the reader that owed the
-     * promise never read.
      */
     public static final class Block<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -114,11 +114,16 @@ public final class Sameness<A> {
     public final void filing(Set<Block<A>>... these) {
         for (Set<Block<A>> filed : these) {
             for (Block<A> block : filed) {
-                Set<Block<A>> here = holding(block);
-                if (here.size() != 1 || !here.contains(block)) {
-                    throw new IllegalArgumentException("an answer at " + block
-                            + " is filed under a coordinate this reading does not answer in,"
-                            + " which holds those positions as " + InOneOrder.of(here));
+                // Asked of each position rather than of the blocks they land in. The two say the
+                // same thing — a block every position of it lands on is the block they are all in
+                // — and this one reads nothing but the map, where gathering the blocks first is a
+                // set built for every answer a reading files.
+                for (A member : block.members()) {
+                    if (!block.equals(blockOf(member))) {
+                        throw new IllegalArgumentException("an answer at " + block
+                                + " is filed under a coordinate this reading does not answer in,"
+                                + " which holds those positions as " + InOneOrder.of(holding(block)));
+                    }
                 }
             }
         }
@@ -127,6 +132,11 @@ public final class Sameness<A> {
     /** The blocks this holds {@code block}'s positions in, which is one block where it holds them
      *  as {@code block} does and several where it cuts them apart. */
     Set<Block<A>> holding(Block<A> block) {
+        // One position is in one block, so there is nothing to gather and nothing two of them
+        // could disagree about. Which is what nearly every block asked about is.
+        if (block.isOne()) {
+            return Set.of(blockOf(block.members().iterator().next()));
+        }
         Set<Block<A>> out = new LinkedHashSet<>();
         block.members().forEach(each -> out.add(blockOf(each)));
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -15,6 +15,7 @@ import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -142,6 +143,41 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
         assertEquals(2, at.where().size(), "one block, not the four positions of both");
         assertEquals(new Emptiness.AtAField.Where.In("p"), at.where().getFirst(),
                 "and the one whose places the value declares first, whichever was shown first");
+    }
+
+    /**
+     * And the sentence is the same whichever order the blocks and their positions were reached in.
+     *
+     * <p>Which is what the naming being the declaration's own comes to. A block is a set and holds
+     * its positions in no order; a refusal holds its blocks in the order the readings were met. So
+     * the same proof arrives written several ways, and every one of them names the same places in
+     * the same order — the value's.
+     *
+     * <p>Asked over the arrangements rather than at one of them. The line above says "whichever was
+     * shown first" and one arrangement cannot say it, since either of them passes a naming that
+     * reads whatever it was handed.
+     */
+    @Test
+    void andOneProofIsOneSentenceHoweverItWasReached() {
+        List<Emptiness> said = List.of(
+                named(emptyAt(ordered(List.of(block(P, Q), block(R, S)))), declared()),
+                named(emptyAt(ordered(List.of(block(R, S), block(P, Q)))), declared()),
+                named(emptyAt(ordered(List.of(block(Q, P), block(S, R)))), declared()),
+                named(emptyAt(ordered(List.of(block(S, R), block(Q, P)))), declared()));
+
+        said.forEach(each -> assertEquals(said.getFirst(), each,
+                "one proof of one model is one sentence"));
+        assertEquals(List.of(new Emptiness.AtAField.Where.In("p"),
+                        new Emptiness.AtAField.Where.In("q")),
+                assertInstanceOf(Emptiness.AtEqualPositions.class, said.getFirst()).where(),
+                "and it names the places where the value declares them");
+    }
+
+    /** These blocks, in the order they are given, which is what a refusal met the other way round
+     *  would not have. */
+    private static Set<Sameness.Block<FactSubject>> ordered(
+            List<Sameness.Block<FactSubject>> these) {
+        return new LinkedHashSet<>(these);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -98,7 +98,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         Sameness<String> heldAsOne = Sameness.of("p", "q");
         Sameness.Block<String> both = heldAsOne.blockOf("p");
 
-        Apartness<String> filed = Apartness.of("q", "r").filedIn(heldAsOne);
+        Apartness<String> filed = Apartness.of("q", "r").filedIn(Refinement.of(Sameness.discrete(), heldAsOne));
 
         assertEquals(Set.of(both, R), filed.blocks());
         assertEquals(Set.of(both), filed.apartFrom(R));
@@ -107,7 +107,8 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     /** And where both ends land on one block, the rules state that a value differs from itself. */
     @Test
     void andWhereBothEndsLandOnOneBlockAValueIsStatedToDifferFromItself() {
-        Apartness<String> filed = Apartness.of("p", "q").filedIn(Sameness.of("p", "q"));
+        Apartness<String> filed = Apartness.of("p", "q")
+                .filedIn(Refinement.of(Sameness.discrete(), Sameness.of("p", "q")));
 
         assertTrue(filed.holdsABlockApartFromItself());
         assertInstanceOf(RelationalLack.ABlockApartFromItself.class,
@@ -128,7 +129,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     @Test
     void aChoiceKeepsWhatBothAlternativesStateAtTheFinerBlocks() {
         Sameness<String> coarser = Sameness.of("p", "q");
-        Apartness<String> one = Apartness.of("p", "r").filedIn(coarser);
+        Apartness<String> one = Apartness.of("p", "r").filedIn(Refinement.of(Sameness.discrete(), coarser));
         Apartness<String> other = Apartness.of("p", "r").and(Apartness.of("q", "r"));
 
         Apartness<String> both = one.commonWith(other, Sameness.discrete());

--- a/souther-compiler/src/test/java/souther/compiler/values/APositionIsNotToldApartByHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/APositionIsNotToldApartByHowItIsWrittenTest.java
@@ -1,0 +1,155 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a position is called is the caller's, and how it is written says nothing about which one it
+ * is.
+ *
+ * <p>A rendering is not an order over positions and not an identity for them. The types this is
+ * instantiated at say so themselves — {@code FactSubject#rendered} is "for a reader, not for
+ * equality", and an evaluation carries a position that "takes no part in telling two apart" — so a
+ * relation reading the spelling would be reading something its own positions have told it not to.
+ *
+ * <p>Asked with two positions written the same way, because that is the case a spelling cannot
+ * answer and the one every rule below has to hold for anyway. A test whose positions all render
+ * differently is one an ordering by rendering passes.
+ */
+class APositionIsNotToldApartByHowItIsWrittenTest {
+
+    /**
+     * A position written the same way as another and equal to none of them.
+     *
+     * <p>Equality is identity, which is what a value nothing may share is. The rendering is fixed
+     * so that no two of these can be told apart by it, which is the whole of what this is for.
+     */
+    private static final class Alike {
+
+        private final String written;
+
+        private Alike(String written) {
+            this.written = written;
+        }
+
+        @Override
+        public String toString() {
+            return written;
+        }
+    }
+
+    private static final Alike ONE = new Alike("x");
+    private static final Alike OTHER = new Alike("x");
+    private static final Alike THIRD = new Alike("x");
+
+    /** And one written differently, so that a block holding it with the others has something an
+     *  order over renderings can move. Without it every arrangement writes the same string
+     *  whether or not anything was put in an order. */
+    private static final Alike APART = new Alike("a");
+
+    /** Two of them are two positions, however one reads. */
+    @Test
+    void twoPositionsWrittenAlikeAreTwoPositions() {
+        assertNotEquals(ONE, OTHER);
+        assertEquals(String.valueOf(ONE), String.valueOf(OTHER));
+        assertEquals(2, Sameness.of(ONE, OTHER).blockOf(ONE).members().size());
+    }
+
+    /**
+     * A block is its positions, so the same ones gathered in any order are one block.
+     *
+     * <p>Over every order they can be gathered in and not over two of them. What this is about is
+     * that no order decides anything, and a property over permutations is the only way to say it —
+     * a pair of cases is a pair of cases, and the ordering this replaced passed one of them.
+     */
+    @Test
+    void aBlockIsOneBlockHoweverItsPositionsWereGathered() {
+        Sameness.Block<Alike> first = null;
+        for (List<Alike> order : permutations(List.of(ONE, OTHER, APART))) {
+            Sameness.Block<Alike> made = Sameness.Block.of(new LinkedHashSet<>(order));
+            if (first == null) {
+                first = made;
+            }
+            assertEquals(first, made, "a block is equal by its positions");
+            assertEquals(first.hashCode(), made.hashCode(), "and hashes by them");
+            assertEquals(String.valueOf(first), String.valueOf(made), "and reads by them");
+            assertTrue(made.holds(APART), "and holds every one of them");
+        }
+        assertEquals("[a, x, x]", String.valueOf(first),
+                "written in the order the renderings fall in, both of the alike ones kept");
+    }
+
+    /**
+     * And a relation is one relation however its equalities were reached.
+     *
+     * <p>Which is the promise the ordering was written for. It is kept by putting the renderings in
+     * an order where the relation is written out, and there two that are alike are two entries of
+     * one string rather than two positions in an order that decides nothing.
+     */
+    @Test
+    void aRelationReadsTheSameHoweverItsEqualitiesWereReached() {
+        Sameness<Alike> here = Sameness.of(ONE, OTHER).joining(OTHER, APART);
+        Sameness<Alike> there = Sameness.of(APART, OTHER).joining(OTHER, ONE);
+
+        assertEquals(here, there);
+        assertEquals(String.valueOf(here), String.valueOf(there));
+        assertEquals("[[a, x, x]]", String.valueOf(here),
+                "and the two written alike are written twice and not folded to one");
+    }
+
+    /** And two blocks of one relation that read alike are two blocks. */
+    @Test
+    void twoBlocksThatReadAlikeAreTwoBlocks() {
+        Sameness<Alike> two = Sameness.of(ONE, OTHER).joining(THIRD, new Alike("x"));
+
+        assertEquals(2, two.joined().size());
+        assertEquals("[[x, x], [x, x]]", String.valueOf(two),
+                "and both of them are written, since what is put in an order is what is written");
+    }
+
+    /** A block of one is written as the position itself, which two of them being alike does not
+     *  make one. */
+    @Test
+    void aBlockOfOnePositionIsWrittenAsThatPosition() {
+        assertEquals("x", String.valueOf(Sameness.Block.of(ONE)));
+        assertNotEquals(Sameness.Block.of(ONE), Sameness.Block.of(OTHER));
+        assertFalse(Sameness.Block.of(ONE).holds(OTHER));
+    }
+
+    /** Every order these can be gathered in. */
+    private static <T> List<List<T>> permutations(List<T> these) {
+        if (these.size() <= 1) {
+            return List.of(these);
+        }
+        List<List<T>> out = new ArrayList<>();
+        for (int at = 0; at < these.size(); at++) {
+            List<T> rest = new ArrayList<>(these);
+            T taken = rest.remove(at);
+            for (List<T> tail : permutations(rest)) {
+                List<T> made = new ArrayList<>();
+                made.add(taken);
+                made.addAll(tail);
+                out.add(made);
+            }
+        }
+        return out;
+    }
+
+    /** That the fake above is the case this is about: a set of them keeps all three. */
+    @Test
+    void theseArePositionsASpellingCannotTellApart() {
+        Set<Alike> all = new LinkedHashSet<>(List.of(ONE, OTHER, THIRD));
+
+        assertEquals(3, all.size());
+        assertEquals(1, all.stream().map(String::valueOf).distinct().count());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/APositionIsNotToldApartByHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/APositionIsNotToldApartByHowItIsWrittenTest.java
@@ -67,9 +67,9 @@ class APositionIsNotToldApartByHowItIsWrittenTest {
     /**
      * A block is its positions, so the same ones gathered in any order are one block.
      *
-     * <p>Over every order they can be gathered in and not over two of them. What this is about is
-     * that no order decides anything, and a property over permutations is the only way to say it —
-     * a pair of cases is a pair of cases, and the ordering this replaced passed one of them.
+     * <p>Over every order they can be gathered in and not over two of them. What is claimed is that
+     * no order decides anything, and a pair of cases claims it of that pair — an order over the
+     * positions' renderings passes one of them.
      */
     @Test
     void aBlockIsOneBlockHoweverItsPositionsWereGathered() {

--- a/souther-compiler/src/test/java/souther/compiler/values/APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest.java
@@ -1,0 +1,85 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What one reading promises, read at a block holding more positions than its own did.
+ *
+ * <p>A conjunction leaves a coarser relation: {@code p == q} met with {@code q == r} holds the
+ * three as one value. So a side that stated only the first is asked about a block it never had, and
+ * what it promises there is what it promises at every one of its own blocks those positions fall
+ * in. A value at the three of them is a value at each.
+ *
+ * <p>Read off one position of the block before. Which of its own blocks answered then turned on
+ * which position was taken out, so a side promising {@code S} where it held two positions as one
+ * answered {@code S} or its default depending on where the pick landed — and the default is every
+ * value, which is a promise nothing proved.
+ */
+class APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest {
+
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+    private static final Value C = Value.text("C");
+
+    /** What builds the sets of these readings — every one of them is written out, so nothing here
+     *  is refused for want of allowance. */
+    private static final Allowance<String> SETS = AsACompilationAllows.forAdmittedValues();
+
+    /** A reading holding {@code p} and {@code q} as one value and promising {@code A} or {@code B}
+     *  there, saying nothing about {@code r}. */
+    private static PlannedValues<String> here() {
+        return PlannedValues.<String>holdingAsOne("p", "q")
+                .meet(PlannedValues.at("p", AdmittedPlan.of(ValueSet.oneOf(Set.of(A, B)))));
+    }
+
+    /** And one holding {@code q} and {@code r} as one value and promising {@code B} or {@code C}
+     *  there, saying nothing about {@code p}. */
+    private static PlannedValues<String> there() {
+        return PlannedValues.<String>holdingAsOne("q", "r")
+                .meet(PlannedValues.at("r", AdmittedPlan.of(ValueSet.oneOf(Set.of(B, C)))));
+    }
+
+    /**
+     * The conjunction promises what both sides promise of the one value the three positions hold.
+     *
+     * <p>{@code B} and neither side's own promise: read at one block of a side, the answer would be
+     * that side's promise alone or every value, and both of those promise a value the other side's
+     * rules leave nowhere.
+     */
+    @Test
+    void aConjunctionPromisesWhatBothSidesPromiseOfTheOneValue() {
+        AdmissibleValues<String> both = built(here()).meet(built(there()), SETS);
+
+        assertEquals(Set.of("p", "q", "r"), both.blockOf("p").members());
+        assertEquals(ValueSet.just(B), both.guaranteedAt("p"));
+        assertEquals(ValueSet.just(B), both.guaranteedAt("r"));
+    }
+
+    /** And the same while it is still a description, where putting two promises together costs
+     *  nothing and the same rule is written a second time. */
+    @Test
+    void andTheSameOfTheDescriptionTheConjunctionIsBuiltFrom() {
+        AdmissibleValues<String> both = built(here().meet(there()));
+
+        assertEquals(ValueSet.just(B), both.guaranteedAt("q"));
+    }
+
+    /** And whichever side is met with which, since a conjunction is one reading however it was
+     *  written. */
+    @Test
+    void andWhicheverSideWasMetWithWhich() {
+        AdmissibleValues<String> one = built(here()).meet(built(there()), SETS);
+        AdmissibleValues<String> back = built(there()).meet(built(here()), SETS);
+
+        assertEquals(one.guaranteedAt("q"), back.guaranteedAt("q"));
+        assertEquals(String.valueOf(one.sameness()), String.valueOf(back.sameness()));
+    }
+
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(SETS).values();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest.java
@@ -14,10 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * what it promises there is what it promises at every one of its own blocks those positions fall
  * in. A value at the three of them is a value at each.
  *
- * <p>Read off one position of the block before. Which of its own blocks answered then turned on
- * which position was taken out, so a side promising {@code S} where it held two positions as one
- * answered {@code S} or its default depending on where the pick landed — and the default is every
- * value, which is a promise nothing proved.
+ * <p>Every one of them and not one, because a side's default is every value: a promise read at one
+ * of its blocks and not the rest says a value stands wherever that block's positions are silent,
+ * which nothing proved.
  */
 class APromiseIsReadAtEveryBlockOfItsOwnACoarserOneCoversTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/values/AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Carrying a block from one relation to another, which is two operations and not one.
+ *
+ * <p>A block of the finer relation is inside one block of the coarser, so what was said about it is
+ * said about that one — an answer any of its positions gives. A block of the coarser relation is
+ * made of several of the finer, so what the finer says about it is what it says about all of them —
+ * an answer no one position gives. Both were written by handing a position to
+ * {@link Sameness#blockOf}, which is why the second was being answered as though it were the first.
+ *
+ * <p>The warrant is asked for where the step is made and not where it is taken, so a relation that
+ * is not a coarsening is refused once rather than answered wrongly at every block.
+ */
+class AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest {
+
+    /** {@code p == q} met with {@code q == r}, which is the conjunction's relation. */
+    private static final Sameness<String> COARSER =
+            Sameness.of("p", "q").meet(Sameness.of("q", "r"));
+
+    /** One side of it, which states the first equality and not the second. */
+    private static final Sameness<String> FINER = Sameness.of("p", "q");
+
+    /** Every block of the finer relation lands on one block, which is what making this proves. */
+    @Test
+    void aBlockOfTheFinerRelationIsInsideOneBlockOfTheCoarser() {
+        Refinement<String> up = Refinement.of(FINER, COARSER);
+
+        assertEquals(COARSER.blockOf("p"), up.coarseBlockOf(FINER.blockOf("p")));
+        assertEquals(Set.of("p", "q", "r"), up.coarseBlockOf(FINER.blockOf("p")).members());
+    }
+
+    /** And a position the finer relation holds with nothing is inside one block just the same. */
+    @Test
+    void andSoIsAPositionHeldWithNothing() {
+        Refinement<String> up = Refinement.of(FINER, COARSER);
+
+        assertEquals(COARSER.blockOf("r"), up.coarseBlockOf(Sameness.Block.of("r")));
+    }
+
+    /**
+     * A block of the coarser relation is several of the finer, and all of them are the answer.
+     *
+     * <p>Which is the case the pick was wrong about: {@code p} and {@code q} are one block of the
+     * finer relation and {@code r} is another, so a reader handed one position would be told about
+     * whichever of the two that position is in.
+     */
+    @Test
+    void aBlockOfTheCoarserRelationIsSeveralOfTheFiner() {
+        Refinement<String> up = Refinement.of(FINER, COARSER);
+
+        assertEquals(Set.of(FINER.blockOf("p"), Sameness.Block.of("r")),
+                up.fineBlocksWithin(COARSER.blockOf("p")));
+    }
+
+    /**
+     * A relation that holds a block's positions apart is refused, and refused where it is read
+     * rather than at the first ask.
+     *
+     * <p>Which is the other way round: the conjunction's relation read against one side's. What is
+     * wanted there is every block of the side the coarse block covers, and that is
+     * {@link Refinement#fineBlocksWithin} of a step made the way round it exists.
+     */
+    @Test
+    void aRelationThatIsNotACoarseningIsRefusedWhereItIsRead() {
+        IllegalArgumentException refused =
+                assertThrows(IllegalArgumentException.class, () -> Refinement.of(COARSER, FINER));
+
+        assertEquals("positions held as one at [p, q, r] are held apart by the relation they are"
+                + " read against, which holds [p=[p, q], q=[p, q], r=r]", refused.getMessage());
+    }
+
+    /** And a discrete relation is finer than everything, which is where a denial stated of single
+     *  positions is carried from. */
+    @Test
+    void aDiscreteRelationIsFinerThanEveryOther() {
+        Refinement<String> up = Refinement.of(Sameness.discrete(), COARSER);
+
+        assertEquals(COARSER.blockOf("q"), up.coarseBlockOf(Sameness.Block.of("q")));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest.java
@@ -13,11 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * <p>A block of the finer relation is inside one block of the coarser, so what was said about it is
  * said about that one — an answer any of its positions gives. A block of the coarser relation is
  * made of several of the finer, so what the finer says about it is what it says about all of them —
- * an answer no one position gives. Both were written by handing a position to
- * {@link Sameness#blockOf}, which is why the second was being answered as though it were the first.
+ * an answer no one position gives. So the two are asked for by name, and the one that has no block
+ * to give back cannot be spelled as though it had.
  *
  * <p>The warrant is asked for where the step is made and not where it is taken, so a relation that
- * is not a coarsening is refused once rather than answered wrongly at every block.
+ * is not a coarsening is refused once rather than answered wrongly at every block. What each end
+ * may be asked about is its own relation's blocks, which is asked for at the ask.
  */
 class AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest {
 
@@ -75,6 +76,34 @@ class AStepBetweenTwoRelationsIsOneWayUpAndManyWaysDownTest {
 
         assertEquals("positions held as one at [p, q, r] are held apart by the relation they are"
                 + " read against, which holds [p=[p, q], q=[p, q], r=r]", refused.getMessage());
+    }
+
+    /**
+     * A set of positions the finer relation does not hold together has no block up there.
+     *
+     * <p>Which is the ask that could still be answered from one position. A block is a set and
+     * anybody may build one, so the step being total over the blocks that were walked is not the
+     * step being total — and the positions of a block nothing made are in whatever blocks they are
+     * in.
+     */
+    @Test
+    void aSetOfPositionsTheFinerRelationDoesNotHoldTogetherIsNotItsToCarry() {
+        Refinement<String> up = Refinement.of(FINER, COARSER);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> up.coarseBlockOf(Sameness.Block.of(Set.of("p", "s"))));
+
+        assertEquals("the relation these positions are read from does not hold them as one value:"
+                + " [p, s], which it holds as [[p, q], s]", refused.getMessage());
+    }
+
+    /** And the other end asks the same of the relation it reads against. */
+    @Test
+    void norIsOneTheCoarserRelationDoesNotHoldTogether() {
+        Refinement<String> up = Refinement.of(FINER, COARSER);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> up.fineBlocksWithin(Sameness.Block.of(Set.of("p", "s"))));
     }
 
     /** And a discrete relation is finer than everything, which is where a denial stated of single

--- a/souther-compiler/src/test/java/souther/compiler/values/AnAlternativeRefusedTwoWaysSaysBothOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnAlternativeRefusedTwoWaysSaysBothOfThemTest.java
@@ -46,7 +46,8 @@ class AnAlternativeRefusedTwoWaysSaysBothOfThemTest {
     /** Denials that state {@link #BOTH} to differ from itself, which nothing satisfies. */
     private static WhatARelationShows<String> denialsApartFromItself() {
         return WhatARelationShows.statedApart(
-                Apartness.of("p", "q").filedIn(Sameness.of("p", "q")));
+                Apartness.of("p", "q")
+                        .filedIn(Refinement.of(Sameness.discrete(), Sameness.of("p", "q"))));
     }
 
     /** Denials that refuse nothing, which is what an alternative stating none holds. */

--- a/souther-compiler/src/test/java/souther/compiler/values/PositionsHeldAsOneAreClosedByAConjunctionAndCutByAChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/PositionsHeldAsOneAreClosedByAConjunctionAndCutByAChoiceTest.java
@@ -123,16 +123,15 @@ class PositionsHeldAsOneAreClosedByAConjunctionAndCutByAChoiceTest {
         assertEquals(here, there);
     }
 
-    /** And its positions are read in one order however the equalities reached them, so that a
-     *  proof naming them comes out the same on two compiles of one model. */
+    /** And it reads the same however the equalities reached its positions, because what is put in
+     *  an order to write it out is the positions' renderings and not the positions. */
     @Test
-    void aBlockReadsItsPositionsInOneOrder() {
+    void aBlockReadsTheSameHoweverItsPositionsWereReached() {
         Sameness<String> here = Sameness.of("c", "a").meet(Sameness.of("a", "b"));
         Sameness<String> there = Sameness.of("b", "a").meet(Sameness.of("a", "c"));
 
-        assertEquals(List.of("a", "b", "c"), List.copyOf(here.blockOf("a").members()));
-        assertEquals(List.copyOf(here.blockOf("a").members()),
-                List.copyOf(there.blockOf("a").members()));
+        assertEquals(String.valueOf(here.blockOf("a")), String.valueOf(there.blockOf("a")));
+        assertEquals(String.valueOf(here), String.valueOf(there));
     }
 
     /** A renaming names two positions two positions, so a block has as many members after it. */

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsPromisedIsOneQuestionAndCostsOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatABlockIsPromisedIsOneQuestionAndCostsOnceTest.java
@@ -1,0 +1,122 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternRead;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a block of a conjunction is promised is one question, put to the allowance once.
+ *
+ * <p>A conjunction's block covers several of each side's own, and what it is promised is what every
+ * one of those promises. Gathered per side and met, the sides' halves are two sets nobody asked
+ * about, built and charged to the block before the set that was wanted is built from them — so what
+ * the block costs is how many blocks each side happened to hold its positions in.
+ *
+ * <p><b>Asked of sets that cost something.</b> A promise written out as values is free: the
+ * descriptions meet plainly and every arrangement of them comes to one set without a machine. It is
+ * a promise the rules describe rather than list that is built under an allowance, so that is what
+ * these readings promise — with anything else the halves and the whole are one plan and this
+ * measures nothing.
+ *
+ * <p>And of a conjunction where both sides hold two of their own blocks inside one of its. With
+ * fewer, a side's half is a meet with what a reading promises where it promised nothing, which is
+ * every value and drops out — the plan comes to the same thing and no second question is put.
+ */
+class WhatABlockIsPromisedIsOneQuestionAndCostsOnceTest {
+
+    /** What the rules of a position describe rather than list, which is built under an allowance
+     *  and is what makes a meet of two of them cost anything. */
+    private static ValueSet matching(String regex) {
+        PatternRead said = PatternParser.read(regex);
+        return ValueSet.matching(
+                PatternPlan.of(assertInstanceOf(PatternRead.Read.class, said).syntax())
+                        .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter()));
+    }
+
+    private static final ValueSet ONE = matching("x|a{40}");
+    private static final ValueSet TWO = matching("x|b{40}");
+    private static final ValueSet THREE = matching("x|c{40}");
+    private static final ValueSet FOUR = matching("x|d{40}");
+
+    /**
+     * One side, holding two pairs as one value and promising each pair its own set.
+     *
+     * <p>Both of its blocks are inside the conjunction's one, so both of its promises are about
+     * that block's value and neither of them is every value.
+     */
+    private static AdmissibleValues<String> side(String one, String other, ValueSet said,
+                                                 String third, String fourth, ValueSet also) {
+        return built(PlannedValues.<String>holdingAsOne(one, other)
+                .meet(PlannedValues.at(one, AdmittedPlan.of(said)))
+                .meet(PlannedValues.<String>holdingAsOne(third, fourth))
+                .meet(PlannedValues.at(third, AdmittedPlan.of(also))));
+    }
+
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(AsACompilationAllows.forAdmittedValues()).values();
+    }
+
+    /** What every one of these promises, said as one plan. */
+    private static AdmittedPlan asOnePlan(ValueSet... these) {
+        return AdmittedPlan.meeting(List.of(these).stream().map(AdmittedPlan::of).toList());
+    }
+
+    /**
+     * The conjunction puts the whole meet to the allowance, and never a side's half of it.
+     *
+     * <p>{@code p == q} with {@code r == s} met with {@code q == r} and {@code p == s} holds all
+     * four as one value. Each side promises two of the four sets, and what stands there is what all
+     * four admit — one plan, worked out once, and no plan of one side's two.
+     */
+    @Test
+    void aConjunctionAsksForTheWholeMeetAndNeverASidesHalf() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+        AdmissibleValues<String> met =
+                side("p", "q", ONE, "r", "s", TWO).meet(side("q", "r", THREE, "p", "s", FOUR), sets);
+
+        Sameness.Block<String> block = met.blockOf("p");
+        assertEquals(4, block.members().size(), "the four are one value, or this asks nothing");
+        assertNotNull(sets.known(block, asOnePlan(ONE, TWO, THREE, FOUR)),
+                "what the block is promised was put as one question");
+        assertNull(sets.known(block, asOnePlan(ONE, TWO)),
+                "and no side's own two were met into a set of their own");
+        assertNull(sets.known(block, asOnePlan(THREE, FOUR)),
+                "on either side");
+    }
+
+    /** And what it promises is what all four admit, which is the one string they share. */
+    @Test
+    void andWhatItPromisesIsWhatAllFourAdmit() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+        AdmissibleValues<String> met =
+                side("p", "q", ONE, "r", "s", TWO).meet(side("q", "r", THREE, "p", "s", FOUR), sets);
+
+        ValueSet promised = met.guaranteedAt("p");
+        assertTrue(promised.has(Value.text("x")), "the string all four admit");
+        assertFalse(promised.has(Value.text("a".repeat(40))), "and none that only one of them does");
+        assertFalse(promised.has(Value.text("d".repeat(40))));
+        assertEquals(promised, met.guaranteedAt("s"), "which is one promise across the block");
+    }
+
+    /** That these sets are ones a machine is made for, so the meet above is work the allowance
+     *  sees rather than a description that folds itself away. */
+    @Test
+    void theseArePromisesTheAllowanceIsAskedToBuild() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+        int before = sets.spentSoFar();
+        sets.meetingPromised(Sameness.Block.of("p"), List.of(ONE, TWO));
+
+        assertTrue(sets.spentSoFar() > before, "a meet of these costs something");
+    }
+}


### PR DESCRIPTION
A block put its members in the order their spellings fall in, so that a proof naming them would not read differently for the order the equalities behind it were written in. A spelling is an order over renderings. Used on the positions it left two that render alike in the order a closure reached them, and the reader that was owed the promise never read the order at all — a proof names positions in the order the value declares them, which is a total order over exactly the positions a sentence can name.

The types this is instantiated at say the same thing themselves. A subject's rendering is for a reader and not for equality; the evaluation under it carries a position that takes no part in telling two apart. `Apartness.Edge` already refused to order its ends for this reason, and `InOneOrder` already said where the boundary is. So the members are a set with no order to read, and what is put in an order is what is written out.

Taking the order away showed what else it had been deciding. A block was carried from one relation to another by handing one of its members to the other relation, which is an answer any member gives where the step is up and an answer that follows the pick where it is down. The two were one spelling. They are now two operations on a relation between the partitions, whose making walks every block and refuses a step that is not a coarsening — so which of the two a line is doing is in what it calls.

Under a conjunction the step is down: a promise made where two positions were one is read at a block holding three. Read off a member, it answered about whichever positions that member's block held, and where the pick landed on a block with no promise it handed back the default, which is every value. It is now what the reading promises at every one of its own blocks those positions fall in, met — as a description where nothing is built, and under the allowance where the sets are already made, handed over at once so that what it costs is not the order the positions were walked in.

What is left where a block's positions reach a report was read rather than assumed: the reasons a rule is answerable for are sorted by where they were written, or by the reason itself across texts, and the limit an answer ran into refuses two that differ instead of taking the first. Neither reads an order off what the block handed them.

Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)