### PR TITLE
Let a reader that only knows what the arguments state apply a signature

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -238,7 +238,8 @@ public final class CallElaborator {
         if (call.args().size() != params.size()) {
             arity(call, params.size());
         }
-        Map<String, Type> bind = settledByValues(call, params, kept.result(), expected, ca::type, ctx);
+        Map<String, Type> bind = SignatureApplication.settledByValues(
+                params, kept.result(), expected, ca::type, ctx.symbols());
         requireValueArgs(call, params, ca, bind);
         for (int i = 0; i < params.size(); i++) {
             if (params.get(i) instanceof Type.FnOf declared) {
@@ -271,65 +272,6 @@ public final class CallElaborator {
         return new Core.PreservedCall(kept.declaring(), ca.cores(),
                 new Core.KeptCallPlace(call.answered().origin(), call.application()),
                 TypeOps.substitute(kept.result(), bind), call.pos());
-    }
-
-    /**
-     * What a call settles of the signature it applies, before any function argument is typed.
-     *
-     * <p>Two things state something about a polymorphic signature's variables, and they are asked in
-     * this order because the order is the whole of the rule.
-     *
-     * <ol>
-     *   <li>What the context expects of the result, where the signature takes a function at all. A
-     *       variable a function parameter mentions has to be decided before that function is typed,
-     *       and where no argument decides it the position the call stands in is the only thing that
-     *       does.</li>
-     *   <li>What each value argument states, the ones that state something first. An argument that
-     *       answers no value — an empty collection carries a bottom — says nothing about what it
-     *       holds, and letting it settle a variable would hold every other argument to the element
-     *       type of nothing. A bottom then widens to what the others settled instead of the other way
-     *       round.</li>
-     * </ol>
-     *
-     * <p>Every reader of a declared signature asks this: the call that expands one, the call that
-     * keeps one standing, and the walk that reads one to learn what a function it was handed takes.
-     * They differ in what they do with a function argument afterwards — a fold reads its result as
-     * the accumulator to grow, an ordinary application does not — and in nothing before it. Said once
-     * because a difference here is not a failure but a variable settled to the wrong type, which is
-     * reported somewhere else as something else.
-     */
-    static Map<String, Type> settledByValues(Hir.Apply call, List<Type> params, Type result,
-                                             Type expected,
-                                             java.util.function.IntFunction<Type> argType,
-                                             CheckContext ctx) {
-        Map<String, Type> bind = new HashMap<>();
-        if (params.stream().anyMatch(Type.FnOf.class::isInstance)) {
-            BottomInfer.pinResultTypeVars(result, expected, bind, ctx.symbols());
-        }
-        // Each value argument is asked once, here, in the order it is written. What the ordering
-        // below decides is which of them settles a variable first, and nothing about how many times
-        // an argument is read: typing one can decide a variable of the application it stands in, so a
-        // second reading is a second answer, and then the argument classified and the argument
-        // unified are not the same reading of it.
-        Type[] stated = new Type[params.size()];
-        List<Integer> stating = new ArrayList<>();
-        List<Integer> bottoms = new ArrayList<>();
-        for (int i = 0; i < params.size(); i++) {
-            if (params.get(i) instanceof Type.FnOf) {
-                continue;
-            }
-            stated[i] = argType.apply(i);
-            (Type.mentions(stated[i], BottomInfer::answersNoValue) ? bottoms : stating).add(i);
-        }
-        stating.addAll(bottoms);
-        // What an argument settles, and not whether it fits: that is required of each argument once
-        // the substitution is complete, and required there because that is where the argument itself
-        // is in hand. A refusal from here would name the argument in words and point at the callee,
-        // the two being as far apart as an argument list is long.
-        for (int i : stating) {
-            TypeOps.bindVars(params.get(i), stated[i], bind, ctx.symbols());
-        }
-        return bind;
     }
 
     /**
@@ -537,8 +479,8 @@ public final class CallElaborator {
             throw new IllegalStateException("`" + call.written() + "` reached signature application"
                     + " with " + args.size() + " argument(s) against " + signature.params().size());
         }
-        Map<String, Type> bind = settledByValues(call, signature.params(), signature.result(),
-                expected, ca::type, ctx);
+        Map<String, Type> bind = SignatureApplication.settledByValues(
+                signature.params(), signature.result(), expected, ca::type, ctx.symbols());
         requireValueArgs(call, signature.params(), ca, bind);
         try {
             for (int i = 0; i < args.size(); i++) {
@@ -569,7 +511,8 @@ public final class CallElaborator {
     }
 
     /** Each value argument held to the parameter it was given to, at its own position — the
-     * refusal {@link #settledByValues} leaves to whoever has the argument in hand. */
+     * refusal {@link SignatureApplication#settledByValues} leaves to whoever has the argument in
+     * hand. */
     private static void requireValueArgs(Hir.Apply call, List<Type> params, CallArgs ca,
                                          Map<String, Type> bind) {
         for (int i = 0; i < params.size(); i++) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -1227,8 +1227,8 @@ public final class Elaborator {
                 // The same settling the call itself does — this walk is reading that call's own
                 // question one position early, and an answer that differed from the one the call
                 // reaches would be a parameter type nothing later agrees with.
-                bind = CallElaborator.settledByValues(call, kept.params(), kept.result(), null,
-                        j -> typeOf(call.args().get(j), env, ctx), ctx);
+                bind = SignatureApplication.settledByValues(kept.params(), kept.result(), null,
+                        j -> typeOf(call.args().get(j), env, ctx), ctx.symbols());
             } catch (CompileException _) {
                 return;   // this call decides nothing here; what is wrong with it is reported there
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/SignatureApplication.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SignatureApplication.java
@@ -1,0 +1,94 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+/**
+ * A declared signature applied to what stands at its parameters.
+ *
+ * <p>The one step every reader of a declared signature takes, and nothing beside it. What a
+ * signature's variables are settled to by a result the context expects and by arguments that state
+ * a type is here; making a Core, refusing an argument that does not fit, typing a function
+ * argument and reporting any of it are the caller's. A reader that only knows what the arguments
+ * state can take this step and no further, which is what lets the reading that types a text and
+ * the reading that says what declarations already state share the rule rather than each writing
+ * one.
+ *
+ * <p>Nothing here is about a call. What was written, where it points and how many arguments it has
+ * are a caller's questions, and a step that took a call would be one only a caller could take.
+ */
+final class SignatureApplication {
+
+    private SignatureApplication() {
+    }
+
+    /**
+     * What applying a signature settles of its variables, before any function argument is typed.
+     *
+     * <p>Two things state something about a polymorphic signature's variables, and they are asked
+     * in this order because the order is the whole of the rule.
+     *
+     * <ol>
+     *   <li>What the context expects of the result, where the signature takes a function at all. A
+     *       variable a function parameter mentions has to be decided before that function is typed,
+     *       and where no argument decides it the position the call stands in is the only thing that
+     *       does.</li>
+     *   <li>What each value argument states, the ones that state something first. An argument that
+     *       answers no value — an empty collection carries a bottom — says nothing about what it
+     *       holds, and letting it settle a variable would hold every other argument to the element
+     *       type of nothing. A bottom then widens to what the others settled instead of the other way
+     *       round.</li>
+     * </ol>
+     *
+     * <p>Every reader of a declared signature asks this: the call that expands one, the call that
+     * keeps one standing, the walk that reads one to learn what a function it was handed takes, and
+     * the walk that reads what declarations state about an application. They differ in what they do
+     * with a function argument afterwards — a fold reads its result as the accumulator to grow, an
+     * ordinary application does not — and in nothing before it. Said once because a difference here
+     * is not a failure but a variable settled to the wrong type, which is reported somewhere else as
+     * something else.
+     *
+     * @param params   what the signature declares it takes
+     * @param result   what the signature declares it answers
+     * @param expected what the position the application stands in requires of the result, or null
+     *                 where the reader has no position to read
+     * @param stated   what stands at each parameter, asked by position and asked once
+     * @param symbols  what the names in the types denote
+     */
+    static Map<String, Type> settledByValues(List<Type> params, Type result, Type expected,
+                                             IntFunction<Type> stated, Symbols symbols) {
+        Map<String, Type> bind = new HashMap<>();
+        if (params.stream().anyMatch(Type.FnOf.class::isInstance)) {
+            BottomInfer.pinResultTypeVars(result, expected, bind, symbols);
+        }
+        // Each value argument is asked once, here, in the order it is written. What the ordering
+        // below decides is which of them settles a variable first, and nothing about how many times
+        // an argument is read: typing one can decide a variable of the application it stands in, so a
+        // second reading is a second answer, and then the argument classified and the argument
+        // unified are not the same reading of it.
+        Type[] at = new Type[params.size()];
+        List<Integer> stating = new ArrayList<>();
+        List<Integer> bottoms = new ArrayList<>();
+        for (int i = 0; i < params.size(); i++) {
+            if (params.get(i) instanceof Type.FnOf) {
+                continue;
+            }
+            at[i] = stated.apply(i);
+            (Type.mentions(at[i], BottomInfer::answersNoValue) ? bottoms : stating).add(i);
+        }
+        stating.addAll(bottoms);
+        // What an argument settles, and not whether it fits: that is required of each argument once
+        // the substitution is complete, and required there because that is where the argument itself
+        // is in hand. A refusal from here would name the argument in words and point at the callee,
+        // the two being as far apart as an argument list is long.
+        for (int i : stating) {
+            TypeOps.bindVars(params.get(i), at[i], bind, symbols);
+        }
+        return bind;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
@@ -112,13 +112,12 @@ class OneCallSettlesOneSignatureTest {
                 Type.fn(List.of(new Type.Var("a", false)), Type.BOOL),
                 Type.list(new Type.Var("a", false)));
         int[] reads = new int[params.size()];
-        Hir.Apply call = (Hir.Apply) filterOverAnEmptyList();
 
-        CallElaborator.settledByValues(call, params, Type.list(new Type.Var("a", false)),
+        SignatureApplication.settledByValues(params, Type.list(new Type.Var("a", false)),
                 Type.list(Type.INT), i -> {
                     reads[i]++;
                     return Type.list(Type.INT);
-                }, CheckContext.of(Symbols.none(DefaultStdlib.get())));
+                }, Symbols.none(DefaultStdlib.get()));
 
         assertEquals(0, reads[0], "a function argument is typed after the values, not here");
         assertEquals(1, reads[1], "and a value argument is read once, however it is ordered");


### PR DESCRIPTION
Applying a declared signature to what stands at its parameters was reachable
only from a caller holding a call, though the step reads nothing of the call —
it took one and never looked at it, and the context it took was consulted for
its symbols alone.

It is its own component now. The reading that types a text still takes it and
goes on to refuse arguments, type function arguments and build a Core; a reader
that knows only what the arguments state can take the step and stop there,
which is what #1487 needs and could not reach.

No answer moves: the callers hand over the same lists and read the same
substitution back.

Towards #1487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)