### PR TITLE
Keep what a declaration's reading came to with the reading itself

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -1,0 +1,296 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Nothing this compiler runs reads a declaration that somebody has already read.
+ *
+ * <p>Reading a declaration is what a question about its rules costs, and the readings a question
+ * needs beyond the first are readings of the same declaration again: attributing an end reads it
+ * once per conjunct that could be holding one. So a reading is lent — made once for a declaration
+ * under a revision, and handed to whoever asks next — and where the lending is reached is where the
+ * reader says where it borrows from ({@code DeclarationReadings}).
+ *
+ * <p><b>A reader that says nothing gets nothing, and nothing about that fails.</b> The entry points
+ * come in pairs: one takes the lending and one does not, and the second reads for itself and
+ * answers the same. A caller that reached for the shorter one loses every reading the lending had
+ * to give and is told by nothing at all — which is how a boundary search came to build a
+ * declaration's string machines again for each value it probed.
+ *
+ * <p>So the pairs are what this walks, and the rule is about the callers rather than about the
+ * shapes. The shorter entry points stay, because a test standing one declaration up to look at it
+ * is a reader with no store and saying so is not a defect; what may not happen is this compiler
+ * reaching for one while a store is answering.
+ *
+ * <p><b>Both halves of the pair are found rather than listed.</b> A name with two static entry
+ * points, one taking the lending and one not, is a pair wherever it is written — so an entry point
+ * added later is in the population the day it is written, and one whose partner is deleted leaves
+ * the population the same day. A list of names would be a second answer to which entry points these
+ * are, kept up by whoever remembered.
+ *
+ * <p>Read off the compiled classes, because what is being asked is which method a call site
+ * resolved to. The overloads differ by one argument and the shorter is reached by leaving it out,
+ * which is a fact about resolution rather than about the text: a walk over spellings would be
+ * deciding overload resolution again, and getting it wrong quietly.
+ */
+class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
+
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
+
+    private static final String LENDING = "souther/compiler/check/DeclarationReadings";
+
+    private static final String LENDING_TYPE = "L" + LENDING + ";";
+
+    /**
+     * The readers that say outright that they read for themselves.
+     *
+     * <p>Each is a place where the lending cannot be reached rather than one where it would not
+     * help, and they are all the same place: a walk over what an author wrote, handed what it is
+     * reading and nothing that says where a reading comes from. Two are the named ways in that a
+     * reader under such a walk takes; the other three build the walk itself, and what they build
+     * has nowhere to put a lending. Borrowing in any of them would take a capability carried
+     * through that walk, and whether it belongs there — and what a borrower asking for a reading
+     * that is already being made should be handed — is not settled.
+     *
+     * <p>Named here so that what is unsettled can be counted. Whoever settles it takes these rows
+     * away; until then they are what stands between this compiler and the shorter entry points, and
+     * nothing else may say it reads for itself.
+     */
+    private static final List<String> READS_FOR_ITSELF = List.of(
+            "souther/compiler/check/FieldDomains#unshared",
+            "souther/compiler/check/InvariantChecker#seedFieldsUnshared",
+            "souther/compiler/check/InvariantChecker#capabilityOf",
+            "souther/compiler/check/ContractDischarge#of",
+            "souther/compiler/check/PathReachability#of");
+
+    /**
+     * Every pair: a static method taking the lending, and one of the same name on the same class
+     * that does not.
+     *
+     * <p>The shorter of each pair is what nothing here may call. Which they are is read off the
+     * compiled classes and not decided here — a name with both shapes is a reader that could borrow
+     * and a way of reaching it that does not.
+     */
+    private static Map<String, Set<MethodTypeDesc>> theShorterOfEachPair() {
+        Map<String, Set<MethodTypeDesc>> found = new LinkedHashMap<>();
+        for (ClassModel read : COMPILED.all()) {
+            String owner = read.thisClass().name().stringValue();
+            Map<String, List<MethodModel>> byName = new LinkedHashMap<>();
+            for (MethodModel method : read.methods()) {
+                if (method.flags().has(java.lang.reflect.AccessFlag.STATIC)) {
+                    byName.computeIfAbsent(method.methodName().stringValue(),
+                            each -> new ArrayList<>()).add(method);
+                }
+            }
+            byName.forEach((name, overloads) -> {
+                Set<MethodTypeDesc> shorter = new LinkedHashSet<>();
+                for (MethodModel each : overloads) {
+                    if (!lends(each) && overloads.stream()
+                            .anyMatch(other -> reachedByLeavingTheLendingOut(each, other))) {
+                        shorter.add(each.methodTypeSymbol());
+                    }
+                }
+                if (!shorter.isEmpty()) {
+                    found.put(owner + "#" + name, shorter);
+                }
+            });
+        }
+        return found;
+    }
+
+    /**
+     * Whether {@code method} is itself one of the ways in that read for themselves.
+     *
+     * <p>Asked of what it takes and not of what it is called. Two overloads of one name are two
+     * methods, and the one that takes a lending is a reader like any other — exempting it because
+     * something of that name reads for itself would leave the reader this is about unread.
+     */
+    private static boolean readsForItself(Map<String, Set<MethodTypeDesc>> pairs, String from,
+                                          MethodModel method) {
+        Set<MethodTypeDesc> shorter = pairs.get(from);
+        return shorter != null && shorter.contains(method.methodTypeSymbol());
+    }
+
+    /**
+     * Whether {@code shorter} is what a caller gets by leaving the lending out of {@code lending}.
+     *
+     * <p>What tells the pairs from the overloads that merely differ. A reader handed something that
+     * carries a lending of its own is not reading for itself, and the two would look alike to a
+     * rule that only asked whether one of the shapes names the lending: a meaning read off clauses
+     * already holds where those clauses borrow from, and the shape beside it that takes a source and
+     * a lending is where the clauses are made.
+     *
+     * <p>So the shapes have to line up: everything the longer one takes before the lending, in the
+     * order it takes them. A shorter one that takes something else takes something else, whatever
+     * the two are called.
+     */
+    private static boolean reachedByLeavingTheLendingOut(MethodModel shorter, MethodModel lending) {
+        if (!lends(lending)) {
+            return false;
+        }
+        List<java.lang.constant.ClassDesc> taken = lending.methodTypeSymbol().parameterList().stream()
+                .filter(each -> !LENDING_TYPE.equals(each.descriptorString()))
+                .toList();
+        List<java.lang.constant.ClassDesc> without = shorter.methodTypeSymbol().parameterList();
+        return without.size() <= taken.size() && without.equals(taken.subList(0, without.size()));
+    }
+
+    /** Whether {@code method} is handed somewhere to borrow a reading from. */
+    private static boolean lends(MethodModel method) {
+        return method.methodTypeSymbol().parameterList().stream()
+                .anyMatch(each -> LENDING_TYPE.equals(each.descriptorString()));
+    }
+
+    /**
+     * The pairs exist, so that a walk finding none would not read as a walk finding no callers.
+     *
+     * <p>Named rather than counted. What this is about is that the population is derived, and a
+     * derivation that came back empty because the shapes had been renamed would pass every row
+     * below without looking at anything.
+     */
+    @Test
+    void theEntryPointsThatReadForThemselvesAreFound() {
+        Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
+
+        assertTrue(pairs.containsKey("souther/compiler/check/FieldDomains#of"),
+                () -> "what a record's rules leave has a way in that reads for itself: " + pairs);
+        assertTrue(pairs.containsKey("souther/compiler/check/InvariantChecker#seedFields"),
+                () -> "and so does the seeding it is read off: " + pairs);
+    }
+
+    /**
+     * Nothing this compiler runs calls the shorter of a pair.
+     *
+     * <p>Every caller is listed rather than the first one found, because what a reader wants when
+     * this fails is which readers lost their lending — the same list javac would have given had the
+     * shorter entry points been deleted instead.
+     */
+    @Test
+    void nothingHereReachesForTheEntryPointThatReadsForItself() {
+        Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
+        Set<String> reaching = new TreeSet<>();
+        for (ClassModel read : COMPILED.all()) {
+            String owner = read.thisClass().name().stringValue();
+            for (MethodModel method : read.methods()) {
+                String from = owner + "#" + method.methodName().stringValue();
+                // The shorter entry point itself, which is a way in and not a reader. Told apart
+                // from the one beside it by what it takes: a name is exempt here only in the shape
+                // that leaves the lending out, so the partner that takes one is read like anything
+                // else.
+                if (readsForItself(pairs, from, method)) {
+                    continue;
+                }
+                for (Instruction instruction : instructionsOf(method)) {
+                    if (instruction instanceof InvokeInstruction call) {
+                        String to = call.owner().name().stringValue() + "#"
+                                + call.name().stringValue();
+                        Set<MethodTypeDesc> shorter = pairs.get(to);
+                        if (shorter != null && shorter.contains(call.typeSymbol())) {
+                            reaching.add(from + " -> " + to + call.typeSymbol().descriptorString());
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(Set.of(), reaching,
+                () -> "these read a declaration for themselves where a store was answering, and"
+                        + " each of them pays every reading the lending had to give:\n  "
+                        + String.join("\n  ", reaching)
+                        + "\nTake the entry point that is handed somewhere to borrow from, or say"
+                        + " outright that this reader has nowhere to borrow from.");
+    }
+
+    /**
+     * And saying so outright is the two readers that say it.
+     *
+     * <p>The other half of the rule. Left at the first alone, a reader that had lost its lending
+     * could say so and be done, and the count of what is unsettled would move whenever somebody
+     * found the shorter way blocked.
+     *
+     * <p>The shorter entry points name it too, because saying that a reader has nowhere to borrow
+     * from is the whole of what they are.
+     */
+    @Test
+    void onlyTheTwoThatSaySoNameTheLendingThereIsNothingToBorrowFrom() {
+        Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
+        Set<String> naming = new TreeSet<>();
+        for (ClassModel read : COMPILED.all()) {
+            String owner = read.thisClass().name().stringValue();
+            for (MethodModel method : read.methods()) {
+                String from = owner + "#" + method.methodName().stringValue();
+                if (readsForItself(pairs, from, method) || READS_FOR_ITSELF.contains(from)) {
+                    continue;
+                }
+                for (Instruction instruction : instructionsOf(method)) {
+                    if (instruction instanceof FieldInstruction field
+                            && field.opcode() == Opcode.GETSTATIC
+                            && LENDING.equals(field.owner().name().stringValue())
+                            && "NONE".equals(field.name().stringValue())) {
+                        naming.add(from);
+                    }
+                }
+            }
+        }
+
+        assertEquals(Set.of(), naming,
+                () -> "these say they have nowhere to borrow a reading from, which is a thing to"
+                        + " settle rather than to write:\n  " + String.join("\n  ", naming)
+                        + "\nHand the reader somewhere to borrow from, or add it to the readers"
+                        + " that say outright that they read for themselves.");
+    }
+
+    /**
+     * And each of those two is reached, so that a name left behind by a rename reads as a row here
+     * rather than as a licence nobody uses.
+     */
+    @Test
+    void eachReaderThatSaysSoIsThere() {
+        Set<String> written = new LinkedHashSet<>();
+        for (ClassModel read : COMPILED.all()) {
+            String owner = read.thisClass().name().stringValue();
+            for (MethodModel method : read.methods()) {
+                written.add(owner + "#" + method.methodName().stringValue());
+            }
+        }
+
+        List<String> gone = READS_FOR_ITSELF.stream().filter(each -> !written.contains(each))
+                .toList();
+        assertEquals(List.of(), gone,
+                () -> "these are licensed to read for themselves and are not written: " + gone);
+    }
+
+    /** Whether anything at all was read, so that an empty population fails rather than passes. */
+    @Test
+    void theCompiledClassesWereRead() {
+        assertFalse(COMPILED.all().isEmpty(), "this repository compiled nothing to read");
+    }
+
+    private static List<Instruction> instructionsOf(MethodModel method) {
+        Optional<java.lang.classfile.CodeModel> code = method.code();
+        return code.map(each -> each.elementList().stream()
+                .filter(Instruction.class::isInstance)
+                .map(Instruction.class::cast)
+                .toList()).orElse(List.of());
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -7,8 +7,14 @@ import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.constantpool.LoadableConstantEntry;
+import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -23,13 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Nothing this compiler runs reads a declaration that somebody has already read.
+ * Every place this compiler starts a reading of a declaration that somebody else has already made
+ * is written down here.
  *
  * <p>Reading a declaration is what a question about its rules costs, and the readings a question
  * needs beyond the first are readings of the same declaration again: attributing an end reads it
  * once per conjunct that could be holding one. So a reading is lent — made once for a declaration
- * under a revision, and handed to whoever asks next — and where the lending is reached is where the
- * reader says where it borrows from ({@code DeclarationReadings}).
+ * under a revision and handed to whoever asks next — and where the lending is reached, a reader
+ * says where it borrows from ({@code DeclarationReadings}).
  *
  * <p><b>A reader that says nothing gets nothing, and nothing about that fails.</b> The entry points
  * come in pairs: one takes the lending and one does not, and the second reads for itself and
@@ -37,21 +44,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * to give and is told by nothing at all — which is how a boundary search came to build a
  * declaration's string machines again for each value it probed.
  *
- * <p>So the pairs are what this walks, and the rule is about the callers rather than about the
- * shapes. The shorter entry points stay, because a test standing one declaration up to look at it
- * is a reader with no store and saying so is not a defect; what may not happen is this compiler
- * reaching for one while a store is answering.
+ * <p><b>What is written down is the edge and not the place it arrives at.</b> A reader that starts
+ * such a reading is reached by a call, and a table of readers says nothing about who is calling
+ * them: a way in named here as allowed would let a new caller of it arrive with nothing to fail.
+ * So each row is one production instruction reaching one place, both ends said in full, and the
+ * whole set is compared — a row that has gone is as much a finding as one that has appeared,
+ * because a reader that stops reading for itself is what settles this and the row has to go with
+ * it.
  *
- * <p><b>Both halves of the pair are found rather than listed.</b> A name with two static entry
- * points, one taking the lending and one not, is a pair wherever it is written — so an entry point
- * added later is in the population the day it is written, and one whose partner is deleted leaves
- * the population the same day. A list of names would be a second answer to which entry points these
- * are, kept up by whoever remembered.
+ * <p>The shorter entry points stay, because a test standing one declaration up to look at it is a
+ * reader with no store and saying so is not a defect. What may not happen is this compiler reaching
+ * for one without a row here.
  *
  * <p>Read off the compiled classes, because what is being asked is which method a call site
  * resolved to. The overloads differ by one argument and the shorter is reached by leaving it out,
  * which is a fact about resolution rather than about the text: a walk over spellings would be
  * deciding overload resolution again, and getting it wrong quietly.
+ *
+ * <p><b>Every way an instruction names a method.</b> A call is one; handing the method over to be
+ * called later is another, and that arrives as a handle among the arguments a bootstrap is given.
+ * A reader that passes one of these along rather than calling it starts the same reading.
  */
 class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
 
@@ -61,35 +73,90 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
 
     private static final String LENDING_TYPE = "L" + LENDING + ";";
 
+    /** What a row names when a reader takes nothing to borrow from rather than reaching a way in
+     *  that does. */
+    private static final String NOTHING_TO_BORROW_FROM = LENDING + "#NONE";
+
     /**
-     * The readers that say outright that they read for themselves.
+     * Every edge this compiler has into a reading nobody else made, and why each of them is one.
      *
-     * <p>Each is a place where the lending cannot be reached rather than one where it would not
-     * help, and they are all the same place: a walk over what an author wrote, handed what it is
-     * reading and nothing that says where a reading comes from. Two are the named ways in that a
-     * reader under such a walk takes; the other three build the walk itself, and what they build
-     * has nowhere to put a lending. Borrowing in any of them would take a capability carried
-     * through that walk, and whether it belongs there — and what a borrower asking for a reading
-     * that is already being made should be handed — is not settled.
+     * <p>Two kinds, and both are the same fact said at a different distance. A reader that names
+     * {@link #NOTHING_TO_BORROW_FROM} is starting such a reading itself; one that calls a way in is
+     * starting it a call away. Written together because what is being counted is the places, and
+     * which of the two shapes a place happens to have is not what anybody has to settle.
      *
-     * <p>Named here so that what is unsettled can be counted. Whoever settles it takes these rows
-     * away; until then they are what stands between this compiler and the shorter entry points, and
-     * nothing else may say it reads for itself.
+     * <p>Each of them sits under a walk over what an author wrote, which is handed what it is
+     * reading and nothing that says where a reading comes from. Some are the readers under such a
+     * walk and some build the walk itself; borrowing in any of them would take a capability carried
+     * through it, and whether it belongs there — and what a borrower asking for a reading that is
+     * already being made should be handed — is not settled.
+     *
+     * <p>Settling it takes these rows away, and taking one away without settling it is what the
+     * comparison below refuses in the other direction.
      */
-    private static final List<String> READS_FOR_ITSELF = List.of(
-            "souther/compiler/check/FieldDomains#unshared",
-            "souther/compiler/check/InvariantChecker#seedFieldsUnshared",
-            "souther/compiler/check/InvariantChecker#capabilityOf",
-            "souther/compiler/check/ContractDischarge#of",
-            "souther/compiler/check/PathReachability#of");
+    private static final String CHECK = "souther/compiler/check/";
+
+    private static final String SOURCE_AND_POLICY =
+            "L" + CHECK + "RuleReadingSource;L" + CHECK + "ReadingPolicy;";
+
+    private static final Set<String> EDGES_INTO_A_READING_OF_ONES_OWN = Set.of(
+            // The two ways in themselves, which is where a reading with nothing to borrow from is
+            // started for whoever asked.
+            CHECK + "FieldDomains#unshared(Lsouther/compiler/types/TypeSymbol$AtModule;"
+                    + SOURCE_AND_POLICY + "Ljava/util/Map;)L" + CHECK + "FieldDomains; -> "
+                    + NOTHING_TO_BORROW_FROM,
+            CHECK + "InvariantChecker#seedFieldsUnshared("
+                    + "Lsouther/compiler/types/TypeSymbol$AtModule;" + SOURCE_AND_POLICY + ")L"
+                    + CHECK + "InvariantChecker$Seeded; -> " + NOTHING_TO_BORROW_FROM,
+            // Choosing what stands at each field of a record, under the composing of a value: it is
+            // handed a plan and a strategy for filling it, and neither carries a lending.
+            "souther/compiler/partition/Partitions#fieldsOf("
+                    + "Lsouther/compiler/types/TypeSymbol$AtModule;" + SOURCE_AND_POLICY
+                    + "Ljava/util/Set;Ljava/util/Map;)Ljava/util/Map; -> "
+                    + CHECK + "FieldDomains#unshared",
+            // What a value's rules guarantee, asked from under a reading that is under way.
+            CHECK + "ValueGuarantees#seededOf(Lsouther/compiler/types/TypeSymbol$AtModule;"
+                    + SOURCE_AND_POLICY + ")L" + CHECK + "InvariantChecker$Seeded; -> "
+                    + CHECK + "InvariantChecker#seedFieldsUnshared",
+            // What a clause of a contract may take, read in the terms of the walk it stands in.
+            // Both shapes, and the store question that asks for one: what a capability is read
+            // against is the reading in hand, and there is nothing there that says where another
+            // declaration's reading comes from.
+            CHECK + "InvariantChecker#capabilityOf(L" + CHECK
+                    + "ClausesForDischarge$ClauseReading;Lsouther/compiler/types/"
+                    + "TypeSymbol$AtModule;" + SOURCE_AND_POLICY + ")L" + CHECK
+                    + "ClauseDischarge; -> " + NOTHING_TO_BORROW_FROM,
+            CHECK + "InvariantChecker#capabilityOf(L" + CHECK + "StatedContract$Conjunct;L"
+                    + CHECK + "Denotations;" + SOURCE_AND_POLICY + "Ljava/lang/String;)L"
+                    + CHECK + "ClauseDischarge; -> " + NOTHING_TO_BORROW_FROM,
+            "souther/compiler/query/Shapes$InvariantCapabilities#compute("
+                    + "Lsouther/compiler/query/Db;)Lsouther/compiler/query/Answer; -> "
+                    + CHECK + "InvariantChecker#capabilityOf",
+            // The clauses a contract's rules are read from, and the overload that reaches them.
+            CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;L" + CHECK
+                    + "StatedContract$StatedRule;" + SOURCE_AND_POLICY + ")Ljava/util/List; -> "
+                    + NOTHING_TO_BORROW_FROM,
+            CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;" + SOURCE_AND_POLICY
+                    + ")L" + CHECK + "ContractDischarge; -> " + CHECK + "ContractDischarge#of",
+            // The engine a body is run on, and the overload that reaches it.
+            CHECK + "PathReachability#of(Lsouther/compiler/core/Core;L" + CHECK + "Scope;"
+                    + "Lsouther/compiler/coverage/CoverageSites$Plan;"
+                    + "Lsouther/compiler/inputs/InputDomain;" + SOURCE_AND_POLICY + ")L"
+                    + CHECK + "PathReachability$Answers; -> " + NOTHING_TO_BORROW_FROM,
+            CHECK + "PathReachability#of(Lsouther/compiler/core/Core;L" + CHECK + "ReadingPolicy;L"
+                    + CHECK + "SpecImplementation$Implemented;"
+                    + "Lsouther/compiler/coverage/CoverageSites$Plan;"
+                    + "Lsouther/compiler/inputs/InputDomain;L" + CHECK + "RuleReadingSource;)L"
+                    + CHECK + "PathReachability$Answers; -> " + CHECK + "PathReachability#of");
 
     /**
      * Every pair: a static method taking the lending, and one of the same name on the same class
-     * that does not.
+     * reached by leaving it out.
      *
-     * <p>The shorter of each pair is what nothing here may call. Which they are is read off the
-     * compiled classes and not decided here — a name with both shapes is a reader that could borrow
-     * and a way of reaching it that does not.
+     * <p>Both halves are found rather than listed, so an entry point written later is in the
+     * population the day it is written and one whose partner is deleted leaves it the same day. A
+     * list of names would be a second answer to which entry points these are, kept up by whoever
+     * remembered.
      */
     private static Map<String, Set<MethodTypeDesc>> theShorterOfEachPair() {
         Map<String, Set<MethodTypeDesc>> found = new LinkedHashMap<>();
@@ -97,7 +164,7 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
             String owner = read.thisClass().name().stringValue();
             Map<String, List<MethodModel>> byName = new LinkedHashMap<>();
             for (MethodModel method : read.methods()) {
-                if (method.flags().has(java.lang.reflect.AccessFlag.STATIC)) {
+                if (method.flags().has(AccessFlag.STATIC)) {
                     byName.computeIfAbsent(method.methodName().stringValue(),
                             each -> new ArrayList<>()).add(method);
                 }
@@ -119,26 +186,13 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
     }
 
     /**
-     * Whether {@code method} is itself one of the ways in that read for themselves.
-     *
-     * <p>Asked of what it takes and not of what it is called. Two overloads of one name are two
-     * methods, and the one that takes a lending is a reader like any other — exempting it because
-     * something of that name reads for itself would leave the reader this is about unread.
-     */
-    private static boolean readsForItself(Map<String, Set<MethodTypeDesc>> pairs, String from,
-                                          MethodModel method) {
-        Set<MethodTypeDesc> shorter = pairs.get(from);
-        return shorter != null && shorter.contains(method.methodTypeSymbol());
-    }
-
-    /**
      * Whether {@code shorter} is what a caller gets by leaving the lending out of {@code lending}.
      *
      * <p>What tells the pairs from the overloads that merely differ. A reader handed something that
      * carries a lending of its own is not reading for itself, and the two would look alike to a
      * rule that only asked whether one of the shapes names the lending: a meaning read off clauses
-     * already holds where those clauses borrow from, and the shape beside it that takes a source and
-     * a lending is where the clauses are made.
+     * already holds where those clauses borrow from, and the shape beside it that takes a source
+     * and a lending is where the clauses are made.
      *
      * <p>So the shapes have to line up: everything the longer one takes before the lending, in the
      * order it takes them. A shorter one that takes something else takes something else, whatever
@@ -148,10 +202,10 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
         if (!lends(lending)) {
             return false;
         }
-        List<java.lang.constant.ClassDesc> taken = lending.methodTypeSymbol().parameterList().stream()
+        List<ClassDesc> taken = lending.methodTypeSymbol().parameterList().stream()
                 .filter(each -> !LENDING_TYPE.equals(each.descriptorString()))
                 .toList();
-        List<java.lang.constant.ClassDesc> without = shorter.methodTypeSymbol().parameterList();
+        List<ClassDesc> without = shorter.methodTypeSymbol().parameterList();
         return without.size() <= taken.size() && without.equals(taken.subList(0, without.size()));
     }
 
@@ -162,11 +216,11 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
     }
 
     /**
-     * The pairs exist, so that a walk finding none would not read as a walk finding no callers.
+     * The pairs exist, so that a walk finding none would not read as a walk finding no edges.
      *
      * <p>Named rather than counted. What this is about is that the population is derived, and a
-     * derivation that came back empty because the shapes had been renamed would pass every row
-     * below without looking at anything.
+     * derivation that came back empty because the shapes had been renamed would let every row below
+     * pass without looking at anything.
      */
     @Test
     void theEntryPointsThatReadForThemselvesAreFound() {
@@ -179,105 +233,156 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
     }
 
     /**
-     * Nothing this compiler runs calls the shorter of a pair.
+     * Every edge into a reading nobody else made is one that is written down.
      *
-     * <p>Every caller is listed rather than the first one found, because what a reader wants when
-     * this fails is which readers lost their lending — the same list javac would have given had the
-     * shorter entry points been deleted instead.
+     * <p>Compared whole and in both directions. An edge nobody wrote down is a reader that lost its
+     * lending with nothing to say so; a row nothing reaches any more is a licence outliving what it
+     * was for, and the day somebody settles where a lending may go the rows have to go with it.
      */
     @Test
-    void nothingHereReachesForTheEntryPointThatReadsForItself() {
+    void everyEdgeIntoAReadingOfOnesOwnIsWrittenDown() {
         Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
+        Set<Named> waysIn = theWaysInThatSayTheyReadForThemselves(pairs);
         Set<String> reaching = new TreeSet<>();
         for (ClassModel read : COMPILED.all()) {
             String owner = read.thisClass().name().stringValue();
             for (MethodModel method : read.methods()) {
-                String from = owner + "#" + method.methodName().stringValue();
-                // The shorter entry point itself, which is a way in and not a reader. Told apart
-                // from the one beside it by what it takes: a name is exempt here only in the shape
-                // that leaves the lending out, so the partner that takes one is read like anything
-                // else.
-                if (readsForItself(pairs, from, method)) {
+                String from = owner + "#" + method.methodName().stringValue()
+                        + method.methodTypeSymbol().descriptorString();
+                // A way in reading for itself is how one of them is written rather than a place
+                // this compiler starts such a reading, and what it names inside is its own.
+                if (readsForItself(pairs, owner, method)) {
+                    continue;
+                }
+                if (waysIn.contains(new Named(owner + "#" + method.methodName().stringValue(),
+                        method.methodTypeSymbol()))) {
+                    reaching.add(from + " -> " + NOTHING_TO_BORROW_FROM);
                     continue;
                 }
                 for (Instruction instruction : instructionsOf(method)) {
-                    if (instruction instanceof InvokeInstruction call) {
-                        String to = call.owner().name().stringValue() + "#"
-                                + call.name().stringValue();
-                        Set<MethodTypeDesc> shorter = pairs.get(to);
-                        if (shorter != null && shorter.contains(call.typeSymbol())) {
-                            reaching.add(from + " -> " + to + call.typeSymbol().descriptorString());
+                    for (Named named : whatItNames(instruction)) {
+                        if (startsAReadingOfItsOwn(pairs, waysIn, named)) {
+                            reaching.add(from + " -> " + named.member());
                         }
                     }
                 }
             }
         }
 
-        assertEquals(Set.of(), reaching,
-                () -> "these read a declaration for themselves where a store was answering, and"
-                        + " each of them pays every reading the lending had to give:\n  "
-                        + String.join("\n  ", reaching)
+        assertFalse(reaching.isEmpty(), "this check is reading no edges at all");
+        assertEquals(EDGES_INTO_A_READING_OF_ONES_OWN, reaching,
+                () -> "the edges into a reading nobody else made are not the ones written down.\n"
+                        + "  found and not written down:\n    "
+                        + String.join("\n    ", minus(reaching, EDGES_INTO_A_READING_OF_ONES_OWN))
+                        + "\n  written down and not found:\n    "
+                        + String.join("\n    ", minus(EDGES_INTO_A_READING_OF_ONES_OWN, reaching))
                         + "\nTake the entry point that is handed somewhere to borrow from, or say"
-                        + " outright that this reader has nowhere to borrow from.");
+                        + " here what this reader has nowhere to borrow from.");
+    }
+
+    private static List<String> minus(Set<String> these, Set<String> those) {
+        return these.stream().filter(each -> !those.contains(each)).sorted().toList();
     }
 
     /**
-     * And saying so outright is the two readers that say it.
+     * What an instruction names: nothing, a member it calls, or a member it hands over to be called
+     * later.
      *
-     * <p>The other half of the rule. Left at the first alone, a reader that had lost its lending
-     * could say so and be done, and the count of what is unsettled would move whenever somebody
-     * found the shorter way blocked.
-     *
-     * <p>The shorter entry points name it too, because saying that a reader has nowhere to borrow
-     * from is the whole of what they are.
+     * <p>The last is what a method reference comes to. A reader passing one along starts the
+     * reading the same way a caller does, and it is named in the arguments a bootstrap is given
+     * rather than in an instruction of its own.
      */
-    @Test
-    void onlyTheTwoThatSaySoNameTheLendingThereIsNothingToBorrowFrom() {
-        Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
-        Set<String> naming = new TreeSet<>();
+    private static List<Named> whatItNames(Instruction instruction) {
+        return switch (instruction) {
+            case InvokeInstruction call -> List.of(new Named(
+                    call.owner().name().stringValue() + "#" + call.name().stringValue(),
+                    call.typeSymbol()));
+            case FieldInstruction field when field.opcode() == Opcode.GETSTATIC -> List.of(
+                    new Named(field.owner().name().stringValue() + "#"
+                            + field.name().stringValue(), null));
+            case InvokeDynamicInstruction handed -> {
+                List<Named> named = new ArrayList<>();
+                for (LoadableConstantEntry each
+                        : handed.invokedynamic().bootstrap().arguments()) {
+                    if (each instanceof MethodHandleEntry handle) {
+                        MemberRefEntry member = handle.reference();
+                        // A handle onto a field names a field, whose descriptor is not a method's.
+                        // What it reaches is the member, and a member with nothing to take is not
+                        // one of the entry points this is about.
+                        String type = member.type().stringValue();
+                        named.add(new Named(member.owner().name().stringValue() + "#"
+                                + member.name().stringValue(),
+                                type.startsWith("(") ? MethodTypeDesc.ofDescriptor(type) : null));
+                    }
+                }
+                yield named;
+            }
+            default -> List.of();
+        };
+    }
+
+    /** A member an instruction names: which one, and what it takes where that is a method. */
+    private record Named(String member, MethodTypeDesc taking) {}
+
+    /**
+     * Whether reaching {@code named} is starting a reading nobody else made.
+     *
+     * <p>Which method, and not which name. The pairs differ by one argument, so a name says
+     * nothing on its own: the entry point that takes the lending and the one beside it that does
+     * not are the same name, and a rule reading the name alone would report every caller of the
+     * first as a caller of the second.
+     */
+    private static boolean startsAReadingOfItsOwn(Map<String, Set<MethodTypeDesc>> pairs,
+                                                  Set<Named> waysIn, Named named) {
+        if (named.member().equals(NOTHING_TO_BORROW_FROM) || waysIn.contains(named)) {
+            return true;
+        }
+        Set<MethodTypeDesc> shorter = pairs.get(named.member());
+        return shorter != null && shorter.contains(named.taking());
+    }
+
+    /**
+     * The ways in that say outright that they read for themselves.
+     *
+     * <p>Derived and not listed: a method that takes nothing to borrow from is one that names the
+     * lending there is nothing to borrow from, and is not one of the pair of entry points reached
+     * by leaving an argument out — those are what a caller with no store reaches, and are found
+     * already. So a way in written later is one the day it is written, and one whose reason is
+     * settled leaves the population when the naming goes.
+     */
+    private static Set<Named> theWaysInThatSayTheyReadForThemselves(
+            Map<String, Set<MethodTypeDesc>> pairs) {
+        Set<Named> found = new LinkedHashSet<>();
         for (ClassModel read : COMPILED.all()) {
             String owner = read.thisClass().name().stringValue();
             for (MethodModel method : read.methods()) {
-                String from = owner + "#" + method.methodName().stringValue();
-                if (readsForItself(pairs, from, method) || READS_FOR_ITSELF.contains(from)) {
+                if (readsForItself(pairs, owner, method)) {
                     continue;
                 }
                 for (Instruction instruction : instructionsOf(method)) {
-                    if (instruction instanceof FieldInstruction field
-                            && field.opcode() == Opcode.GETSTATIC
-                            && LENDING.equals(field.owner().name().stringValue())
-                            && "NONE".equals(field.name().stringValue())) {
-                        naming.add(from);
+                    for (Named named : whatItNames(instruction)) {
+                        if (named.member().equals(NOTHING_TO_BORROW_FROM)) {
+                            found.add(new Named(owner + "#" + method.methodName().stringValue(),
+                                    method.methodTypeSymbol()));
+                        }
                     }
                 }
             }
         }
-
-        assertEquals(Set.of(), naming,
-                () -> "these say they have nowhere to borrow a reading from, which is a thing to"
-                        + " settle rather than to write:\n  " + String.join("\n  ", naming)
-                        + "\nHand the reader somewhere to borrow from, or add it to the readers"
-                        + " that say outright that they read for themselves.");
+        return found;
     }
 
     /**
-     * And each of those two is reached, so that a name left behind by a rename reads as a row here
-     * rather than as a licence nobody uses.
+     * Whether {@code method} is itself one of the ways in that read for themselves.
+     *
+     * <p>Asked of what it takes and not of what it is called. Two overloads of one name are two
+     * methods, and the one that takes a lending is a reader like any other — exempting it because
+     * something of that name reads for itself would leave the reader this is about unread.
      */
-    @Test
-    void eachReaderThatSaysSoIsThere() {
-        Set<String> written = new LinkedHashSet<>();
-        for (ClassModel read : COMPILED.all()) {
-            String owner = read.thisClass().name().stringValue();
-            for (MethodModel method : read.methods()) {
-                written.add(owner + "#" + method.methodName().stringValue());
-            }
-        }
-
-        List<String> gone = READS_FOR_ITSELF.stream().filter(each -> !written.contains(each))
-                .toList();
-        assertEquals(List.of(), gone,
-                () -> "these are licensed to read for themselves and are not written: " + gone);
+    private static boolean readsForItself(Map<String, Set<MethodTypeDesc>> pairs, String owner,
+                                          MethodModel method) {
+        Set<MethodTypeDesc> shorter = pairs.get(owner + "#" + method.methodName().stringValue());
+        return shorter != null && shorter.contains(method.methodTypeSymbol());
     }
 
     /** Whether anything at all was read, so that an empty population fails rather than passes. */

--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -132,10 +132,15 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
             "souther/compiler/query/Shapes$InvariantCapabilities#compute("
                     + "Lsouther/compiler/query/Db;)Lsouther/compiler/query/Answer; -> "
                     + CHECK + "InvariantChecker#capabilityOf",
-            // The clauses a contract's rules are read from, and the overload that reaches them.
+            // The clauses a contract's rules are read from, and the overload that reaches them. It
+            // does both things a reader here can do: it makes the terms a rule is read in, and it
+            // asks what each conjunct may take.
             CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;L" + CHECK
                     + "StatedContract$StatedRule;" + SOURCE_AND_POLICY + ")Ljava/util/List; -> "
                     + NOTHING_TO_BORROW_FROM,
+            CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;L" + CHECK
+                    + "StatedContract$StatedRule;" + SOURCE_AND_POLICY + ")Ljava/util/List; -> "
+                    + CHECK + "InvariantChecker#capabilityOf",
             CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;" + SOURCE_AND_POLICY
                     + ")L" + CHECK + "ContractDischarge; -> " + CHECK + "ContractDischarge#of",
             // The engine a body is run on, and the overload that reaches it.
@@ -252,11 +257,6 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
                 // A way in reading for itself is how one of them is written rather than a place
                 // this compiler starts such a reading, and what it names inside is its own.
                 if (readsForItself(pairs, owner, method)) {
-                    continue;
-                }
-                if (waysIn.contains(new Named(owner + "#" + method.methodName().stringValue(),
-                        method.methodTypeSymbol()))) {
-                    reaching.add(from + " -> " + NOTHING_TO_BORROW_FROM);
                     continue;
                 }
                 for (Instruction instruction : instructionsOf(method)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReading.java
@@ -1,0 +1,64 @@
+package souther.compiler.check;
+
+import java.util.function.Function;
+
+/**
+ * One reading of one declaration, and everything that reading alone decides.
+ *
+ * <p>What a reading comes to is one thing and the answers derived from it are another, and the two
+ * used to be held apart: the reading was handed on and each reader worked the answers out again.
+ * Held together, whoever is handed the reading is handed what was made of it, and a question that
+ * costs a reading of the declaration is put once however many readers put it.
+ *
+ * <p><b>Whether this is the declaration's canonical reading is not asked here.</b> A canonical one
+ * is kept by a lender and handed to every question that reaches the declaration; one made with
+ * something settled or something left out belongs to the question that asked for it and to nothing
+ * else. Which of the two is being made is decided where a reading is asked for
+ * ({@link InvariantChecker#readFields}), and this holds either the same way — so nothing derived
+ * from a reading has to work out which kind it came from before it can be kept.
+ *
+ * <p>Not a value and not thread-safe on its own. What it holds is named by identity, and it is
+ * owned by the store that lends it, whose walk is what its one thread is doing ({@link
+ * LentReadings}). What is derived here is confined the same way and by the same owner.
+ */
+public final class DeclarationReading {
+
+    private final InvariantChecker.Seeded seeded;
+
+    /** What the rules leave the declaration's fields able to hold, made when the first question
+     *  asks for it. Null until then, and the same object afterwards. */
+    private FieldDomains fields;
+
+    private DeclarationReading(InvariantChecker.Seeded seeded) {
+        this.seeded = seeded;
+    }
+
+    /** The reading {@code seeded} is, with nothing derived from it yet. */
+    static DeclarationReading of(InvariantChecker.Seeded seeded) {
+        return new DeclarationReading(seeded);
+    }
+
+    /** The reading itself: what the clauses came to, as the seeding left them. */
+    public InvariantChecker.Seeded seeded() {
+        return seeded;
+    }
+
+    /**
+     * What this reading leaves the declaration's fields able to hold, worked out by {@code derive}
+     * where nothing has yet.
+     *
+     * <p>Derived from the reading and from nothing the asker brings, which is what lets the answer
+     * outlive the question that first wanted it. The ends a conjunct moved are read by asking what
+     * the rules leave without it, and each of those is a reading of the declaration — so a second
+     * asker working them out again pays the whole attribution a second time.
+     */
+    FieldDomains fields(Function<InvariantChecker.Seeded, FieldDomains> derive) {
+        FieldDomains had = fields;
+        if (had != null) {
+            return had;
+        }
+        FieldDomains made = derive.apply(seeded);
+        fields = made;
+        return made;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationReadings.java
@@ -63,10 +63,10 @@ public interface DeclarationReadings {
      * one declaration's rules does exactly that — and what comes back is a reading of what that
      * source left, which is not the declaration's own.
      */
-    default InvariantChecker.Seeded reading(TypeKey declaration, RuleReadingSource source,
-                                            ReadingPolicy policy,
-                                            Supplier<InvariantChecker.Seeded> read) {
-        return read.get();
+    default DeclarationReading reading(TypeKey declaration, RuleReadingSource source,
+                                       ReadingPolicy policy,
+                                       Supplier<InvariantChecker.Seeded> read) {
+        return DeclarationReading.of(read.get());
     }
 
     /**
@@ -77,10 +77,10 @@ public interface DeclarationReadings {
      * nothing. What it makes is kept, because it is the declaration's canonical reading and the
      * question that asked for the answer is the next to want it.
      */
-    default InvariantChecker.Seeded readingForAnAnswer(TypeKey declaration, RuleReadingSource source,
-                                                       ReadingPolicy policy,
-                                                       Supplier<InvariantChecker.Seeded> read) {
-        return read.get();
+    default DeclarationReading readingForAnAnswer(TypeKey declaration, RuleReadingSource source,
+                                                  ReadingPolicy policy,
+                                                  Supplier<InvariantChecker.Seeded> read) {
+        return DeclarationReading.of(read.get());
     }
 
     /**
@@ -119,17 +119,17 @@ public interface DeclarationReadings {
             }
 
             @Override
-            public InvariantChecker.Seeded reading(TypeKey declaration, RuleReadingSource source,
-                                                   ReadingPolicy policy,
-                                                   Supplier<InvariantChecker.Seeded> read) {
+            public DeclarationReading reading(TypeKey declaration, RuleReadingSource source,
+                                              ReadingPolicy policy,
+                                              Supplier<InvariantChecker.Seeded> read) {
                 return lender.readingForAnAnswer(declaration, source, policy, read);
             }
 
             @Override
-            public InvariantChecker.Seeded readingForAnAnswer(TypeKey declaration,
-                                                              RuleReadingSource source,
-                                                              ReadingPolicy policy,
-                                                              Supplier<InvariantChecker.Seeded> read) {
+            public DeclarationReading readingForAnAnswer(TypeKey declaration,
+                                                         RuleReadingSource source,
+                                                         ReadingPolicy policy,
+                                                         Supplier<InvariantChecker.Seeded> read) {
                 return lender.readingForAnAnswer(declaration, source, policy, read);
             }
         };
@@ -137,6 +137,11 @@ public interface DeclarationReadings {
 
     /**
      * Nothing to borrow, for a reading with no store to ask.
+     *
+     * <p>Named where it is wanted and never arrived at by leaving an argument out. Reading a
+     * declaration for oneself where somebody has already read it is not a slower way to the same
+     * answer — it is the whole of what a reading costs, paid again — so which readers do that is a
+     * thing said in the source rather than a consequence of which overload was to hand.
      *
      * <p>A reading's own answers all the same, and a fresh one at each asking: a reading that
      * borrows nothing still comes to the machines it built, and what it came to is what its own

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -66,6 +66,13 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
     public static DeclaredBorders of(TypeSymbol declaredOn, PublishedDeclarations declarations,
                                      DeclarationCitations citations, RuleReadingSource source,
                                      ReadingPolicy policy) {
+        return of(declaredOn, declarations, citations, source, policy, DeclarationReadings.NONE);
+    }
+
+    /** The same, asking {@code machines} for what somebody has already made of the declaration. */
+    public static DeclaredBorders of(TypeSymbol declaredOn, PublishedDeclarations declarations,
+                                     DeclarationCitations citations, RuleReadingSource source,
+                                     ReadingPolicy policy, DeclarationReadings machines) {
         // One address, and two questions put to it. What kind of declaration this is decides whether
         // there are lines to read at all; where its code is decides what a report calls the place.
         // Neither is looked up by the name a second time, which is what would give one declaration
@@ -80,7 +87,8 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
         }
         Citation at = citations.of(named.key());
         Map<Key, NumberAt<RuleKey>> forms = new LinkedHashMap<>();
-        for (FieldDomains.Placed placed : Rules.of(declaredOn, source, policy).bounds().placed()) {
+        for (FieldDomains.Placed placed
+                : Rules.of(declaredOn, source, policy, machines).bounds().placed()) {
             // A clause reaching this declaration through a spread is written on another one and is
             // that one's to name, the way a line is named by the rule that drew it (ADR-0090). Its
             // own reading answers for it.

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -367,19 +367,28 @@ public final class FieldDomains {
      * fields is this reading's question, so the body it is written on is this reading's to fetch —
      * a caller made to fetch one has a declaration in its hands for a question that was never its
      * own, and can read the record's structure back out of it.
+     *
+     * <p>Where the reading comes from is said. A reader with a store to ask hands it over; one
+     * with none says so, and the overloads that leave it out read for themselves and are a test's
+     * to call — what keeps a reading of this compiler's own from quietly becoming one of those is
+     * checked over the compiled classes rather than left to which overload was to hand.
      */
-    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
-                                  ReadingPolicy policy) {
-        return of(named, source, policy, Map.of());
-    }
-
-    /** The same, asking {@code machines} for what somebody has already made of the declaration's
-     *  string rules before building any of it. */
     public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy, DeclarationReadings machines) {
         return of(named, source, policy, Map.of(), machines);
     }
 
+    /** The same, reading for itself. */
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                  ReadingPolicy policy) {
+        return unshared(named, source, policy, Map.of());
+    }
+
+    /** The same, with some fields already settled at a value and reading for itself. */
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                  ReadingPolicy policy, Map<RuleKey, Count> settled) {
+        return unshared(named, source, policy, settled);
+    }
 
     /**
      * The same, with some fields already settled at a value.
@@ -389,12 +398,6 @@ public final class FieldDomains {
      * not read off {@code endsAt}'s own range — which still runs from 1 — but off what is left of it
      * once the other end is fixed, which is 1440 and nothing else.
      */
-    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
-                                  ReadingPolicy policy, Map<RuleKey, Count> settled) {
-        return of(named, source, policy, settled, DeclarationReadings.NONE);
-    }
-
-    /** The same, asking {@code machines} first. */
     public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy, Map<RuleKey, Count> settled,
                                   DeclarationReadings machines) {
@@ -406,6 +409,22 @@ public final class FieldDomains {
                 ? of(named, data, source, policy, atValues(settled),
                         InvariantChecker.Reach.EVERYTHING, machines)
                 : NONE;
+    }
+
+    /**
+     * The same, read without borrowing anything anybody else has made of the declaration.
+     *
+     * <p><b>Where a reading cannot be reached rather than where none would help.</b> The callers
+     * here are inside the composing of a value, which is handed a plan and a strategy for filling
+     * it and is handed nothing that could say where a reading comes from — so what borrowing would
+     * take is a capability carried through the composing, and whether it belongs there is not
+     * settled. This keeps what those callers did before while saying that is what it is: named, so
+     * that what is unsettled can be found by looking for it, and separate from
+     * {@link DeclarationReadings#NONE}, which is what a reader with no store says.
+     */
+    public static FieldDomains unshared(TypeSymbol.AtModule named, RuleReadingSource source,
+                                        ReadingPolicy policy, Map<RuleKey, Count> settled) {
+        return of(named, source, policy, settled, DeclarationReadings.NONE);
     }
 
     /** Settlings written as names, read as what stands at each. What a caller naming a place means
@@ -441,8 +460,23 @@ public final class FieldDomains {
         // is the value it is, so there are no siblings to relate. Everything else is the same
         // question — its own rules can hold a hole no range keeps, and they can contradict, and both
         // answers were being given away by treating it as a value with nothing to say.
-        InvariantChecker.Seeded seeded =
-                InvariantChecker.seedFields(named, source, policy, settled, reach, machines);
+        //
+        // Asked of the reading and kept there. What the rules leave is decided by the reading and
+        // by nothing the asker brings, and the ends its conjuncts moved are read by reading the
+        // declaration again without each of them — so a second asker working this out again puts
+        // the whole attribution a second time. Which readings are kept and which belong to one
+        // question is settled where a reading is asked for, and is not asked again here.
+        return InvariantChecker.readFields(named, source, policy, settled, reach, machines)
+                .fields(seeded -> leftBy(seeded, named, data, source, policy, settled, reach,
+                        machines));
+    }
+
+    /** What the reading {@code seeded} leaves the fields able to hold, under the terms it was made
+     *  with. */
+    private static FieldDomains leftBy(InvariantChecker.Seeded seeded, TypeSymbol.AtModule named,
+                                       Hir.Data data, RuleReadingSource source,
+                                       ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled,
+                                       InvariantChecker.Reach reach, DeclarationReadings machines) {
         Map<RuleKey, NumericDomain.Bounds> out = new LinkedHashMap<>();
         seeded.atoms().forEach((field, atom) -> {
             // The value itself is at no name of its own, and its range is the one thing not worth
@@ -1613,8 +1647,15 @@ public final class FieldDomains {
      */
     public static boolean mayHoldNothingAt(TypeSymbol.AtModule named, Hir.Data data, RuleKey path,
                                            RuleReadingSource source, ReadingPolicy policy) {
+        return mayHoldNothingAt(named, data, path, source, policy, DeclarationReadings.NONE);
+    }
+
+    /** The same, asking {@code machines} for what somebody has already made of the declaration. */
+    public static boolean mayHoldNothingAt(TypeSymbol.AtModule named, Hir.Data data, RuleKey path,
+                                           RuleReadingSource source, ReadingPolicy policy,
+                                           DeclarationReadings machines) {
         // A count is never below none, so leaving it no room above none is leaving it at none.
-        return OccurrenceCounts.of(named, source, policy).mayHoldAtMost(path, 0);
+        return OccurrenceCounts.of(named, source, policy, machines).mayHoldAtMost(path, 0);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -637,44 +637,47 @@ public final class InvariantChecker {
         }
     }
 
-    /** {@link Seeded} for one declaration. A declaration this cannot read is one whose fields it says
-     * nothing about, which is the same answer as a declaration with no rules — so nothing about the
-     * declaration throws. {@link Terms.OneTermTwoKinds} is not about the declaration, and nothing
-     * below here catches it. */
-    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
-                             ReadingPolicy policy) {
-        return seedFields(named, source, policy, Map.of());
-    }
-
-    /** The same, asking {@code machines} for what somebody has already made of the declaration's
-     *  string rules before building any of it. */
+    /** {@link Seeded} for one declaration, asking {@code machines} for what somebody has already
+     * made of its string rules before building any of it. A declaration this cannot read is one
+     * whose fields it says nothing about, which is the same answer as a declaration with no rules —
+     * so nothing about the declaration throws. {@link Terms.OneTermTwoKinds} is not about the
+     * declaration, and nothing below here catches it. */
     static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy, DeclarationReadings machines) {
         return seedFields(named, source, policy, Map.of(), Reach.EVERYTHING, machines);
     }
 
     /**
-     * {@link Seeded} with some of the fields already settled at a value.
+     * The same, borrowing nothing anybody else has made of the declaration.
      *
-     * <p>What is left for the others, given those. The same domain and the same closure — settling a
-     * field is one more assertion into it — so what comes back is the range each remaining field can
-     * still take, which is where a row completing that assignment has to look.
+     * <p><b>Where a reading cannot be reached rather than where none would help.</b> The caller
+     * here runs while a reading is being made, from a reader that is handed the terms of the
+     * reading in progress and nothing that says where another declaration's reading comes from — so
+     * borrowing would take a capability carried into the reading itself, and what such a borrower
+     * should be handed when the reading it asks for is the one under way is not settled. This keeps
+     * what that caller did before while saying that is what it is: named, so that what is unsettled
+     * can be found by looking for it, and separate from {@link DeclarationReadings#NONE}, which is
+     * what a reader with no store says.
      */
-    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
-                             ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled) {
-        return seedFields(named, source, policy, settled, Reach.EVERYTHING);
+    static Seeded seedFieldsUnshared(TypeSymbol.AtModule named, RuleReadingSource source,
+                                     ReadingPolicy policy) {
+        return seedFields(named, source, policy, DeclarationReadings.NONE);
     }
 
-    /**
-     * The same, reading only as far as {@code reach} says at each name it meets.
-     *
-     * <p>What a rule did is read by asking what happens without it. Which clause moved an edge is not
-     * something the closure records — it answers with a number and not with how it got there — and
-     * this is that question put to the same reader rather than answered by a second one: seed the
-     * value again without one declaration's clauses, and an end that moves is an end that
-     * declaration was holding. Supposing a declaration has values is the other thing {@code reach}
-     * says, and it is not that one — see {@link Reach}.
-     */
+    /** The same, reading for itself. */
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
+                             ReadingPolicy policy) {
+        return seedFields(named, source, policy, DeclarationReadings.NONE);
+    }
+
+    /** The same, with some of the fields already settled at a value, reading for itself. */
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
+                             ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled) {
+        return seedFields(named, source, policy, settled, Reach.EVERYTHING,
+                DeclarationReadings.NONE);
+    }
+
+    /** The same, reading only as far as {@code reach} says, and reading for itself. */
     static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled,
                              Reach reach) {
@@ -682,8 +685,19 @@ public final class InvariantChecker {
     }
 
     /**
-     * The same, asking {@code readings} first — for the canonical reading of the declaration where
-     * this is one, and for its string machines in any case.
+     * The same, with some of the fields settled at a value and reading only as far as {@code reach}
+     * says at each name it meets.
+     *
+     * <p>What is left for the others, given those. The same domain and the same closure — settling
+     * a field is one more assertion into it — so what comes back is the range each remaining field
+     * can still take, which is where a row completing that assignment has to look.
+     *
+     * <p>What a rule did is read by asking what happens without it. Which clause moved an edge is
+     * not something the closure records — it answers with a number and not with how it got there —
+     * and this is that question put to the same reader rather than answered by a second one: seed
+     * the value again without one declaration's clauses, and an end that moves is an end that
+     * declaration was holding. Supposing a declaration has values is the other thing {@code reach}
+     * says, and it is not that one — see {@link Reach}.
      *
      * <p>The canonical reading is the declaration's rules read whole: nothing settled at a value,
      * nothing left out at any name it reaches. Every question that reaches the declaration and has
@@ -693,19 +707,40 @@ public final class InvariantChecker {
      * which is what {@code readings} is answering for.
      *
      * <p>A reading with something settled or something left out is not that reading and is made
-     * here every time. There is no lending to arrange: a counterfactual is asked for by one reader
-     * about one end, and the next reader's counterfactual is about another.
+     * here every time. It belongs to the question that asked for it: what it leaves out is that
+     * question's, and the next question leaves out something else.
      */
     static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled,
                              Reach reach, DeclarationReadings readings) {
+        return readFields(named, source, policy, settled, reach, readings).seeded();
+    }
+
+    /**
+     * The same, as the reading it is rather than as what the seeding left.
+     *
+     * <p>Which of the two a caller wants turns on whether it derives anything. What is worked out
+     * from a reading is worked out once and kept with it, so a caller that derives asks for the
+     * reading and is handed what the last of them made; one that only reads the seeding off has
+     * nothing to keep and takes {@link #seedFields}.
+     *
+     * <p><b>Whether the reading is the declaration's canonical one is decided here and nowhere
+     * else.</b> A reading with something settled or something left out is not that one: it belongs
+     * to the question that asked for it, and what it derives belongs there too. Both come back as
+     * the same kind of thing, so no reader downstream has to put the question again to know what it
+     * may keep.
+     */
+    static DeclarationReading readFields(TypeSymbol.AtModule named, RuleReadingSource source,
+                                         ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled,
+                                         Reach reach, DeclarationReadings readings) {
         // What the declaration's string rules came to, asked for before anything else. Where a store
         // is answering, making that answer is what makes the declaration's canonical reading — so a
         // borrower asks for the machines and then looks for the reading, rather than reading for
         // itself and standing a second reading beside the answer's.
         StringMachineAnswers answers = readings.of(named.key());
         if (!settled.isEmpty() || !reach.everything()) {
-            return seedFieldsFresh(named, source, policy, settled, reach, readings, answers);
+            return DeclarationReading.of(
+                    seedFieldsFresh(named, source, policy, settled, reach, readings, answers));
         }
         return readings.reading(named.key(), source, policy,
                 () -> seedFieldsFresh(named, source, policy, settled, reach, readings, answers));

--- a/souther-compiler/src/main/java/souther/compiler/check/LentReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LentReadings.java
@@ -31,8 +31,18 @@ import java.util.function.Supplier;
  * to lend to another — it is what this revision has found out, and every reading made under the
  * revision asks the one table.
  *
+ * <p>What a reading decides on its own goes with it. The ends a declaration's conjuncts moved are
+ * read by asking what its rules leave without each of them, and each of those is a reading of the
+ * declaration — so what a lent reading has been asked is lent along with it, and the borrowers of
+ * one reading put such a question once between them ({@link DeclarationReading}).
+ *
  * <p>This shares work and not answers. Which questions are recomputed is settled before anything is
  * asked of this, and an answer is never kept here for a reader to find later.
+ *
+ * <p><b>Confined to the thread its store's walk is on.</b> Nothing here is synchronised and nothing
+ * lent from here is: a store answers its questions on the one thread holding it, and what is lent
+ * is reached through the store. That is ownership rather than a property of any one object, so a
+ * store answered from two threads is not made sound by synchronising what it lends.
  */
 public final class LentReadings implements DeclarationReadings {
 
@@ -42,7 +52,7 @@ public final class LentReadings implements DeclarationReadings {
                                       ReadingPolicy policy) {}
 
     /** A reading, and what the store was asked to make it. */
-    private record Shared(InvariantChecker.Seeded seeded, StoreWork.Reads reads) {}
+    private record Shared(DeclarationReading reading, StoreWork.Reads reads) {}
 
     private final DeclarationReadings machines;
     private final LongSupplier revision;
@@ -100,9 +110,9 @@ public final class LentReadings implements DeclarationReadings {
     };
 
     @Override
-    public InvariantChecker.Seeded reading(TypeKey declaration, RuleReadingSource source,
-                                           ReadingPolicy policy,
-                                           Supplier<InvariantChecker.Seeded> read) {
+    public DeclarationReading reading(TypeKey declaration, RuleReadingSource source,
+                                      ReadingPolicy policy,
+                                      Supplier<InvariantChecker.Seeded> read) {
         Shared held = current().get(new OfDeclarationUnder(declaration, source.origin(), policy));
         if (held == null) {
             return readingForAnAnswer(declaration, source, policy, read);
@@ -110,17 +120,18 @@ public final class LentReadings implements DeclarationReadings {
         // What the making read is what whoever is being answered out of it read: they are getting
         // the reading rather than doing it, and an edit to what it was made from has to reach them.
         held.reads().here();
-        return held.seeded();
+        return held.reading();
     }
 
     @Override
-    public InvariantChecker.Seeded readingForAnAnswer(TypeKey declaration, RuleReadingSource source,
-                                                      ReadingPolicy policy,
-                                                      Supplier<InvariantChecker.Seeded> read) {
+    public DeclarationReading readingForAnAnswer(TypeKey declaration, RuleReadingSource source,
+                                                 ReadingPolicy policy,
+                                                 Supplier<InvariantChecker.Seeded> read) {
         StoreWork.Made<InvariantChecker.Seeded> made = work.watching(read);
+        DeclarationReading reading = DeclarationReading.of(made.value());
         current().put(new OfDeclarationUnder(declaration, source.origin(), policy),
-                new Shared(made.value(), made.reads()));
-        return made.value();
+                new Shared(reading, made.reads()));
+        return reading;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
@@ -50,8 +50,21 @@ public final class OccurrenceCounts {
      * clauses.
      */
     public static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                       ReadingPolicy policy, DeclarationReadings machines) {
+        return of(named, source, policy, Set.of(), machines);
+    }
+
+    /** The same, reading for itself. */
+    public static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
                                        ReadingPolicy policy) {
         return of(named, source, policy, Set.of(), DeclarationReadings.NONE);
+    }
+
+    /** The same, with the declarations {@code granted} names supposed to hold values, reading for
+     *  itself. */
+    static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                 ReadingPolicy policy, Set<TypeSymbol> granted) {
+        return of(named, source, policy, granted, DeclarationReadings.NONE);
     }
 
     /**
@@ -61,13 +74,6 @@ public final class OccurrenceCounts {
      * rules are what say it has none — its own, and the ones under whatever it wraps — so supposing
      * it has a value is not reading it at all.
      */
-    static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
-                                 ReadingPolicy policy,
-                                 Set<TypeSymbol> granted) {
-        return of(named, source, policy, granted, DeclarationReadings.NONE);
-    }
-
-    /** The same, asking {@code machines} first. */
     static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
                                  ReadingPolicy policy,
                                  Set<TypeSymbol> granted,

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
@@ -40,9 +40,22 @@ public final class OccurrenceValues {
     }
 
     /** What the declaration {@code named} is leaves the values at each of its names. */
-    public static OccurrenceValues of(TypeSymbol.AtModule named,
-                                      RuleReadingSource source, ReadingPolicy policy) {
+    public static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                      ReadingPolicy policy, DeclarationReadings machines) {
+        return of(named, source, policy, Set.of(), machines);
+    }
+
+    /** The same, reading for itself. */
+    public static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                      ReadingPolicy policy) {
         return of(named, source, policy, Set.of(), DeclarationReadings.NONE);
+    }
+
+    /** The same, with the declarations {@code granted} names supposed to hold values, reading for
+     *  itself. */
+    static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
+                                 ReadingPolicy policy, Set<TypeSymbol> granted) {
+        return of(named, source, policy, granted, DeclarationReadings.NONE);
     }
 
     /**
@@ -52,13 +65,6 @@ public final class OccurrenceValues {
      * rules are what say it has none — its own, and the ones under whatever it wraps — so supposing
      * it has a value is not reading it at all.
      */
-    static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
-                                 ReadingPolicy policy,
-                                 Set<TypeSymbol> granted) {
-        return of(named, source, policy, granted, DeclarationReadings.NONE);
-    }
-
-    /** The same, asking {@code machines} first. */
     static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
                                  ReadingPolicy policy,
                                  Set<TypeSymbol> granted,

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -50,7 +50,8 @@ public final class TypeCardinality {
 
     private TypeCardinality() {}
 
-    /** How many values each declaration {@code declarations} reaches has at most. */
+    /** How many values each declaration {@code declarations} reaches has at most, read for
+     *  itself. */
     public static Cardinalities solve(List<Hir.Def> declarations, RuleReadingSource source,
                                       ReadingPolicy policy) {
         return solve(declarations, source, policy, DeclarationReadings.NONE);
@@ -78,7 +79,8 @@ public final class TypeCardinality {
         return new Cardinalities(
                 Map.copyOf(pass(components, declared, edges, cuts, source, policy, Set.of(),
                         machines)),
-                components, declared, edges, cuts, source, policy, asked.everyRuleReached());
+                components, declared, edges, cuts, source, policy, machines,
+                asked.everyRuleReached());
     }
 
     /**
@@ -132,13 +134,18 @@ public final class TypeCardinality {
         private final CardinalityCuts cuts;
         private final RuleReadingSource source;
         private final ReadingPolicy policy;
+        /** Where the readings taken again here borrow what has already been made of a declaration:
+         *  the same place the first pass borrowed from, because it is the same declarations. */
+        private final DeclarationReadings machines;
         private final boolean everyRuleReached;
 
         private Cardinalities(Map<TypeSymbol, Cardinality> upper, List<List<TypeSymbol>> components,
                               Map<TypeSymbol, Hir.Def> declared,
                               Map<TypeSymbol, Set<TypeSymbol>> edges, CardinalityCuts cuts,
                               RuleReadingSource source, ReadingPolicy policy,
+                              DeclarationReadings machines,
                               boolean everyRuleReached) {
+            this.machines = machines;
             this.everyRuleReached = everyRuleReached;
             this.upper = upper;
             this.components = components;
@@ -199,10 +206,11 @@ public final class TypeCardinality {
          * was shown by under another.
          */
         Map<TypeSymbol, Cardinality> granting(Set<TypeSymbol> granted) {
-            // Read afresh with nothing lent: what is asked here is what a declaration would hold
-            // if another had values, and that reading is made once for the asking.
-            return pass(components, declared, edges, cuts, source, policy, granted,
-                    DeclarationReadings.NONE);
+            // The readings are made afresh — what is asked here is what a declaration would hold if
+            // another had values, and no reading with something supposed is a declaration's own —
+            // but what has already been made of the declarations is borrowed all the same: what a
+            // rule's strings come to is settled by the rule and not by what is supposed beside it.
+            return pass(components, declared, edges, cuts, source, policy, granted, machines);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
@@ -77,7 +77,8 @@ public final class ValueGuarantees {
      * a declaration says. */
     private static InvariantChecker.Seeded seededOf(TypeSymbol.AtModule named,
                                                     RuleReadingSource source, ReadingPolicy policy) {
-        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, source, policy);
+        InvariantChecker.Seeded seeded =
+                InvariantChecker.seedFieldsUnshared(named, source, policy);
         return seeded.everyClauseRead() && !seeded.constraints().isBottom() ? seeded : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -160,10 +160,26 @@ public final class InputDomain {
      */
     private final List<CasesRead> cases;
 
+    /**
+     * Where the declarations this walk read get what somebody has already made of them.
+     *
+     * <p>Kept because a later reader of the same declarations is a later reader of the same
+     * declarations. What a position is offered and why it was offered no more are asked of the
+     * rules of the record a parameter is, long after the walk that read them — asked with nothing
+     * to borrow, that reader reads every one of them again.
+     *
+     * <p>No part of what makes two readings one. It is a capability rather than a value: two of
+     * them built from one store answer alike and compare unlike, so a reading that took this into
+     * the comparison would say a walk taken again came to something else.
+     */
+    private final DeclarationReadings machines;
+
     private InputDomain(List<Position> positions, Map<BindingId, String> read,
                         List<Parameter> parameters, List<RuleRoot> roots, ReadingPolicy policy,
                         NameReach reach, List<PlacementSeed> placed,
-                        List<ClauseWithoutAnEnd> clauses, List<CasesRead> cases) {
+                        List<ClauseWithoutAnEnd> clauses, List<CasesRead> cases,
+                        DeclarationReadings machines) {
+        this.machines = Objects.requireNonNull(machines, "a reading says where it borrows from");
         this.cases = List.copyOf(cases);
         this.placed = List.copyOf(placed);
         this.clauses = List.copyOf(clauses);
@@ -232,8 +248,20 @@ public final class InputDomain {
 
     /** Every position of an input, in the order the parameters are declared and descended into. */
     public static InputDomain of(List<Parameter> parameters, RuleReadingSource source,
+                                 ReadingPolicy policy, DeclarationReadings machines) {
+        return of(parameters, source, policy, InputDemand.NONE, machines);
+    }
+
+    /** The same, reading for itself. */
+    public static InputDomain of(List<Parameter> parameters, RuleReadingSource source,
                                  ReadingPolicy policy) {
-        return of(parameters, source, policy, InputDemand.NONE);
+        return of(parameters, source, policy, InputDemand.NONE, DeclarationReadings.NONE);
+    }
+
+    /** The same, closed over the finite paths a behavior's measurement names, reading for itself. */
+    public static InputDomain of(List<Parameter> parameters, RuleReadingSource source,
+                                 ReadingPolicy policy, InputDemand demand) {
+        return of(parameters, source, policy, demand, DeclarationReadings.NONE);
     }
 
     /**
@@ -250,18 +278,11 @@ public final class InputDomain {
      * everything derived from it — what a report counts, what a quantity is left, what a row is
      * asked for — is taken from it once. So a path nobody demanded is a path this has no position
      * for, whoever asks and whenever.
-     */
-    public static InputDomain of(List<Parameter> parameters, RuleReadingSource source,
-                                 ReadingPolicy policy, InputDemand demand) {
-        return of(parameters, source, policy, demand, DeclarationReadings.NONE);
-    }
-
-    /**
-     * The same, asking {@code machines} for what somebody has already made of each declaration's
-     * string rules before building any of it.
      *
-     * <p>A capability and not a part of the reading: handed to every reading this walk opens,
-     * and kept by nothing the walk answers with.
+     * <p>{@code machines} is where each declaration this opens borrows what somebody has already
+     * made of it. A capability and not a part of the reading: handed to every reading this walk
+     * opens, kept by nothing the walk answers with, and kept here for the readers of those same
+     * declarations that come after the walk ({@link #machines}).
      */
     public static InputDomain of(List<Parameter> parameters, RuleReadingSource source,
                                  ReadingPolicy policy, InputDemand demand,
@@ -310,7 +331,7 @@ public final class InputDomain {
         // it reached. Answered with a value standing for no reading at all, an input nobody could
         // read would be the same value as an input there was nothing to read.
         return new InputDomain(settled, read, parameters, roots, policy, observed.reach(),
-                account.placed(), account.clauses(), observed.cases());
+                account.placed(), account.clauses(), observed.cases(), machines);
     }
 
     /**
@@ -353,15 +374,9 @@ public final class InputDomain {
      */
     public static InputDomain of(DeclaredSig declared,
                                  List<SpecImplementation.ParameterBinding.AnInput> arriving,
-                                 RuleReadingSource source, ReadingPolicy policy) {
-        return of(declared, arriving, source, policy, InputDemand.NONE);
-    }
-
-    /** The same, closed over the finite paths this behavior's measurement names as well. */
-    public static InputDomain of(DeclaredSig declared,
-                                 List<SpecImplementation.ParameterBinding.AnInput> arriving,
-                                 RuleReadingSource source, ReadingPolicy policy, InputDemand demand) {
-        return of(declared, arriving, source, policy, demand, DeclarationReadings.NONE);
+                                 RuleReadingSource source, ReadingPolicy policy,
+                                 DeclarationReadings machines) {
+        return of(declared, arriving, source, policy, InputDemand.NONE, machines);
     }
 
     /**
@@ -403,8 +418,31 @@ public final class InputDomain {
      * that used it would find every claim and every comparison naming nothing.
      */
     public static InputDomain of(DeclaredSig declared, RuleReadingSource source,
+                                 ReadingPolicy policy, DeclarationReadings machines) {
+        return of(declared, List.of(), source, policy, machines);
+    }
+
+    /** The same, reading for itself. */
+    public static InputDomain of(DeclaredSig declared, RuleReadingSource source,
                                  ReadingPolicy policy) {
-        return of(declared, List.of(), source, policy);
+        return of(declared, List.of(), source, policy, DeclarationReadings.NONE);
+    }
+
+    /** The same, of an input nothing reads a body against, reading for itself. */
+    public static InputDomain of(DeclaredSig declared,
+                                 List<SpecImplementation.ParameterBinding.AnInput> arriving,
+                                 RuleReadingSource source, ReadingPolicy policy) {
+        return of(declared, arriving, source, policy, InputDemand.NONE,
+                DeclarationReadings.NONE);
+    }
+
+    /** The same, closed over the finite paths this behavior's measurement names, reading for
+     *  itself. */
+    public static InputDomain of(DeclaredSig declared,
+                                 List<SpecImplementation.ParameterBinding.AnInput> arriving,
+                                 RuleReadingSource source, ReadingPolicy policy,
+                                 InputDemand demand) {
+        return of(declared, arriving, source, policy, demand, DeclarationReadings.NONE);
     }
 
     /** The positions, in the order they were read. */
@@ -426,6 +464,12 @@ public final class InputDomain {
     /** How the names in it are read, which is the policy this reading was made under. */
     public ReadingPolicy policy() {
         return policy;
+    }
+
+    /** Where this reading borrowed what had already been made of the declarations it read, for a
+     *  reader of those same declarations that comes after it. */
+    public DeclarationReadings machines() {
+        return machines;
     }
 
     /**
@@ -803,7 +847,8 @@ public final class InputDomain {
             // are about. Read without it, the cases of a sum are rules about every row and refuse
             // an input between them.
             byRoot.computeIfAbsent(root.at(),
-                    at -> new OpenedRules(PlacedRules.of(at, root.type(), source, policy),
+                    at -> new OpenedRules(
+                            PlacedRules.of(at, root.type(), source, policy, machines),
                             root.opening()));
         }
         // Where a term's subject stands, handed over already answered. What comes back asks a

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -8,6 +8,7 @@ import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.DeclaredBounds;
+import souther.compiler.check.DeclarationReadings;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Shape;
 import souther.compiler.check.TypeView;
@@ -3665,7 +3666,7 @@ public final class Generator {
         // has to meet that too: a row holding an element in the class and breaking the rule about
         // how many the list holds is not a row.
         FieldDomains under = rulesOf(subject.types().get(p), subject.rules(),
-                subject.inputs().policy(), under(root, settled));
+                subject.inputs().policy(), under(root, settled), subject.machines());
         ConstructionPlan.Result planned = ConstructionPlan.of(subject.types().get(p), root,
                 subject.symbols(), decided.keySet(), additional,
                 (at, building) -> heldRange(under, at, building, subject.rules()));
@@ -4086,7 +4087,7 @@ public final class Generator {
         }
         TermPath at = TermPath.of(subject.parameters().get(p));
         FieldDomains left = rulesOf(subject.types().get(p), subject.rules(),
-                subject.inputs().policy(), under(at, settled));
+                subject.inputs().policy(), under(at, settled), subject.machines());
         RuleKey field = fieldUnder(position.at());
         return Partitions.displacedRepresentativesOf(position.type(), subject.rules(),
                 subject.inputs().policy(), field == null ? null : left.at(field).bounds(),
@@ -4161,7 +4162,8 @@ public final class Generator {
         // A position the caller fixed holds nothing back: it was given the value it is to take.
         List<List<FixtureTemplate>> reserves = new ArrayList<>(
                 java.util.Collections.nCopies(paths.size(), List.<FixtureTemplate>of()));
-        FieldDomains left = rulesOf(subject.types().get(p), ruleSource, policy, under(at, settled));
+        FieldDomains left = rulesOf(subject.types().get(p), ruleSource, policy, under(at, settled),
+                subject.machines());
         for (ConstructionPlan.Slot slot : plan.slots()) {
             if (paths.contains(slot.at())) {
                 continue;   // an axis decides here
@@ -4331,16 +4333,24 @@ public final class Generator {
      * <p>Written once because two readers want it: what a position is offered, and why a position
      * offered less than its rules allow. Those are the two halves of one floor and they were the two
      * halves this was already asymmetric about.
+     *
+     * <p>Read with what the walk that read the inputs has already made of these declarations.
+     * Settling a coordinate is what makes each of these a reading of its own — a probe fixes a
+     * different value every time and none of the readings is the declaration's own — but what the
+     * declaration's string rules come to is settled by the rules and not by what is fixed beside
+     * them, so a reading here that borrowed nothing would build every one of those machines again
+     * for each value probed.
      */
     private static FieldDomains rulesOf(Type type, RuleReadingSource source, ReadingPolicy policy,
-                                        Map<RuleKey, Count> settled) {
+                                        Map<RuleKey, Count> settled,
+                                        DeclarationReadings machines) {
         // Whether the position is a record, and which record, are one answer and it is the
         // reading's. The rules are then read on the declaration the fields came off — a position
         // written under a name takes its fields from what that name wraps, and reading the rules on
         // the name instead would be asking a declaration that has no such field.
         return TypeView.of(type, source.symbols()).shape()
                         instanceof Shape.Product(TypeSymbol.AtModule declared, Map<String, Type> _)
-                ? FieldDomains.of(declared, source, policy, settled) : FieldDomains.NONE;
+                ? FieldDomains.of(declared, source, policy, settled, machines) : FieldDomains.NONE;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.DeclarationReadings;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputReading;
@@ -47,9 +48,23 @@ public final class MeasuredInput {
     private final BehaviorInputs written;
     private final Quantities quantities;
     private final Partitions.Partitioning divided;
+    /**
+     * Where the declarations this input reaches get what the walk that read it already made of
+     * them.
+     *
+     * <p>Kept because choosing a value reads those declarations again. A probe fixes a coordinate
+     * and reads what is left beside it, which is a reading of its own every time; what the
+     * declarations' string rules come to is not, and is what the walk has already worked out.
+     *
+     * <p>No part of what makes two of these one. It is a capability: two built from one store
+     * answer alike and compare unlike, so a comparison that took it in would say a reading taken
+     * again was another reading.
+     */
+    private final DeclarationReadings machines;
 
     private MeasuredInput(String behavior, BehaviorInputs written, Quantities quantities,
-                          Partitions.Partitioning divided) {
+                          Partitions.Partitioning divided, DeclarationReadings machines) {
+        this.machines = machines;
         this.behavior = behavior;
         this.written = written;
         this.quantities = quantities;
@@ -92,7 +107,8 @@ public final class MeasuredInput {
             // refuses such a term, so asking it is the check.
             read.quantities().ordersOf(axis.term());
         }
-        return new MeasuredInput(behavior, BehaviorInputs.of(read), read.quantities(), divided);
+        return new MeasuredInput(behavior, BehaviorInputs.of(read), read.quantities(), divided,
+                read.domain().machines());
     }
 
     /**
@@ -138,6 +154,12 @@ public final class MeasuredInput {
      */
     public BehaviorInputs inputs() {
         return written;
+    }
+
+    /** Where a reader of the declarations this input reaches borrows what the walk that read it
+     *  already made of them. */
+    public DeclarationReadings machines() {
+        return machines;
     }
 
     /** What the rules reaching this input leave its numbers. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1800,7 +1800,7 @@ public final class Partitions {
         java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
         Map<RuleKey, Count> settled = new LinkedHashMap<>();
-        FieldDomains left = FieldDomains.of(record, ruleSource, policy, settled);
+        FieldDomains left = FieldDomains.unshared(record, ruleSource, policy, settled);
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {
             return null;
@@ -1823,7 +1823,7 @@ public final class Partitions {
             // which leaves `b` its whole range and takes the bottom of it.
             if (Counts.writtenIn(at.value()) instanceof Count count) {
                 settled.put(RuleKey.of(field.getKey()), count);
-                left = FieldDomains.of(record, ruleSource, policy, settled);
+                left = FieldDomains.unshared(record, ruleSource, policy, settled);
             }
         }
         return chosen;

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -22,6 +22,7 @@ import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.DeclarationCitations;
+import souther.compiler.check.DeclarationReadings;
 import souther.compiler.check.DeclaredSig;
 import souther.compiler.check.PublishedDeclarations;
 import souther.compiler.check.RuleRef;
@@ -1860,7 +1861,8 @@ public final class Adequacy {
             resolved.put(debt.point(), new BorderAccount.Answer(debt,
                     debt.id().owedToTheDeclaration().isPresent()
                             ? axisOf(debt.id(), declarations, Shapes.publishedDeclarations(db),
-                                    Shapes.declarationCitations(db), ruleReading, policy) : null,
+                                    Shapes.declarationCitations(db), ruleReading, policy,
+                                    db.readings()) : null,
                     PointResolver.resolveAt(debt.owed(), List.copyOf(debt.met().keySet()),
                             reading -> readingOf(db, module, scope, debt, debt.at(), reading))));
         }
@@ -4387,7 +4389,8 @@ public final class Adequacy {
                 }
                 out.add(new DeclaredDebt(debt,
                         axisOf(debt.id(), declarations, Shapes.publishedDeclarations(db),
-                                Shapes.declarationCitations(db), reading, policy), owners));
+                                Shapes.declarationCitations(db), reading, policy, db.readings()),
+                        owners));
             }
             return Answer.of(new DeclaredBoundaries(out, went));
         }
@@ -4411,11 +4414,13 @@ public final class Adequacy {
                                  Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
                                  PublishedDeclarations published, DeclarationCitations citations,
                                  RuleReadingSource reading,
-                                 souther.compiler.check.ReadingPolicy policy) {
+                                 souther.compiler.check.ReadingPolicy policy,
+                                 DeclarationReadings machines) {
         TypeSymbol declaredOn = id.owedToTheDeclaration().orElseThrow(
                 () -> new IllegalStateException("what a line with no declaration is on is not"
                         + " something anybody wrote: " + id));
-        String named = declarationRead(read, declaredOn, published, citations, reading, policy)
+        String named = declarationRead(read, declaredOn, published, citations, reading, policy,
+                        machines)
                 // Which line of the declaration this is, asked of the rule. Taken apart
                 // here, a reader would be deciding which rules have a clause and a
                 // conjunct, which is the rule's own answer.
@@ -4430,9 +4435,10 @@ public final class Adequacy {
     private static souther.compiler.check.DeclaredBorders declarationRead(
             Map<TypeSymbol, souther.compiler.check.DeclaredBorders> kept, TypeSymbol declaredOn,
             PublishedDeclarations published, DeclarationCitations citations,
-            RuleReadingSource reading, souther.compiler.check.ReadingPolicy policy) {
+            RuleReadingSource reading, souther.compiler.check.ReadingPolicy policy,
+            DeclarationReadings machines) {
         return kept.computeIfAbsent(declaredOn, each -> souther.compiler.check.DeclaredBorders
-                .of(each, published, citations, reading, policy));
+                .of(each, published, citations, reading, policy, machines));
     }
 
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatOneReadingDecidesIsLentWithItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatOneReadingDecidesIsLentWithItTest.java
@@ -1,0 +1,291 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.numeric.Count;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.KnownExtents;
+import souther.compiler.values.StringMachineAnswers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reading of a declaration decides is decided once, and every question handed that reading
+ * is handed it.
+ *
+ * <p>Which conjuncts account for where a coordinate stops is read by reading the declaration again
+ * without each of them, so a reader working it out costs a reading of the declaration for every
+ * end it attributes. The reading those come off is lent to every question that reaches the
+ * declaration; what it came to has to be lent with it, or each borrower puts the whole attribution
+ * again and the lending saves the first reading and no other.
+ *
+ * <p>Held by identity where the claim is about one object, and by counting readings where it is
+ * about the work. The two say different things: one asker being handed another's answer is what
+ * makes the count what it is, and a count alone would also be held down by an implementation that
+ * attributed less.
+ */
+class WhatOneReadingDecidesIsLentWithItTest {
+
+    /**
+     * Two declarations bounding one coordinate, and a conjunct about it that places no end.
+     *
+     * <p>Both kinds of counterfactual are asked of this. Which of {@code Common} and {@code Held}
+     * holds the floor under {@code hi} is asked by leaving each declaration's clauses out, and what
+     * the conjuncts about it were holding is asked by leaving each conjunct out. The behavior is
+     * what makes an input walk read the declaration beside the questions the module's own types
+     * put.
+     */
+    private static final String MODULE = """
+            module demo exposing ( Held, keep )
+
+            data Common =
+                { lo: Int
+                , code: String
+                }
+                invariant floor = lo >= 0
+                invariant hole = lo /= 0
+                invariant ceiling = lo <= 100
+                invariant coded = String.matches("[A-Z]{2}[0-9]{3}", code)
+
+            data Held = { ...Common }
+                invariant tighter = lo <= 50
+
+            behavior keep : (h: Held) -> Held
+
+            let keep (h) = h
+            """;
+
+    /** The same declarations with three more behaviors over them, each of which walks the input it
+     *  takes and reaches the declaration the same way the first does. */
+    private static final String MORE_QUESTIONS = MODULE + """
+
+            behavior alsoKeep : (h: Held) -> Held
+            let alsoKeep (h) = h
+
+            behavior floorOf : (h: Held) -> Int
+            let floorOf (h) = h.lo
+
+            behavior heldBy : (h: Held) -> Held
+            let heldBy (h) = h
+            """;
+
+    /**
+     * The second asker is handed what the first's reading came to, and it is the same object.
+     *
+     * <p>The counterfactual readings an attribution needs are kept by the reading that was asked
+     * for them, so two askers holding one reading put such a question once between them and two
+     * holding a reading each put it twice. Said as identity because that is what decides it: what
+     * is shared is the reading, and an answer equal to it made beside it shares nothing.
+     */
+    @Test
+    void aSecondAskerIsHandedWhatTheFirstsReadingCameTo() {
+        Compilation compilation = compiled(MODULE);
+        FieldDomains first = asTheCompilationReads(compilation, "Held");
+        FieldDomains second = asTheCompilationReads(compilation, "Held");
+
+        assertSame(first, second,
+                "the second asker is handed the answer the first's reading came to");
+    }
+
+    /**
+     * A declaration's ends are attributed as many times as the declaration is read, and not as many
+     * times as it is asked about.
+     *
+     * <p>Said as a comparison between two models rather than as a number. What the number would pin
+     * is how many readers there are, which is a fact about who asks; what this is about is that a
+     * reader beyond the first pays nothing.
+     */
+    @Test
+    void moreQuestionsOverOneDeclarationAttributeItsEndsNoMoreOften() {
+        long few = readingsMadeCompiling(MODULE);
+        long many = readingsMadeCompiling(MORE_QUESTIONS);
+
+        assertEquals(few, many,
+                () -> "a model with more questions over the same declarations read them " + many
+                        + " times against " + few + ", so a question reaching a declaration is"
+                        + " attributing its ends again rather than being handed the attribution");
+    }
+
+    /**
+     * A reading with something settled at a value is not the declaration's own, and what it comes
+     * to is not lent as one.
+     *
+     * <p>What a coordinate's rules leave once another is fixed is a different answer about the same
+     * clauses, and a reader handed the canonical one under a settling would be reading a range that
+     * runs where nothing fixed it.
+     */
+    @Test
+    void whatAReadingWithSomethingSettledComesToIsNotLent() {
+        Compilation compilation = compiled(MODULE);
+        FieldDomains canonical = asTheCompilationReads(compilation, "Held");
+        FieldDomains settled = FieldDomains.of(declared("Held"),
+                RuleReadings.of(compilation, "demo"), ReadAs.THE_COMPILATION_DOES,
+                Map.of(RuleKey.of("lo"), Count.of(500)),
+                compilation.db().readings());
+
+        assertNotSame(canonical, settled,
+                "a reading with a coordinate fixed is not the declaration's own reading");
+    }
+
+    /**
+     * Nor is one that leaves something out, which is what every counterfactual does.
+     *
+     * <p>Supposing a declaration holds values is reading the rules under it and no further, and the
+     * answer that comes of it says what would be left if it did. Lent as the declaration's own, it
+     * would say the rules under a name state nothing.
+     */
+    @Test
+    void whatAReadingWithSomethingLeftOutComesToIsNotLent() {
+        Compilation compilation = compiled(MODULE);
+        FieldDomains canonical = asTheCompilationReads(compilation, "Held");
+        TypeSymbol.AtModule held = declared("Held");
+        RuleReadingSource source = RuleReadings.of(compilation, "demo");
+        Hir.Data data = (Hir.Data) source.symbols().declaredNode(held.key());
+        FieldDomains granting = FieldDomains.granting(held, data, source,
+                ReadAs.THE_COMPILATION_DOES, Set.of(declared("Common")),
+                compilation.db().readings());
+
+        assertNotSame(canonical, granting,
+                "a reading that supposes a declaration has values is not the declaration's own");
+    }
+
+    /**
+     * What was worked out of one world is not handed to a reader of the next.
+     *
+     * <p>The reading is lent for as long as the world it was read from is the current one, and what
+     * was derived from it is the reading's. Moved by hand, because a compile that edits a source
+     * answers its questions again for that reason and would come out fresh whether or not anything
+     * was dropped.
+     */
+    @Test
+    void whatWasDerivedOfOneWorldIsNotHandedIntoTheNext() {
+        Compilation compilation = compiled(MODULE);
+        RuleReadingSource source = RuleReadings.of(compilation, "demo");
+        long[] world = { 7 };
+        LentReadings lender = new LentReadings(DeclarationReadings.NONE, () -> world[0],
+                StoreWork.UNWATCHED);
+
+        FieldDomains read = FieldDomains.of(declared("Held"), source,
+                ReadAs.THE_COMPILATION_DOES, lender);
+        assertSame(read, FieldDomains.of(declared("Held"), source,
+                        ReadAs.THE_COMPILATION_DOES, lender),
+                "what this world's reading came to is handed on while it is this world");
+
+        world[0]++;
+        assertNotSame(read, FieldDomains.of(declared("Held"), source,
+                        ReadAs.THE_COMPILATION_DOES, lender),
+                "and is not handed into the next, which its reading is not a reading of");
+    }
+
+    /**
+     * What the declaration's own reading came to is what a reader working it out for itself would
+     * come to.
+     *
+     * <p>The reading that is lent is made while the store's answer about the declaration's string
+     * machines is being made, so it builds those machines rather than borrowing them, and every
+     * counterfactual of it borrows what it built. A reader of its own borrows the finished answer
+     * and its counterfactuals borrow that. The two are different worlds to have read in and the
+     * same rules to have read, and what they leave has to be the same — otherwise which of them a
+     * question was handed decides what the model says.
+     *
+     * <p>Compared by what the reading answers rather than by what it holds. Which fields it built
+     * are its own business and are allowed to differ; the ends, the attributions and what stands at
+     * each name are what a report is written from.
+     *
+     * <p>That a machine says the same thing whoever built it is held where machines are
+     * ({@link ACounterfactualBorrowsTheMachinesTheReadingMadeTest}), and this rests on it rather
+     * than restating it: what a set admits is compared here, but a reading that built its own
+     * machines and one handed the store's are the same reading of the same rules, so no model
+     * written here tells them apart.
+     */
+    @Test
+    void whatTheLentReadingCameToIsWhatAReaderOfItsOwnComesTo() {
+        Compilation compilation = compiled(MODULE);
+        FieldDomains lent = asTheCompilationReads(compilation, "Held");
+        FieldDomains ofItsOwn = FieldDomains.of(declared("Held"),
+                RuleReadings.of(compilation, "demo"), ReadAs.THE_COMPILATION_DOES,
+                borrowingMachinesAndNoReading(compilation));
+
+        assertNotSame(lent, ofItsOwn, "the reader of its own read for itself");
+        assertFalse(lent.movedEnds().isEmpty(),
+                "the model under test has ends its conjuncts moved rather than placed");
+        assertEquals(lent.movedEnds(), ofItsOwn.movedEnds(),
+                "the ends the conjuncts moved are the same ends, attributed to the same parts");
+        assertEquals(lent.placed(), ofItsOwn.placed(),
+                "and so is every end the declaration places");
+        for (String field : List.of("lo", "code")) {
+            RuleKey path = RuleKey.of(field);
+            assertEquals(lent.at(path), ofItsOwn.at(path),
+                    () -> "what may stand at `" + field + "` is the same either way");
+            assertEquals(lent.noLineAt(path), ofItsOwn.noLineAt(path),
+                    () -> "and so are the rules about `" + field + "` that placed no end");
+            assertEquals(lent.admits(path), ofItsOwn.admits(path),
+                    () -> "and which values `" + field + "` admits, which is what the machines the"
+                            + " two worlds differ by decide");
+        }
+        assertEquals(lent.infeasible(), ofItsOwn.infeasible(),
+                "and whether the rules leave a value at all");
+    }
+
+    /**
+     * A lender of the store's answers about string machines that lends no reading.
+     *
+     * <p>What a borrower of the store had before a reading could be handed on: the machines are the
+     * store's answer and the reading is the borrower's own. Written here rather than reached for,
+     * because the point of the comparison is that the two readings were made in different worlds.
+     */
+    private static DeclarationReadings borrowingMachinesAndNoReading(Compilation compilation) {
+        DeclarationReadings store = compilation.db().readings();
+        return new DeclarationReadings() {
+
+            @Override
+            public StringMachineAnswers of(TypeKey declaration) {
+                return store.of(declaration);
+            }
+
+            @Override
+            public KnownExtents extents() {
+                return store.extents();
+            }
+        };
+    }
+
+    /** What the rules of {@code declaration} leave, asked the way the compilation asks it. */
+    private static FieldDomains asTheCompilationReads(Compilation compilation,
+                                                     String declaration) {
+        return FieldDomains.of(declared(declaration), RuleReadings.of(compilation, "demo"),
+                ReadAs.THE_COMPILATION_DOES, compilation.db().readings());
+    }
+
+    private static TypeSymbol.AtModule declared(String declaration) {
+        return TypeSymbols.declared(new TypeKey("demo", declaration));
+    }
+
+    private static Compilation compiled(String source) {
+        Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        assertTrue(compilation.diagnostics().values().stream().allMatch(List::isEmpty),
+                () -> "the model under test compiles clean: " + compilation.diagnostics());
+        return compilation;
+    }
+
+    private static long readingsMadeCompiling(String source) {
+        long before = InvariantChecker.readingsMade();
+        compiled(source);
+        return InvariantChecker.readingsMade() - before;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
@@ -88,13 +88,19 @@ class WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest {
      * with a position settled are both called {@code of}, and the second is the one that takes the
      * settlings — so a check on the name alone would report every reader of a declaration as one
      * that settles a position of it.
+     *
+     * <p>Whether the settlings are taken, and not where in the list they are. A reader may be
+     * handed something else beside them — where it borrows what has already been made of the
+     * declaration is one such thing — and a check that looked at the last argument would go quiet
+     * the day one was added, which is a check that reads nothing while reporting nothing.
      */
     private static boolean conditions(String member, java.lang.constant.MethodTypeDesc taken) {
         if (member.equals("given")) {
             return true;
         }
-        return member.equals("of") && taken.parameterCount() > 0
-                && taken.parameterType(taken.parameterCount() - 1).displayName().equals("Map");
+        return (member.equals("of") || member.equals("unshared"))
+                && taken.parameterList().stream()
+                        .anyMatch(each -> each.displayName().equals("Map"));
     }
 
     /** The nest a class belongs to: a lambda written inside a reader is that reader. */

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -268,6 +268,25 @@ final class AnswerClosure {
                             + "answer is compared by is what the plan is a numbering of, which is a "
                             + "value");
 
+    /**
+     * Where a reading of a declaration borrows what has already been made of it.
+     *
+     * <p>Held by a reading of an input so that a later reader of the same declarations is not made
+     * to read them again: what a search asks about the record a parameter is is asked long after
+     * the walk that read it, and asked with nothing to borrow it pays every reading over.
+     *
+     * <p>Two of them built from one store answer alike and compare unlike, so the answers holding
+     * one are compared without it — a reading taken again would otherwise come back as another
+     * reading and put every measure through again. What it lends is dropped when the revision moves
+     * and it is the store's own, so an answer kept across one hands out nothing of the world it was
+     * read from.
+     */
+    private static final Reading A_LENDING_OF_READINGS =
+            new Reading("A_LENDING_OF_READINGS", CAPABILITY,
+                    "where a reading of a declaration borrows what somebody has already made of it,"
+                            + " which is a way of asking the store rather than an answer, and never"
+                            + " equals the same way of asking built again");
+
     /** How a module is found, which is something run rather than something said. */
     private static final Reading MODULE_PATH = new Reading("MODULE_PATH", CAPABILITY,
             "a module path resolves a module by running something, and a function never equals the "
@@ -588,6 +607,13 @@ final class AnswerClosure {
                     Traversal.Why.SAYS_NOTHING_OF_ITSELF),
             new KnownDeclared(declared(Q + "Front$Path", "souther.compiler.meta.ModulePath"),
                     MODULE_PATH, Traversal.Why.NOTHING_CLOSES_IT),
+            // Where the declarations a reading of an input reached borrow what has already been
+            // made of them, kept by the reading for the readers of those declarations that come
+            // after the walk.
+            new KnownDeclared(declared(Q + "Adequacy$Inputs",
+                    "souther.compiler.check.DeclarationReadings", MAP_VALUE,
+                    part("souther.compiler.inputs.InputDomain", "machines")),
+                    A_LENDING_OF_READINGS, Traversal.Why.NOTHING_CLOSES_IT),
             // Where the places of a module's bodies are, held by the check that walked them. One
             // place and not the maps under it: the plan says nothing of itself, so the walk stops
             // here — which is the whole of what is being allowed, and the maps under it are what
@@ -647,6 +673,15 @@ final class AnswerClosure {
             generationReader("souther.compiler.inputs.ReadQuantities",
                     part("souther.compiler.partition.MeasuredInput", "quantities"),
                     arm("souther.compiler.inputs.ReadQuantities")),
+            // Where the declarations this subject reaches borrow what has already been made of
+            // them. A search chooses a value by reading those declarations with a coordinate fixed,
+            // which is a reading of its own every time; what their string rules come to is not, and
+            // is what the walk that read the input already worked out.
+            new KnownDeclared(
+                    declared(Q + "Adequacy$Generated", "souther.compiler.check.DeclarationReadings",
+                            then(A_SUBJECT,
+                                    part("souther.compiler.partition.MeasuredInput", "machines"))),
+                    A_LENDING_OF_READINGS, Traversal.Why.NOTHING_CLOSES_IT),
             new KnownDeclared(declared(Q + "Names$Resolution",
                     "souther.compiler.diag.CompileException",
                     part("souther.compiler.check.Resolve$Resolution", "unresolved"), HELD),


### PR DESCRIPTION
Closes #1511.

A reading of a declaration is lent — made once under a revision and handed to whoever asks next — and what was derived from it was not. Each borrower built its own answer about what the rules leave, and worked out again which conjuncts hold each end. That last question costs a reading of the declaration for every end it attributes, so a second borrower paid the whole attribution a second time, and the lending saved the first reading and no other. Two of them stand in one walk of an input, at the same declaration under the same terms.

What was already there is the fix. The store's answer about a declaration's string machines is made by reading the declaration whole, and that reading's answer about the fields was built and dropped. Now the reading is one object holding both, so the declaration's own answer about what its rules leave outlives the question that first wanted it, and the counterfactual readings an attribution needs are made once for the declaration rather than once per reader. Which of the two kinds a reading is — the declaration's own, or one belonging to the question that asked for it — is decided where a reading is asked for, and nothing downstream puts the question again.

The lending also reaches two readers that had lost it. A boundary search reads the record a parameter is once per value it probes; a probe fixes a coordinate, so the reading is its own every time, but what the declaration's string rules come to is not. An account of a declared line reads the declaration once per line. Both now borrow, from the walk that read the input in the first case and from the store in the second, and what those answers are compared by leaves the lending out: it is a way of asking rather than an answer.

## What is left, and why it is not here

Where the lending is not reached is under a walk over what an author wrote, which is handed what it is reading and nothing that says where a reading comes from. Taking it there means deciding what a borrower is handed when the reading it asks for is the one being made, and whether such a capability belongs to a strategy's identity or to what invokes it. That is #1546. Those readers say outright that they read for themselves, and a check over the compiled classes refuses a new one: the entry points come in pairs, both halves are found rather than listed, and reaching for the shorter one is what nothing here may do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
