### PR TITLE
Read a declaration's clauses from what it publishes, not from the tree it was written as

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadTheTermOfAReadingTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadTheTermOfAReadingTest.java
@@ -1,0 +1,103 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may take the term out of a reading of one.
+ *
+ * <p>{@code TermMeaning} is what a reader in another module depends on, and two of them are equal
+ * where the terms they hold say the same thing whatever the places on those terms are. So two
+ * readings a store has called one answer hold terms that are not the same object and were written
+ * at different places, and anything read off the term and published would be a fact about which of
+ * two equal answers the store happened to keep.
+ *
+ * <p>One reader takes the term out all the same, and what makes that sound is where it goes rather
+ * than what it is: the reading of a declaration's clauses builds its own tree out of it, publishes
+ * what the clauses state and never a tree, and asks where a clause is written of the thing that
+ * says where a clause is written. That is a fact about the caller, so the caller is what is written
+ * down here.
+ *
+ * <p>Being package-private is not what holds it. Every class beside it in the package may call it,
+ * and one written tomorrow would compile; the row below is what says which of them does.
+ *
+ * <p>Read off the compiled classes, so a reader that reaches it through a method reference is one
+ * of these: a method handed to something that will call it reads the term as surely as calling it.
+ */
+class WhoMayReadTheTermOfAReadingTest {
+
+    private static final String OWNER = "souther/compiler/check/TermMeaning";
+
+    private static final String READING_THE_TERM = "termForClauseReading";
+
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
+
+    /**
+     * The one class that reads it, and why it is entitled to.
+     *
+     * <p>{@code Clauses} is the reading of a declaration's clauses. It puts what a construction
+     * gives each field where that field is read and hands back a tree of its own, which is this
+     * check's from there on; nothing it answers with holds the term it was given, and nothing it
+     * answers with says where anything was written.
+     */
+    private static final List<String> READING_IT =
+            List.of("souther/compiler/check/Clauses -> " + OWNER + "#" + READING_THE_TERM);
+
+    @Test
+    void everyClassThatTakesATermOutOfAReadingIsWrittenDown() {
+        assertEquals(READING_IT, new ArrayList<>(reading()),
+                "a row added here is a reader that can tell two equal answers apart, so it is a"
+                        + " reader that has to be able to say why what it does with the term never"
+                        + " reaches an answer");
+    }
+
+    /**
+     * The walk reads every module's classes.
+     *
+     * <p>Asked of the modules the repository has and not of what a build happened to leave: a module
+     * whose classes are missing is one whose calls this cannot see, and the rows from the rest would
+     * match and this would pass while answering about fewer modules than it names.
+     */
+    @Test
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        assertTrue(modulesRead() > 1,
+                "the classes this reads are in more than the one module that declares the reading");
+    }
+
+    /** Every class naming the accessor, as the class and what it named. */
+    private static Set<String> reading() {
+        Set<String> found = new TreeSet<>();
+        for (ClassModel model : COMPILED.all()) {
+            for (PoolEntry entry : model.constantPool()) {
+                if (entry instanceof MemberRefEntry member
+                        && OWNER.equals(member.owner().name().stringValue())
+                        && READING_THE_TERM.equals(member.name().stringValue())) {
+                    found.add(model.thisClass().asInternalName() + " -> "
+                            + OWNER + "#" + READING_THE_TERM);
+                }
+            }
+        }
+        return found;
+    }
+
+    private static int modulesRead() {
+        int read = 0;
+        for (Path module : COMPILED.modules()) {
+            if (COMPILED.mainOutputOf(module).isPresent()) {
+                read++;
+            }
+        }
+        return read;
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadTheTermOfAReadingTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadTheTermOfAReadingTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Who may take the term out of a reading of one.
+ * Where the term of a reading enters a reading of the model.
  *
  * <p>{@code TermMeaning} is what a reader in another module depends on, and two of them are equal
  * where the terms they hold say the same thing whatever the places on those terms are. So two
@@ -23,14 +23,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * at different places, and anything read off the term and published would be a fact about which of
  * two equal answers the store happened to keep.
  *
- * <p>One reader takes the term out all the same, and what makes that sound is where it goes rather
- * than what it is: the reading of a declaration's clauses builds its own tree out of it, publishes
- * what the clauses state and never a tree, and asks where a clause is written of the thing that
- * says where a clause is written. That is a fact about the caller, so the caller is what is written
- * down here.
+ * <p>One reader takes the term out all the same, and this is where it does.
  *
- * <p>Being package-private is not what holds it. Every class beside it in the package may call it,
- * and one written tomorrow would compile; the row below is what says which of them does.
+ * <p><b>What this holds, said exactly.</b> It holds that there is one door and which class it is.
+ * It does not hold that the term stops there: what comes back is a {@code Core}, and the reading
+ * that takes it passes trees down to everything under it, so a reader below could read a place off
+ * one. Reading this row as "only this class can see an authored tree" is reading it for more than
+ * it says.
+ *
+ * <p>What holds the rest is a fact about answers rather than about calls, and is asked of the
+ * answers: a reading of one source is the same reading whichever compile built the terms it was
+ * told about, and what a module publishes about a declaration does not move when the declaration
+ * only moves. A row added here is a second door, which is worth knowing about on its own.
+ *
+ * <p>Being package-private is not what holds even that much. Every class beside it in the package
+ * may call it, and one written tomorrow would compile; the row below is what says which of them
+ * does.
  *
  * <p>Read off the compiled classes, so a reader that reaches it through a method reference is one
  * of these: a method handed to something that will call it reads the term as surely as calling it.
@@ -57,9 +65,9 @@ class WhoMayReadTheTermOfAReadingTest {
     @Test
     void everyClassThatTakesATermOutOfAReadingIsWrittenDown() {
         assertEquals(READING_IT, new ArrayList<>(reading()),
-                "a row added here is a reader that can tell two equal answers apart, so it is a"
-                        + " reader that has to be able to say why what it does with the term never"
-                        + " reaches an answer");
+                "a row added here is a second place a term enters a reading of the model, which is"
+                        + " a place that has to say why what it does with the term never reaches an"
+                        + " answer");
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
@@ -85,7 +85,7 @@ public sealed interface AuthoredShape {
      * Each part of the clause with the subtree of the expanded {@code read} it became, as a part of
      * {@code rule}.
      *
-     * <p>The same recovery {@link #onto(ClauseExpr, RuleRef.Invariant)} does of a reading, done of
+     * <p>The same recovery {@link ClauseMeaning.Parts#onto(ClauseExpr)} does of a reading, done of
      * the tree an expansion left. What a helper's body joined stands under a binding there, so a
      * reader splitting that tree for itself would find parts this shape never issued — which is
      * why the shape drives the descent here as well.

--- a/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AuthoredShape.java
@@ -48,19 +48,20 @@ public sealed interface AuthoredShape {
     }
 
     /**
-     * Each part of the clause with the subtree of {@code read} it was read into, as a part of
-     * {@code rule}.
+     * The same shape as a reader anywhere may hold it: which rules there are and how they are
+     * joined, and none of what says where they stand.
      *
-     * <p>{@code read} is what the whole clause came to, and every part of it is a subtree of that
-     * one reading — not a tree of its own read alongside it. What a clause states is read as one
-     * thing (a rule's conjuncts meet inside that reading, and a choice one of them rules out is
-     * ruled out there), and what an author is answerable for is the parts; both come out of the one
-     * reading, which is why this recovers them from it rather than reading them apart.
+     * <p>What is left behind is the node each part was written as, which is what makes this shape
+     * unpublishable as it is — a node says where it stands, so a declaration moved down its file
+     * would hand a reader parts that had changed. The expansion needs those nodes and is here;
+     * every reader that only has to find the parts again in a tree it read takes this.
      */
-    default List<Clauses.StatedPart> onto(ClauseExpr read, RuleRef.Invariant rule) {
-        List<Clauses.StatedPart> out = new ArrayList<>();
-        found(read, rule, out);
-        return List.copyOf(out);
+    default ClauseMeaning.Parts asWritten(RuleRef.Invariant rule) {
+        return switch (this) {
+            case One it -> new ClauseMeaning.Parts.One(it.part().idFor(rule));
+            case Both it -> new ClauseMeaning.Parts.Both(it.left().asWritten(rule),
+                    it.right().asWritten(rule));
+        };
     }
 
     /**
@@ -110,22 +111,4 @@ public sealed interface AuthoredShape {
         }
     }
 
-    private void found(ClauseExpr read, RuleRef.Invariant rule, List<Clauses.StatedPart> out) {
-        switch (this) {
-            case One it -> out.add(new Clauses.StatedPart(it.part().idFor(rule), read));
-            case Both it -> {
-                // The author wrote two rules here, so what they were read into has two sides. Asked
-                // of the tree instead — whether this node joins two conditions — this would be a
-                // second reading of what a clause is made of, and the reading it agreed with until
-                // somebody changed one of them.
-                if (!(read instanceof ClauseExpr.Joined joined)) {
-                    throw new IllegalStateException("an author wrote two rules where this reading"
-                            + " has one " + read.getClass().getSimpleName() + ", so the clause was"
-                            + " read into a shape it was not written in");
-                }
-                it.left().found(joined.left(), rule, out);
-                it.right().found(joined.right(), rule, out);
-            }
-        }
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseMeaning.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -50,14 +52,85 @@ public sealed interface ClauseMeaning permits ClauseMeaning.Stated, ClauseMeanin
      * @param states what its form says
      * @param fieldsRead the fields of the declaration's value that its form reads, including the
      *     ones reached through what the declaration spreads
+     * @param parts the rules its author wrote it as, and how they are joined
      */
-    record Stated(Clause.Ref ref, TermMeaning states, Set<String> fieldsRead)
+    record Stated(Clause.Ref ref, TermMeaning states, Set<String> fieldsRead, Parts parts)
             implements ClauseMeaning {
 
         public Stated {
             Objects.requireNonNull(ref, "a clause that states something is some clause");
             Objects.requireNonNull(states, "a clause that has a form states what the form says");
+            Objects.requireNonNull(parts, "a clause is written as some rules");
             fieldsRead = Set.copyOf(fieldsRead);
+        }
+    }
+
+    /**
+     * The rules an author wrote a clause as, and how they are joined.
+     *
+     * <p>Which parts a clause has is settled where the clause is split ({@link ClauseHelpers}) and
+     * is published because every reading of the clause needs it: a reader that recovered the parts
+     * from a tree it typed would be a second answer to how many there are, and two answers to that
+     * is what numbering a clause in two walks came to.
+     *
+     * <p>The shape and the ordinals, and nothing an author wrote. What the split also holds is the
+     * node each part was written as ({@link AuthoredShape}), which the expansion needs and which no
+     * reader across a boundary may have — a node says where it stands, so a declaration moved down
+     * its file would publish parts that had changed.
+     */
+    sealed interface Parts permits Parts.Both, Parts.One {
+
+        /** Two rules, written as one clause. */
+        record Both(Parts left, Parts right) implements Parts {
+
+            public Both {
+                Objects.requireNonNull(left, "a clause of two rules has a left");
+                Objects.requireNonNull(right, "a clause of two rules has a right");
+            }
+        }
+
+        /**
+         * One rule, written as itself, under the name the split that found it issued.
+         *
+         * <p>The name and not the number it holds. A part is named where the clause was split
+         * ({@code ClauseHelpers.AuthoredPart#idFor}), which is the one place that may put a number
+         * beside a rule; carried as a number here, every reader that wanted the name would be
+         * putting one beside whichever rule it happened to be holding.
+         */
+        record One(PartId<RuleRef.Invariant> id) implements Parts {
+
+            public One {
+                Objects.requireNonNull(id, "a rule an author wrote is some part of a clause");
+            }
+        }
+
+        /**
+         * Each part with the subtree of {@code read} it was read into.
+         *
+         * <p>{@code read} is what the whole clause came to, and every part of it is a subtree of
+         * that one reading rather than a tree read alongside it. It says where to go and never
+         * asks: where the author wrote two rules the reading has two sides, and a reading that has
+         * one there is this compiler disagreeing with itself.
+         */
+        default List<Clauses.StatedPart> onto(ClauseExpr read) {
+            List<Clauses.StatedPart> out = new ArrayList<>();
+            found(read, out);
+            return List.copyOf(out);
+        }
+
+        private void found(ClauseExpr read, List<Clauses.StatedPart> out) {
+            switch (this) {
+                case One it -> out.add(new Clauses.StatedPart(it.id(), read));
+                case Both it -> {
+                    if (!(read instanceof ClauseExpr.Joined joined)) {
+                        throw new IllegalStateException("an author wrote two rules where this"
+                                + " reading has one " + read.getClass().getSimpleName() + ", so the"
+                                + " clause was read into a shape it was not written in");
+                    }
+                    it.left().found(joined.left(), out);
+                    it.right().found(joined.right(), out);
+                }
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseMeanings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseMeanings.java
@@ -38,4 +38,17 @@ public interface ClauseMeanings {
 
     /** Nothing declared anywhere — for a reading over primitives, which asks of no declaration. */
     ClauseMeanings NONE = _ -> List.of();
+
+    /**
+     * The reading that makes these, which consults none.
+     *
+     * <p>Refused rather than empty. A reading that is producing what a declaration states cannot
+     * also be reading it — asking would be asking for the answer being worked out — and an empty
+     * answer would say instead that the declaration states nothing, which is a different thing and
+     * one every clause of it would then be reported as.
+     */
+    ClauseMeanings THE_ONE_THAT_MAKES_THEM = declaration -> {
+        throw new IllegalStateException("the reading that works out what `" + declaration
+                + "` states is being asked what it states");
+    };
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseMeanings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseMeanings.java
@@ -1,0 +1,41 @@
+package souther.compiler.check;
+
+import souther.compiler.types.TypeKey;
+
+import java.util.List;
+
+/**
+ * What each clause of a declaration states, as the module that wrote the declaration read it.
+ *
+ * <p>The pair of {@link ClauseLocations}, and the reason the two are separate. What a clause states
+ * and where it is written are two facts about one clause: the first is what a reading is built on,
+ * the second is what one sentence puts a caret under. Answered together, an edit that moves a
+ * clause and changes nothing it states would be an edit that changes what the model says.
+ *
+ * <p>One question and one input: which declaration. Who is asking is not an input, for the reason
+ * {@link ExpandedClauseLookup} gives — a reading whose answer could differ between two askers is a
+ * reading where a declaration was read in whichever representation the asker happened to hold.
+ *
+ * <p><b>What crosses here is what a clause states, and never a tree.</b> The reading that consumes
+ * this builds a term of its own out of what it is told and keeps it inside; nothing it publishes
+ * carries one. That is what lets a clause be read at all without the authored tree crossing the
+ * boundary with it, which is what carried a declaration's every move into every module that
+ * imported it.
+ */
+@FunctionalInterface
+public interface ClauseMeanings {
+
+    /**
+     * What {@code declaration} states, clause by clause, in the order it writes them — empty where
+     * nothing here declares one, and empty where it writes none.
+     *
+     * <p>Its own clauses and not the ones it spreads in. A clause reaching a declaration through a
+     * spread is written on the declaration it was written on, and that one answers for it: asked of
+     * the reader instead, what a clause states would depend on which of the declarations that hold
+     * it was asked.
+     */
+    List<ClauseMeaning> of(TypeKey declaration);
+
+    /** Nothing declared anywhere — for a reading over primitives, which asks of no declaration. */
+    ClauseMeanings NONE = _ -> List.of();
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -187,11 +187,35 @@ final class Clauses {
         // Fail-open: a clause with no form leaves its run-time check standing, whichever way the
         // form went missing. Which of the two it was matters to a reader that publishes a sentence
         // about the clause, and this is not one.
-        if (!(stated(clause) instanceof ClauseMeaning.Stated it)) {
+        if (!(meaningOf(clause) instanceof ClauseMeaning.Stated it)) {
             return null;
         }
         return everyFieldRead(given, named, it.fieldsRead())
                 ? substituted(it.states().termForClauseReading(), given) : null;
+    }
+
+    /**
+     * What {@code clause} states as this reading's own tree, with nothing put in for the fields, or
+     * {@code null} where its declaration has no form for it.
+     *
+     * <p>For the reader that seeds a declaration's own fields, where each field stands for itself
+     * and there is nothing to substitute. The same statement the reading above puts a
+     * construction's values into, taken the same way and from the same place.
+     */
+    Core stated(TypeOps.Declared clause) {
+        return meaningOf(clause) instanceof ClauseMeaning.Stated it
+                ? it.states().termForClauseReading() : null;
+    }
+
+    /**
+     * The rules {@code clause}'s author wrote it as, as its declaration published them.
+     *
+     * <p>Asked of the declaration and not worked out from a tree. Which parts a clause has was
+     * settled where it was split, and a reader that recovered them from what it typed would be a
+     * second answer to how many there are.
+     */
+    ClauseMeaning.Parts partsOf(TypeOps.Declared clause) {
+        return meaningOf(clause) instanceof ClauseMeaning.Stated it ? it.parts() : null;
     }
 
     /**
@@ -203,7 +227,7 @@ final class Clauses {
      * reading that asked the declaration in hand would be asking a declaration about a clause it
      * did not write.
      */
-    private ClauseMeaning stated(TypeOps.Declared clause) {
+    private ClauseMeaning meaningOf(TypeOps.Declared clause) {
         Clause.Id wanted = Clause.Ref.of(clause).id();
         for (ClauseMeaning each : meanings.of(clause.declaredOn().key())) {
             if (each.ref().id().equals(wanted)) {
@@ -246,8 +270,7 @@ final class Clauses {
                 // very reading. Read apart instead, a conjunct would be read without the conjunct
                 // beside it, and a branch one of them rules out would stand.
                 stated.add(new Stated(clause, one,
-                        inv.shape().onto(ClauseExpr.of(one, true),
-                                new RuleRef.Invariant(clause))));
+                        partsOf(inv).onto(ClauseExpr.of(one, true))));
             } else {
                 lost.add(new RuleRef.Invariant(clause));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -35,6 +35,9 @@ final class Clauses {
     private final ExpandedClauseLookup expandedClauses;
     private final ClauseLocations written;
     private final DeclarationReadings machines;
+    /** Where what each clause of a declaration states is answered from — the declaration's own
+     *  reading of it, and not one this reader makes out of the tree it was handed. */
+    private final ClauseMeanings meanings;
     private final Map<TypeSymbol.AtModule, Map<String, Type>> fields = new HashMap<>();
     private final Map<TypeSymbol.AtModule, Map<String, BindingId>> bindings =
             new HashMap<>();
@@ -61,17 +64,24 @@ final class Clauses {
      *        what those readings answer with.
      */
     Clauses(Symbols symbols, ExpandedClauseLookup expandedClauses, ClauseLocations written,
-            DeclarationReadings machines) {
+            DeclarationReadings machines, ClauseMeanings meanings) {
         this.symbols = symbols;
         this.expandedClauses = expandedClauses;
         this.written = written;
         this.machines = machines;
+        this.meanings = meanings;
     }
 
     /** The representation this reads a declaration's clauses in, for a reader that has to hand it
      *  on rather than ask for one of its own. */
     ExpandedClauseLookup expandedClauses() {
         return expandedClauses;
+    }
+
+    /** Where what each clause of a declaration states is answered from, for a reader that has to
+     *  hand it on rather than ask for one of its own. */
+    ClauseMeanings states() {
+        return meanings;
     }
 
     /** Where a clause of a declaration is written, for the same reader — asked where a sentence
@@ -156,24 +166,51 @@ final class Clauses {
     }
 
     /**
-     * What a clause of {@code data} states where each field is given what {@code given} says, or
-     * {@code null} where it states nothing this check can read.
+     * What {@code clause} states where each field is given what {@code given} says, or {@code null}
+     * where it states nothing this check can read.
+     *
+     * <p>Taken from what the declaration that wrote the clause publishes, and not worked out from
+     * the tree that declaration was written as. What a clause states is that declaration's answer,
+     * and a reader typing the authored tree again is a second answer to it — one that is made
+     * afresh for every reader and that moves whenever anything above the declaration is edited.
+     *
+     * <p>The term goes no further than this reading. What comes back to the caller is a clause read
+     * at the fields it was given, which is this reading's own tree from here on; where the clause is
+     * written is asked of {@link ClauseLocations} by whoever puts a caret under it.
      *
      * <p>A field nothing was given — one a construction leaves out — leaves the clause naming a value
      * that is not there, and the clause is left to the run-time check rather than read against
      * nothing.
      */
-    Core statedAt(ClauseAsExpanded clause, TypeSymbol.AtModule named,
-                  Map<BindingId, Core> given) {
+    private Core statedAt(TypeOps.Declared clause, TypeSymbol.AtModule named,
+                          Map<BindingId, Core> given) {
         // Fail-open: a clause with no form leaves its run-time check standing, whichever way the
         // form went missing. Which of the two it was matters to a reader that publishes a sentence
         // about the clause, and this is not one.
-        Core stated = typed(clause, named).orNull();
-        if (stated == null) {
+        if (!(stated(clause) instanceof ClauseMeaning.Stated it)) {
             return null;
         }
-        return everyFieldRead(given, named, fieldsRead(stated, named))
-                ? substituted(stated, given) : null;
+        return everyFieldRead(given, named, it.fieldsRead())
+                ? substituted(it.states().termForClauseReading(), given) : null;
+    }
+
+    /**
+     * What the declaration that wrote {@code clause} says it states, or {@code null} where it says
+     * nothing about it.
+     *
+     * <p>Asked of the declaration the clause was written on and not of the one being read. A clause
+     * a spread brought in was written elsewhere and is that declaration's to answer for, so a
+     * reading that asked the declaration in hand would be asking a declaration about a clause it
+     * did not write.
+     */
+    private ClauseMeaning stated(TypeOps.Declared clause) {
+        Clause.Id wanted = Clause.Ref.of(clause).id();
+        for (ClauseMeaning each : meanings.of(clause.declaredOn().key())) {
+            if (each.ref().id().equals(wanted)) {
+                return each;
+            }
+        }
+        return null;
     }
 
     /** Whether {@code given} holds a value for every one of {@code fields}, which are named as the
@@ -203,7 +240,7 @@ final class Clauses {
         List<RuleRef.Invariant> lost = new ArrayList<>();
         for (TypeOps.Declared inv : declared(named)) {
             Clause.Ref clause = Clause.Ref.of(inv);
-            Core one = statedAt(inv.asExpanded(), named, given);
+            Core one = statedAt(inv, named, given);
             if (one != null) {
                 // The clause as one reading, and the parts its author wrote as subtrees of that
                 // very reading. Read apart instead, a conjunct would be read without the conjunct

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -182,40 +182,48 @@ final class Clauses {
      * that is not there, and the clause is left to the run-time check rather than read against
      * nothing.
      */
-    private Core statedAt(TypeOps.Declared clause, TypeSymbol.AtModule named,
-                          Map<BindingId, Core> given) {
+    private AsStated statedAt(TypeOps.Declared clause, TypeSymbol.AtModule named,
+                              Map<BindingId, Core> given) {
         // Fail-open: a clause with no form leaves its run-time check standing, whichever way the
         // form went missing. Which of the two it was matters to a reader that publishes a sentence
         // about the clause, and this is not one.
-        if (!(meaningOf(clause) instanceof ClauseMeaning.Stated it)) {
+        if (!(meaningOf(clause) instanceof ClauseMeaning.Stated it)
+                || !everyFieldRead(given, named, it.fieldsRead())) {
             return null;
         }
-        return everyFieldRead(given, named, it.fieldsRead())
-                ? substituted(it.states().termForClauseReading(), given) : null;
+        return new AsStated(substituted(it.states().termForClauseReading(), given), it.parts());
     }
 
     /**
-     * What {@code clause} states as this reading's own tree, with nothing put in for the fields, or
-     * {@code null} where its declaration has no form for it.
+     * What a clause states as this reading's own tree, and the rules its author wrote it as.
+     *
+     * <p>The two together because they are one answer about one clause and a reader takes both: the
+     * parts are found again in the very tree beside them, so a reader handed them apart can be
+     * handed them from two lookups that need not have agreed.
+     *
+     * @param states what it states, with nothing put in for the fields
+     * @param parts the rules its author wrote it as
+     */
+    record AsStated(Core states, ClauseMeaning.Parts parts) {
+
+        AsStated {
+            if (states == null || parts == null) {
+                throw new IllegalArgumentException(
+                        "a clause that states something states it as some rules");
+            }
+        }
+    }
+
+    /**
+     * What {@code clause} states, or {@code null} where its declaration has no form for it.
      *
      * <p>For the reader that seeds a declaration's own fields, where each field stands for itself
-     * and there is nothing to substitute. The same statement the reading above puts a
+     * and there is nothing to substitute. The same statement the reading below puts a
      * construction's values into, taken the same way and from the same place.
      */
-    Core stated(TypeOps.Declared clause) {
+    AsStated stated(TypeOps.Declared clause) {
         return meaningOf(clause) instanceof ClauseMeaning.Stated it
-                ? it.states().termForClauseReading() : null;
-    }
-
-    /**
-     * The rules {@code clause}'s author wrote it as, as its declaration published them.
-     *
-     * <p>Asked of the declaration and not worked out from a tree. Which parts a clause has was
-     * settled where it was split, and a reader that recovered them from what it typed would be a
-     * second answer to how many there are.
-     */
-    ClauseMeaning.Parts partsOf(TypeOps.Declared clause) {
-        return meaningOf(clause) instanceof ClauseMeaning.Stated it ? it.parts() : null;
+                ? new AsStated(it.states().termForClauseReading(), it.parts()) : null;
     }
 
     /**
@@ -264,13 +272,13 @@ final class Clauses {
         List<RuleRef.Invariant> lost = new ArrayList<>();
         for (TypeOps.Declared inv : declared(named)) {
             Clause.Ref clause = Clause.Ref.of(inv);
-            Core one = statedAt(inv, named, given);
+            AsStated one = statedAt(inv, named, given);
             if (one != null) {
                 // The clause as one reading, and the parts its author wrote as subtrees of that
                 // very reading. Read apart instead, a conjunct would be read without the conjunct
                 // beside it, and a branch one of them rules out would stand.
-                stated.add(new Stated(clause, one,
-                        partsOf(inv).onto(ClauseExpr.of(one, true))));
+                stated.add(new Stated(clause, one.states(),
+                        one.parts().onto(ClauseExpr.of(one.states(), true))));
             } else {
                 lost.add(new RuleRef.Invariant(clause));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -82,7 +82,7 @@ public record ContractDischarge(List<RuleDischarge> rules,
         // one every other reader of this module's rules uses.
         Terms naming = new Terms(source.symbols(), Terms.Of.THE_DISCHARGE_TREE, policy,
                 new Clauses(source.symbols(), source.invariants(), source.written(),
-                        DeclarationReadings.NONE));
+                        DeclarationReadings.NONE, source.states()));
         Denotations locations =
                 Denotations.none().locations(named, naming::placeSubject, naming::placeTerm);
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -51,10 +51,8 @@ public sealed interface DeclarationMeaning {
      */
     public static DeclarationMeaning of(Hir.Def declared, RuleReadingSource source,
                                         DeclarationReadings machines) {
-        // Reading no meanings, because this is where they are made. A reading that consulted them
-        // to make one would be asking for the answer it is producing.
         return of(declared, new Clauses(source.symbols(), source.invariants(), source.written(),
-                machines, ClauseMeanings.NONE));
+                machines, ClauseMeanings.THE_ONE_THAT_MAKES_THEM));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -51,8 +51,10 @@ public sealed interface DeclarationMeaning {
      */
     public static DeclarationMeaning of(Hir.Def declared, RuleReadingSource source,
                                         DeclarationReadings machines) {
+        // Reading no meanings, because this is where they are made. A reading that consulted them
+        // to make one would be asking for the answer it is producing.
         return of(declared, new Clauses(source.symbols(), source.invariants(), source.written(),
-                machines));
+                machines, ClauseMeanings.NONE));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationMeaning.java
@@ -149,7 +149,8 @@ public sealed interface DeclarationMeaning {
             clauses.add(switch (reading.typed(each.asExpanded(), named)) {
                 case TypedClause.Typed typed -> new ClauseMeaning.Stated(clause,
                         TermMeaning.of(typed.value()),
-                        reading.fieldsRead(typed.value(), named));
+                        reading.fieldsRead(typed.value(), named),
+                        each.shape().asWritten(new RuleRef.Invariant(clause)));
                 case TypedClause.Stopped _ -> new ClauseMeaning.Stopped(clause);
             });
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -838,7 +838,7 @@ public final class InvariantChecker {
                 skipped = true;
                 continue;
             }
-            Core stated = c.clauses.typed(declared.asExpanded(), named).orNull();
+            Core stated = c.clauses.stated(declared);
             if (stated == null) {
                 read = false;
                 gathering.missed(RuleKey.THE_VALUE, new RulesMissed.ClauseNotTyped());
@@ -850,7 +850,7 @@ public final class InvariantChecker {
             // it, so what a reader says about an occurrence of one is said in the numbering the
             // clause hands out rather than in a numbering that starts wherever a part does.
             ClauseView view = reach.withoutParts()
-                    .viewOf(declared.shape().onto(ClauseExpr.of(stated, true), origin));
+                    .viewOf(c.clauses.partsOf(declared).onto(ClauseExpr.of(stated, true)));
             // A part at a time, and the ones this world holds. Which parts a clause has was settled
             // where it was split, so a part left out is one left out of the list — never a node a
             // walk was told to step over.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -226,7 +226,8 @@ public final class InvariantChecker {
      * the reason {@link ClauseLocations} gives.
      */
     public record Source(Hir.Expr body, ElementProvenance elements, ExpandedClauseLookup invariants,
-                         ClauseLocations written, DeclarationReadings machines,
+                         ClauseMeanings states, ClauseLocations written,
+                         DeclarationReadings machines,
                          Map<ValueName.Behavior, AssumedContract> contracts) {
 
         public Source {
@@ -276,21 +277,23 @@ public final class InvariantChecker {
     private final List<Diagnostic> warnings = new ArrayList<>();
 
     private InvariantChecker(Symbols symbols,
-                             ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
+                             ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+                             ClauseLocations written,
                              DeclarationReadings machines, ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, written, machines, Map.of(), policy);
+        this(symbols, dischargeInvariants, states, written, machines, Map.of(), policy);
     }
 
     private InvariantChecker(Symbols symbols,
-                             ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
+                             ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+                             ClauseLocations written,
                              DeclarationReadings machines,
                              Map<ValueName.Behavior, AssumedContract> contracts,
                              ReadingPolicy policy) {
         // Where the answers about a declaration's string machines are asked for, for every
         // declaration this check reads: a capability handed on to the engine, which hands it to
         // every reading made through it, and kept by nothing any of them answers with.
-        this.engine = new PathEngine(symbols, dischargeInvariants, written, machines, contracts,
-                policy);
+        this.engine = new PathEngine(symbols, dischargeInvariants, states, written, machines,
+                contracts, policy);
         // Borrowing nothing, since no declaration is being seeded yet, and knowing what the
         // revision knows: where a set stops is the same answer whoever met it.
         this.answers = StringMachineAnswers.unborrowed(machines.extents());
@@ -313,7 +316,7 @@ public final class InvariantChecker {
                                                TypeSymbol.AtModule named,
                                                RuleReadingSource source, ReadingPolicy policy) {
         InvariantChecker c = new InvariantChecker(source.symbols(), source.invariants(),
-                source.written(), DeclarationReadings.NONE, policy);
+                source.states(), source.written(), DeclarationReadings.NONE, policy);
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built. These
         // stand for a value rather than holding one, so they are entered as locations and nothing is
@@ -361,8 +364,8 @@ public final class InvariantChecker {
     static ClauseDischarge capabilityOf(StatedContract.Conjunct conjunct,
                                         Denotations locations, RuleReadingSource source,
                                         ReadingPolicy policy, String describing) {
-        return new InvariantChecker(source.symbols(), source.invariants(), source.written(),
-                DeclarationReadings.NONE, policy)
+        return new InvariantChecker(source.symbols(), source.invariants(), source.states(),
+                source.written(), DeclarationReadings.NONE, policy)
                 .capabilityOf(conjunct.stated(), conjunct.at(), locations, describing);
     }
 
@@ -742,8 +745,8 @@ public final class InvariantChecker {
         READINGS.incrementAndGet();
         Symbols symbols = source.symbols();
         InvariantChecker c =
-                new InvariantChecker(symbols, source.invariants(), source.written(), machines,
-                        policy);
+                new InvariantChecker(symbols, source.invariants(), source.states(),
+                        source.written(), machines, policy);
         c.answers = answers;
         // A newtype's value is the same location as the newtype, so it is at no name of its own and
         // its fields are the first step there is. Read from the world rather than off a node handed
@@ -3318,12 +3321,14 @@ public final class InvariantChecker {
      * analysis representation could not be built or typed for, and is not analyzed at all, which is
      * the {@code ABANDONED} this answers with.
      */
-    static Findings analyze(Core body, ExpandedClauseLookup invariants, ClauseLocations written,
+    static Findings analyze(Core body, ExpandedClauseLookup invariants, ClauseMeanings states,
+                            ClauseLocations written,
                             DeclarationReadings machines,
                             Map<ValueName.Behavior, AssumedContract> contracts,
                             Scope params, Symbols symbols, ReadingPolicy policy) {
         InvariantChecker c =
-                new InvariantChecker(symbols, invariants, written, machines, contracts, policy);
+                new InvariantChecker(symbols, invariants, states, written, machines, contracts,
+                        policy);
         if (body == null) {
             return new Findings(c.errors, c.warnings, Status.ABANDONED);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -838,19 +838,20 @@ public final class InvariantChecker {
                 skipped = true;
                 continue;
             }
-            Core stated = c.clauses.stated(declared);
-            if (stated == null) {
+            Clauses.AsStated states = c.clauses.stated(declared);
+            if (states == null) {
                 read = false;
                 gathering.missed(RuleKey.THE_VALUE, new RulesMissed.ClauseNotTyped());
                 continue;
             }
+            Core stated = states.states();
             // The clause as one reading, and the parts its author wrote as subtrees of it. Which
             // parts there are was settled where the clause was split; nothing here decides it.
             // The shape of the whole clause, read out of the tree once. The parts are subtrees of
             // it, so what a reader says about an occurrence of one is said in the numbering the
             // clause hands out rather than in a numbering that starts wherever a part does.
             ClauseView view = reach.withoutParts()
-                    .viewOf(c.clauses.partsOf(declared).onto(ClauseExpr.of(stated, true)));
+                    .viewOf(states.parts().onto(ClauseExpr.of(stated, true)));
             // A part at a time, and the ones this world holds. Which parts a clause has was settled
             // where it was split, so a part left out is one left out of the list — never a node a
             // walk was told to step over.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -71,16 +71,16 @@ final class PathEngine {
     /** What each behavior a body may call states about its answer, by the name it is called under. */
     private final Map<ValueName.Behavior, AssumedContract> contracts;
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
-               DeclarationReadings machines, ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, written, machines, Map.of(),
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+               ClauseLocations written, DeclarationReadings machines, ReadingPolicy policy) {
+        this(symbols, dischargeInvariants, states, written, machines, Map.of(),
                 Terms.Of.THE_DISCHARGE_TREE, policy);
     }
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
-               DeclarationReadings machines, Map<ValueName.Behavior, AssumedContract> contracts,
-               ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, written, machines, contracts,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+               ClauseLocations written, DeclarationReadings machines,
+               Map<ValueName.Behavior, AssumedContract> contracts, ReadingPolicy policy) {
+        this(symbols, dischargeInvariants, states, written, machines, contracts,
                 Terms.Of.THE_DISCHARGE_TREE, policy);
     }
 
@@ -92,16 +92,18 @@ final class PathEngine {
      * recorded the fold as a shape this compiler has no term for would be answering about the
      * representation under the name of a gap.
      */
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
-               DeclarationReadings machines, Terms.Of reading, ReadingPolicy policy) {
-        this(symbols, dischargeInvariants, written, machines, Map.of(), reading, policy);
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+               ClauseLocations written, DeclarationReadings machines, Terms.Of reading,
+               ReadingPolicy policy) {
+        this(symbols, dischargeInvariants, states, written, machines, Map.of(), reading, policy);
     }
 
-    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseLocations written,
-               DeclarationReadings machines, Map<ValueName.Behavior, AssumedContract> contracts,
+    PathEngine(Symbols symbols, ExpandedClauseLookup dischargeInvariants, ClauseMeanings states,
+               ClauseLocations written, DeclarationReadings machines,
+               Map<ValueName.Behavior, AssumedContract> contracts,
                Terms.Of reading, ReadingPolicy policy) {
         this.symbols = symbols;
-        this.clauses = new Clauses(symbols, dischargeInvariants, written, machines);
+        this.clauses = new Clauses(symbols, dischargeInvariants, written, machines, states);
         this.terms = new Terms(symbols, reading, policy, clauses);
         this.predicates = terms.predicates();
         this.guarantees = terms.guarantees();

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -208,8 +208,8 @@ public final class PathReachability {
             return Answers.NONE;
         }
         PathEngine engine =
-                new PathEngine(source.symbols(), source.invariants(), source.written(),
-                        DeclarationReadings.NONE,
+                new PathEngine(source.symbols(), source.invariants(), source.states(),
+                        source.written(), DeclarationReadings.NONE,
                         Terms.Of.THE_TREE_THAT_RUNS, policy);
         Map<ControlPointId, Reachability> out = new LinkedHashMap<>();
         Map<ConstructOccurrence,

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleReadingSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleReadingSource.java
@@ -31,6 +31,11 @@ package souther.compiler.check;
  *
  * @param symbols    the module's resolved scope
  * @param invariants where a declaration's clauses in the representation this reads are answered from
+ * @param states     where what each of those clauses states is answered from, which is the
+ *                   declaration that wrote it. Beside {@code invariants} and not inside it: which
+ *                   clauses a declaration has is a question about the declaration, and what one of
+ *                   them states is a question about the clause — and the first is asked of a walk
+ *                   that reaches spreads while the second is asked of whoever wrote the clause
  * @param written    where a clause of a declaration is written, for the sentences this reading
  *                   produces that point at one. Beside {@code invariants} and not inside it: what a
  *                   clause states is what the reading is built on, and where it is written is what
@@ -39,20 +44,22 @@ package souther.compiler.check;
  * @param origin     which source this is, for a reader telling two of them apart
  */
 public record RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants,
-                                ClauseLocations written, Origin origin) {
+                                ClauseMeanings states, ClauseLocations written, Origin origin) {
 
     public RuleReadingSource {
-        if (symbols == null || invariants == null || written == null || origin == null) {
+        if (symbols == null || invariants == null || states == null || written == null
+                || origin == null) {
             throw new IllegalArgumentException(
                     "reading a declaration's rules takes a scope, somewhere to read clauses from,"
-                            + " somewhere to read where one is written, and which source that is");
+                            + " somewhere to read what one states, somewhere to read where one is"
+                            + " written, and which source that is");
         }
     }
 
     /** A source made for a reading of its own, which nobody else can name. */
     public RuleReadingSource(Symbols symbols, ExpandedClauseLookup invariants,
-                             ClauseLocations written) {
-        this(symbols, invariants, written, AReadingOfItsOwn.next());
+                             ClauseMeanings states, ClauseLocations written) {
+        this(symbols, invariants, states, written, AReadingOfItsOwn.next());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -458,8 +458,8 @@ public final class SpecChecker {
         InvariantChecker.Findings inv = discharge == null
                 ? InvariantChecker.Findings.notRun()
                 : InvariantChecker.analyze(dischargeBody, discharge.invariants(),
-                        discharge.written(), discharge.machines(), discharge.contracts(), env,
-                        symbols, policy);
+                        discharge.states(), discharge.written(), discharge.machines(),
+                        discharge.contracts(), env, symbols, policy);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
@@ -89,6 +89,27 @@ public final class TermMeaning {
         return predicates.assumed(term, at, decidesFalse);
     }
 
+    /**
+     * The term, for the one reader that reads a declaration's clauses into the state the discharge
+     * is made of ({@link Clauses}).
+     *
+     * <p><b>Not an unwrapping, and named so that it cannot be read as one.</b> What this type keeps
+     * from a reader is the ability to observe a term it was handed as an answer: two of these
+     * compare equal while holding terms written at different places, so anything read off the term
+     * and published would be a fact about which of two equal answers a store happened to keep.
+     * Nothing about holding the term inside one reading is that.
+     *
+     * <p>So the term comes out here and reaches no answer. The reading it goes into publishes what
+     * the clauses state and never a tree, and where a clause is written is asked of the thing that
+     * says where a clause is written ({@link ClauseLocations}) rather than read off what comes out
+     * of here. Being package-private is not what holds that: the compiler lets any neighbour call
+     * this, and what says who may is the ledger that names the callers
+     * ({@code WhoMayReadTheTermOfAMeaningTest}).
+     */
+    Core termForClauseReading() {
+        return term;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other instanceof TermMeaning it

--- a/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
@@ -99,12 +99,22 @@ public final class TermMeaning {
      * and published would be a fact about which of two equal answers a store happened to keep.
      * Nothing about holding the term inside one reading is that.
      *
-     * <p>So the term comes out here and reaches no answer. The reading it goes into publishes what
-     * the clauses state and never a tree, and where a clause is written is asked of the thing that
-     * says where a clause is written ({@link ClauseLocations}) rather than read off what comes out
-     * of here. Being package-private is not what holds that: the compiler lets any neighbour call
-     * this, and what says who may is the ledger that names the callers
-     * ({@code WhoMayReadTheTermOfAReadingTest}).
+     * <p><b>What is held here, and what is not.</b> One ledger says who may call this
+     * ({@code WhoMayReadTheTermOfAReadingTest}), and that is all it says: the term this hands back
+     * is a {@link Core}, and the reading it goes into passes trees of its own down to everything
+     * below it. So the caller written down there is where the term <em>enters</em> the reading and
+     * not the last place it can be seen — a reader below that one holds a tree like any other and
+     * could read a place off it.
+     *
+     * <p>What holds the rest is not a ledger. It is that nothing the reading publishes carries a
+     * tree or a place: what a body is checked against comes back as what the clauses state, and
+     * where a clause is written is asked of the thing that says where a clause is written
+     * ({@link ClauseLocations}). That is a fact about answers rather than about calls, so it is
+     * held by asking the answers — a reading of one source is the same reading whichever compile
+     * built the terms it was told about
+     * ({@code AClauseReadsTheSameWhicheverCompileBuiltTheTermTest}), and what a module publishes
+     * about a declaration does not move when the declaration only moves
+     * ({@code AnInputsReadingDoesNotDependOnWhichCompileBuiltItTest}).
      */
     Core termForClauseReading() {
         return term;

--- a/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TermMeaning.java
@@ -104,7 +104,7 @@ public final class TermMeaning {
      * says where a clause is written ({@link ClauseLocations}) rather than read off what comes out
      * of here. Being package-private is not what holds that: the compiler lets any neighbour call
      * this, and what says who may is the ledger that names the callers
-     * ({@code WhoMayReadTheTermOfAMeaningTest}).
+     * ({@code WhoMayReadTheTermOfAReadingTest}).
      */
     Core termForClauseReading() {
         return term;

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -328,7 +328,8 @@ final class Terms {
      */
     Terms(Symbols symbols, Of reading, ReadingPolicy policy, Clauses clauses) {
         this.symbols = symbols;
-        this.rules = new RuleReadingSource(symbols, clauses.expandedClauses(), clauses.written());
+        this.rules = new RuleReadingSource(symbols, clauses.expandedClauses(), clauses.states(),
+                clauses.written());
         this.reading = reading;
         this.policy = policy;
         this.predicates = new Predicates(this);

--- a/souther-compiler/src/main/java/souther/compiler/check/TheCompilationsSources.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TheCompilationsSources.java
@@ -32,6 +32,7 @@ public final class TheCompilationsSources {
 
     private final Function<String, Symbols> scopeOf;
     private final ExpandedClauseLookup clauses;
+    private final ClauseMeanings states;
     private final ClauseLocations written;
 
     /** Which mint this is, told to nobody: what it stamps says this and what another stamps says
@@ -48,14 +49,16 @@ public final class TheCompilationsSources {
      * to read.
      */
     public TheCompilationsSources(Function<String, Symbols> scopeOf, ExpandedClauseLookup clauses,
-                                  ClauseLocations written) {
-        if (scopeOf == null || clauses == null || written == null) {
+                                  ClauseMeanings states, ClauseLocations written) {
+        if (scopeOf == null || clauses == null || states == null || written == null) {
             throw new IllegalArgumentException(
-                    "a compilation reads its modules under a scope, reads clauses somewhere, and"
-                            + " reads where one is written somewhere");
+                    "a compilation reads its modules under a scope, reads clauses somewhere, reads"
+                            + " what one states somewhere, and reads where one is written"
+                            + " somewhere");
         }
         this.scopeOf = scopeOf;
         this.clauses = clauses;
+        this.states = states;
         this.written = written;
     }
 
@@ -64,7 +67,7 @@ public final class TheCompilationsSources {
     public RuleReadingSource of(String module) {
         Symbols scope = scopeOf.apply(module);
         return scope == null ? null
-                : new RuleReadingSource(scope, clauses, written,
+                : new RuleReadingSource(scope, clauses, states, written,
                         new AModulesRules(mint, module));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -67,7 +67,7 @@ public final class TypeCardinality {
         // through a spread, which the graph below does not follow, so a set taken from the graph
         // would leave out exactly the rules that arrive from somewhere else.
         Asked asked = new Asked(source.invariants());
-        source = new RuleReadingSource(symbols, asked, source.written());
+        source = new RuleReadingSource(symbols, asked, source.states(), source.written());
         Map<TypeSymbol, Hir.Def> declared = reached(declarations, symbols);
         Map<TypeSymbol, Set<TypeSymbol>> edges = new LinkedHashMap<>();
         declared.forEach((name, def) -> edges.put(name, read(def, symbols, declared.keySet())));

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -2008,7 +2008,8 @@ public final class Bodies {
                     discharge.present()
                     ? new InvariantChecker.Source(discharge.value().value().writtenBody(),
                             discharge.value().provenance(),
-                            Shapes.expandedClauses(db), Shapes.clauseLocations(db), db.readings(),
+                            Shapes.expandedClauses(db), Shapes.clauseMeanings(db),
+                            Shapes.clauseLocations(db), db.readings(),
                             contracts.present() ? contracts.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -174,6 +174,7 @@ public final class Db implements StoreWork {
         if (sources == null) {
             sources = new TheCompilationsSources(this::scopeOf,
                     named -> ask(new Shapes.ClausesExpandedFor(named)).value(),
+                    Shapes.clauseMeanings(this),
                     Shapes.clauseLocations(this));
         }
         return sources.of(module);

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.ClauseLocations;
+import souther.compiler.check.ClauseMeanings;
 import souther.compiler.check.DeclarationCitations;
 import souther.compiler.check.DeclarationLocations;
 import souther.compiler.check.DeclarationMeaning;
@@ -907,6 +908,23 @@ public final class Shapes {
         return declaration -> {
             Answer<DeclarationMeaning> said = db.ask(new MeaningOf(declaration));
             return said.present() ? said.value() : null;
+        };
+    }
+
+    /**
+     * Where a reading asks what each clause of a declaration states, answered by the declaration
+     * that wrote it ({@link MeaningOf}).
+     *
+     * <p>Empty where nothing declares one and empty where what is declared writes no clauses, which
+     * are the same answer to this question: a reader is asking what the clauses of a declaration
+     * state, and a declaration with none states nothing. Which of the two happened is a question
+     * about the declaration, and it is asked of the declaration.
+     */
+    public static ClauseMeanings clauseMeanings(Db db) {
+        return declaration -> {
+            Answer<DeclarationMeaning> said = db.ask(new MeaningOf(declaration));
+            return said.present() && said.value() instanceof DeclarationMeaning.Product it
+                    ? it.clauses() : List.of();
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
@@ -20,19 +20,25 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * A clause reads the same whichever compile built the term it states.
  *
- * <p>What a declaration states is published, and two published readings of one unedited source are
- * equal while holding terms that are not the same objects and carry different places. So a reader
- * handed either of them has to come to the same answer, or "equal" is a word about two things a
- * reader can tell apart.
+ * <p>What a declaration states is published, and two readings of one clause written a line apart
+ * are equal while holding terms that are neither the same object nor written at the same place. So
+ * a reader handed either of them has to come to the same answer, or "equal" is a word about two
+ * things a reader can tell apart.
  *
- * <p>Compared as readings and not as terms. Two compiles write the same clause at two places, so
- * the terms differ where the reading does not — which is the whole of what {@link TermMeaning} is
- * for, and using it here is using the thing the boundary is built on.
+ * <p>Three things are held here at once, and the first two are what make the third worth asking:
+ * the published readings are equal, the terms behind them are two objects written at two places,
+ * and what a reading of the model comes to is the same either way.
+ *
+ * <p>Compared as readings and not as terms. Two compiles write the clause at two places, so the
+ * terms differ where the reading does not — which is the whole of what {@link TermMeaning} is for,
+ * and using it here is using the thing the boundary is built on.
  *
  * <p><b>Nothing known makes this red, and that is worth writing down.</b> It was written expecting
  * to catch a reader that works out which fields a clause reads by walking the term it was handed:
@@ -44,9 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
  * not there.
  *
  * <p>So this holds a property rather than guarding a defect: what a reader comes to is a function
- * of what it was told and not of which compile built it. That is what the boundary means, it is
- * what nothing else asks of the readings themselves, and the day something below starts reading a
- * place off the tree it was handed, this is where it shows.
+ * of what it was told and not of which compile built it. What it would show is a reading below
+ * this one letting the place a term was written at change what it concludes; a place published as
+ * where to put a caret is not that, and is not compared here.
  */
 class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
 
@@ -61,6 +67,9 @@ class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
                 invariant kept = ok
             """;
 
+    /** The same, written a line further down and saying nothing more. */
+    private static final String MOVED = "// what is held\n" + SOURCE;
+
     /**
      * The reading of one compile, handed what another compile published.
      *
@@ -69,17 +78,27 @@ class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
      */
     @Test
     void aReadingIsTheSameWhicheverCompilePublishedWhatTheClauseStates() {
-        Compilation mine = compiled();
-        Compilation other = compiled();
+        Compilation mine = compiled(SOURCE);
+        Compilation moved = compiled(MOVED);
+
+        ClauseMeaning.Stated here = published(mine);
+        ClauseMeaning.Stated there = published(moved);
+
+        // What the two compiles published is one reading of one clause.
+        assertEquals(here.states(), there.states(),
+                "one clause moved down its file states what it stated");
+        // And it is one reading of two terms: were it one term, everything below would be one
+        // answer compared with itself.
+        assertNotSame(here.states().termForClauseReading(), there.states().termForClauseReading(),
+                "two compiles built two terms, which is what makes this a crossing");
+        assertNotEquals(here.states().termForClauseReading().pos(),
+                there.states().termForClauseReading().pos(),
+                "and wrote them at two places, which is what the readings being equal is about");
 
         Clauses.StatedClauses own = readOf(mine, Shapes.clauseMeanings(mine.db()));
-        Clauses.StatedClauses crossed = readOf(mine, Shapes.clauseMeanings(other.db()));
+        Clauses.StatedClauses crossed = readOf(mine, Shapes.clauseMeanings(moved.db()));
 
         assertFalse(own.clauses().isEmpty(), "the reading under test reads the clause at all");
-        // The control. Two compiles build two trees, so the crossing is a crossing: were the terms
-        // one object, everything below would be one answer compared with itself.
-        assertNotSame(own.clauses().getFirst().expr(), crossed.clauses().getFirst().expr(),
-                "the two compiles built two terms, which is what makes this a crossing");
         assertEquals(said(own), said(crossed),
                 "what the clause states is what it states, whichever compile built the term it was"
                         + " published as");
@@ -87,6 +106,14 @@ class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
                 "and the rules its author wrote it as are the same rules");
         assertEquals(own.lost(), crossed.lost(),
                 "and neither reading dropped a clause the other kept");
+    }
+
+    /** What {@code Held}'s one clause states, as {@code c} publishes it. */
+    private static ClauseMeaning.Stated published(Compilation c) {
+        List<ClauseMeaning> clauses = Shapes.clauseMeanings(c.db()).of(HELD.key());
+        assertEquals(1, clauses.size(), "the declaration under test writes one clause");
+        return assertInstanceOf(ClauseMeaning.Stated.class, clauses.getFirst(),
+                "and this reading has a form for it");
     }
 
     /** What each clause came to, as a reading of it — which is what two of them are compared by. */
@@ -124,8 +151,8 @@ class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
 
-    private static Compilation compiled() {
-        Compilation c = Compilation.ofSources(List.of(SOURCE), ModulePath.EMPTY);
+    private static Compilation compiled(String source) {
+        Compilation c = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
         c.answerEverything();
         return c;
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * A clause reads the same whichever compile built the term it states.
@@ -29,17 +30,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * handed either of them has to come to the same answer, or "equal" is a word about two things a
  * reader can tell apart.
  *
- * <p><b>What this is about is silent.</b> A reader that works out which fields a clause reads by
- * walking the term it was handed looks for the declaring module's bindings in a tree another
- * reading built, finds none of them, and concludes that the clause reads no fields — from which
- * follows that every field it needs is filled, and the clause is read against values that were
- * never put in. Nothing is thrown and nothing is reported; the reading is simply about a clause
- * nobody wrote. So the two readings are put side by side here rather than either being checked
- * against a value written down.
- *
  * <p>Compared as readings and not as terms. Two compiles write the same clause at two places, so
  * the terms differ where the reading does not — which is the whole of what {@link TermMeaning} is
  * for, and using it here is using the thing the boundary is built on.
+ *
+ * <p><b>Nothing known makes this red, and that is worth writing down.</b> It was written expecting
+ * to catch a reader that works out which fields a clause reads by walking the term it was handed:
+ * looking for the declaring module's bindings in a tree another reading built, finding none, and
+ * concluding the clause reads no fields — from which follows that every field it needs is filled.
+ * Made to do exactly that, this still passes. A binding is named by the declaration that wrote the
+ * field and by a number among that declaration's fields, so two compiles of one source name it
+ * alike and the walk finds what it is looking for. The discontinuity that reasoning turns on is
+ * not there.
+ *
+ * <p>So this holds a property rather than guarding a defect: what a reader comes to is a function
+ * of what it was told and not of which compile built it. That is what the boundary means, it is
+ * what nothing else asks of the readings themselves, and the day something below starts reading a
+ * place off the tree it was handed, this is where it shows.
  */
 class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
 
@@ -69,6 +76,10 @@ class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
         Clauses.StatedClauses crossed = readOf(mine, Shapes.clauseMeanings(other.db()));
 
         assertFalse(own.clauses().isEmpty(), "the reading under test reads the clause at all");
+        // The control. Two compiles build two trees, so the crossing is a crossing: were the terms
+        // one object, everything below would be one answer compared with itself.
+        assertNotSame(own.clauses().getFirst().expr(), crossed.clauses().getFirst().expr(),
+                "the two compiles built two terms, which is what makes this a crossing");
         assertEquals(said(own), said(crossed),
                 "what the clause states is what it states, whichever compile built the term it was"
                         + " published as");

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseReadsTheSameWhicheverCompileBuiltTheTermTest.java
@@ -1,0 +1,121 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A clause reads the same whichever compile built the term it states.
+ *
+ * <p>What a declaration states is published, and two published readings of one unedited source are
+ * equal while holding terms that are not the same objects and carry different places. So a reader
+ * handed either of them has to come to the same answer, or "equal" is a word about two things a
+ * reader can tell apart.
+ *
+ * <p><b>What this is about is silent.</b> A reader that works out which fields a clause reads by
+ * walking the term it was handed looks for the declaring module's bindings in a tree another
+ * reading built, finds none of them, and concludes that the clause reads no fields — from which
+ * follows that every field it needs is filled, and the clause is read against values that were
+ * never put in. Nothing is thrown and nothing is reported; the reading is simply about a clause
+ * nobody wrote. So the two readings are put side by side here rather than either being checked
+ * against a value written down.
+ *
+ * <p>Compared as readings and not as terms. Two compiles write the same clause at two places, so
+ * the terms differ where the reading does not — which is the whole of what {@link TermMeaning} is
+ * for, and using it here is using the thing the boundary is built on.
+ */
+class AClauseReadsTheSameWhicheverCompileBuiltTheTermTest {
+
+    private static final TypeSymbol.AtModule HELD =
+            TypeSymbols.declared(new TypeKey("demo", "Held"));
+
+    /** Two fields and a clause that reads one of them, so which fields it reads is not empty. */
+    private static final String SOURCE = """
+            module demo exposing ( Held )
+
+            data Held = { ok: Bool, other: Bool }
+                invariant kept = ok
+            """;
+
+    /**
+     * The reading of one compile, handed what another compile published.
+     *
+     * <p>Both answers are worked out by the same reading over the same scope, so what differs
+     * between them is only which compile built the term each was told about.
+     */
+    @Test
+    void aReadingIsTheSameWhicheverCompilePublishedWhatTheClauseStates() {
+        Compilation mine = compiled();
+        Compilation other = compiled();
+
+        Clauses.StatedClauses own = readOf(mine, Shapes.clauseMeanings(mine.db()));
+        Clauses.StatedClauses crossed = readOf(mine, Shapes.clauseMeanings(other.db()));
+
+        assertFalse(own.clauses().isEmpty(), "the reading under test reads the clause at all");
+        assertEquals(said(own), said(crossed),
+                "what the clause states is what it states, whichever compile built the term it was"
+                        + " published as");
+        assertEquals(parts(own), parts(crossed),
+                "and the rules its author wrote it as are the same rules");
+        assertEquals(own.lost(), crossed.lost(),
+                "and neither reading dropped a clause the other kept");
+    }
+
+    /** What each clause came to, as a reading of it — which is what two of them are compared by. */
+    private static Map<Clause.Ref, TermMeaning> said(Clauses.StatedClauses read) {
+        Map<Clause.Ref, TermMeaning> out = new LinkedHashMap<>();
+        read.clauses().forEach(each -> out.put(each.clause(), TermMeaning.of(each.expr())));
+        return out;
+    }
+
+    /** What each clause's parts are called. */
+    private static Map<Clause.Ref, List<PartId<RuleRef.Invariant>>> parts(
+            Clauses.StatedClauses read) {
+        Map<Clause.Ref, List<PartId<RuleRef.Invariant>>> out = new LinkedHashMap<>();
+        read.clauses().forEach(each -> out.put(each.clause(),
+                each.parts().stream().map(Clauses.StatedPart::id).toList()));
+        return out;
+    }
+
+    /**
+     * {@code Held}'s clauses as {@code mine} reads them, told by {@code states} what they state,
+     * with every field given a value.
+     *
+     * <p>Every field, so that a clause is not left to its run-time check for want of one — which is
+     * the answer a reader that could not tell which fields are read would fall into.
+     */
+    private static Clauses.StatedClauses readOf(Compilation mine, ClauseMeanings states) {
+        Clauses reading = new Clauses(Scopes.resolved(mine.db(), "demo").value(),
+                RuleReadings.declaredBy(mine.db(), "demo"), ClauseLocations.NONE,
+                DeclarationReadings.NONE, states);
+        Map<BindingId, Core> given = new LinkedHashMap<>();
+        reading.bindingsOf(HELD).values()
+                .forEach(each -> given.put(each, new Core.Bool(true, Type.BOOL, POS)));
+        return reading.statedAt(HELD, given);
+    }
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofSources(List.of(SOURCE), ModulePath.EMPTY);
+        c.answerEverything();
+        return c;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest.java
@@ -69,7 +69,7 @@ class ACountOfWhatATypeHoldsSaysWhetherItGotEveryRuleTest {
         RuleReadingSource shortOfOne = new RuleReadingSource(whole.symbols(),
                 named -> named.equals(held)
                         ? new ExpandedClauseResult.Unavailable(named) : whole.invariants().of(named),
-                whole.written());
+                whole.states(), whole.written());
 
         assertFalse(TypeCardinality.solve(declarations, shortOfOne, policy).everyRuleReached(),
                 "a count that walked into a declaration whose rules could not be worked out has not"

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeclarationIsReadOnceForEveryQuestionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeclarationIsReadOnceForEveryQuestionThatReachesItTest.java
@@ -198,7 +198,7 @@ class ADeclarationIsReadOnceForEveryQuestionThatReachesItTest {
         // The nearest thing a reader can assemble: the compilation's own scope, and a lookup that
         // answers for no clause anybody wrote.
         RuleReadingSource ofItsOwn = new RuleReadingSource(asTheCompilationReads.symbols(),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE);
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE);
         long beforeItsOwn = InvariantChecker.readingsMade();
         InvariantChecker.seedFields(code, ofItsOwn, AS_THE_COMPILE_READS, readings);
 
@@ -210,7 +210,7 @@ class ADeclarationIsReadOnceForEveryQuestionThatReachesItTest {
         // answers for nothing, saying of what they make the name the compilation writes.
         RuleReadingSource minted = new TheCompilationsSources(
                 _ -> asTheCompilationReads.symbols(), RuleReadings.noClauseFiled(),
-                ClauseLocations.NONE).of("demo");
+                ClauseMeanings.NONE, ClauseLocations.NONE).of("demo");
         long beforeMinted = InvariantChecker.readingsMade();
         InvariantChecker.seedFields(code, minted, AS_THE_COMPILE_READS, readings);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -11,6 +11,7 @@ import souther.compiler.diag.Severity;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
+import souther.compiler.query.Shapes;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeKey;
@@ -97,7 +98,7 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
     private static Clauses readBy(Compilation c, String reading) {
         return new Clauses(Scopes.resolved(c.db(), reading).value(),
                 RuleReadings.declaredBy(c.db(), reading), ClauseLocations.NONE,
-                DeclarationReadings.NONE);
+                DeclarationReadings.NONE, Shapes.clauseMeanings(c.db()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
@@ -76,8 +76,8 @@ class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.written(),
-            DeclarationReadings.NONE,
+    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.states(),
+            rules.written(), DeclarationReadings.NONE,
             Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermEntersAReadingAndDoesNotComeBackOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermEntersAReadingAndDoesNotComeBackOutTest.java
@@ -60,9 +60,10 @@ class ATermEntersAReadingAndDoesNotComeBackOutTest {
                     + " the state the discharge is made of. The asymmetry above is about what a"
                     + " reader handed an answer can observe, and this is inside one reading:"
                     + " what that reading publishes carries no term, and where a clause is"
-                    + " written is asked of ClauseLocations rather than read off this. Who may"
-                    + " call it is what holds that, and it is written down in"
-                    + " WhoMayReadTheTermOfAReadingTest"));
+                    + " written is asked of ClauseLocations rather than read off this. Which"
+                    + " class this door is, is written down in WhoMayReadTheTermOfAReadingTest;"
+                    + " that the readings under it come out the same is asked of the answers, in"
+                    + " AClauseReadsTheSameWhicheverCompileBuiltTheTermTest"));
 
     @Test
     void theOperationsOnAReadingAreTheOnesWrittenDown() {

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermEntersAReadingAndDoesNotComeBackOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermEntersAReadingAndDoesNotComeBackOutTest.java
@@ -54,7 +54,15 @@ class ATermEntersAReadingAndDoesNotComeBackOutTest {
             "int hashCode()"
                     + " — of the same projection equals compares",
             "String toString()"
-                    + " — what it read, for whoever is looking at two that differ"));
+                    + " — what it read, for whoever is looking at two that differ",
+            "Core termForClauseReading()"
+                    + " — the term, for the one reader that reads a declaration's clauses into"
+                    + " the state the discharge is made of. The asymmetry above is about what a"
+                    + " reader handed an answer can observe, and this is inside one reading:"
+                    + " what that reading publishes carries no term, and where a clause is"
+                    + " written is asked of ClauseLocations rather than read off this. Who may"
+                    + " call it is what holds that, and it is written down in"
+                    + " WhoMayReadTheTermOfAReadingTest"));
 
     @Test
     void theOperationsOnAReadingAreTheOnesWrittenDown() {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -58,7 +58,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                DeclarationReadings.NONE,
                 Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
@@ -191,7 +192,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
         Core.Binder y = CoreBinders.of(binders.binder("y", POS));
         PathEngine reading = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                DeclarationReadings.NONE,
                 Map.of(FIND, statesThatTheIntIsPositive()), Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
@@ -283,7 +285,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     void aRuleHoldsOfAnArmWhoseValuesAreAllOnesItIsAbout() {
         Symbols symbols = symbolsOf(NESTED);
         PathEngine reading = new PathEngine(symbols, RuleReadings.noClauseFiled(),
-                ClauseLocations.NONE, DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                ClauseMeanings.NONE, ClauseLocations.NONE, DeclarationReadings.NONE,
+                Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");
@@ -303,7 +306,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     void anArmNamingSeveralTakesARuleThatIsAboutAllOfThem() {
         Symbols symbols = symbolsOf(NESTED);
         PathEngine reading = new PathEngine(symbols, RuleReadings.noClauseFiled(),
-                ClauseLocations.NONE, DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                ClauseMeanings.NONE, ClauseLocations.NONE, DeclarationReadings.NONE,
+                Terms.Of.THE_DISCHARGE_TREE,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");

--- a/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ClauseReadings.java
@@ -62,7 +62,7 @@ final class ClauseReadings {
     static Read readBy(Db db, String module, TypeSymbol.AtModule named) {
         Symbols symbols = Scopes.derived(db, module).value();
         Clauses clauses = new Clauses(symbols, RuleReadings.declaredBy(db, module),
-                ClauseLocations.NONE, DeclarationReadings.NONE);
+                ClauseLocations.NONE, DeclarationReadings.NONE, ClauseMeanings.NONE);
         Map<Clause.Ref, TermMeaning> stated = new LinkedHashMap<>();
         List<Clause.Ref> stopped = new ArrayList<>();
         for (TypeOps.Declared each : clauses.of(named).reached()) {
@@ -86,7 +86,7 @@ final class ClauseReadings {
         Symbols symbols = Scopes.derived(db, module).value();
         return DeclarationMeaning.of(symbols.declaredNode(named),
                 new Clauses(symbols, RuleReadings.declaredBy(db, module),
-                        ClauseLocations.NONE, DeclarationReadings.NONE));
+                        ClauseLocations.NONE, DeclarationReadings.NONE, ClauseMeanings.NONE));
     }
 
     /** One declaration, the module that wrote it, and a module that reads it without having. */

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -113,7 +113,8 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
             assertNotNull(prepared);
 
             Clauses clauses =
-                    new Clauses(symbols, declared, ClauseLocations.NONE, DeclarationReadings.NONE);
+                    new Clauses(symbols, declared, ClauseLocations.NONE, DeclarationReadings.NONE,
+                            ClauseMeanings.NONE);
             int read = 0;
             for (Hir.Def def : prepared.defs().stream().map(each -> each.declaration().node()).toList()) {
                 if (!(def instanceof Hir.Data data)) {

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
@@ -156,8 +156,9 @@ class EveryTermIsReadForWhatItSaysTest {
     @Test
     void twoReadingsOfOneTermAreAssumedAlike() {
         PathEngine engine = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
-                Terms.Of.THE_DISCHARGE_TREE, ReadAs.THE_COMPILATION_DOES);
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                ReadAs.THE_COMPILATION_DOES);
         Predicates predicates = engine.predicates();
 
         Predicates.Owed one = TermMeaning.of(containment(POS))

--- a/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
@@ -51,8 +51,9 @@ class FollowingWhatANameWasGivenCostsTheChainOnceTest {
      * link is a name for the one before it and the first is arithmetic. */
     private static long followedOver(int links) {
         PathEngine engine = new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
-                Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Hir.Binders binders = new Hir.Binders(OWNER);
         Core.Binder first = CoreBinders.of(binders.binder("x0", POS));
         Denotations at = engine.enter(Terms.read(CoreBinders.of(binders.binder("a", POS)), Type.INT, POS),

--- a/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
@@ -42,7 +42,8 @@ public final class RuleReadings {
      *  about a declaration is asking for a reading this never had, and it answers that nothing
      *  declares one rather than the tree the declaration happens to carry. */
     public static RuleReadingSource ofNoClauseFiled(Symbols symbols) {
-        return new RuleReadingSource(symbols, noClauseFiled(), ClauseLocations.NONE);
+        return new RuleReadingSource(symbols, noClauseFiled(), ClauseMeanings.NONE,
+                ClauseLocations.NONE);
     }
 
     /** Where a reading with nothing expanded anywhere gets its clauses. */
@@ -79,6 +80,6 @@ public final class RuleReadings {
     static Terms termsOfNoClauseFiled(Symbols symbols, ReadingPolicy policy) {
         return new Terms(symbols, Terms.Of.THE_DISCHARGE_TREE, policy,
                 new Clauses(symbols, noClauseFiled(), ClauseLocations.NONE,
-                        DeclarationReadings.NONE));
+                        DeclarationReadings.NONE, ClauseMeanings.NONE));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
@@ -43,8 +43,9 @@ class WhatANameIsAboutIsWhatItWasGivenIsAboutTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
-                Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+                RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     @Test
     void aNameGivenAPlaceIsAboutThatPlace() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -69,8 +69,8 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.written(),
-            DeclarationReadings.NONE,
+    private final PathEngine engine = new PathEngine(symbols, rules.invariants(), rules.states(),
+            rules.written(), DeclarationReadings.NONE,
             Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
@@ -230,7 +230,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         Scope params = heldTo(new Type.Ref(TypeSymbols.declared(new TypeKey("demo", "制限木"))));
 
         assertEquals(InvariantChecker.Status.COMPLETE,
-                InvariantChecker.analyze(body, lookupOf(c), ClauseLocations.NONE,
+                InvariantChecker.analyze(body, lookupOf(c), ClauseMeanings.NONE,
+                        ClauseLocations.NONE,
                         DeclarationReadings.NONE, Map.of(), params,
                         symbolsOf(c), POLICY).status(),
                 "the control: read through a lookup that answers, this analysis runs to the end");
@@ -239,7 +240,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
             throw new IllegalStateException("this compiler could not read its own answer");
         };
         IllegalStateException why = assertThrows(IllegalStateException.class,
-                () -> InvariantChecker.analyze(body, broken, ClauseLocations.NONE,
+                () -> InvariantChecker.analyze(body, broken, ClauseMeanings.NONE,
+                        ClauseLocations.NONE,
                         DeclarationReadings.NONE, Map.of(), params,
                         symbolsOf(c), POLICY),
                 "the analysis has no rule that makes this the program's problem");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
@@ -47,8 +47,8 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
     private final Hir.Binders binders = new Hir.Binders(OWNER);
     private final PathEngine engine =
             new PathEngine(Symbols.none(DefaultStdlib.get()),
-                    RuleReadings.noClauseFiled(), ClauseLocations.NONE, DeclarationReadings.NONE,
-                    Terms.Of.THE_DISCHARGE_TREE,
+                    RuleReadings.noClauseFiled(), ClauseMeanings.NONE, ClauseLocations.NONE,
+                    DeclarationReadings.NONE, Terms.Of.THE_DISCHARGE_TREE,
                     souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -629,6 +629,16 @@ final class AnswerClosure {
                     part("souther.compiler.partition.MeasuredInput", "written"),
                     part("souther.compiler.partition.BehaviorInputs", "rules"),
                     part("souther.compiler.check.RuleReadingSource", "written")),
+            // What each clause of a declaration states, beside where it is written and for the
+            // same reason: a capability, whose only input is which declaration is being asked
+            // about. Held as an answer here it would be this reading's copy of what the declaring
+            // module made of its own clauses, which is the copy that goes on saying what the
+            // clause used to state.
+            generationReader("souther.compiler.check.ClauseMeanings",
+                    Traversal.Why.NOTHING_CLOSES_IT,
+                    part("souther.compiler.partition.MeasuredInput", "written"),
+                    part("souther.compiler.partition.BehaviorInputs", "rules"),
+                    part("souther.compiler.check.RuleReadingSource", "states")),
             generationReader("souther.compiler.inputs.ReadQuantities",
                     part("souther.compiler.partition.MeasuredInput", "quantities"),
                     arm("souther.compiler.inputs.ReadQuantities")),


### PR DESCRIPTION
The check that discharges a declaration's rules was handed the clauses of every declaration it reaches as the tree their author wrote, and worked out for itself what each one states: it typed that tree in the declaring module's scope, walked the result for the fields the clause reads, and recovered the parts the author wrote from the shape beside it. All of that is the declaring module answering questions it has already answered, once per reader, against bindings that belong to the reader's reading rather than to the declaration.

Two of those questions now come from the declaration, on the path that reads a declaration's clauses as clauses.

What a clause states is taken from what its declaration publishes. The term itself comes out of the reading through one accessor named for the one reader that may use it, and goes no further: the check builds its own tree from it, publishes what the clauses state and never a tree, and asks where a clause is written of the thing that says where a clause is written. Being package-private is not what holds that — a ledger names the caller, and a second one names the operation among the ones a reading has.

Which rules the author wrote is taken from there too. The shape the split issued carries the node each part was written as, which is what the expansion needs and what no reader across a boundary may have; the published form is the same shape with the names the split issued and none of what says where they stand. The descent that finds the parts again in a tree moved with it, so there is one of it rather than two. A clause is asked once for both, because the parts are found again in the very tree beside them and two lookups need not have agreed.

The reading that works these out consults none of them, and says so by refusing rather than by answering emptily: asking it would be asking for the answer it is producing, and an empty answer would say instead that the declaration states nothing.

Two things this does not do, both measured rather than assumed.

It does not cut the dependency. A comment written above the declaration leaves what it publishes equal and leaves the importer's own resolved scope unequal — that scope holds the authored declarations of the modules it imports, and every reading reaches them through it. So the clause path is no longer what carries an edit that says nothing across a module boundary, and something else still is.

And one reader of a clause is not on this path. What a construction may be held to is worked out from a part of a clause rather than from a clause, through a carrier that says which part it is and not which clause of which declaration — so it still types what it was handed. Moving it is a piece of its own.

Part of #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)