### PR TITLE
Name a condition on the way to a border, and ask where it is where the sentence is written

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -270,14 +270,16 @@ final class AReportOfOneBorder {
                                 .filter(point -> point.belongsToBehaviorAccount("weigh"))
                                 .toList()),
                         null),
-                souther.compiler.query.ClaimAnnotations.NONE, List.of(), java.util.Map.of());
+                souther.compiler.query.ClaimAnnotations.NONE, List.of(), java.util.Map.of(),
+                java.util.Map.of());
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test",
                 held, WeakeningSet.none(),
                 List.of(new AdequacyReport.ModuleReport("example.wide",
                         new SourceId("wide.sou"), List.of(behavior), List.of(),
                         // Nothing this module's declarations are owed, and nothing that finding
                         // them went without: the fixture is about one behavior's own lines.
-                        new Adequacy.DeclaredBoundaries(List.of(), java.util.Map.of()))))
+                        new Adequacy.DeclaredBoundaries(List.of(), java.util.Map.of()),
+                        java.util.Map.of())))
                 .adequacy();
     }
 }

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -278,8 +278,9 @@ final class AReportOfOneBorder {
                         new SourceId("wide.sou"), List.of(behavior), List.of(),
                         // Nothing this module's declarations are owed, and nothing that finding
                         // them went without: the fixture is about one behavior's own lines.
-                        new Adequacy.DeclaredBoundaries(List.of(), java.util.Map.of()),
-                        java.util.Map.of())))
+                        new AdequacyReport.DeclarationsShown(
+                                new Adequacy.DeclaredBoundaries(List.of(), java.util.Map.of()),
+                                java.util.Map.of()))))
                 .adequacy();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -63,11 +64,13 @@ import java.util.Set;
  * out its way established — which is the whole of what makes this per comparison rather than per
  * fork. Everything else evaluates its parts under what stood at it.
  */
-record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
+record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
+                          Map<ConditionOccurrence, Citation> conditionsMet) {
 
     ComparisonReadings {
         comparisons = List.copyOf(comparisons);
         forks = List.copyOf(forks);
+        conditionsMet = Map.copyOf(conditionsMet);
     }
 
     /**
@@ -188,9 +191,16 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
     static ComparisonReadings of(String behavior, Core body, InputReading read, InputReads reads) {
         List<Reading> readings = new ArrayList<>();
         List<ForkMet> forks = new ArrayList<>();
+        // The names the conditions of this body take, handed out as the walk meets them. One of
+        // these per body, because what a name is counted within is the body: counted over the
+        // module, an edit to one behavior would rename the conditions of every one after it. Whose
+        // reading it is comes off the names it is made against, which is the module being compiled
+        // — a condition inside a helper spliced in from elsewhere is still one this reading met.
+        ConditionNumbering numbering =
+                new ConditionNumbering(read.symbols().module(), behavior);
         walk(body, new Body(behavior, read), reads,
-                LiveFlow.of(body), List.of(), true, readings, forks);
-        return new ComparisonReadings(readings, forks);
+                LiveFlow.of(body), List.of(), true, readings, forks, numbering);
+        return new ComparisonReadings(readings, forks, numbering.metAt());
     }
 
     /**
@@ -201,7 +211,7 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
      */
     private static void walk(Core e, Body in, InputReads reads, LiveFlow flow,
                              List<OnTheWay> assumed, boolean live, List<Reading> out,
-                             List<ForkMet> forks) {
+                             List<ForkMet> forks, ConditionNumbering numbering) {
         Symbols symbols = in.symbols();
         RuleReadingSource ruleSource = in.rules();
         // A comparison the source wrote, recognised by the one thing that says what one is
@@ -230,21 +240,27 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
             // any fork above it: there need not be one, and where there is, this is what the fork
             // would have been reading anyway.
             case Core.Binary both when both.op() == BinOp.AND -> {
-                walk(both.left(), in, reads, flow, assumed, live, out, forks);
+                walk(both.left(), in, reads, flow, assumed, live, out, forks, numbering);
                 walk(both.right(), in, reads, flow,
-                        taking(both.left(), true, in.read().domain(), reads, assumed, ruleSource),
-                        live, out, forks);
+                        taking(Condition.of(both.left(), reads, symbols, numbering), true,
+                                in.read().domain(), assumed, ruleSource),
+                        live, out, forks, numbering);
             }
             case Core.Binary either when either.op() == BinOp.OR -> {
-                walk(either.left(), in, reads, flow, assumed, live, out, forks);
+                walk(either.left(), in, reads, flow, assumed, live, out, forks, numbering);
                 walk(either.right(), in, reads, flow,
-                        taking(either.left(), false, in.read().domain(), reads, assumed, ruleSource),
-                        live, out, forks);
+                        taking(Condition.of(either.left(), reads, symbols, numbering), false,
+                                in.read().domain(), assumed, ruleSource),
+                        live, out, forks, numbering);
             }
             // The condition under what stood above the fork, and each arm under what that arm proves
             // of it. A comparison inside a condition is not below the fork: it runs to decide it.
             case Core.If iff -> {
-                walk(iff.cond(), in, reads, flow, assumed, live, out, forks);
+                walk(iff.cond(), in, reads, flow, assumed, live, out, forks, numbering);
+                // Read once, whichever arm is being entered. Reaching the `then` and reaching the
+                // `els` are two things one condition says, and a second reading for the second arm
+                // would name that one condition twice.
+                Condition condition = Condition.of(iff.cond(), reads, symbols, numbering);
                 // What this walk found in the condition, for the reader that decides whether the
                 // fork states a rule of its own. Said of every fork an author wrote, and of none
                 // this compiler composed — a `guard`'s supplied arm and a lowering's test state
@@ -275,19 +291,20 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
                             reads, atoms, owned));
                 }
                 walk(iff.then(), in, reads, flow,
-                        taking(iff.cond(), true, in.read().domain(), reads, assumed, ruleSource),
-                        live, out, forks);
+                        taking(condition, true, in.read().domain(), assumed, ruleSource),
+                        live, out, forks, numbering);
                 walk(iff.els(), in, reads, flow,
-                        taking(iff.cond(), false, in.read().domain(), reads, assumed, ruleSource),
-                        live, out, forks);
+                        taking(condition, false, in.read().domain(), assumed, ruleSource),
+                        live, out, forks, numbering);
             }
             // What a `let` computes is read on the way to the answer only where the name is read;
             // everywhere else a value stands in a body it is consumed by what it stands in. And its
             // body is where the name stands for what was bound to it.
             case Core.LetIn let -> {
-                walk(let.value(), in, reads, flow, assumed, live && flow.reads(let), out, forks);
+                walk(let.value(), in, reads, flow, assumed, live && flow.reads(let), out, forks,
+                        numbering);
                 walk(let.body(), in, reads.and(let.binder(), let.value()), flow, assumed, live,
-                        out, forks);
+                        out, forks, numbering);
             }
             // And each arm under what the arm says the value it matched turned out to be. A name
             // the arm binds is the scrutinee's position narrowed to that case, so a comparison
@@ -299,15 +316,17 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
             // inside an arm was owed a row by a walk that had been told nothing stood on the way to
             // it, and the row composed for it was written in whichever arm the values fell in.
             case Core.Match match -> {
-                walk(match.scrutinee(), in, reads, flow, assumed, live, out, forks);
-                for (Core.Case arm : match.cases()) {
+                walk(match.scrutinee(), in, reads, flow, assumed, live, out, forks, numbering);
+                for (int part = 0; part < match.cases().size(); part++) {
+                    Core.Case arm = match.cases().get(part);
                     walk(arm.body(), in, reads.insideArm(match, arm, symbols), flow,
-                            entering(match, arm, in.read().domain(), reads, assumed, ruleSource),
-                            live, out, forks);
+                            entering(match, arm, part, in.read().domain(), reads, assumed,
+                                    ruleSource, numbering),
+                            live, out, forks, numbering);
                 }
             }
             default -> Core.forEachChild(e, child ->
-                    walk(child, in, reads, flow, assumed, live, out, forks));
+                    walk(child, in, reads, flow, assumed, live, out, forks, numbering));
         }
     }
 
