### PR TITLE
Send an author to the part of the clause they wrote, not to the tree a reading was over

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -127,20 +127,22 @@ final class AdmissibleReading {
      * already turned {@code p == false} and {@code p /= true} into this leaf denied
      * ({@link ClauseExpr}), so nothing here asks how the author spelled it.
      */
-    PlannedValues<FactSubject> leaf(Core e, boolean positive, Denotations at) {
+    PlannedValues<FactSubject> leaf(ClauseExpr.Part part, Denotations at) {
+        Core e = part.of();
+        boolean positive = part.positive();
         if (e instanceof Core.Binary b
                 && Comparison.of(b).map(Comparison::claim).orElse(null)
                         instanceof ComparisonClaim.Singled singled) {
             // Which of the two it states, once the denials above have been counted: what the
             // comparison holds at the value it names, turned over by each denial it stands under.
-            return comparison(b, singled.holdsAtTheValue() == positive, at);
+            return comparison(part, b, singled.holdsAtTheValue() == positive, at);
         }
         PlannedValues<FactSubject> truth = truthValued(e, positive, at);
         if (truth != null) {
             return truth;
         }
-        PlannedValues<FactSubject> matched = pattern(e, positive, at);
-        return matched != null ? matched : unreadable(e, at);
+        PlannedValues<FactSubject> matched = pattern(part, at);
+        return matched != null ? matched : unreadable(part, at);
     }
 
     /** What naming a position of two values says about it, or null where {@code e} is not one. */
@@ -171,8 +173,9 @@ final class AdmissibleReading {
      * of the same thing. That is every leaf that is not one of these, and every one of these whose
      * reading stopped at something other than this reading's own limit.
      */
-    private PlannedValues<FactSubject> pattern(Core e, boolean states, Denotations at) {
-        StringPredicates.Stated stated = statedIn(e, at);
+    private PlannedValues<FactSubject> pattern(ClauseExpr.Part part, Denotations at) {
+        boolean states = part.positive();
+        StringPredicates.Stated stated = statedIn(part.of(), at);
         FactSubject position = stated == null ? null : positionIn(stated.subject(), at);
         if (position == null) {
             return null;
@@ -184,10 +187,10 @@ final class AdmissibleReading {
             // that much less for the meet it does need. So what is said is which machine would
             // answer this rule, and whether one is ever made of it is settled where the position's
             // plan is worked out under its allowance.
-            case StringPredicates.Reading.Accepting it -> asking(e, position,
+            case StringPredicates.Reading.Accepting it -> asking(part, position,
                     new AdmittedPlan.Pattern(states ? PatternPlan.of(it.accepts())
                             : PatternPlan.notMatching(it.accepts())));
-            case StringPredicates.Reading.PatternNotRead it -> stoppedBy(e, it.why(), position);
+            case StringPredicates.Reading.PatternNotRead it -> stoppedBy(part, it.why(), position);
             // A rule whose text this could not work out is a rule this did not read, and what that
             // costs is the leaf's to say — over every position the clause names, which is more than
             // this one wherever the text is written out of another.
@@ -209,13 +212,13 @@ final class AdmissibleReading {
      * <p>No {@code default}: a construct the subset learns to stop at is one somebody decides about
      * here, rather than one that quietly takes the answer its neighbours were given.
      */
-    private PlannedValues<FactSubject> stoppedBy(Core e, PatternRead.Unsupported why,
+    private PlannedValues<FactSubject> stoppedBy(ClauseExpr.Part part, PatternRead.Unsupported why,
                                                  FactSubject position) {
         return switch (why) {
             // The clause as well as the position. What a rule is answerable for is about the
             // pattern somebody wrote, and the position is where the reading was left short — read
             // back off the second, this would be every rule that named the place.
-            case NESTED_TOO_DEEPLY -> shortOf(e, Set.of(position),
+            case NESTED_TOO_DEEPLY -> shortOf(part, Set.of(position),
                     UnreadReason.PATTERN_TOO_DEEPLY_NESTED);
             case A_GROUP_ABOUT_THE_MATCH,
                  A_BACK_REFERENCE,
@@ -241,7 +244,8 @@ final class AdmissibleReading {
      * Given up on instead, the two stayed two answers with a rule between them that reached
      * neither, and a declaration whose positions cannot hold one value together was admitted.
      */
-    private PlannedValues<FactSubject> comparison(Core.Binary b, boolean states, Denotations at) {
+    private PlannedValues<FactSubject> comparison(ClauseExpr.Part part, Core.Binary b,
+                                                  boolean states, Denotations at) {
         PlannedValues<FactSubject> read = sided(b.left(), b.right(), states, at);
         if (read == null) {
             // `"A" == value` says what `value == "A"` says.
@@ -250,7 +254,7 @@ final class AdmissibleReading {
         if (read == null) {
             read = relating(b, states, at);
         }
-        return read != null ? read : unreadable(b, at);
+        return read != null ? read : unreadable(part, at);
     }
 
     /**
@@ -296,8 +300,9 @@ final class AdmissibleReading {
      * ordering comparison and an equality answer alike — written per shape, {@code <} fell through
      * one path and {@code ==} another, and a relation came out as a form nobody could read.
      */
-    private PlannedValues<FactSubject> unreadable(Core e, Denotations at) {
-        return shortOf(e, names(e, at), relatesTwoPositions(e, at)
+    private PlannedValues<FactSubject> unreadable(ClauseExpr.Part part, Denotations at) {
+        Core e = part.of();
+        return shortOf(part, names(e, at), relatesTwoPositions(e, at)
                 ? UnreadReason.RELATES_TWO_POSITIONS : UnreadReason.FORM_NOT_READ);
     }
 
@@ -306,23 +311,30 @@ final class AdmissibleReading {
      *
      * <p>Both from the one decision and neither from the other. What a place is left holding is the
      * reading's answer about the place; what a rule is answerable for is about the thing somebody
-     * wrote, which is the node in hand here and is nowhere in what the places come back with. Read
+     * wrote, which is the part in hand here and is nowhere in what the places come back with. Read
      * off the places afterwards, the second is a list of reasons and no clause — every rule reaching
      * a position pays into its answer, so the place has as many claimants as it has rules.
+     *
+     * <p>Which written part it was is taken from the shape and not from the node. The two say the
+     * same thing about one reading and part company across two: a rule is read once for every place
+     * a value is opened at, over the tree the substitution built there, and the shape numbers the
+     * clause the author wrote whichever tree it was read over.
      *
      * <p>Written down against the node rather than returned beside the values, because the fold
      * carries one answer upward and this is not part of it. What is recorded here is asked for at
      * the leaf that was read ({@link #shortfallsAt}), which is a handing over and not a second
      * reading: nothing looks at what the clause came to in order to work out what was decided.
      */
-    private PlannedValues<FactSubject> shortOf(Core e, Set<FactSubject> named, UnreadReason why) {
+    private PlannedValues<FactSubject> shortOf(ClauseExpr.Part part, Set<FactSubject> named,
+                                               UnreadReason why) {
+        Core e = part.of();
         // That this reading gave up here, which is not the same as what it gave up on. A clause
         // about no position of this value is one nothing read all the same, and a choice needs to
         // know: had it been read, the alternative holding it might have turned out one nobody can
         // be in, and then the choice would have been the other branch.
         gaveUp.add(e);
         List<RuleShortfall> mine = shortfalls.computeIfAbsent(e, _ -> new ArrayList<>());
-        RuleShortfall.Site site = new RuleShortfall.Site.AtALeaf(e);
+        RuleShortfall.Site site = siteOf(part);
         named.forEach(each -> {
             RuleShortfall one = new RuleShortfall(each, why, site);
             if (!mine.contains(one)) {
@@ -340,11 +352,22 @@ final class AdmissibleReading {
      * position pays into that allowance, so the place cannot say which of them asked, and the
      * pattern alone is the same pattern wherever somebody wrote it.
      */
-    private PlannedValues<FactSubject> asking(Core e, FactSubject position,
+    private PlannedValues<FactSubject> asking(ClauseExpr.Part part, FactSubject position,
                                               AdmittedPlan.Pattern plan) {
-        asked.computeIfAbsent(e, _ -> new LinkedHashSet<>())
-                .add(new AskedAt(position, plan.plan(), new RuleShortfall.Site.AtALeaf(e)));
+        asked.computeIfAbsent(part.of(), _ -> new LinkedHashSet<>())
+                .add(new AskedAt(position, plan.plan(), siteOf(part)));
         return PlannedValues.at(position, plan);
+    }
+
+    /**
+     * Where in its clause {@code part} stands, and where an author wrote it.
+     *
+     * <p>Made where the leaf is read and nowhere after. What is decided later about this clause is
+     * filed at the site it was handed, so a copy a conjunction distributed over a choice carries
+     * the one an author wrote rather than a second of the same shape.
+     */
+    private static RuleShortfall.Site siteOf(ClauseExpr.Part part) {
+        return new RuleShortfall.Site.AtALeaf(part.at(), part.of().pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
@@ -74,6 +74,12 @@ record RuleShortfall(FactSubject position, UnreadReason why, RuleShortfall.Site 
          * answerable for is filed under that rule ({@link ReadingEvidence}) and never met with
          * another's — and this says the rest.
          *
+         * <p>The place is the part with the denials above it taken off, which is one of the two
+         * spellings the shape holds ({@link ClauseExpr#spelled}). Which of them an author is shown
+         * — the comparison, or the {@code not} written over it — is a question about what a report
+         * points at and is answered where the site is made, so it stays a choice among what the
+         * clause was written as rather than becoming a fact read off whatever tree was in hand.
+         *
          * @param at which part of the clause it is, in the clause's own numbering
          * @param writtenAt where that part stands, which is settled by {@code at} and carried
          *                  because the reader that puts these in the author's order has no clause

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.values.UnreadReason;
 
@@ -61,33 +60,43 @@ record RuleShortfall(FactSubject position, UnreadReason why, RuleShortfall.Site 
         /** Where an author wrote it, which is what an order among them is taken over. */
         SourcePos writtenAt();
 
-        /** One clause the reading had no word for, as the node it was written as. */
-        record AtALeaf(Core node) implements Site {
+        /**
+         * One clause the reading had no word for, as where in its clause the author wrote it.
+         *
+         * <p>The identity and the place beside each other, as a choice holds them
+         * ({@link ChoiceSite}). Which part of the clause this is, is what
+         * {@link ClauseExpr.Occurrence} says and a node cannot: a clause is read once for every
+         * place the walk opens a value at, over whatever tree the substitution built there, so two
+         * readings of one rule meet the same written part as two objects. Told apart by the tree
+         * they landed in, one thing an author wrote came back as two things to look at.
+         *
+         * <p>Which rule's clause it is an occurrence of is the carrier's — what a rule is
+         * answerable for is filed under that rule ({@link ReadingEvidence}) and never met with
+         * another's — and this says the rest.
+         *
+         * @param at which part of the clause it is, in the clause's own numbering
+         * @param writtenAt where that part stands, which is settled by {@code at} and carried
+         *                  because the reader that puts these in the author's order has no clause
+         *                  left to ask
+         */
+        record AtALeaf(ClauseExpr.Occurrence at, SourcePos writtenAt) implements Site {
 
             public AtALeaf {
-                if (node == null) {
-                    throw new IllegalArgumentException("a leaf is some node of a clause");
+                if (at == null || writtenAt == null) {
+                    throw new IllegalArgumentException(
+                            "a leaf is some part of a clause, written somewhere");
                 }
             }
 
+            /** This part of the clause and no other, whichever reading met it. */
             @Override
             public boolean equals(Object other) {
-                return other instanceof AtALeaf it && node == it.node;
+                return other instanceof AtALeaf it && at.equals(it.at);
             }
 
             @Override
             public int hashCode() {
-                return System.identityHashCode(node);
-            }
-
-            @Override
-            public SourcePos writtenAt() {
-                return node.pos();
-            }
-
-            @Override
-            public String toString() {
-                return "leaf@" + Integer.toHexString(System.identityHashCode(node));
+                return at.hashCode();
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -706,7 +706,7 @@ sealed interface StatedByClauses {
         public StatedByClauses whole(ClauseExpr.Part part, Denotations at) {
             Core e = part.of();
             boolean positive = part.positive();
-            PlannedValues<FactSubject> said = values.leaf(e, positive, at);
+            PlannedValues<FactSubject> said = values.leaf(part, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
             // What the leaf states, asked once and read by both of the questions below: which

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -2,11 +2,9 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
-import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
@@ -218,7 +216,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     @Test
     void andWhichOfTheTwoIsNotAskedOfWhereItWasWritten() {
         RuleShortfall form = new RuleShortfall(CONSTRAINED, UnreadReason.FORM_NOT_READ,
-                new RuleShortfall.Site.AtALeaf(new Core.Bool(true, Type.BOOL, new SourcePos(1, 1))));
+                new RuleShortfall.Site.AtALeaf(new ClauseExpr.Occurrence(0), new SourcePos(1, 1)));
         ChoiceSite choice = aChoice();
 
         assertEquals(java.util.Set.of(form),

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
@@ -243,7 +243,7 @@ class AChoiceSaysWhatNothingElseSaidAboutAPositionTest {
         List<Integer> columns = new java.util.ArrayList<>();
         shortfallsAt(EIGHT_FORMS_NOTHING_READS, "a").forEach(each -> {
             if (each.site() instanceof RuleShortfall.Site.AtALeaf leaf) {
-                columns.add(leaf.node().pos().column());
+                columns.add(leaf.writtenAt().column());
             }
         });
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest.java
@@ -1,0 +1,86 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Where a rule was given up on is a part of the clause an author wrote, and not the tree a reading
+ * happened to be over.
+ *
+ * <p>A clause is read once for every place the walk opens a value at, over whatever tree the
+ * substitution built there, and two compiles of one source build two trees again. Told apart by the
+ * tree, one written part comes back as several things for an author to look at, and which of them a
+ * reader is handed is a fact about how the compiler allocated.
+ *
+ * <p>The two sides of that are held here together, because either alone passes with the wrong
+ * answer: sites that are all equal would satisfy the first and sites that are never equal would
+ * satisfy the second.
+ */
+class WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest {
+
+    private static final String UNREAD_A = souther.compiler.ARuleNoReadingTakesIn.about("a");
+
+    /**
+     * Two parts nothing reads, spelled the same way, about the one position.
+     *
+     * <p>Spelled the same on purpose: what tells them apart is where an author put them and nothing
+     * else, so a site that stopped saying where it stands would have them come out as one.
+     */
+    private static final String TWO_PARTS_NOTHING_READS = """
+            module demo
+
+            data N = { a: String }
+                invariant r = UNREAD_A && UNREAD_A
+            """.replace("UNREAD_A", UNREAD_A);
+
+    /** One source, compiled twice, is one set of places. */
+    @Test
+    void twoCompilesOfOneSourceGiveUpAtTheSamePlaces() {
+        assertEquals(sitesIn(TWO_PARTS_NOTHING_READS), sitesIn(TWO_PARTS_NOTHING_READS),
+                "which part of a clause an author is sent to is the clause's answer, and two"
+                        + " compiles of one source are two trees of it");
+    }
+
+    /** And two parts of one clause are two places, however alike they are spelled. */
+    @Test
+    void andTwoPartsOfOneClauseAreTwoPlaces() {
+        assertEquals(2, sitesIn(TWO_PARTS_NOTHING_READS).size(),
+                "an author wrote two of them and has two things to look at");
+    }
+
+    /** Everywhere the reading of values gave up, of every rule of {@code N}. */
+    private static Set<RuleShortfall.Site> sitesIn(String source) {
+        Set<RuleShortfall.Site> out = new LinkedHashSet<>();
+        read(source).accounting().values().forEach(accounting ->
+                accounting.answers().forEach((_, outcome) -> {
+                    if (outcome instanceof RuleAccounting.Outcome.Unaccounted it
+                            && it.why() instanceof RuleAccounting.Why.TheValueReadingSays says) {
+                        says.shortfalls().forEach(each -> out.add(each.site()));
+                    }
+                }));
+        return out;
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest.java
@@ -2,12 +2,14 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.diag.SourcePos;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -57,6 +59,30 @@ class WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest {
     void andTwoPartsOfOneClauseAreTwoPlaces() {
         assertEquals(2, sitesIn(TWO_PARTS_NOTHING_READS).size(),
                 "an author wrote two of them and has two things to look at");
+    }
+
+    /**
+     * And each of them stands where it stood, which the sites above do not say.
+     *
+     * <p>Said separately because a site is told from another by which part of the clause it is and
+     * by nothing else ({@code AtALeaf.equals}), so comparing sites compares the identities and
+     * leaves what an author is shown unasked. The two halves of a site are two claims and one
+     * comparison would carry only the first.
+     */
+    @Test
+    void andEachOfThemStandsWhereItStood() {
+        assertEquals(placesIn(TWO_PARTS_NOTHING_READS), placesIn(TWO_PARTS_NOTHING_READS),
+                "where a part was written is the source's answer, and two compiles read one"
+                        + " source");
+    }
+
+    /** Where each of them stands, in the order the clause numbers them. */
+    private static List<SourcePos> placesIn(String source) {
+        return sitesIn(source).stream()
+                .map(RuleShortfall.Site.AtALeaf.class::cast)
+                .sorted(Comparator.comparingInt(each -> each.at().ordinal()))
+                .map(RuleShortfall.Site::writtenAt)
+                .toList();
     }
 
     /** Everywhere the reading of values gave up, of every rule of {@code N}. */


### PR DESCRIPTION
`RuleShortfall.Site.AtALeaf` held the `Core` node a reading gave up on and was told from every other by that object. A clause is read once for every place the walk opens a value at, over whatever tree the substitution built there, and two compiles of one source build the tree again — so what an author is sent to was settled by how the compiler allocated. The place it reported came from the same node, which made the provenance an answer read off the identity.

It now says which part of the clause it is, in the clause's own numbering, with the place beside it — the shape a choice already carries (`ChoiceSite`). Which rule's clause the occurrence belongs to is the carrier's: what a rule is answerable for is filed under that rule and never met with another's.

The leaf reading is handed the shape rather than the node, so the site is made where the decision is and out of what the clause says rather than out of the tree in hand.

Measured on the whole suite before the change, so the grain is a fact and not an argument:

- every leaf a shortfall is filed at is a part of its clause's shape, and no filing landed outside one;
- the same rule is read more than once in a declaration, and the readings never gave up on one node together — the old address was already per reading;
- two readings do meet at one part of a clause, so the part alone without the rule around it would have merged them;
- one part of one rule never had two source positions behind it, so the place is settled by the part and may be carried beside it;
- nothing collapses: no two facts about one rule, one position and one part were ever filed under two nodes. The answers are the ones they were.

`WhereAReadingGaveUpIsAPartOfTheClauseAndNotATreeItWasReadOverTest` states both halves — one source compiled twice gives up at the same places, and two parts of one clause spelled alike are two places. Each half is red under the mutation that takes the other away.

Part of #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)