@@ -320,24 +339,24 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks) {
      * written apart they would agree by having been derived alike — until one of them learned to
      * read a shape of condition the other did not.
      */
-    private static List<OnTheWay> taking(Core node, boolean holding,
+    private static List<OnTheWay> taking(Condition condition, boolean holding,
                                          souther.compiler.inputs.InputDomain inputs,
-                                         InputReads reads, List<OnTheWay> assumed,
+                                         List<OnTheWay> assumed,
                                          RuleReadingSource ruleSource) {
         List<OnTheWay> out = new ArrayList<>(assumed);
-        out.addAll(ReachingCuts.stating(Condition.of(node, reads, ruleSource.symbols()), inputs,
-                holding, ruleSource));
+        out.addAll(ReachingCuts.stating(condition, inputs, holding, ruleSource));
         return List.copyOf(out);
     }
 
     /** The same, for what standing inside one arm of a fork establishes ({@link
      *  ReachingCuts#entering}). */
-    private static List<OnTheWay> entering(Core.Match match, Core.Case arm,
+    private static List<OnTheWay> entering(Core.Match match, Core.Case arm, int part,
                                            souther.compiler.inputs.InputDomain inputs,
                                            InputReads reads, List<OnTheWay> assumed,
-                                           RuleReadingSource ruleSource) {
+                                           RuleReadingSource ruleSource,
+                                           ConditionNumbering numbering) {
         List<OnTheWay> out = new ArrayList<>(assumed);
-        out.add(ReachingCuts.entering(match, arm, inputs, reads, ruleSource));
+        out.add(ReachingCuts.entering(match, arm, part, inputs, reads, ruleSource, numbering));
         return List.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -110,9 +110,15 @@ sealed interface Condition {
      * <p>Bindings are looked through and their names taken in; the two operators are taken apart;
      * everything else is either one comparison or nowhere this reading goes.
      *
-     * <p>Called once for the condition it is about, however many outcomes of it a reader goes on to
-     * ask about. Reaching one arm of a fork and reaching the other are two things this one
-     * condition says, and a second fold for the second arm would name the same condition twice.
+     * <p><b>One condition however often it is read.</b> A subtree is read as a condition more than
+     * once — what stands past a short-circuit operator's left operand is read where the walk meets
+     * the operator, and again inside whatever encloses it — and the readings are of one condition.
+     * So the reading of a site is asked for and filed rather than made again, and the name it goes
+     * by comes back with it. Made again, one condition would wear a name per reading, and two
+     * accounts of it would agree about nothing.
+     *
+     * <p>Asked after the way in has been looked through, so that what is filed is the condition
+     * rather than the route to it: a truth reached through a binding is the truth.
      */
     static Condition of(Core e, InputReads reads, Symbols symbols, ConditionNumbering numbering) {
         if (e instanceof Core.LetIn let) {
@@ -134,29 +140,40 @@ sealed interface Condition {
                 && reads.meaningOf(name, symbols) instanceof ReadMeaning.Through through) {
             return of(through.denotes().value(), through.denotes().at(), symbols, numbering);
         }
+        Condition already = numbering.alreadyRead(e, reads);
+        if (already != null) {
+            return already;
+        }
+        // The recognition stays in this one method, which is what the registers of who reads an
+        // operator name. Read in a helper beside it, the one place a condition becomes a shape
+        // would be somewhere those registers do not look.
+        Condition made = null;
         if (e instanceof Core.Binary binary) {
             ConditionJoin joined = ConditionJoin.of(binary.op()).orElse(null);
+            Comparison comparison = joined == null ? Comparison.of(binary).orElse(null) : null;
             if (joined != null) {
                 // The whole node is named before its operands are, so that the order the names come
                 // in is the order a reader meets the conditions in.
                 ConditionOccurrence met = numbering.met();
-                return new Joined(met,
+                made = new Joined(met,
                         numbering.anchorOf(binary.origin(), binary.pos(), met), joined,
                         of(binary.left(), reads, symbols, numbering),
                         of(binary.right(), reads, symbols, numbering));
-            }
-            Comparison comparison = Comparison.of(binary).orElse(null);
-            if (comparison != null) {
+            } else if (comparison != null) {
                 ConditionOccurrence met = numbering.met();
-                return new Compares(comparison, met,
+                made = new Compares(comparison, met,
                         numbering.anchorOf(binary.origin(), binary.pos(), met), reads);
             }
         }
-        // Where this stops. A condition may be anything a `Bool` is, and the source wrote no
-        // construct here to name one by — so this is placed by the reading that met it, which is
-        // what handing no origin over says.
-        ConditionOccurrence met = numbering.met();
-        return new NotRead(met, numbering.anchorOf(null, e.pos(), met));
+        if (made == null) {
+            // Where this stops. A condition may be anything a `Bool` is, and the source wrote no
+            // construct here to name one by — so this is placed by the reading that met it, which
+            // is what handing no origin over says.
+            ConditionOccurrence met = numbering.met();
+            made = new NotRead(met, numbering.anchorOf(null, e.pos(), met));
+        }
+        numbering.read(e, reads, made);
+        return made;
     }
 
     // Which binaries are comparisons is `Comparison#of`'s answer and is asked rather than spelled

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.Comparison;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.diag.Citation;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.ReadMeaning;
 import souther.compiler.semantics.ConditionJoin;
@@ -52,18 +51,29 @@ import souther.compiler.semantics.ConditionJoin;
 sealed interface Condition {
 
     /**
-     * Where this is written, as a report may say it.
+     * Which condition of this reading it is.
      *
-     * <p>Kept by every shape, because a reader that could not take one in owes the place it is
-     * written. Recovered afterwards from what is under a node, the place would be a child's — a
-     * conjunction nothing could turn into a region would be reported at whichever operand happened
-     * to be first, which is a second account of where a condition stands and is the kind of thing
+     * <p>Kept by every shape, because a reader that could not take one in owes something to name it
+     * by. Recovered afterwards from what is under a node, the name would be a child's — a
+     * conjunction nothing could turn into a region would be named after whichever operand happened
+     * to be first, which is a second account of which condition this is and is the kind of thing
      * this vocabulary exists to have one of.
      *
-     * <p>The place and not the node it was read from. Every reader of this wants somewhere to point
-     * at, and the node would let one ask the tree what the reading has already answered.
+     * <p>Which condition and not where it is written. Every reader of this wants something to tell
+     * one condition from its neighbours, and a place answers that only for as long as no two of
+     * them are written alike; where a report about one points is {@link #anchor}'s question, asked
+     * of whoever can answer it.
      */
-    Citation at();
+    ConditionOccurrence occurrence();
+
+    /**
+     * Which question a report about it asks for its place.
+     *
+     * <p>Settled here, where what the source wrote is still in hand. Below this a reader holds a
+     * condition and no node, and working out which question to put would mean going back to the
+     * tree for something the recognition has already answered.
+     */
+    ConditionReportAnchor anchor();
 
     /**
      * Two conditions put together, and what the connective makes of them.
@@ -73,8 +83,8 @@ sealed interface Condition {
      *            reads it again for the same answer, and the two readings can be taught different
      *            ones
      */
-    record Joined(Citation at, ConditionJoin how, Condition left, Condition right)
-            implements Condition {}
+    record Joined(ConditionOccurrence occurrence, ConditionReportAnchor anchor, ConditionJoin how,
+                  Condition left, Condition right) implements Condition {}
 
     /**
      * One comparison, and where the names in it point.
@@ -87,21 +97,26 @@ sealed interface Condition {
      *                   an expanded helper is about the argument the call handed it, and read
      *                   against the outer names it is about nothing
      */
-    record Compares(Comparison comparison, Citation at, InputReads reads)
-            implements Condition {}
+    record Compares(Comparison comparison, ConditionOccurrence occurrence,
+                    ConditionReportAnchor anchor, InputReads reads) implements Condition {}
 
     /** Where this reading stops: a condition of a shape it has no words for. */
-    record NotRead(Citation at) implements Condition {}
+    record NotRead(ConditionOccurrence occurrence, ConditionReportAnchor anchor)
+            implements Condition {}
 
     /**
-     * {@code e} read as a condition, under {@code reads}.
+     * {@code e} read as a condition, under {@code reads}, taking its names from {@code numbering}.
      *
      * <p>Bindings are looked through and their names taken in; the two operators are taken apart;
      * everything else is either one comparison or nowhere this reading goes.
+     *
+     * <p>Called once for the condition it is about, however many outcomes of it a reader goes on to
+     * ask about. Reaching one arm of a fork and reaching the other are two things this one
+     * condition says, and a second fold for the second arm would name the same condition twice.
      */
-    static Condition of(Core e, InputReads reads, Symbols symbols) {
+    static Condition of(Core e, InputReads reads, Symbols symbols, ConditionNumbering numbering) {
         if (e instanceof Core.LetIn let) {
-            return of(let.body(), reads.and(let.binder(), let.value()), symbols);
+            return of(let.body(), reads.and(let.binder(), let.value()), symbols, numbering);
         }
         // A name standing for a truth is that truth. What a `let` binds is already carried for the
         // sake of which position a term names, and stopping at the name here left a fork on one
@@ -117,20 +132,31 @@ sealed interface Condition {
         // each step of this goes strictly outwards.
         if (e instanceof Core.Read name
                 && reads.meaningOf(name, symbols) instanceof ReadMeaning.Through through) {
-            return of(through.denotes().value(), through.denotes().at(), symbols);
+            return of(through.denotes().value(), through.denotes().at(), symbols, numbering);
         }
         if (e instanceof Core.Binary binary) {
             ConditionJoin joined = ConditionJoin.of(binary.op()).orElse(null);
             if (joined != null) {
-                return new Joined(Citation.of(binary.pos()), joined,
-                        of(binary.left(), reads, symbols), of(binary.right(), reads, symbols));
+                // The whole node is named before its operands are, so that the order the names come
+                // in is the order a reader meets the conditions in.
+                ConditionOccurrence met = numbering.met();
+                return new Joined(met,
+                        numbering.anchorOf(binary.origin(), binary.pos(), met), joined,
+                        of(binary.left(), reads, symbols, numbering),
+                        of(binary.right(), reads, symbols, numbering));
             }
             Comparison comparison = Comparison.of(binary).orElse(null);
             if (comparison != null) {
-                return new Compares(comparison, Citation.of(binary.pos()), reads);
+                ConditionOccurrence met = numbering.met();
+                return new Compares(comparison, met,
+                        numbering.anchorOf(binary.origin(), binary.pos(), met), reads);
             }
         }
-        return new NotRead(Citation.of(e.pos()));
+        // Where this stops. A condition may be anything a `Bool` is, and the source wrote no
+        // construct here to name one by — so this is placed by the reading that met it, which is
+        // what handing no origin over says.
+        ConditionOccurrence met = numbering.met();
+        return new NotRead(met, numbering.anchorOf(null, e.pos(), met));
     }
 
     // Which binaries are comparisons is `Comparison#of`'s answer and is asked rather than spelled

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
@@ -46,12 +46,16 @@ final class ConditionNumbering {
     /**
      * One condition of this reading: the node a fold arrives at, under the names in force there.
      *
-     * <p><b>The two halves are compared differently, and each for its own reason.</b> A node is the
-     * node and not one shaped like it: {@link Core} is a tree of records, so two comparisons an
-     * author wrote in two places are equal — read as one site, two conditions this compiler tells
-     * apart would take one name. The names in force are what they say and not which object says
-     * them: a {@code let} body reached by two folds is under two environments built the same way,
-     * and read as two sites the condition inside it would be named twice.
+     * <p><b>The two halves are compared differently, and each for its own reason.</b> A site is
+     * which node the reading arrived at, which is an identity question: a node is the same site as
+     * itself and as nothing else, and asking a whole subtree whether it says what another says
+     * would make what it costs to name a condition grow with the tree the condition is in. Today
+     * either comparison would tell the nodes apart — a {@link Core} node carries where it stands —
+     * so what is settled here is which question a site is, not which nodes happen to be told apart.
+     *
+     * <p>The names in force are what they say and not which object says them: a {@code let} body
+     * reached by two folds is under two environments built the same way, and read as two sites the
+     * condition inside it would be named twice.
      *
      * <p>The node the fold arrives at, which is not the node it was handed. Bindings and a name
      * standing for a truth are looked through on the way in, so a condition reached through one is

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
@@ -1,0 +1,91 @@
+package souther.compiler.partition;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.sites.WrittenCondition;
+import souther.compiler.types.SourceConstructOrigin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The names one reading gives the conditions it meets, while it is meeting them.
+ *
+ * <p>A number and what it names are one act: the fold asks for the next name as it recognises a
+ * condition, so there is no moment at which a name exists and which condition it is has still to be
+ * worked out. Which is what the whole of the identity rests on — a number paired with a condition
+ * anywhere else would be that correspondence built a second time, by something that had not done
+ * the recognising.
+ *
+ * <p><b>One of these per body read, and every condition of that reading takes its name here.</b> A
+ * condition of a guard and an arm of a fork are both things a row had to satisfy to get somewhere,
+ * so they are counted together: numbered apart, two of them would wear one name and nothing
+ * downstream could tell them apart.
+ *
+ * <p>It also says which question places a condition, because that is settled where the condition is
+ * read and nowhere else. Whether the code is written somewhere a reader can open is what a position
+ * already says, and it is the one thing about a position that survives the code moving — so it is
+ * the last thing read off the position, and what comes out is which question a report puts later.
+ *
+ * <p>Where the answer is this reading's own, the place is written down in the same act. So there is
+ * one entry per condition a report can ask about and none for the ones whose construct a reader can
+ * go and open.
+ */
+final class ConditionNumbering {
+
+    private final String module;
+    private final String behavior;
+    private final Map<ConditionOccurrence, Citation> metAt = new LinkedHashMap<>();
+    private int next;
+
+    ConditionNumbering(String module, String behavior) {
+        this.module = module;
+        this.behavior = behavior;
+    }
+
+    /** The name of the condition being recognised now. */
+    ConditionOccurrence met() {
+        return new ConditionOccurrence(behavior, next++);
+    }
+
+    /**
+     * Where a report about the condition {@code met} points, it having been written as
+     * {@code construct} at {@code at}.
+     *
+     * <p>The writing module answers where it wrote a construct of its own that a reader can open.
+     * Everything else — a construct this compiler composed, a condition of a shape the reading has
+     * no words for, code in a file this compilation does not hold — is placed by this reading,
+     * which is the only thing that met it.
+     */
+    ConditionReportAnchor anchorOf(SourceConstructOrigin construct, SourcePos at,
+                                   ConditionOccurrence met) {
+        Citation where = Citation.of(at);
+        if (where instanceof Citation.Written && construct != null && construct.isWritten()) {
+            return new ConditionReportAnchor.WhereItIsWritten(
+                    new WrittenCondition.Construct(construct));
+        }
+        return metHere(met, where);
+    }
+
+    /** The same, for reaching one arm of a fork the source wrote as {@code fork}. */
+    ConditionReportAnchor anchorOfArm(SourceConstructOrigin fork, int part, SourcePos at,
+                                      ConditionOccurrence met) {
+        Citation where = Citation.of(at);
+        if (where instanceof Citation.Written && fork != null && fork.isWritten()) {
+            return new ConditionReportAnchor.WhereItIsWritten(
+                    new WrittenCondition.ForkArm(fork, part));
+        }
+        return metHere(met, where);
+    }
+
+    /** An address of this reading, with the place it addresses written down in the same act. */
+    private ConditionReportAnchor metHere(ConditionOccurrence met, Citation where) {
+        metAt.put(met, where);
+        return new ConditionReportAnchor.WhereTheReadingMetIt(module, met);
+    }
+
+    /** Where this reading met each condition it places itself. */
+    Map<ConditionOccurrence, Citation> metAt() {
+        return Map.copyOf(metAt);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionNumbering.java
@@ -1,21 +1,31 @@
 package souther.compiler.partition;
 
+import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.inputs.InputReads;
 import souther.compiler.sites.WrittenCondition;
 import souther.compiler.types.SourceConstructOrigin;
 
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * The names one reading gives the conditions it meets, while it is meeting them.
+ * The conditions one reading of a body met, and the name each of them goes by.
  *
- * <p>A number and what it names are one act: the fold asks for the next name as it recognises a
- * condition, so there is no moment at which a name exists and which condition it is has still to be
- * worked out. Which is what the whole of the identity rests on — a number paired with a condition
- * anywhere else would be that correspondence built a second time, by something that had not done
- * the recognising.
+ * <p><b>A register of what was met and not a count of the reading.</b> A subtree is read as a
+ * condition more than once — the walk reads a short-circuit operator's left operand to say what
+ * stands past it, and reads it again inside whatever encloses it — and every one of those readings
+ * is of the same condition. Counted per reading, one condition would wear as many names as the
+ * shape of the tree happens to produce, and a reader joining two accounts on the name would join
+ * them on nothing.
+ *
+ * <p>So a name and what it names are one act: the first reading of a site asks for the next name,
+ * and every reading after it is answered with what the first came to. A number paired with a
+ * condition anywhere else would be that correspondence built a second time, by something that had
+ * not done the recognising.
  *
  * <p><b>One of these per body read, and every condition of that reading takes its name here.</b> A
  * condition of a guard and an arm of a fork are both things a row had to satisfy to get somewhere,
@@ -33,8 +43,40 @@ import java.util.Map;
  */
 final class ConditionNumbering {
 
+    /**
+     * One condition of this reading: the node a fold arrives at, under the names in force there.
+     *
+     * <p><b>The two halves are compared differently, and each for its own reason.</b> A node is the
+     * node and not one shaped like it: {@link Core} is a tree of records, so two comparisons an
+     * author wrote in two places are equal — read as one site, two conditions this compiler tells
+     * apart would take one name. The names in force are what they say and not which object says
+     * them: a {@code let} body reached by two folds is under two environments built the same way,
+     * and read as two sites the condition inside it would be named twice.
+     *
+     * <p>The node the fold arrives at, which is not the node it was handed. Bindings and a name
+     * standing for a truth are looked through on the way in, so a condition reached through one is
+     * the same condition as the one reached without.
+     */
+    private record Site(Core node, InputReads reads) {
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Site that && node == that.node && reads.equals(that.reads);
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(node) * 31 + reads.hashCode();
+        }
+    }
+
     private final String module;
     private final String behavior;
+    private final Map<Site, Condition> read = new HashMap<>();
+    /** The name each arm of each fork goes by. Beside {@link #read} because an arm is not a fold of
+     *  a subtree: what is met is the fork and which of its arms, and there is no node of its own to
+     *  be at. */
+    private final Map<Core.Match, Map<Integer, ConditionOccurrence>> arms = new IdentityHashMap<>();
     private final Map<ConditionOccurrence, Citation> metAt = new LinkedHashMap<>();
     private int next;
 
@@ -43,9 +85,41 @@ final class ConditionNumbering {
         this.behavior = behavior;
     }
 
+    /** What this reading already made of the condition at {@code at} under {@code reads}, or null
+     *  where it has not met it. */
+    Condition alreadyRead(Core at, InputReads reads) {
+        return read.get(new Site(at, reads));
+    }
+
+    /** Files {@code condition} as what the condition at {@code at} under {@code reads} is. */
+    void read(Core at, InputReads reads, Condition condition) {
+        read.put(new Site(at, reads), condition);
+    }
+
     /** The name of the condition being recognised now. */
     ConditionOccurrence met() {
         return new ConditionOccurrence(behavior, next++);
+    }
+
+    /**
+     * The name reaching {@code part} of {@code fork} goes by.
+     *
+     * <p>Refused where this reading has already named that arm, rather than answered with the name
+     * it gave the first time. A fold of a subtree is asked for more than once and is registered
+     * because of it; an arm is met where the walk meets the fork, and a second naming would be a
+     * walk that had come to reach one arm twice — which is a walk saying a row satisfied one thing
+     * two ways, and nothing downstream could tell the two apart. So it is raised here rather than
+     * resolved by keeping one of them.
+     */
+    ConditionOccurrence metEntering(Core.Match fork, int part) {
+        Map<Integer, ConditionOccurrence> named =
+                arms.computeIfAbsent(fork, _ -> new LinkedHashMap<>());
+        ConditionOccurrence already = named.putIfAbsent(part, met());
+        if (already != null) {
+            throw new IllegalStateException(
+                    "this reading has already named arm " + part + " of a fork: " + already);
+        }
+        return named.get(part);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionOccurrence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionOccurrence.java
@@ -1,0 +1,47 @@
+package souther.compiler.partition;
+
+/**
+ * Which condition on the way to a border this is, as the reading that met it names them.
+ *
+ * <p>What tells one condition from every other, and nothing about where it stands. A report is sent
+ * to a place and this is not one: two conditions written a page apart are two of these because the
+ * reading met two, and a condition that moves is the same one.
+ *
+ * <p><b>Minted by the fold and not read off the tree.</b> A condition is what
+ * {@link Condition#of} makes of an expression, and that reading looks through a binding and through
+ * a name standing for what it was bound to — so a path down the tree that runs is not an address
+ * among the conditions, and two readings of one subtree would number by different shapes. What
+ * numbers them is the fold itself, once, and every reader below is handed the answer.
+ *
+ * <p><b>Counted within the body being read, not over the module.</b> A count over the module makes
+ * the number a function of everything read before it there, so an edit to one behavior renames the
+ * conditions of every one after it — and an identity that moves for an edit nothing about it can
+ * see is not one. The two halves travel together for the reason
+ * {@link souther.compiler.types.SourceConstructOrigin} keeps its owner beside its ordinal: a number
+ * says which condition only under something that says which conditions were being counted.
+ *
+ * <p>Not a name anything outside one reading can be matched by, and not one to work a place out of.
+ * Where a report about a condition points is
+ * {@link ConditionReportAnchor}'s question, asked of whoever can answer it.
+ *
+ * @param behavior the body whose reading met it
+ * @param ordinal  which condition of that reading, by the fold's own count over it
+ */
+public record ConditionOccurrence(String behavior, int ordinal) {
+
+    public ConditionOccurrence {
+        if (behavior == null) {
+            throw new IllegalArgumentException(
+                    "a condition on the way is one some reading met: " + ordinal);
+        }
+        if (ordinal < 0) {
+            throw new IllegalArgumentException(
+                    "a condition stands somewhere among the ones a reading met: " + ordinal);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "condition " + ordinal + " of `" + behavior + "`";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionReportAnchor.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionReportAnchor.java
@@ -1,0 +1,65 @@
+package souther.compiler.partition;
+
+import souther.compiler.sites.WrittenCondition;
+
+/**
+ * Which question a report about one condition asks for its place.
+ *
+ * <p>Not the place. What an answer holds is what it is about, and where a reader is sent is worked
+ * out when a sentence is written — so a helper whose conditions move, saying the same thing, moves
+ * where the sentences point and leaves every answer about them alone.
+ *
+ * <p><b>Two questions and not a first choice with a fallback.</b> A condition the source wrote is
+ * placed by the module that wrote it, wherever it was met; a condition of a shape the reading has
+ * no words for is any expression at all, and the module that wrote it filed nothing under a name
+ * this could ask by — so it is placed by the reading that met it. Which of the two applies is
+ * settled where the condition is read, and asked the other way round, a condition written in a file
+ * this compilation has stopped holding would quietly be reported at wherever a reading met a copy
+ * of it.
+ *
+ * <p>Beside {@link souther.compiler.coverage.ArmReportAnchor} and not the same shape as it. What
+ * the two share is the rule rather than the arms: an answer holds no place, and an anchor says only
+ * which question to put.
+ */
+public sealed interface ConditionReportAnchor {
+
+    /**
+     * The module that wrote it places it.
+     *
+     * <p>Which condition of that module, under an identity a copy cannot change: a condition inside
+     * a helper spliced into three callers is one condition, and where it is written is not a
+     * question any of the three can answer for itself.
+     */
+    record WhereItIsWritten(WrittenCondition condition) implements ConditionReportAnchor {
+
+        public WhereItIsWritten {
+            if (condition == null) {
+                throw new IllegalArgumentException(
+                        "a condition placed by whoever wrote it is some condition they wrote");
+            }
+        }
+    }
+
+    /**
+     * The reading that met it places it.
+     *
+     * <p>For a condition the source wrote no construct of — an expression this reading has no words
+     * for, or one under a fork nothing wrote. There is nothing to open where such a condition is
+     * written, and what a reader can be shown is where this compilation met it, which is this
+     * module's own text and moves only when this module does.
+     *
+     * @param module    whose reading met it, which is what makes the occurrence an address and not
+     *                  half of one
+     * @param condition which condition of that reading
+     */
+    record WhereTheReadingMetIt(String module, ConditionOccurrence condition)
+            implements ConditionReportAnchor {
+
+        public WhereTheReadingMetIt {
+            if (module == null || condition == null) {
+                throw new IllegalArgumentException("a condition placed by the reading that met it"
+                        + " is one of some module's readings: " + module + ", " + condition);
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -37,6 +37,7 @@ import souther.compiler.types.Type;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.SequencedMap;
 
 /**
@@ -82,16 +83,18 @@ public final class GuardThresholds {
                          RulesWithNoLine noLine,
                          List<LineDrawn> between,
                          ReachingCuts reaching,
-                         List<ComparisonReadings.ForkMet> forks) {
+                         List<ComparisonReadings.ForkMet> forks,
+                         Map<ConditionOccurrence, Citation> conditionsMet) {
 
         public static final Guards NONE =
                 new Guards(List.of(), RulesWithNoLine.NONE, List.of(), ReachingCuts.NONE,
-                        List.of());
+                        List.of(), Map.of());
 
         public Guards {
             evidence = List.copyOf(evidence);
             between = List.copyOf(between);
             forks = List.copyOf(forks);
+            conditionsMet = Map.copyOf(conditionsMet);
         }
 
         /** The lines, read off what the walk said. Not a list of their own: the walk met these and
@@ -270,7 +273,7 @@ public final class GuardThresholds {
             }
         }
         return new Guards(found, withoutALine.found(), between, cuts.made(),
-                comparisons.forks());
+                comparisons.forks(), comparisons.conditionsMet());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
@@ -90,6 +90,15 @@ public sealed interface OnTheWay {
                 throw new IllegalArgumentException(
                         "a condition this reading declined is some condition it met");
             }
+            // And the one it is named after is the one a report is sent to. Where the reading
+            // places it, the anchor says which condition of the reading that is — so the two are
+            // one answer said twice, and a value whose halves named different conditions would be
+            // reported at a condition other than the one it says was declined.
+            if (anchor instanceof ConditionReportAnchor.WhereTheReadingMetIt(
+                    String _, ConditionOccurrence anchored) && !condition.equals(anchored)) {
+                throw new IllegalArgumentException("a condition declined here is reported here: "
+                        + condition + " reported at " + anchored);
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
@@ -1,6 +1,5 @@
 package souther.compiler.partition;
 
-import souther.compiler.diag.Citation;
 import souther.compiler.inputs.TermPath;
 
 /**
@@ -26,17 +25,22 @@ import souther.compiler.inputs.TermPath;
 public sealed interface OnTheWay {
 
     /**
-     * Where the condition is, as a report is entitled to say it.
+     * Which question a report about it asks for its place.
      *
-     * <p>A {@link Citation} and not a {@link souther.compiler.diag.SourcePos}, because what this is
-     * for is being said. Whether a reader can be sent to the text and whether the condition is
-     * written at the place are the two questions that type answers, and a helper's condition
-     * reached from a call is exactly where a raw position sends a reader somewhere the code is not.
+     * <p>An anchor and not a place. A location held here reaches whoever reads a finding, so a
+     * helper whose conditions move — saying the same thing — would move every answer about them;
+     * what is held is which question to put, and the place is worked out where a sentence is
+     * written.
      */
-    Citation at();
+    ConditionReportAnchor anchor();
 
-    /** A condition the arithmetic took in, and the cut it came to. */
-    record TakenIn(Citation at, ReachingCuts.Cut cut) implements OnTheWay {}
+    /**
+     * A condition the arithmetic took in, and the cut it came to.
+     *
+     * <p>The cut is what says which condition this is. Two of them stating one inequality over one
+     * form are one thing to compose against, and nothing here needs to tell them apart.
+     */
+    record TakenIn(ConditionReportAnchor anchor, ReachingCuts.Cut cut) implements OnTheWay {}
 
     /**
      * A condition that says which values a position is one of, as the position it narrows.
@@ -50,9 +54,11 @@ public sealed interface OnTheWay {
      * other reader of a narrowing asks; carried as a position and a refinement side by side, this
      * would be the one place that splits them its own way.
      *
+     * <p>The position is what says which condition this is, the way a cut does for the one above.
+     *
      * @param position the scrutinee's position with the arm's case narrowed onto it
      */
-    record Narrowed(Citation at, TermPath position) implements OnTheWay {
+    record Narrowed(ConditionReportAnchor anchor, TermPath position) implements OnTheWay {
 
         public Narrowed {
             if (position == null || !position.narrowsWhatItReaches()) {
@@ -62,8 +68,30 @@ public sealed interface OnTheWay {
         }
     }
 
-    /** A condition nothing here could turn into a cut, and what stopped it. */
-    record Declined(Citation at, Why why) implements OnTheWay {}
+    /**
+     * A condition nothing here could turn into a cut, and what stopped it.
+     *
+     * <p><b>The one of the three that has to say which condition it is.</b> What the other two
+     * carry beside the anchor already tells one from its neighbours: a cut is an inequality over a
+     * form, a narrowing is a position. What this carries beside the anchor is only why it was
+     * declined, and two conditions declined for one reason are one reason — so without a name for
+     * the condition, two conditions this compiler does tell apart would be one value.
+     *
+     * <p>Named and not placed. Where two of them are written is what used to tell them apart, which
+     * is a location doing identity's work because nothing else was doing it.
+     *
+     * @param condition which condition of the reading was declined
+     */
+    record Declined(ConditionOccurrence condition, ConditionReportAnchor anchor, Why why)
+            implements OnTheWay {
+
+        public Declined {
+            if (condition == null) {
+                throw new IllegalArgumentException(
+                        "a condition this reading declined is some condition it met");
+            }
+        }
+    }
 
     /**
      * What stopped a condition from being stated in either vocabulary.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachabilityGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachabilityGap.java
@@ -22,15 +22,16 @@ import java.util.Collection;
  */
 public sealed interface ReachabilityGap {
 
-    /** Where the condition is, as a report is entitled to say it. */
-    souther.compiler.diag.Citation at();
+    /** Which question a report about the condition asks for its place, which is the condition's own
+     *  answer and not a second one worked out here. */
+    ConditionReportAnchor anchor();
 
     /** The walk had no words for it, so nothing downstream ever saw it. */
     record Unstated(OnTheWay.Declined condition) implements ReachabilityGap {
 
         @Override
-        public souther.compiler.diag.Citation at() {
-            return condition.at();
+        public ConditionReportAnchor anchor() {
+            return condition.anchor();
         }
     }
 
@@ -45,8 +46,8 @@ public sealed interface ReachabilityGap {
     record Uncomposed(OnTheWay.TakenIn condition, Why why) implements ReachabilityGap {
 
         @Override
-        public souther.compiler.diag.Citation at() {
-            return condition.at();
+        public ConditionReportAnchor anchor() {
+            return condition.anchor();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -2,7 +2,6 @@ package souther.compiler.partition;
 
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.core.Core;
-import souther.compiler.diag.Citation;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
@@ -112,11 +111,11 @@ public record ReachingCuts(Map<ModelOccurrence, List<OnTheWay>> byComparison) {
             case Condition.Joined joined -> joined.how().under(holding) == ConditionJoin.BOTH
                     ? and(stating(joined.left(), inputs, holding, ruleSource),
                             stating(joined.right(), inputs, holding, ruleSource))
-                    : List.of(new OnTheWay.Declined(joined.at(),
+                    : List.of(new OnTheWay.Declined(joined.occurrence(), joined.anchor(),
                             new OnTheWay.Why.OneOfTwoThings()));
             case Condition.Compares one -> List.of(of(one, inputs, holding, ruleSource));
             case Condition.NotRead not -> List.of(new OnTheWay.Declined(
-                    not.at(), new OnTheWay.Why.NoWordsForTheShape()));
+                    not.occurrence(), not.anchor(), new OnTheWay.Why.NoWordsForTheShape()));
         };
     }
 
@@ -144,12 +143,16 @@ public record ReachingCuts(Map<ModelOccurrence, List<OnTheWay>> byComparison) {
      * nothing and an arm nothing could be read of are the two answers a walk has to tell apart, and
      * a silence is both of them.
      */
-    static OnTheWay entering(Core.Match match, Core.Case arm, InputDomain inputs, InputReads reads,
-                             RuleReadingSource ruleSource) {
-        Citation at = Citation.of(arm.pos());
+    static OnTheWay entering(Core.Match match, Core.Case arm, int part, InputDomain inputs,
+                             InputReads reads, RuleReadingSource ruleSource,
+                             ConditionNumbering numbering) {
+        ConditionOccurrence met = numbering.met();
+        ConditionReportAnchor at =
+                numbering.anchorOfArm(match.origin(), part, arm.pos(), met);
         Refinement narrowing = arm.selectedCase().map(Refinement::of).orElse(null);
         if (narrowing == null) {
-            return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
+            return new OnTheWay.Declined(met, at,
+                    new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
         // The arm is declined for either answer: a search composes against a position read as one
         // of its cases, and there is no position to narrow whether the scrutinee stands at none or
@@ -171,7 +174,8 @@ public record ReachingCuts(Map<ModelOccurrence, List<OnTheWay>> byComparison) {
         // Two values and not one: where the name stands is what the environment answers, and
         // whether the input's rules hold a position there is the reading's.
         if (scrutinee == null || inputs.at(scrutinee) == null) {
-            return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
+            return new OnTheWay.Declined(met, at,
+                    new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
         return new OnTheWay.Narrowed(at, scrutinee.refine(narrowing));
     }
@@ -194,11 +198,12 @@ public record ReachingCuts(Map<ModelOccurrence, List<OnTheWay>> byComparison) {
      */
     private static OnTheWay of(Condition.Compares comparison, InputDomain inputs, boolean holding,
                                RuleReadingSource ruleSource) {
-        Citation at = comparison.at();
+        ConditionReportAnchor at = comparison.anchor();
         AffineReading read = AffineReading.of(
                 comparison.comparison(), inputs, comparison.reads(), ruleSource);
         if (read == null) {
-            return new OnTheWay.Declined(at, new OnTheWay.Why.ComparisonNotRepresentedAsACut());
+            return new OnTheWay.Declined(comparison.occurrence(), at,
+                    new OnTheWay.Why.ComparisonNotRepresentedAsACut());
         }
         // What the comparison states, in the words a domain is told things in. Taken the way the
         // path met it: an arm reached by the condition failing has what holds exactly where the

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -146,7 +146,7 @@ public record ReachingCuts(Map<ModelOccurrence, List<OnTheWay>> byComparison) {
     static OnTheWay entering(Core.Match match, Core.Case arm, int part, InputDomain inputs,
                              InputReads reads, RuleReadingSource ruleSource,
                              ConditionNumbering numbering) {
-        ConditionOccurrence met = numbering.met();
+        ConditionOccurrence met = numbering.metEntering(match, part);
         ConditionReportAnchor at =
                 numbering.anchorOfArm(match.origin(), part, arm.pos(), met);
         Refinement narrowing = arm.selectedCase().map(Refinement::of).orElse(null);

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1439,6 +1439,72 @@ public final class Adequacy {
 
         @Override
         public Answer<souther.compiler.partition.Partitions.Partitioning> compute(Db db) {
+            Answer<BodyDivided> read = db.ask(new Dividing(name, behavior));
+            return read.present() ? Answer.of(read.value().geometry()) : Answer.absent();
+        }
+    }
+
+    /**
+     * What one reading of a body leaves, of the parts an answer may hold.
+     *
+     * <p>The reading of the input itself is not here. It holds a way of asking the declarations a
+     * further question, so it compares by which of them built it — held in an answer, it would make
+     * the answer a thing two compilations of one source could not find equal.
+     */
+    record BodyDivided(souther.compiler.partition.Partitions.Partitioning geometry,
+                       java.util.Map<souther.compiler.partition.ConditionOccurrence,
+                               souther.compiler.diag.Citation> conditionsMet) {}
+
+    /**
+     * Where the reading that divided one behavior met each condition it places itself.
+     *
+     * <p>Beside {@link Divided} and read off the same reading. Told apart by what a reader holds:
+     * one holds a row to compose and asks what the model divides, and this is asked by a reader
+     * writing a sentence about a condition and holding no place at all.
+     *
+     * <p>Its own question so that what each of the two says stops where its own meaning stops. Both
+     * are worked out again whenever the reading comes out different; what a report is told about a
+     * place then comes back the same where nothing about the places moved, and goes no further.
+     *
+     * <p>Of the reading that met the conditions and not of the module that wrote them. A condition
+     * a reader can go and open is placed by whoever wrote it
+     * ({@link Sites.WhereAConditionIsWritten}); what is here is the rest — a construct this
+     * compiler composed, a condition of a shape the reading has no words for, code in a file this
+     * compilation does not hold.
+     */
+    public record ConditionsMet(String name, String behavior)
+            implements Key<java.util.Map<souther.compiler.partition.ConditionOccurrence,
+                    souther.compiler.diag.Citation>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<java.util.Map<souther.compiler.partition.ConditionOccurrence,
+                souther.compiler.diag.Citation>> compute(Db db) {
+            Answer<BodyDivided> read = db.ask(new Dividing(name, behavior));
+            return read.present() ? Answer.of(read.value().conditionsMet()) : Answer.absent();
+        }
+    }
+
+    /**
+     * One reading of one behavior's body, which both questions about it are projections of.
+     *
+     * <p>Here rather than at each of them, because a body is read once: answered apart, the two
+     * would be two readings of one body, agreeing until the day one of them was taught something
+     * the other was not.
+     */
+    record Dividing(String name, String behavior) implements Key<BodyDivided> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<BodyDivided> compute(Db db) {
             // The assembly. What says whether there is anything to divide is the behavior's own
             // signature: a module one of whose declarations did not come out still has behaviors
             // whose boundary was built, and those are divided like any other.
@@ -1479,7 +1545,7 @@ public final class Adequacy {
             souther.compiler.coverage.CoverageSites.Plan plan =
                     checked == null
                             ? souther.compiler.coverage.CoverageSites.Plan.NONE : checked.plan();
-            return Answer.of(Coverages.partitioningOf(spec,
+            Coverages.Partitioned read = Coverages.partitioningOf(spec,
                     domain.reading(reading.value()), bodies.get(behavior),
                     plan,
                     arrivalsOf(db.ask(new PathReached(name)).value(), spec),
@@ -1491,7 +1557,8 @@ public final class Adequacy {
                     // further in, a position would be allowed its machines once per caller and what
                     // the two came to would be bought by nobody.
                     db.ask(new Front.Adequacy()).value().measures()
-                            .allowanceForBehaviorDistinctions()).geometry());
+                            .allowanceForBehaviorDistinctions());
+            return Answer.of(new BodyDivided(read.geometry(), read.conditionsMet()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -69,7 +69,9 @@ final class Coverages {
      * twice would read them twice.
      */
     record Partitioned(Partitions.Partitioning geometry,
-                       souther.compiler.inputs.Quantities reading) {}
+                       souther.compiler.inputs.Quantities reading,
+                       java.util.Map<souther.compiler.partition.ConditionOccurrence,
+                               souther.compiler.diag.Citation> conditionsMet) {}
 
     /**
      * The positions one behavior is measured at, with what its own comparisons divide them into.
@@ -152,7 +154,11 @@ final class Coverages {
                 // What a row had to satisfy to arrive at each comparison, from the walk that
                 // assumed it. A clause of a declaration is not written at a place in a body and has
                 // nothing on the way to it, so only the guards have any of this.
-                guards.reaching()), quantities);
+                guards.reaching()), quantities,
+                // Where this reading met each condition it places itself, beside the geometry and
+                // not inside it. A report points at a condition and an answer says which condition
+                // it is, and the two are kept apart so that moving one leaves the other alone.
+                guards.conditionsMet());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Sites.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Sites.java
@@ -5,7 +5,11 @@ import souther.compiler.check.Prepared;
 import souther.compiler.coverage.ArmReportAnchor;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.partition.ConditionOccurrence;
+import souther.compiler.partition.ConditionReportAnchor;
 import souther.compiler.sites.AuthoredSites;
+import souther.compiler.sites.WrittenCondition;
+import souther.compiler.sites.WrittenConditions;
 import souther.compiler.sites.WrittenForks;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeSymbol;
@@ -272,6 +276,97 @@ public final class Sites {
             }
             return Answer.absent();
         }
+    }
+
+    /**
+     * Where one condition of a module's source is written.
+     *
+     * <p>The sibling of {@link WhereAForkIsWritten}, and asked by the same kind of reader: one that
+     * holds a condition it met somewhere else and no place at all. A condition inside a helper
+     * expanded into three callers is one condition written once, so where it is is not a question
+     * any of the three can answer for itself.
+     *
+     * <p>Absent where nothing this compilation holds wrote it. What the language itself ships is
+     * the case that matters: its conditions stand in every module that calls into it, and no source
+     * of this compilation is where they are written.
+     */
+    public record WhereAConditionIsWritten(WrittenCondition condition) implements Key<Citation> {
+
+        @Override
+        public String module() {
+            return condition.construct().module();
+        }
+
+        @Override
+        public Answer<Citation> compute(Db db) {
+            if (condition.construct().module() == null) {
+                return Answer.absent();
+            }
+            Answer<WrittenConditions> written =
+                    db.ask(new ConditionsWrittenIn(condition.construct().module()));
+            if (!written.present()) {
+                return Answer.absent();
+            }
+            SourcePos at = written.value().at(condition);
+            return at == null ? Answer.absent() : Answer.of(Citation.of(at));
+        }
+    }
+
+    /**
+     * Where each condition one module's source wrote stands.
+     *
+     * <p>Under {@link WhereAConditionIsWritten} for the reason {@link ForksWrittenIn} is under
+     * {@link WhereAForkIsWritten}: what a report means is one place, and one walk answers for every
+     * place at once. Asked condition by condition, the answer would be built again for each
+     * sentence written about one.
+     */
+    record ConditionsWrittenIn(String name) implements Key<WrittenConditions> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<WrittenConditions> compute(Db db) {
+            Answer<AuthoredSites.Walked> walked = db.ask(new Walk(name));
+            return walked.present() ? Answer.of(walked.value().conditions()) : Answer.absent();
+        }
+    }
+
+    /**
+     * Where a report about {@code anchor}'s condition points.
+     *
+     * <p>The one place the two questions come back together, and a switch rather than a fallback,
+     * for the reason {@link #placeOf(Db, ArmReportAnchor)} is one. Asked the other way round, a
+     * condition written in a file this compilation has stopped holding would quietly be reported
+     * wherever a reading met a copy of it.
+     *
+     * @throws NothingPlacesIt where the question the anchor names has no answer
+     */
+    public static Citation placeOf(Db db, ConditionReportAnchor anchor) {
+        Answer<Citation> at = switch (anchor) {
+            case ConditionReportAnchor.WhereItIsWritten(WrittenCondition condition) ->
+                    db.ask(new WhereAConditionIsWritten(condition));
+            case ConditionReportAnchor.WhereTheReadingMetIt(String module,
+                    ConditionOccurrence condition) ->
+                    metIn(db, module, condition);
+        };
+        if (!at.present()) {
+            throw new NothingPlacesIt("a condition reported at " + anchor);
+        }
+        return at.value();
+    }
+
+    /** Where the reading of {@code condition}'s body met it, as an answer that may be missing. */
+    private static Answer<Citation> metIn(Db db, String module, ConditionOccurrence condition) {
+        Answer<Map<ConditionOccurrence, Citation>> met =
+                db.ask(new Adequacy.ConditionsMet(module, condition.behavior()));
+        if (!met.present()) {
+            return Answer.absent();
+        }
+        Citation at = met.value().get(condition);
+        return at == null ? Answer.absent() : Answer.of(at);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -192,19 +192,42 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /**
+     * What a module's declarations are owed, with where this report shows the conditions on the way
+     * to their lines.
+     *
+     * <p>The places are here, beside the account they are about, and not on the module. A module
+     * says which of this compilation's sources it is written in, and these say where each condition
+     * a sentence names is — including the ones another module wrote. Held side by side, the two
+     * would be a value that answers "which file" twice, and the second answer would be about
+     * whichever condition a reader happened to be looking at.
+     *
+     * @param owed what the declarations are owed, or null where the compile did not get far enough
+     *             to be asked
+     */
+    public record DeclarationsShown(Adequacy.DeclaredBoundaries owed,
+                                    Map<ConditionReportAnchor, Citation> conditionPlaces) {
+
+        public DeclarationsShown {
+            conditionPlaces = Map.copyOf(conditionPlaces);
+        }
+
+        /** Nothing owed and nothing to point at, for a module nobody could ask. */
+        public static final DeclarationsShown NONE = new DeclarationsShown(null, Map.of());
+    }
+
+    /**
      * What one module's compile came to, as this report says it.
      *
      * @param owedByDeclarations what this module's declarations are owed and how far the reading it
      *                           was made from got. An account and not a list of debts: a module
      *                           whose lines nobody could read holds no debts anybody found, and read
      *                           as a list that is the same answer as a module whose declarations owe
-     *                           nothing. Null where the compile did not get far enough to be asked
+     *                           nothing
      */
     public record ModuleReport(String module, SourceId declaredIn,
                                List<BehaviorReport> behaviors,
                                List<ReportedFinding> declarations,
-                               Adequacy.DeclaredBoundaries owedByDeclarations,
-                               Map<ConditionReportAnchor, Citation> conditionPlaces) {
+                               DeclarationsShown owedByDeclarations) {
 
         /**
          * What the module is short of that is not any behavior's.
@@ -220,13 +243,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         public ModuleReport {
             behaviors = List.copyOf(behaviors);
             declarations = List.copyOf(declarations);
-            conditionPlaces = Map.copyOf(conditionPlaces);
         }
 
         /** The debts themselves, for a reader walking them. Empty where nobody could be asked,
          *  which {@link #declarationsWeakenedBy()} is what says. */
         public List<Adequacy.DeclaredDebt> debts() {
-            return owedByDeclarations == null ? List.of() : owedByDeclarations.owed();
+            return owedByDeclarations.owed() == null
+                    ? List.of() : owedByDeclarations.owed().owed();
         }
 
         /**
@@ -295,8 +318,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
          * entries.
          */
         public WeakeningSet declarationsWeakenedBy() {
-            return owedByDeclarations == null
-                    ? WeakeningSet.none() : owedByDeclarations.weakening();
+            return owedByDeclarations.owed() == null
+                    ? WeakeningSet.none() : owedByDeclarations.owed().weakening();
         }
 
         /** How far this module's measurement got. Derived, for the reason
@@ -595,10 +618,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                         instanceof FindingSubject.OfABehavior))
                                 .map(each -> reported(compilation, name, each))
                                 .toList(),
-                declared,
                 // The declarations' own block names conditions too, and the lines it names them
                 // under are the debts' rather than any behavior's.
-                conditionPlaces(compilation, declaredLines(declared)));
+                new DeclarationsShown(declared,
+                        conditionPlaces(compilation, declaredLines(declared))));
     }
 
     /** The lines a module's declarations were read at, which is where the block about them looks
@@ -688,6 +711,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         Map<ConditionReportAnchor, Citation> places = new LinkedHashMap<>();
         for (BorderAssessment line : lines) {
             for (BorderAssessment.Point point : line.points()) {
+                // A point nobody is owed a row at ran no search, so there is nothing under it to
+                // point at. Asked all the same, this would be reading an absence as an empty list.
+                if (point.owed() == null) {
+                    continue;
+                }
                 for (ItemAssessment.Attempt attempt : point.owed().searches().each()) {
                     for (ReachabilityGap gap : attempt.unaccountedFor()) {
                         places.computeIfAbsent(gap.anchor(),
@@ -754,7 +782,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, each.debt(), _ -> true, at -> whatWasTried(
-                    at.owedAt(each.debt().at()).searches(), module.conditionPlaces(), names, null));
+                    at.owedAt(each.debt().at()).searches(),
+                    module.owedByDeclarations().conditionPlaces(), names, null));
         }
         Map<String, List<Adequacy.Finding>> byDeclaration = new LinkedHashMap<>();
         for (ReportedFinding each : module.declarations()) {
@@ -823,12 +852,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // and deciding that here would be this view working out what an account means.
             ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
                     carriedBy(m.declarations(), behaviors),
-                    m.owedByDeclarations() == null ? null
-                            : m.owedByDeclarations().keptFor(names),
-                    // Kept whole. A filtered view shows fewer debts and the conditions under the
-                    // ones it does show are the same conditions, so narrowing this would be a place
-                    // going missing from a sentence the view still writes.
-                    m.conditionPlaces());
+                    // The debts narrow with the behaviors shown; the places do not. A filtered view
+                    // shows fewer debts and the conditions under the ones it does show are the same
+                    // conditions, so narrowing the places would be one going missing from a
+                    // sentence the view still writes.
+                    new DeclarationsShown(m.owedByDeclarations().owed() == null ? null
+                            : m.owedByDeclarations().owed().keptFor(names),
+                            m.owedByDeclarations().conditionPlaces()));
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -15,6 +15,7 @@ import souther.compiler.numeric.Towards;
 import souther.compiler.partition.AuthoredLine;
 import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.partition.ClosureGap;
+import souther.compiler.partition.ConditionReportAnchor;
 import souther.compiler.partition.CompositionBudget;
 import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.DomainPoint;
@@ -202,7 +203,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     public record ModuleReport(String module, SourceId declaredIn,
                                List<BehaviorReport> behaviors,
                                List<ReportedFinding> declarations,
-                               Adequacy.DeclaredBoundaries owedByDeclarations) {
+                               Adequacy.DeclaredBoundaries owedByDeclarations,
+                               Map<ConditionReportAnchor, Citation> conditionPlaces) {
 
         /**
          * What the module is short of that is not any behavior's.
@@ -218,6 +220,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         public ModuleReport {
             behaviors = List.copyOf(behaviors);
             declarations = List.copyOf(declarations);
+            conditionPlaces = Map.copyOf(conditionPlaces);
         }
 
         /** The debts themselves, for a reader walking them. Empty where nobody could be asked,
@@ -344,15 +347,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      *                  build is warned about
      * @param armPlaces where each arm of this behavior is shown, for the lines that name one no
      *                  finding is about
+     * @param conditionPlaces where each condition on the way to one of this behavior's lines is
+     *                  shown. Beside the searches rather than in them: what a search holds is which
+     *                  condition it could not compose against, and where a reader is sent for one
+     *                  is asked here, once per condition the page may name
      */
     public record BehaviorReport(String name, BehaviorImplementation implementation,
                                  BehaviorEvidence evidence,
                                  ClaimAnnotations claimed,
                                  List<ReportedFinding> reported,
-                                 Map<ArmReportAnchor, Citation> armPlaces) {
+                                 Map<ArmReportAnchor, Citation> armPlaces,
+                                 Map<ConditionReportAnchor, Citation> conditionPlaces) {
         public BehaviorReport {
             reported = List.copyOf(reported);
             armPlaces = Map.copyOf(armPlaces);
+            conditionPlaces = Map.copyOf(conditionPlaces);
         }
 
         /**
@@ -574,8 +583,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     claims == null ? ClaimAnnotations.NONE
                             : claims.getOrDefault(behavior.name(), ClaimAnnotations.NONE),
                     ofBehavior(compilation, name, findings, behavior.name()),
-                    armPlaces(compilation, branch)));
+                    armPlaces(compilation, branch),
+                    conditionPlaces(compilation, linesOf(read))));
         }
+        Adequacy.DeclaredBoundaries declared =
+                compilation.db().ask(new Adequacy.DeclaredBorders(name)).value();
         return new ModuleReport(name, compilation.sourceIdOf(name), behaviors,
                 findings == null ? List.of()
                         : findings.stream()
@@ -583,7 +595,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                         instanceof FindingSubject.OfABehavior))
                                 .map(each -> reported(compilation, name, each))
                                 .toList(),
-                compilation.db().ask(new Adequacy.DeclaredBorders(name)).value());
+                declared,
+                // The declarations' own block names conditions too, and the lines it names them
+                // under are the debts' rather than any behavior's.
+                conditionPlaces(compilation, declaredLines(declared)));
+    }
+
+    /** The lines a module's declarations were read at, which is where the block about them looks
+     *  for what a search came to. */
+    private static List<BorderAssessment> declaredLines(Adequacy.DeclaredBoundaries owed) {
+        if (owed == null) {
+            return List.of();
+        }
+        List<BorderAssessment> lines = new ArrayList<>();
+        owed.owed().forEach(each -> lines.addAll(each.debt().met().values()));
+        return lines;
     }
 
     /**
@@ -645,6 +671,39 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return places;
     }
 
+    /**
+     * Where this report shows each condition on the way to one of these lines.
+     *
+     * <p>Built from the searches themselves, so that every condition the page may name has an entry
+     * and nothing else does. Asked once per condition and not once per mention: a condition is
+     * named under whichever searches met it, and the place is the same answer each time.
+     *
+     * <p>Every attempt of every point, and not the ones a page happens to print. Which searches are
+     * worth a sentence is the outcomes' answer and is asked where the sentence is written; a
+     * gathering that asked it here would be that decision made twice, and the day the two disagreed
+     * a sentence would be written about a condition with nowhere to point.
+     */
+    private static Map<ConditionReportAnchor, Citation> conditionPlaces(
+            Compilation compilation, List<BorderAssessment> lines) {
+        Map<ConditionReportAnchor, Citation> places = new LinkedHashMap<>();
+        for (BorderAssessment line : lines) {
+            for (BorderAssessment.Point point : line.points()) {
+                for (ItemAssessment.Attempt attempt : point.owed().searches().each()) {
+                    for (ReachabilityGap gap : attempt.unaccountedFor()) {
+                        places.computeIfAbsent(gap.anchor(),
+                                anchor -> Sites.placeOf(compilation.db(), anchor));
+                    }
+                }
+            }
+        }
+        return places;
+    }
+
+    /** The lines one behavior met, or none where the measure could not be made. */
+    private static List<BorderAssessment> linesOf(Measure<List<BorderAssessment>> read) {
+        return read == null ? List.of() : read.made().orElse(List.of());
+    }
+
     /** One finding with where this report shows it. */
     private static ReportedFinding reported(Compilation compilation, String module,
                                             Adequacy.Finding finding) {
@@ -695,7 +754,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, each.debt(), _ -> true, at -> whatWasTried(
-                    at.owedAt(each.debt().at()).searches(), names, null));
+                    at.owedAt(each.debt().at()).searches(), module.conditionPlaces(), names, null));
         }
         Map<String, List<Adequacy.Finding>> byDeclaration = new LinkedHashMap<>();
         for (ReportedFinding each : module.declarations()) {
@@ -765,7 +824,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
                     carriedBy(m.declarations(), behaviors),
                     m.owedByDeclarations() == null ? null
-                            : m.owedByDeclarations().keptFor(names));
+                            : m.owedByDeclarations().keptFor(names),
+                    // Kept whole. A filtered view shows fewer debts and the conditions under the
+                    // ones it does show are the same conditions, so narrowing this would be a place
+                    // going missing from a sentence the view still writes.
+                    m.conditionPlaces());
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }
@@ -1641,7 +1704,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 out.append(String.format("      ? %s%n", said));
             }
             readings(out, point, _ -> true, at -> whatWasTried(
-                    at.owedAt(point.at()).searches(), names, declaredIn));
+                    at.owedAt(point.at()).searches(), behavior.conditionPlaces(), names,
+                    declaredIn));
         }
         // A border the model drew that nothing here answered for, said whether or not one came of
         // it. It is exactly where none did that the question stands, so this cannot be written by
@@ -2274,14 +2338,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /** What the search for a value at an edge came to, where it ran and found none. */
-    private static String whatWasTried(SearchOutcomes outcomes, SourceNameResolver names,
-                                       SourceId declaredIn) {
+    private static String whatWasTried(SearchOutcomes outcomes,
+                                       Map<ConditionReportAnchor, Citation> shown,
+                                       SourceNameResolver names, SourceId declaredIn) {
         // Which searches are worth a sentence is the outcomes' answer, not this one's. Told apart
         // here, two of them would be one piece of news whenever the words for them happened to
         // match — a report deciding what happened from what it was about to write.
         List<String> said = new ArrayList<>();
         for (ItemAssessment.Attempt each : outcomes.worthSaying()) {
-            said.add(whatWasTried(each, names, declaredIn));
+            said.add(whatWasTried(each, shown, names, declaredIn));
         }
         // One sentence per search, with the readings' own separator between them. Run together,
         // two searches of one reading read as one clause that says two things.
@@ -2289,8 +2354,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /** The same, of one search of the point. */
-    private static String whatWasTried(ItemAssessment.Attempt attempt, SourceNameResolver names,
-                                       SourceId declaredIn) {
+    private static String whatWasTried(ItemAssessment.Attempt attempt,
+                                       Map<ConditionReportAnchor, Citation> shown,
+                                       SourceNameResolver names, SourceId declaredIn) {
         // One opening per outcome, and not one for everything that came back without a row. A
         // search this compiler stopped and a search that had everything and reached nothing are
         // different news, and a proof is not a failure at all — read under one opening, an author
@@ -2309,7 +2375,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     " — this compiler stopped at " + said(it.stoppedBy())
                             + andWritesSomeOf(it.notAllOf()) + ": "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
-                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+                            + whatTheRegionLeftOut(it.unaccountedFor(), shown, names, declaredIn);
             // Said as what this compiler writes rather than as a number it stopped at, because
             // there is no number: an author told to raise one would raise it and get the same
             // offer. What would change this is somebody writing the rest of what it walks, and the
@@ -2318,7 +2384,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     " — this compiler writes some of " + writes(it.notAllOf())
                             + " rather than all of them: "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
-                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+                            + whatTheRegionLeftOut(it.unaccountedFor(), shown, names, declaredIn);
             // Both halves, because neither says what the other does. The word is what the search
             // itself came to; the figure is why that word is not about the whole of the point. Said
             // as the word alone, an author reads a proof about a value this compiler never planned
@@ -2327,17 +2393,17 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     " — as far as this compiler plans, which stops at "
                             + said(it.limitedBy()) + ": "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
-                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+                            + whatTheRegionLeftOut(it.unaccountedFor(), shown, names, declaredIn);
             // No search to report on, which is what this says instead of saying what one found. The
             // figure is what an author would raise to get one made at all.
             case ItemAssessment.Attempt.Unplanned it ->
                     " — nothing was planned for it, because this compiler stops at "
                             + said(it.limitedBy())
-                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+                            + whatTheRegionLeftOut(it.unaccountedFor(), shown, names, declaredIn);
             case ItemAssessment.Attempt.Unresolved it ->
                     (it.why().reason().provesInfeasible() ? " — " : " — nothing composed one: ")
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
-                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+                            + whatTheRegionLeftOut(it.unaccountedFor(), shown, names, declaredIn);
         };
     }
 
@@ -2355,7 +2421,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * the wider box would be this report deciding something it has not been shown.
      */
     private static String whatTheRegionLeftOut(
-            List<ReachabilityGap> left,
+            List<ReachabilityGap> left, Map<ConditionReportAnchor, Citation> shown,
             SourceNameResolver names, SourceId declaredIn) {
         if (left.isEmpty()) {
             return "";
@@ -2366,9 +2432,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             out.append(i == 0 ? "" : ", ")
                     .append(whyLeftOut(left.get(i)))
                     // The place last and in brackets, as every other line of this report writes
-                    // one. Written into the sentence, it lands after a verb and reads as part of
-                    // what the sentence says rather than as where to look.
-                    .append(" (").append(left.get(i).at().said(names, declaredIn)).append(")");
+                    // one, and looked up rather than held: what the condition carries is which
+                    // question places it, and this is where that question was put.
+                    .append(" (").append(shown.get(left.get(i).anchor()).said(names, declaredIn))
+                    .append(")");
         }
         return out.toString();
     }

--- a/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
@@ -67,15 +67,15 @@ public final class AuthoredSites {
      * What one walk of a module's source found: its occurrences, and where each construct it wrote
      * stands.
      *
-     * <p>Two answers and one walk, which is the whole of why they are made together. A module wrote
-     * what it wrote once, and two walks of it would be two answers to that — agreeing until the day
-     * one of them was taught something the other was not.
+     * <p>Three answers and one walk, which is the whole of why they are made together. A module
+     * wrote what it wrote once, and three walks of it would be three answers to that — agreeing
+     * until the day one of them was taught something the others were not.
      *
-     * <p>The forks are answered whether or not the occurrences could be told apart. Two expressions
-     * written over one stretch of source is a fact about extents; which fork is which is settled by
-     * an identity the extents play no part in.
+     * <p>The forks and the conditions are answered whether or not the occurrences could be told
+     * apart. Two expressions written over one stretch of source is a fact about extents; which fork
+     * and which condition is which is settled by an identity the extents play no part in.
      */
-    public record Walked(Census census, WrittenForks forks) {}
+    public record Walked(Census census, WrittenForks forks, WrittenConditions conditions) {}
 
     /** {@code module} walked, once. */
     public static Walked walk(Hir.Module module) {
@@ -83,7 +83,8 @@ public final class AuthoredSites {
         walk.module(module);
         return new Walked(walk.refusal != null ? walk.refusal
                 : new Census.Identified(new AuthoredSites(walk.byExtent)),
-                new WrittenForks(walk.byOrigin));
+                new WrittenForks(walk.byOrigin),
+                new WrittenConditions(walk.byCondition));
     }
 
     /** The occurrences of {@code module}, or why they could not be told apart. */
@@ -188,6 +189,10 @@ public final class AuthoredSites {
          *  Filled beside {@link #byExtent} and never instead of it: they answer two questions about
          *  one walk, and a second walk would be a second answer to the first. */
         private final Map<SourceConstructOrigin, SourcePos> byOrigin = new LinkedHashMap<>();
+        /** Where each condition this module wrote stands, under an identity a copy cannot change.
+         *  Beside {@link #byOrigin} rather than inside it: what a body takes an arm of and what a
+         *  row had to satisfy are two questions, and a reader holds one of them. */
+        private final Map<WrittenCondition, SourcePos> byCondition = new LinkedHashMap<>();
         private Census refusal;
 
         /**
@@ -202,6 +207,36 @@ public final class AuthoredSites {
         private void wrote(SourceConstructOrigin origin, SourcePos at) {
             if (origin != null && origin.isWritten() && at != null) {
                 byOrigin.putIfAbsent(origin, at);
+            }
+        }
+
+        /**
+         * Files where a condition the source wrote is.
+         *
+         * <p>Where the condition itself is and never where the construct its identity is borrowed
+         * from is. An arm takes its name from the fork because the source wrote no construct at the
+         * arm; a report about it is still about the arm, and a reader sent to the fork would be
+         * sent past the thing the sentence is about.
+         */
+        private void wroteCondition(WrittenCondition which, SourcePos at) {
+            if (which.construct().isWritten() && at != null) {
+                byCondition.putIfAbsent(which, at);
+            }
+        }
+
+        /**
+         * Files where {@code binary} stands.
+         *
+         * <p>Every one of them, and the operator is not read here. Which binaries a reading takes
+         * for conditions is that reading's answer — a comparison and a connective are conditions
+         * and arithmetic is not — and asking the operator here would be that recognition made a
+         * second time, in a walk that has none of what the reading knows. So what this files is
+         * where each stands, and a reading that recognised one has somewhere to point; the surplus
+         * is places nobody asks for.
+         */
+        private void wroteCondition(Hir.Binary binary) {
+            if (binary.origin() != null) {
+                wroteCondition(new WrittenCondition.Construct(binary.origin()), binary.pos());
             }
         }
 
@@ -328,6 +363,7 @@ public final class AuthoredSites {
                 }
                 case Hir.Binary binary -> {
                     take(e);
+                    wroteCondition(binary);
                     expr(binary.left());
                     expr(binary.right());
                 }
@@ -344,7 +380,16 @@ public final class AuthoredSites {
                     take(e);
                     wrote(match.origin(), match.pos());
                     expr(match.scrutinee());
-                    for (Hir.Case one : match.cases()) {
+                    for (int part = 0; part < match.cases().size(); part++) {
+                        Hir.Case one = match.cases().get(part);
+                        // Reaching the arm is the condition that the value turned out to be the
+                        // case the arm selects, and where that is written is the arm. The fork's
+                        // origin is what names it, since the source wrote no construct here of its
+                        // own; its place is the fork's and is not what a reader is shown.
+                        if (match.origin() != null) {
+                            wroteCondition(new WrittenCondition.ForkArm(match.origin(), part),
+                                    one.pos());
+                        }
                         expr(one.body());
                     }
                 }

--- a/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/AuthoredSites.java
@@ -219,7 +219,7 @@ public final class AuthoredSites {
          * sent past the thing the sentence is about.
          */
         private void wroteCondition(WrittenCondition which, SourcePos at) {
-            if (which.construct().isWritten() && at != null) {
+            if (at != null) {
                 byCondition.putIfAbsent(which, at);
             }
         }
@@ -235,7 +235,7 @@ public final class AuthoredSites {
          * is places nobody asks for.
          */
         private void wroteCondition(Hir.Binary binary) {
-            if (binary.origin() != null) {
+            if (binary.origin() != null && binary.origin().isWritten()) {
                 wroteCondition(new WrittenCondition.Construct(binary.origin()), binary.pos());
             }
         }
@@ -386,7 +386,7 @@ public final class AuthoredSites {
                         // case the arm selects, and where that is written is the arm. The fork's
                         // origin is what names it, since the source wrote no construct here of its
                         // own; its place is the fork's and is not what a reader is shown.
-                        if (match.origin() != null) {
+                        if (match.origin() != null && match.origin().isWritten()) {
                             wroteCondition(new WrittenCondition.ForkArm(match.origin(), part),
                                     one.pos());
                         }

--- a/souther-compiler/src/main/java/souther/compiler/sites/WrittenCondition.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/WrittenCondition.java
@@ -27,15 +27,27 @@ public sealed interface WrittenCondition {
      *  it. */
     SourceConstructOrigin construct();
 
+    /**
+     * Refuses a construct no source wrote.
+     *
+     * <p>Here rather than where one of these is made. What this type is for is a condition the
+     * module that wrote it can be asked about, and a construct nothing wrote is one no module
+     * files — so a value naming one is a question with no answer, and it is refused where the value
+     * is made rather than left to come back absent from a lookup a caller had no reason to doubt.
+     */
+    private static void written(SourceConstructOrigin construct) {
+        if (construct == null || !construct.isWritten()) {
+            throw new IllegalArgumentException(
+                    "a condition the source wrote is one some source wrote: " + construct);
+        }
+    }
+
     /** A comparison or a short-circuit operator: a construct the source wrote, and a condition on
      *  its own. */
     record Construct(SourceConstructOrigin construct) implements WrittenCondition {
 
         public Construct {
-            if (construct == null) {
-                throw new IllegalArgumentException("a condition the source wrote is some"
-                        + " construct it wrote");
-            }
+            written(construct);
         }
 
         @Override
@@ -54,9 +66,7 @@ public sealed interface WrittenCondition {
     record ForkArm(SourceConstructOrigin construct, int part) implements WrittenCondition {
 
         public ForkArm {
-            if (construct == null) {
-                throw new IllegalArgumentException("an arm is an arm of a fork somewhere");
-            }
+            written(construct);
             if (part < 0) {
                 throw new IllegalArgumentException(
                         "an arm stands somewhere among the fork's: " + part);

--- a/souther-compiler/src/main/java/souther/compiler/sites/WrittenCondition.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/WrittenCondition.java
@@ -1,0 +1,71 @@
+package souther.compiler.sites;
+
+import souther.compiler.types.SourceConstructOrigin;
+
+/**
+ * One condition a source wrote, as the module that wrote it files it.
+ *
+ * <p>An address and not a place. What is here is which condition of which source, said so that a
+ * copy cannot change it: a helper expanded into three callers puts one condition in three trees,
+ * and where it is written is the writing module's answer rather than something each copy carries.
+ *
+ * <p><b>Two shapes, because two things are conditions and only one of them is a construct.</b> A
+ * comparison and a short-circuit operator are constructs the source wrote and carry an origin of
+ * their own. An arm of a fork is not: what the source wrote there is the fork, and the arm stands
+ * among its arms by an index. So the arm borrows the fork's identity and does not borrow its place
+ * — what is filed for one is where the arm itself is written, which is what a reader is shown.
+ *
+ * <p><b>Not every condition a reading meets.</b> A condition of a shape the reading has no words
+ * for is any expression at all, and the source wrote no construct there this can name; where such
+ * a one is reported is asked of the reading that met it
+ * ({@link souther.compiler.partition.ConditionReportAnchor}). Widened to cover those, this would
+ * be a question the writing module answers with a place it worked out for something else.
+ */
+public sealed interface WrittenCondition {
+
+    /** The origin of the construct the identity rests on, which is what says whose source files
+     *  it. */
+    SourceConstructOrigin construct();
+
+    /** A comparison or a short-circuit operator: a construct the source wrote, and a condition on
+     *  its own. */
+    record Construct(SourceConstructOrigin construct) implements WrittenCondition {
+
+        public Construct {
+            if (construct == null) {
+                throw new IllegalArgumentException("a condition the source wrote is some"
+                        + " construct it wrote");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "condition " + construct;
+        }
+    }
+
+    /**
+     * One arm of a fork, which is the condition that the value being matched turned out to be the
+     * case the arm selects.
+     *
+     * @param construct the fork, which is what the source wrote
+     * @param part      which arm of it, in the order the fork holds them
+     */
+    record ForkArm(SourceConstructOrigin construct, int part) implements WrittenCondition {
+
+        public ForkArm {
+            if (construct == null) {
+                throw new IllegalArgumentException("an arm is an arm of a fork somewhere");
+            }
+            if (part < 0) {
+                throw new IllegalArgumentException(
+                        "an arm stands somewhere among the fork's: " + part);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "arm " + part + " of " + construct;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/sites/WrittenConditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/WrittenConditions.java
@@ -1,0 +1,64 @@
+package souther.compiler.sites;
+
+import souther.compiler.diag.SourcePos;
+
+import java.util.Map;
+
+/**
+ * Where each condition a module wrote stands in its own source.
+ *
+ * <p>Beside {@link WrittenForks} and read off the same walk, and not folded into it. A fork is what
+ * a body takes an arm of and a condition is what a row had to satisfy to get somewhere; a reader
+ * holds one question or the other, and one table answering both would be a place filed under an
+ * identity a caller has no way to have.
+ *
+ * <p>Filed under {@link WrittenCondition}, which a copy cannot change, so a reader that met a
+ * condition inside a helper spliced into its own body asks the module that wrote the helper. What
+ * it gets back moves when that module's text moves and at no other time.
+ *
+ * <p><b>What a condition can be written as, and not what a reading made of it.</b> A condition that
+ * is a construct is a binary and an arm of a fork is an arm, so those are what is filed — every one
+ * of them, the operator unread. Which of them a reading calls a condition is that reading's answer,
+ * and a walk that decided it here would be that recognition made a second time with none of what
+ * the reading knows. The surplus is places nobody asks for.
+ *
+ * <p>A condition of a shape the reading has no words for is any expression at all, and nothing here
+ * files one; where such a one is reported is asked of the reading that met it. So a lookup that
+ * comes back with nothing is a question asked of the wrong table rather than a module that mislaid
+ * something.
+ */
+public final class WrittenConditions {
+
+    private final Map<WrittenCondition, SourcePos> byCondition;
+
+    WrittenConditions(Map<WrittenCondition, SourcePos> byCondition) {
+        this.byCondition = Map.copyOf(byCondition);
+    }
+
+    /** Where the condition {@code which} names is written, or null where this module wrote no such
+     *  condition. */
+    public SourcePos at(WrittenCondition which) {
+        return which == null ? null : byCondition.get(which);
+    }
+
+    /** How many were found, which is what says a walk reached a module at all. */
+    public int count() {
+        return byCondition.size();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof WrittenConditions written
+                && byCondition.equals(written.byCondition);
+    }
+
+    @Override
+    public int hashCode() {
+        return byCondition.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return byCondition.size() + " written conditions";
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
@@ -1,0 +1,198 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Sites;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What tells one condition on the way to a border from another, and what sends a reader to it, are
+ * two things.
+ *
+ * <p>They were one. A condition carried where it is written, and for a condition the walk could not
+ * turn into a cut that place was the only thing telling it from its neighbours — what else it
+ * carries is why it was declined, and two conditions declined for one reason are one reason. So the
+ * place was doing identity's work because nothing else was doing it, and an edit that moved a
+ * helper's condition without changing anything it says changed every answer about it.
+ *
+ * <p>Both halves are checked here, and the second is what says the first bought anything: the
+ * account comes out the same over source that says the same thing in a different place, and the
+ * report still points at the condition.
+ */
+class AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest {
+
+    /**
+     * Two forks on a truth this reading has no words for, one inside the other.
+     *
+     * <p>A {@code Bool} that is not a comparison is where {@link Condition} stops, so each of these
+     * is declined for the one reason — which is what makes the pair the thing under test. Innermost
+     * is a fork on a comparison, so the account of what stands on the way to the arm under it holds
+     * one of each: two conditions this reading has no words for, and one it took in.
+     */
+    private static String model(String beforeTheBody) {
+        return """
+                module example.way
+
+                behavior twoUnread : (a: Bool, b: Bool, n: Int) -> Bool
+                """
+                + beforeTheBody
+                + """
+                let twoUnread (a, b, n) =
+                    if a then
+                        if b then
+                            if n > 3 then n > 0 else n < 0
+                        else
+                            n < 0
+                    else
+                        n > 5
+                """;
+    }
+
+    /**
+     * Two conditions declined for one reason are two values.
+     *
+     * <p>One account holds both, so a reading that told them apart by nothing would be holding one
+     * value twice — and a report about the way to that comparison would say one thing where the
+     * model says two.
+     */
+    @Test
+    void twoConditionsDeclinedForOneReasonAreTwoValues() {
+        List<OnTheWay.Declined> declined = new ArrayList<>();
+        for (OnTheWay each : longestWay(compiled(""))) {
+            if (each instanceof OnTheWay.Declined left) {
+                declined.add(left);
+            }
+        }
+        assertEquals(2, declined.size(), () -> "both forks are on the way: " + declined);
+        assertEquals(List.of(new OnTheWay.Why.NoWordsForTheShape(),
+                        new OnTheWay.Why.NoWordsForTheShape()),
+                declined.stream().map(OnTheWay.Declined::why).toList(),
+                "and for the one reason, which is what leaves the name doing the telling apart");
+        assertNotEquals(declined.get(0), declined.get(1),
+                () -> "two conditions this compiler tells apart: " + declined);
+    }
+
+    /**
+     * And nothing on the way is told from its neighbours by where a report would point.
+     *
+     * <p>Written out because the fault it guards against is invisible otherwise. A carrier that
+     * carried the anchor and nothing else would pass the test above while the anchor was doing what
+     * the place used to do, one name further along.
+     */
+    @Test
+    void whatTellsThemApartIsTheirNameAndNotWhereAReportWouldPoint() {
+        List<OnTheWay> way = longestWay(compiled(""));
+        Set<ConditionReportAnchor> anchors = new LinkedHashSet<>();
+        way.forEach(each -> anchors.add(each.anchor()));
+        assertEquals(way.size(), anchors.size(),
+                () -> "each of these is somewhere of its own here, so this says nothing yet: " + way);
+        assertEquals(way.size(), new LinkedHashSet<>(way).size(),
+                () -> "and each is its own value: " + way);
+    }
+
+    /**
+     * A condition the source wrote a construct of is placed by the module that wrote it.
+     *
+     * <p>The comparisons are, and the forks on a truth are not: what the source wrote at one of
+     * those is any expression at all, and nothing files a place under a name this could ask by. A
+     * fallback rather than a switch would report the first at wherever a reading met a copy of it.
+     */
+    @Test
+    void whichQuestionPlacesItIsSettledByWhetherTheSourceWroteAConstruct() {
+        List<OnTheWay> way = longestWay(compiled(""));
+        List<String> asked = new ArrayList<>();
+        for (OnTheWay each : way) {
+            asked.add(switch (each.anchor()) {
+                case ConditionReportAnchor.WhereItIsWritten _ -> "whoever wrote it";
+                case ConditionReportAnchor.WhereTheReadingMetIt _ -> "the reading that met it";
+            });
+        }
+        assertEquals(List.of("the reading that met it", "the reading that met it",
+                        "whoever wrote it"),
+                asked.stream().sorted().toList(),
+                () -> "the two forks on a truth are the reading's, and the comparison is the"
+                        + " writing module's: " + way);
+    }
+
+    /**
+     * Source that says the same thing in another place says the same thing.
+     *
+     * <p>The whole of what the change bought. What an answer holds is which condition it is, so
+     * moving the body leaves every value on the account equal — and a reader is still sent to the
+     * condition, because where it is is asked rather than remembered.
+     */
+    @Test
+    void movingTheBodyLeavesTheAccountAndMovesWhereAReportPoints() {
+        Compilation where = compiled("");
+        Compilation moved = compiled("\n\n");
+
+        assertEquals(longestWay(where), longestWay(moved),
+                "an edit that moves a condition and changes nothing it says changes no answer");
+
+        List<Citation> before = placesOf(where);
+        List<Citation> after = placesOf(moved);
+        assertEquals(before.size(), after.size(), "the same conditions are on the way");
+        for (int i = 0; i < before.size(); i++) {
+            assertNotEquals(before.get(i), after.get(i),
+                    "a reader is sent to where the condition is now, and it has moved");
+        }
+    }
+
+    /** Where a report about each condition on the way points, in the order the way carries them. */
+    private static List<Citation> placesOf(Compilation compilation) {
+        List<Citation> out = new ArrayList<>();
+        for (OnTheWay each : longestWay(compilation)) {
+            out.add(Sites.placeOf(compilation.db(), each.anchor()));
+        }
+        return out;
+    }
+
+    /**
+     * The longest account this reading filed, which is the way to the comparison under both forks.
+     *
+     * <p>Named by what is on it rather than by which comparison it belongs to. Which comparison a
+     * walk files first is the walk's business, and asking for one of them by name would be this
+     * check holding the model to the order a map came back in.
+     */
+    private static List<OnTheWay> longestWay(Compilation compilation) {
+        ReachingCuts reaching = reachingIn(compilation);
+        List<OnTheWay> longest = List.of();
+        for (List<OnTheWay> each : reaching.byComparison().values()) {
+            if (each.size() > longest.size()) {
+                longest = each;
+            }
+        }
+        List<OnTheWay> found = longest;
+        assertEquals(3, found.size(),
+                () -> "two forks and the comparison the inner arm stands under: " + found);
+        return found;
+    }
+
+    private static ReachingCuts reachingIn(Compilation compilation) {
+        String module = compilation.modules().get(0);
+        Partitions.Partitioning divided =
+                compilation.db().ask(new Adequacy.Divided(module, "twoUnread")).value();
+        assertNotNull(divided, "the model under test is measured");
+        return divided.reaching();
+    }
+
+    private static Compilation compiled(String beforeTheBody) {
+        Compilation compilation = Compilation.ofSource(model(beforeTheBody), "Main");
+        compilation.answerEverything();
+        assertInstanceOf(String.class, compilation.modules().get(0),
+                "the model under test compiles to a module");
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
@@ -10,12 +10,14 @@ import souther.compiler.query.Sites;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What tells one condition on the way to a border from another, and what sends a reader to it, are
@@ -85,24 +87,6 @@ class AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest {
     }
 
     /**
-     * And nothing on the way is told from its neighbours by where a report would point.
-     *
-     * <p>Written out because the fault it guards against is invisible otherwise. A carrier that
-     * carried the anchor and nothing else would pass the test above while the anchor was doing what
-     * the place used to do, one name further along.
-     */
-    @Test
-    void whatTellsThemApartIsTheirNameAndNotWhereAReportWouldPoint() {
-        List<OnTheWay> way = longestWay(compiled(""));
-        Set<ConditionReportAnchor> anchors = new LinkedHashSet<>();
-        way.forEach(each -> anchors.add(each.anchor()));
-        assertEquals(way.size(), anchors.size(),
-                () -> "each of these is somewhere of its own here, so this says nothing yet: " + way);
-        assertEquals(way.size(), new LinkedHashSet<>(way).size(),
-                () -> "and each is its own value: " + way);
-    }
-
-    /**
      * A condition the source wrote a construct of is placed by the module that wrote it.
      *
      * <p>The comparisons are, and the forks on a truth are not: what the source wrote at one of
@@ -148,6 +132,129 @@ class AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest {
             assertNotEquals(before.get(i), after.get(i),
                     "a reader is sent to where the condition is now, and it has moved");
         }
+    }
+
+    /**
+     * One condition is one name, however many ways carry it.
+     *
+     * <p>The left operand of a short-circuit operator is on the way to its right operand, and on
+     * the way into the arm the whole condition leads to. Those are two accounts of one condition,
+     * and a reader joining them on the name joins them on nothing if the two say different names.
+     *
+     * <p>Its own model, because what this is about is one condition reached twice rather than the
+     * shape of an account.
+     */
+    @Test
+    void oneConditionIsOneNameHoweverManyWaysCarryIt() {
+        String source = """
+                module example.twice
+
+                behavior oneCondition : (a: Bool, n: Int) -> Bool
+                let oneCondition (a, n) =
+                    if a && n > 3 then n > 0 else n < 0
+                """;
+        Compilation compilation = compiledFrom(source);
+        List<OnTheWay.Declined> named = new ArrayList<>();
+        for (List<OnTheWay> way : waysIn(compilation, "oneCondition")) {
+            for (OnTheWay each : way) {
+                if (each instanceof OnTheWay.Declined left
+                        && left.why() instanceof OnTheWay.Why.NoWordsForTheShape) {
+                    named.add(left);
+                }
+            }
+        }
+        assertTrue(named.size() > 1,
+                () -> "the parameter this reading has no words for is on more than one way: "
+                        + named);
+        assertEquals(1, new LinkedHashSet<>(named).size(),
+                () -> "one condition, and every way that carries it says the same one: " + named);
+    }
+
+    /**
+     * And a reading names each condition once, however many times it is read.
+     *
+     * <p>What the reading writes down for the conditions it places itself is one entry per
+     * condition. A name minted per reading of a subtree instead would grow with the shape of the
+     * tree rather than with what is in it — a left-leaning run of operators reads its whole prefix
+     * again at every step — and every one of those names would be an entry in an answer.
+     */
+    @Test
+    void whatTheReadingWritesDownGrowsWithTheConditionsAndNotWithTheReading() {
+        String source = """
+                module example.run
+
+                behavior aRun : (a: Bool, b: Bool, c: Bool, d: Bool, n: Int) -> Bool
+                let aRun (a, b, c, d, n) =
+                    if a && b && c && d then n > 0 else n < 0
+                """;
+        assertEquals(4, placedByTheReading(compiledFrom(source), "aRun").size(),
+                "the four truths it has no words for, and nothing else");
+    }
+
+    /**
+     * Two conditions a report sends a reader to one place for are still two conditions.
+     *
+     * <p>The one that says the name is doing work the anchor cannot. A helper is spliced into each
+     * call of it, so one condition an author wrote stands twice in one body — and where it is
+     * written is one place, because there is one of it in the source. Told apart by where a report
+     * points, the two would be one value; told apart by the name, they are what they are.
+     */
+    @Test
+    void twoConditionsReportedAtOnePlaceAreStillTwo() {
+        String source = """
+                module example.expanded
+
+                let either (x: Int, y: Int): Bool = x > 0 || y > 0
+
+                behavior calledTwice : (m: Int, n: Int) -> Bool
+                let calledTwice (m, n) =
+                    if either(m, n) then
+                        if either(n, m) then n > 0 else n < 0
+                    else
+                        n > 5
+                """;
+        List<OnTheWay.Declined> declined = new ArrayList<>();
+        for (List<OnTheWay> way : waysIn(compiledFrom(source), "calledTwice")) {
+            for (OnTheWay each : way) {
+                if (each instanceof OnTheWay.Declined left
+                        && left.why() instanceof OnTheWay.Why.OneOfTwoThings) {
+                    declined.add(left);
+                }
+            }
+        }
+        Set<ConditionReportAnchor> where = new LinkedHashSet<>();
+        Set<ConditionOccurrence> named = new LinkedHashSet<>();
+        declined.forEach(each -> {
+            where.add(each.anchor());
+            named.add(each.condition());
+        });
+        assertEquals(1, where.size(),
+                () -> "one condition was written, so a report points at one place: " + declined);
+        assertEquals(2, named.size(),
+                () -> "and the reading met two of it, which is what the name says: " + declined);
+        assertEquals(2, new LinkedHashSet<>(declined).size(),
+                () -> "so the two are two values, which the place could not have said: " + declined);
+    }
+
+    /** What the reading of {@code behavior} wrote down for the conditions it places itself. */
+    private static Map<ConditionOccurrence, Citation> placedByTheReading(Compilation compilation,
+                                                                         String behavior) {
+        return compilation.db()
+                .ask(new Adequacy.ConditionsMet(compilation.modules().get(0), behavior)).value();
+    }
+
+    /** Every account the reading of {@code behavior} filed. */
+    private static List<List<OnTheWay>> waysIn(Compilation compilation, String behavior) {
+        Partitions.Partitioning divided = compilation.db()
+                .ask(new Adequacy.Divided(compilation.modules().get(0), behavior)).value();
+        assertNotNull(divided, "the model under test is measured");
+        return List.copyOf(divided.reaching().byComparison().values());
+    }
+
+    private static Compilation compiledFrom(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return compilation;
     }
 
     /** Where a report about each condition on the way points, in the order the way carries them. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest.java
@@ -6,6 +6,8 @@ import souther.compiler.diag.Citation;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Sites;
+import souther.compiler.sites.WrittenCondition;
+import souther.compiler.types.SourceConstructOrigin;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -17,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -236,6 +239,38 @@ class AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest {
                 () -> "so the two are two values, which the place could not have said: " + declined);
     }
 
+    /**
+     * A value that names one condition and reports another is refused.
+     *
+     * <p>The two halves are one answer said twice where the reading places a condition: the name
+     * says which condition it is and the anchor says which condition of the reading to ask about.
+     * Left to agree, a value could say a condition was declined and send a reader to a different
+     * one — and neither half would look wrong on its own.
+     */
+    @Test
+    void aValueThatNamesOneConditionAndReportsAnotherIsRefused() {
+        ConditionOccurrence declined = new ConditionOccurrence("b", 0);
+        ConditionOccurrence reported = new ConditionOccurrence("b", 1);
+        assertThrows(IllegalArgumentException.class, () -> new OnTheWay.Declined(declined,
+                new ConditionReportAnchor.WhereTheReadingMetIt("m", reported),
+                new OnTheWay.Why.NoWordsForTheShape()));
+    }
+
+    /**
+     * And a condition no source wrote is not one whoever wrote it can be asked about.
+     *
+     * <p>What the writing module files is what its source wrote, so a value naming a construct
+     * nothing wrote is a question with no answer. Refused where the value is made rather than left
+     * to come back absent from a lookup a caller had no reason to doubt.
+     */
+    @Test
+    void aConditionNoSourceWroteIsNotOneToAskItsWriterAbout() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new WrittenCondition.Construct(SourceConstructOrigin.unwritten()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new WrittenCondition.ForkArm(SourceConstructOrigin.unwritten(), 0));
+    }
+
     /** What the reading of {@code behavior} wrote down for the conditions it places itself. */
     private static Map<ConditionOccurrence, Citation> placedByTheReading(Compilation compilation,
                                                                          String behavior) {
@@ -274,25 +309,21 @@ class AConditionOnTheWayIsNamedHereAndPlacedByWhoeverWroteItTest {
      * check holding the model to the order a map came back in.
      */
     private static List<OnTheWay> longestWay(Compilation compilation) {
-        ReachingCuts reaching = reachingIn(compilation);
-        List<OnTheWay> longest = List.of();
-        for (List<OnTheWay> each : reaching.byComparison().values()) {
-            if (each.size() > longest.size()) {
-                longest = each;
-            }
-        }
-        List<OnTheWay> found = longest;
+        List<OnTheWay> found = longestWayIn(compilation, "twoUnread");
         assertEquals(3, found.size(),
                 () -> "two forks and the comparison the inner arm stands under: " + found);
         return found;
     }
 
-    private static ReachingCuts reachingIn(Compilation compilation) {
-        String module = compilation.modules().get(0);
-        Partitions.Partitioning divided =
-                compilation.db().ask(new Adequacy.Divided(module, "twoUnread")).value();
-        assertNotNull(divided, "the model under test is measured");
-        return divided.reaching();
+    /** The longest account the reading of {@code behavior} filed. */
+    private static List<OnTheWay> longestWayIn(Compilation compilation, String behavior) {
+        List<OnTheWay> longest = List.of();
+        for (List<OnTheWay> each : waysIn(compilation, behavior)) {
+            if (each.size() > longest.size()) {
+                longest = each;
+            }
+        }
+        return longest;
     }
 
     private static Compilation compiled(String beforeTheBody) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOverASharedNameIsOneTheComposerCanPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOverASharedNameIsOneTheComposerCanPlaceTest.java
@@ -6,8 +6,6 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
-import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Requirements;
@@ -17,7 +15,6 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
-import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -99,9 +96,10 @@ class AConditionOverASharedNameIsOneTheComposerCanPlaceTest {
                 "and no value is written at a sum's own name, which is the construction's answer");
     }
 
-    /** Where the condition under test is written. */
-    private static final Citation WHERE =
-            Citation.of(new SourcePos(1, 1, new SourceId("m.sou")));
+    /** Which question a report about the condition under test would put. */
+    private static final ConditionReportAnchor WHERE =
+            new ConditionReportAnchor.WhereTheReadingMetIt("m",
+                    new ConditionOccurrence("b", 0));
 
     /** A row composed with the plain position fixed at {@code at}, and a condition over the shared
      *  name on the way to it. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest.java
@@ -6,8 +6,6 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
-import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Requirements;
@@ -19,7 +17,6 @@ import souther.compiler.numeric.Place;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Shapes;
-import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -81,8 +78,8 @@ class ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest {
                 "the one cut it was handed and could not place: " + attempt.unrepresented());
         assertInstanceOf(ReachabilityGap.Why.NoValueComposedForItsPositions.class,
                 attempt.unrepresented().get(0).why());
-        assertEquals(WHERE, attempt.unrepresented().get(0).at(),
-                "said at the condition, which is where a reader is sent");
+        assertEquals(WHERE, attempt.unrepresented().get(0).anchor(),
+                "said of the condition, which is what a reader is sent to");
     }
 
     /**
@@ -127,9 +124,10 @@ class ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest {
                         + attempt.unrepresented());
     }
 
-    /** Where the condition under test is written. */
-    private static final Citation WHERE =
-            Citation.of(new SourcePos(1, 1, new SourceId("m.sou")));
+    /** Which question a report about the condition under test would put. */
+    private static final ConditionReportAnchor WHERE =
+            new ConditionReportAnchor.WhereTheReadingMetIt("m",
+                    new ConditionOccurrence("b", 0));
 
     private static OnTheWay.TakenIn cut(NumericTerm over) {
         return new OnTheWay.TakenIn(WHERE,

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
@@ -2,8 +2,6 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.inputs.EmptyInput;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.SearchRegion;
@@ -12,7 +10,6 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
-import souther.compiler.source.SourceId;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -77,8 +74,14 @@ class TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest {
                 LinearForm.atom(new NumericTerm.ValueOf(TermPath.of(position))), rel);
     }
 
-    private static Citation somewhere(int line) {
-        return Citation.of(new SourcePos(line, 1, new SourceId("m.sou")));
+    /** A condition this reading met, named by nothing but which of them it is. */
+    private static ConditionOccurrence met(int which) {
+        return new ConditionOccurrence("b", which);
+    }
+
+    /** Where a report about it would point, which nothing here reads. */
+    private static ConditionReportAnchor somewhere(int which) {
+        return new ConditionReportAnchor.WhereTheReadingMetIt("m", met(which));
     }
 
     /** Every cut the account carries, in the order it carries them, and nothing else. */
@@ -110,9 +113,9 @@ class TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest {
         Recording region = new Recording();
 
         WayToTheBorder way = new WayToTheBorder(List.of(
-                new OnTheWay.Declined(somewhere(1), new OnTheWay.Why.NoWordsForTheShape()),
+                new OnTheWay.Declined(met(1), somewhere(1), new OnTheWay.Why.NoWordsForTheShape()),
                 new OnTheWay.TakenIn(somewhere(2), only),
-                new OnTheWay.Declined(somewhere(3), new OnTheWay.Why.OneOfTwoThings())));
+                new OnTheWay.Declined(met(3), somewhere(3), new OnTheWay.Why.OneOfTwoThings())));
         way.narrowing(region);
 
         assertEquals(List.of(only), region.told, "a decline is a record and not a cut");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
@@ -98,8 +98,8 @@ class WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest {
                 compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
         InputReads reads = InputReads.ofParameters(inputs.parameterReads(),
                 checked.elementBindings().get(behavior));
-        return ReachingCuts.stating(Condition.of(body, reads, rules.symbols()), inputs, holding,
-                rules);
+        return ReachingCuts.stating(Condition.of(body, reads, rules.symbols(),
+                new ConditionNumbering(module, behavior)), inputs, holding, rules);
     }
 
     /** Whether {@code cut} holds where {@code x} and {@code y} stand at these values. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
@@ -2,12 +2,11 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.partition.Generator;
+import souther.compiler.partition.ConditionOccurrence;
+import souther.compiler.partition.ConditionReportAnchor;
 import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.WayToTheBorder;
-import souther.compiler.source.SourceId;
 
 import java.util.List;
 
@@ -38,8 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest {
 
-    private static final OnTheWay.Declined LEFT_OUT = new OnTheWay.Declined(
-            Citation.of(new SourcePos(4, 3, new SourceId("m.sou"))),
+    private static final ConditionOccurrence MET = new ConditionOccurrence("b", 0);
+
+    private static final OnTheWay.Declined LEFT_OUT = new OnTheWay.Declined(MET,
+            new ConditionReportAnchor.WhereTheReadingMetIt("m", MET),
             new OnTheWay.Why.NoWordsForTheShape());
 
     /** One way to a point, with one condition on it that nothing took in. */

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -391,6 +391,11 @@ final class AnswerClosure {
 
     private static final String Q = "souther.compiler.query.";
 
+    /** What the reading of a body left of the model's own divisions, which is the half of it the
+     *  measurement asks for. */
+    private static final TypePath.Step THE_GEOMETRY_THE_READING_LEFT =
+            part(Q + "Adequacy$BodyDivided", "geometry");
+
     private static final List<Known> KNOWN = List.of(
             new Known(at(Q + "Names$ModuleScope", Q + "Db",
                     m(ANSWER, "value"), m("souther.compiler.check.Scoping$Scoped", "values"), m("souther.compiler.check.Resolve$Values", "elsewhere"),
@@ -663,6 +668,34 @@ final class AnswerClosure {
                 part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
                 part("souther.compiler.partition.Axis", "classes"), HELD,
                 part("souther.compiler.partition.PartitionClass", "denotes"));
+        // And the same machines again through the reading the geometry is a projection of. Two
+        // questions are asked of one reading of a body — what the model divides, and where that
+        // reading met each condition it places itself — so the walk arrives at everything the
+        // geometry holds by both names. One thing to fix, met twice.
+        theMachineUnderALanguage(out, Q + "Adequacy$Dividing",
+                THE_GEOMETRY_THE_READING_LEFT,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
+                part("souther.compiler.partition.Axis", "classes"), HELD,
+                part("souther.compiler.partition.PartitionClass", "denotes"));
+        theMachineUnderALanguage(out, Q + "Adequacy$Dividing",
+                THE_GEOMETRY_THE_READING_LEFT,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
+                part("souther.compiler.partition.Axis", "classes"), HELD,
+                part("souther.compiler.partition.PartitionClass", "recognises"),
+                arm("souther.compiler.partition.Recognition$OfASet"),
+                part("souther.compiler.partition.Recognition$OfASet", "values"));
+        theMachineUnderALanguage(out, Q + "Adequacy$Dividing",
+                THE_GEOMETRY_THE_READING_LEFT,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "position"),
+                part("souther.compiler.partition.PositionAccount", "admits"));
+        bothEndsOfARange(out, Q + "Adequacy$Dividing",
+                THE_GEOMETRY_THE_READING_LEFT,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
+                part("souther.compiler.partition.Axis", "narrowed"));
         theMachineUnderALanguage(out, Q + "Adequacy$Generated",
                 then(then(A_SUBJECT, A_MEASUREMENT), HELD,
                         part("souther.compiler.partition.Axis", "classes"), HELD,

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
@@ -2,16 +2,15 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.diag.Citation;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.CompositionBudget;
 import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.Generator;
+import souther.compiler.partition.ConditionOccurrence;
+import souther.compiler.partition.ConditionReportAnchor;
 import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.WayToTheBorder;
 import souther.compiler.publish.PublicationOrders;
-import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -40,8 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
 
+    private static final ConditionOccurrence MET = new ConditionOccurrence("b", 0);
+
     private static final WayToTheBorder WAY = new WayToTheBorder(List.of(
-            new OnTheWay.Declined(Citation.of(new SourcePos(4, 3, new SourceId("m.sou"))),
+            new OnTheWay.Declined(MET,
+                    new ConditionReportAnchor.WhereTheReadingMetIt("m", MET),
                     new OnTheWay.Why.NoWordsForTheShape())));
 
     /** One of each outcome, by the leaf that names it. */

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest.java
@@ -156,14 +156,6 @@ class WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest {
 
     private static Map<String, Standing> whatStillHoldsAPlace() {
         Map<String, Standing> out = new TreeMap<>();
-        // Two conditions this compiler declined to cut were seen told apart by where they are and
-        // by nothing else. So the place is identity here, which the cut has to carry across some
-        // other way before it can stop carrying the position.
-        out.put("souther.compiler.partition.OnTheWay$Declined.at",
-                new Standing(new Because.TwoOfThemDifferOnlyThere(),
-                        new AcrossTheCut.BlocksIt("a condition on the way to a border is given"
-                                + " something to be named by, so that the place is not what tells"
-                                + " one from another (issue #1486)")));
         // Nothing the models reach is one of these. That is a count of what was looked at and not
         // a fact about where the value goes, so the cut waits on somebody looking.
         String lookAtIt = "somebody builds a model that reaches one and reads what its place is"
@@ -191,13 +183,6 @@ class WhatStillHoldsAPlaceUnderAFindingIsReadOnTwoAxesTest {
                 "souther.compiler.inputs.StandingQuestion$NothingClassifiesIt.reachedAt")) {
             out.put(carrier, new Standing(new Because.ReachedAndNotObservedToDiscriminate(),
                     new AcrossTheCut.BlocksIt(splitTheHandle)));
-        }
-        String splitTheWay = "somebody reads what tells one condition on the way to a border from"
-                + " its neighbours, the way the third arm beside these was read (issue #1486)";
-        for (String carrier : List.of("souther.compiler.partition.OnTheWay$Narrowed.at",
-                "souther.compiler.partition.OnTheWay$TakenIn.at")) {
-            out.put(carrier, new Standing(new Because.ReachedAndNotObservedToDiscriminate(),
-                    new AcrossTheCut.BlocksIt(splitTheWay)));
         }
         return out;
     }

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
@@ -21,6 +21,7 @@ import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,7 +65,7 @@ class WhatWasObservedDecidesWhatAReportMayNameTest {
                 new souther.compiler.query.BehaviorEvidence(
                         souther.compiler.query.Adequacy.RowReading.NONE,
                         null, null, null, null, read()),
-                null, List.of(), shown());
+                null, List.of(), shown(), Map.of());
     }
 
     /** Where this report shows each of the two forks. A place per fork and not per arm: the arms of


### PR DESCRIPTION
A condition on the way to a border carried where it is written. For two of the three arms that
place was a handle: what tells a `TakenIn` from its neighbours is the cut it came to, and what tells
a `Narrowed` from its neighbours is the position it narrows. For `Declined` it was identity — what
it carries beside the place is only why it was declined, and two conditions declined for one reason
are one reason — so the place was doing identity's work because nothing else was doing it.

So the reading names every condition it meets, and an answer holds the name and which question
places it rather than the place. `Declined` is the one arm that carries the name, because it is the
one arm whose other half does not tell it from its neighbours; giving all three the same field would
make two of one cut, taken twice, into two things.

Which question places a condition is settled where the condition is read, and it is a switch rather
than a first choice with a fallback. A construct the source wrote is placed by the module that wrote
it, filed beside the forks it already files and under an identity a copy cannot change — so a
condition inside a helper spliced into three callers points into the helper's file. A condition of a
shape the reading has no words for is any expression at all, and the source wrote no construct there
to name one by, so it is placed by the reading that met it, which is the only thing that did. Asked
the other way round, a condition written in a file this compilation has stopped holding would
quietly be reported wherever a reading met a copy of it.

What the reading of a body divides and where that reading met each condition it places itself are
now two questions over one reading, so an edit that moves a condition without changing what it says
leaves the measurement alone and moves only where a sentence points.

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
