### PR TITLE
Name a control place by which alternative of the tree it is, not by an address

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
@@ -446,7 +446,7 @@ class AnArmNothingReachesIsNotOwedARowTest {
         // an arm settles — a lit comparison says it ran, not which way it came out.
         assertTrue(asRun.answers().found().entrySet().stream()
                         .filter(each -> each.getKey()
-                                instanceof souther.compiler.coverage.ControlPointId.ArmPoint)
+                                instanceof souther.compiler.coverage.ControlPlace.Arm)
                         .noneMatch(each -> each.getValue()
                                 instanceof souther.compiler.reach.Reachability.Unreachable),
                 "and what the signature reads is the same answer the arms are counted by");

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -171,9 +171,13 @@ public final class PathReachability {
          * neither is derivable from the other afterwards: the corrected answers no longer say which
          * arms were corrected, and the corrections do not say what everything else came to.
          *
-         * @param lit the probes a row was recorded at
+         * @param lit the probes a row was recorded at, which are places of the numbering this
+         *            reading was made under. A probe of another is one no arm here answers to, so
+         *            the run would correct nothing and every proof would stand — the same answer as
+         *            a run that went nowhere
          */
         public AsRun asRunWith(java.util.Set<ArmProbe> lit) {
+            lit.forEach(probe -> requireNumbering(probe.numbering()));
             Map<ControlPlace, Reachability> out = new LinkedHashMap<>(found);
             java.util.Set<ArmProbe> provedWrong =
                     new java.util.LinkedHashSet<>();
@@ -318,7 +322,7 @@ public final class PathReachability {
      *
      * @return what went unanswered, or empty where nothing did
      */
-    private static java.util.Optional<String> unanswered(
+    private static Optional<String> unanswered(
             Core body, CoverageSites.Plan plan, Map<ControlPlace, Reachability> out,
             Map<ConstructOccurrence,
                     souther.compiler.reach.ComparisonArrival> arriving) {
@@ -326,7 +330,7 @@ public final class PathReachability {
         // owed for the places a run could be recorded at, and a node that is no comparison of this
         // plan is a node there was nothing to answer about.
         if (body instanceof Core.Binary comparison) {
-            java.util.Optional<String> here = unansweredAt(comparison, plan, out, arriving);
+            Optional<String> here = unansweredAt(comparison, plan, out, arriving);
             if (here.isPresent()) {
                 return here;
             }
@@ -334,8 +338,8 @@ public final class PathReachability {
         List<String> missed = new ArrayList<>();
         Core.forEachChild(body, child ->
                 unanswered(child, plan, out, arriving).ifPresent(missed::add));
-        return missed.isEmpty() ? java.util.Optional.empty()
-                : java.util.Optional.of(missed.get(0));
+        return missed.isEmpty() ? Optional.empty()
+                : Optional.of(missed.get(0));
     }
 
     /**
@@ -344,19 +348,19 @@ public final class PathReachability {
      * <p>Owed only where the plan numbers one here. A node that is no comparison of this plan is a
      * place no run is recorded at, so there was never an answer for the walk to have missed.
      */
-    private static java.util.Optional<String> unansweredAt(
+    private static Optional<String> unansweredAt(
             Core.Binary comparison, CoverageSites.Plan plan,
             Map<ControlPlace, Reachability> out,
             Map<ConstructOccurrence,
                     souther.compiler.reach.ComparisonArrival> arriving) {
         ConstructOccurrence which = numbered(comparison, plan);
         if (which == null) {
-            return java.util.Optional.empty();
+            return Optional.empty();
         }
         for (boolean result : new boolean[] {true, false}) {
             ControlPlace where = plan.outcomeOf(which, result).orElse(null);
             if (where != null && !out.containsKey(where)) {
-                return java.util.Optional.of(
+                return Optional.of(
                         "this reading answered for no run through " + comparison.op()
                                 + " at " + comparison.pos() + " coming out " + result
                                 + "; the plan numbered it and a reader below cannot tell an "
@@ -367,13 +371,13 @@ public final class PathReachability {
         // owes it for the same reason it owes them — a reader below reads an absence as the answer
         // that restricts nothing, so only an audit here can tell the two apart.
         if (!arriving.containsKey(which)) {
-            return java.util.Optional.of(
+            return Optional.of(
                     "this reading said nothing about what arrives at " + comparison.op()
                             + " at " + comparison.pos()
                             + "; the plan numbered it and a reader below cannot tell an answer"
                             + " that was never made from one that restricts nothing");
         }
-        return java.util.Optional.empty();
+        return Optional.empty();
     }
 
     private final PathEngine engine;
@@ -562,7 +566,7 @@ public final class PathReachability {
         }
         arriving.put(which, arrivalAt(comparison, k, at, reads));
         for (boolean result : new boolean[] {true, false}) {
-            java.util.Optional<ControlPlace.Outcome> where =
+            Optional<ControlPlace.Outcome> where =
                     plan.outcomeOf(which, result);
             if (where.isEmpty()) {
                 continue;

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -1,9 +1,10 @@
 package souther.compiler.check;
 
 import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.NumberingIdentity;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.inputs.Admits;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
@@ -28,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * What the model's own rules say arrives at each place in a behavior's body.
@@ -39,7 +41,7 @@ import java.util.Objects;
  * guards above had established. Two guards on one position left the second one's departure owed a
  * row that nothing can write.
  *
- * <p>Held by {@link ControlPointId} and not by probe number. An arm answering {@code unreachable}
+ * <p>Held by {@link ControlPlace} and not by probe number. An arm answering {@code unreachable}
  * has no probe, and it is the arm a claim is about.
  *
  * <p><b>Only a proof excludes, and nothing here proves that something arrives.</b> A state the
@@ -53,14 +55,35 @@ import java.util.Objects;
  */
 public final class PathReachability {
 
-    /** What was found, and what a place nothing was found about comes to. */
-    public record Answers(Map<ControlPointId, Reachability> found,
+    /**
+     * What was found, and what a place nothing was found about comes to.
+     *
+     * @param numbering which plan's places these are filed under, or empty where no reading was
+     *                  made at all. Not read off the entries: a reading of a body with nothing to
+     *                  say about it is a reading and answers for that plan, while what a caller
+     *                  holds where a module's reading could not be made is no reading and answers
+     *                  for none. The two are the same map and are not the same fact
+     */
+    public record Answers(Optional<NumberingIdentity> numbering,
+                          Map<ControlPlace, Reachability> found,
                           Map<ConstructOccurrence,
                                   souther.compiler.reach.ComparisonArrival> arriving) {
 
-        public static final Answers NONE = new Answers(Map.of(), Map.of());
+        /** No reading, which every consumer takes the way it takes a place nothing was found
+         *  about, and which goes with any plan because it says nothing about one. */
+        public static final Answers NONE = new Answers(Optional.empty(), Map.of(), Map.of());
 
         public Answers {
+            if (numbering == null) {
+                throw new IllegalArgumentException(
+                        "a reading either was made under some numbering or was not made");
+            }
+            if (numbering.isEmpty() && !(found.isEmpty() && arriving.isEmpty())) {
+                throw new IllegalArgumentException(
+                        "a reading that answered about " + found.size() + " places and "
+                                + arriving.size() + " comparisons was made under some numbering;"
+                                + " its places are of a plan and nothing here would say which");
+            }
             // The order the walk found them in. `Map.copyOf` is unordered and its iteration is
             // salted per run, so the warnings read off this came out in a different order on every
             // JVM — a diagnostic whose place in the output is not a function of the source.
@@ -69,11 +92,40 @@ public final class PathReachability {
         }
 
         /**
+         * That the places {@code of} names are the places this reading answered about.
+         *
+         * <p><b>Said once, where a plan and a reading of it are put together, and not at each
+         * lookup.</b> Absent here reads as unsettled and that is the right answer for a place the
+         * walk did not get to — and the same answer for a place of another module's plan, which is
+         * not an answer about this reading at all. A place cannot be asked which plan it is of: an
+         * arm no run can be recorded in carries no numbering, and giving it one would put the
+         * plan's own address back inside the identity. So the pairing is what is checked, and it is
+         * checked where the two halves meet.
+         *
+         * <p>Beside {@code AlignedObservation}, which refuses a place of another numbering put to a
+         * recording. Both are read back under a numbering, and now both say so.
+         *
+         * <p>{@link #NONE} goes with any plan. What a caller holds where no reading was made says
+         * nothing about any module's places, and every consumer already treats it the way it treats
+         * a place nothing was found about.
+         */
+        public void requireNumbering(NumberingIdentity of) {
+            if (numbering.isPresent() && !numbering.get().equals(of)) {
+                throw new IllegalArgumentException("this reading was made under " + numbering.get()
+                        + " and is being read against " + of
+                        + "; what one plan's reading says about another's places is nothing, and"
+                        + " answering it would report every place of a body as one nothing"
+                        + " reached");
+            }
+        }
+
+        /**
          * What arrives at {@code where}.
          *
          * <p>A place this reading has nothing filed under is one the walk did not get to, which is
          * an answer and not a gap: it is {@link WhyUnsettled.TheWalkDidNotReachIt}, and every
-         * consumer treats it as it treats any other unsettled place.
+         * consumer treats it as it treats any other unsettled place. Which is why the reading and
+         * the plan are held to being one another's first ({@link #requireNumbering}).
          *
          * <p><b>Asked with the place and never with an address of one.</b> A probe says where a run
          * through an arm is recorded, and which arm that is is the numbering's answer, given where
@@ -81,7 +133,7 @@ public final class PathReachability {
          * by search — over the entries of one reading, which knows of no numbering and could not
          * tell two arms answering to one probe apart if a walk ever made them.
          */
-        public Reachability at(ControlPointId where) {
+        public Reachability at(ControlPlace where) {
             Reachability answer = found.get(where);
             return answer != null ? answer
                     : new Reachability.Unsettled(WhyUnsettled.theWalkDidNotReachIt());
@@ -122,11 +174,11 @@ public final class PathReachability {
          * @param lit the probes a row was recorded at
          */
         public AsRun asRunWith(java.util.Set<ArmProbe> lit) {
-            Map<ControlPointId, Reachability> out = new LinkedHashMap<>(found);
+            Map<ControlPlace, Reachability> out = new LinkedHashMap<>(found);
             java.util.Set<ArmProbe> provedWrong =
                     new java.util.LinkedHashSet<>();
             found.forEach((where, said) -> {
-                if (!(where instanceof ControlPointId.ArmPoint arm)
+                if (!(where instanceof ControlPlace.Arm arm)
                         || arm.probe().isEmpty() || !lit.contains(arm.probe().get())) {
                     return;
                 }
@@ -138,7 +190,7 @@ public final class PathReachability {
             });
             // The arrivals as they were: a run corrects what an arm's denominator counts, and the
             // geometry the arrivals decide was settled from the model before any row ran.
-            return new AsRun(new Answers(out, arriving), provedWrong);
+            return new AsRun(new Answers(numbering, out, arriving), provedWrong);
         }
 
         /**
@@ -211,7 +263,7 @@ public final class PathReachability {
                 new PathEngine(source.symbols(), source.invariants(), source.states(),
                         source.written(), DeclarationReadings.NONE,
                         Terms.Of.THE_TREE_THAT_RUNS, policy);
-        Map<ControlPointId, Reachability> out = new LinkedHashMap<>();
+        Map<ControlPlace, Reachability> out = new LinkedHashMap<>();
         Map<ConstructOccurrence,
                 souther.compiler.reach.ComparisonArrival> arriving = new LinkedHashMap<>();
         PathEngine.Entered in = PathEngine.Entered.nothing();
@@ -233,7 +285,7 @@ public final class PathReachability {
         unanswered(body, plan, out, arriving).ifPresent(why ->
                 InvariantChecker.gaveUp("reachability",
                         WhatTheCheckCannotRead.theWalkLeftAnAnswerUnmade(why)));
-        return new Answers(out, arriving);
+        return new Answers(Optional.of(plan.identity()), out, arriving);
     }
 
     /**
@@ -267,7 +319,7 @@ public final class PathReachability {
      * @return what went unanswered, or empty where nothing did
      */
     private static java.util.Optional<String> unanswered(
-            Core body, CoverageSites.Plan plan, Map<ControlPointId, Reachability> out,
+            Core body, CoverageSites.Plan plan, Map<ControlPlace, Reachability> out,
             Map<ConstructOccurrence,
                     souther.compiler.reach.ComparisonArrival> arriving) {
         // Which comparison this is, and only where the plan numbers one there: what is owed is
@@ -294,7 +346,7 @@ public final class PathReachability {
      */
     private static java.util.Optional<String> unansweredAt(
             Core.Binary comparison, CoverageSites.Plan plan,
-            Map<ControlPointId, Reachability> out,
+            Map<ControlPlace, Reachability> out,
             Map<ConstructOccurrence,
                     souther.compiler.reach.ComparisonArrival> arriving) {
         ConstructOccurrence which = numbered(comparison, plan);
@@ -302,7 +354,7 @@ public final class PathReachability {
             return java.util.Optional.empty();
         }
         for (boolean result : new boolean[] {true, false}) {
-            ControlPointId where = plan.outcomeOf(which, result).orElse(null);
+            ControlPlace where = plan.outcomeOf(which, result).orElse(null);
             if (where != null && !out.containsKey(where)) {
                 return java.util.Optional.of(
                         "this reading answered for no run through " + comparison.op()
@@ -330,7 +382,7 @@ public final class PathReachability {
      *  against. A condition narrows a path; a case is refused or left by the rules themselves. */
     private final InputDomain read;
     private final Symbols symbols;
-    private final Map<ControlPointId, Reachability> out;
+    private final Map<ControlPlace, Reachability> out;
     private final Map<ConstructOccurrence,
             souther.compiler.reach.ComparisonArrival> arriving;
     /**
@@ -345,7 +397,7 @@ public final class PathReachability {
     private Denotations entered = Denotations.none();
 
     private PathReachability(PathEngine engine, CoverageSites.Plan plan, InputDomain read,
-                             Symbols symbols, Map<ControlPointId, Reachability> out,
+                             Symbols symbols, Map<ControlPlace, Reachability> out,
                              Map<ConstructOccurrence,
                                      souther.compiler.reach.ComparisonArrival> arriving) {
         this.engine = engine;
@@ -409,7 +461,7 @@ public final class PathReachability {
             }
             case Core.If iff -> {
                 walk(iff.cond(), k, at, reads, decided, nothingAbove);
-                ControlPointId.ArmPoint[] arms = plan.armsOf(iff);
+                ControlPlace.Arm[] arms = plan.armsOf(iff);
                 enterArm(arms, 0, iff, iff.then(), k, at, reads, decided, true);
                 enterArm(arms, 1, iff, iff.els(), k, at, reads, decided, false);
             }
@@ -510,7 +562,7 @@ public final class PathReachability {
         }
         arriving.put(which, arrivalAt(comparison, k, at, reads));
         for (boolean result : new boolean[] {true, false}) {
-            java.util.Optional<ControlPointId.ComparisonPoint> where =
+            java.util.Optional<ControlPlace.Outcome> where =
                     plan.outcomeOf(which, result);
             if (where.isEmpty()) {
                 continue;
@@ -685,7 +737,7 @@ public final class PathReachability {
      * nothing, the arm is proven and what is under it is not walked: everything there is unreachable
      * for the same reason, and one finding is what an author is owed.
      */
-    private void enterArm(ControlPointId.ArmPoint[] arms, int index, Core.If iff, Core arm,
+    private void enterArm(ControlPlace.Arm[] arms, int index, Core.If iff, Core arm,
                           Known k, Denotations at, InputReads reads, List<PathDecision> decided,
                           boolean holds) {
         Predicates.Assumed taken = engine.assuming(iff.cond(), k, at, holds);
@@ -714,7 +766,7 @@ public final class PathReachability {
      * is built here where both are in hand rather than assembled by whoever asks.
      */
     private void cases(Core.Match match, InputReads reads, boolean nothingAbove) {
-        ControlPointId.ArmPoint[] arms = plan.armsOf(match);
+        ControlPlace.Arm[] arms = plan.armsOf(match);
         if (arms == null) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/claims/Claim.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/Claim.java
@@ -1,6 +1,6 @@
 package souther.compiler.claims;
 
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.TypeSymbol;
@@ -26,7 +26,7 @@ import java.util.List;
  *                and it never had one — which is why a claim is judged at the control point
  */
 public record Claim(TermPath at, TypeSymbol named, List<String> reasons, SourcePos said,
-                    ControlPointId.ArmPoint where) {
+                    ControlPlace.Arm where) {
 
     public Claim {
         reasons = List.copyOf(reasons);

--- a/souther-compiler/src/main/java/souther/compiler/claims/Claims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/Claims.java
@@ -63,6 +63,11 @@ public final class Claims {
         if (claims.isEmpty()) {
             return NONE;
         }
+        // The claims name arms of one plan and the reading answers about the places of one plan, so
+        // the two are held to being the same plan's here, where they are put together. Read against
+        // another module's, every arm would be one the reading has nothing filed under — which is
+        // the sentence below, and would be untrue of both bodies.
+        arrives.requireNumbering(claims.numbering().orElseThrow());
         List<Judged> out = new ArrayList<>();
         for (Claim claim : claims.all()) {
             out.add(new Judged(claim, verdictOf(arrives.at(claim.where()))));

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
@@ -3,7 +3,9 @@ package souther.compiler.claims;
 import souther.compiler.check.ElementBindings;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.NormalReturn;
+import souther.compiler.coverage.NumberingIdentity;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.PathResolution;
@@ -11,6 +13,7 @@ import souther.compiler.inputs.TermPath;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * What a behavior's body declares cannot arrive.
@@ -38,12 +41,32 @@ import java.util.List;
 public final class UnreachableClaims {
 
     /** Nothing claimed: a behavior with no body, or one whose body says nothing this can read. */
-    public static final UnreachableClaims NONE = new UnreachableClaims(List.of());
+    public static final UnreachableClaims NONE = new UnreachableClaims(List.of(), Optional.empty());
 
     private final List<Claim> claims;
 
-    private UnreachableClaims(List<Claim> claims) {
+    private final Optional<NumberingIdentity> numbering;
+
+    private UnreachableClaims(List<Claim> claims, Optional<NumberingIdentity> numbering) {
         this.claims = List.copyOf(claims);
+        this.numbering = numbering;
+        if (this.claims.isEmpty() != numbering.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "a claim names an arm of some plan, and nothing claimed names no plan: "
+                            + this.claims.size() + " claimed under " + numbering);
+        }
+    }
+
+    /**
+     * Which plan's arms these claims name, or empty where nothing is claimed.
+     *
+     * <p>What a reading of the body has to have been made under for its answers to be about these
+     * arms. A claim is judged by looking the arm up in that reading, and a reading of some other
+     * plan has nothing filed under any of them — which reads as every claim unproven and is not an
+     * answer about either body.
+     */
+    public Optional<NumberingIdentity> numbering() {
+        return numbering;
     }
 
     /**
@@ -60,7 +83,8 @@ public final class UnreachableClaims {
         List<Claim> found = new ArrayList<>();
         claimedUnder(body, InputReads.ofParameters(read.parameterReads(), ElementBindings.NONE),
                 symbols, plan, NormalReturn.ofBody(body), true, found);
-        return found.isEmpty() ? NONE : new UnreachableClaims(found);
+        return found.isEmpty() ? NONE
+                : new UnreachableClaims(found, Optional.of(plan.identity()));
     }
 
     /**
@@ -124,7 +148,7 @@ public final class UnreachableClaims {
         if (path == null) {
             return;
         }
-        souther.compiler.coverage.ControlPointId.ArmPoint[] arms = plan.armsOf(match);
+        ControlPlace.Arm[] arms = plan.armsOf(match);
         for (int i = 0; i < match.cases().size(); i++) {
             Core.Case arm = match.cases().get(i);
             if (answering.at(arm.body())) {
@@ -133,7 +157,7 @@ public final class UnreachableClaims {
             if (arms == null || i >= arms.length) {
                 continue;   // a fork this plan holds no arms for is one nothing can be asked about
             }
-            souther.compiler.coverage.ControlPointId.ArmPoint where = arms[i];
+            ControlPlace.Arm where = arms[i];
             List<UnreachableReasons.Said> said = UnreachableReasons.said(arm.body(), answering);
             List<String> why = said.stream().map(UnreachableReasons.Said::reason).distinct().toList();
             // Cases written together on one arm are one run of code, and it declares the same thing

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
@@ -11,13 +11,12 @@ import java.util.Optional;
  * The reading's own vocabulary changes as the reading gets better; that a comparison came out false
  * does not.
  *
- * <p>Not every place is one of these. An arm no row that stands can be in carries no probe, so a run
- * through it is not something any recording could hold — and a claim on it would be one nothing could
- * ever satisfy, which is worse than no claim at all: it reads as a combination that was tried and
+ * <p>Not every place is one of these. A place no run could be recorded at is one a claim could never
+ * be satisfied at, which is worse than no claim at all: it reads as a combination that was tried and
  * missed. {@link #of} is where that is decided, so a claim that exists is one an observation can
  * answer.
  */
-public record ControlClaim(ControlPointId at) {
+public record ControlClaim(ControlPlace at) {
 
     public ControlClaim {
         if (at == null) {
@@ -31,14 +30,19 @@ public record ControlClaim(ControlPointId at) {
      * <p>Empty is an ordinary answer and the safe direction: what cannot be witnessed cannot be
      * claimed, so whatever was going to be built on it is left unbuilt rather than built and never
      * satisfiable.
+     *
+     * <p>One rule, read off whichever half of the place answers it. An arm carries its probe and
+     * says outright whether it has one. A comparison coming out one way exists only where the plan
+     * numbered the comparison — which the plan does for a comparison standing where a row can get to
+     * and where what it stands in answers a value — so a {@link ControlPlace.Outcome} that exists is
+     * one a run can be recorded at, and one in a position no run reaches is a place the plan makes
+     * no outcome for at all.
      */
-    public static Optional<ControlClaim> of(ControlPointId at) {
+    public static Optional<ControlClaim> of(ControlPlace at) {
         return switch (at) {
-            case ControlPointId.ArmPoint arm ->
+            case ControlPlace.Arm arm ->
                     arm.isMeasured() ? Optional.of(new ControlClaim(arm)) : Optional.empty();
-            // A comparison is numbered only where the fork it belongs to has an arm a run can be
-            // recorded in, so one that exists is one a run can be recorded at.
-            case ControlPointId.ComparisonPoint point -> Optional.of(new ControlClaim(point));
+            case ControlPlace.Outcome outcome -> Optional.of(new ControlClaim(outcome));
         };
     }
 
@@ -51,18 +55,17 @@ public record ControlClaim(ControlPointId at) {
      */
     public boolean satisfiedBy(AlignedObservation seen) {
         return switch (at) {
-            case ControlPointId.ArmPoint arm ->
+            case ControlPlace.Arm arm ->
                     arm.probe().isPresent() && seen.lit(arm.probe().get());
-            case ControlPointId.ComparisonPoint point -> seen.saw(point.at(), point.held());
+            case ControlPlace.Outcome outcome -> seen.saw(outcome.at(), outcome.held());
         };
     }
 
     @Override
     public String toString() {
         return switch (at) {
-            case ControlPointId.ArmPoint arm -> "arm " + arm.arm();
-            case ControlPointId.ComparisonPoint point ->
-                    point.at() + (point.held() ? " held" : " failed");
+            case ControlPlace.Arm arm -> "arm " + arm.arm();
+            case ControlPlace.Outcome outcome -> outcome.toString();
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlPlace.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlPlace.java
@@ -1,31 +1,41 @@
 package souther.compiler.coverage;
 
+import souther.compiler.types.ConstructOccurrence;
 import souther.compiler.types.SourceConstructOrigin;
 
 import java.util.Optional;
 
 /**
- * A place in a body that something can or cannot arrive at, with what is known about it.
+ * Which control alternative of the tree that runs this is, with what a plan has worked out for
+ * observing it and for reporting about it.
  *
- * <p>Not the probe number. A probe is made where a row can be recorded, which takes two things:
- * the place has to answer a value, and it has to stand where a row can get to. So the arms an
- * author writes and the arms a run can be observed in are different collections, and the ones with
- * no probe are exactly the ones a claim is about — an arm answering {@code unreachable} answers no
- * value, so it never had a number, and the reading that judges what the author declared there was
- * looking for it under one.
+ * <p>Which one it is is the tree's answer. An arm is {@link ArmOccurrence} and a comparison coming
+ * out one way is the comparison's own {@link ConstructOccurrence} beside the way it came out;
+ * neither is a number anything handed out. What this adds is the plan's part: where a run through
+ * the place is recorded, and which question locates a report about it. None of those addresses
+ * names the place, and a reading that took one for the place would be reading the emitter.
  *
- * <p>Which place it is is the tree's answer and not this. An arm is {@link ArmOccurrence} and a
- * comparison coming out one way is the address the emitter issued for it; what this adds is what a
- * plan worked out about the place — where a run through it is recorded, and what a report about it
- * points at. Two readers that need different halves of that read whichever they need, and neither
- * has to build the place again to ask.
+ * <p><b>Not the probe number.</b> A probe is made where a row can be recorded, which takes two
+ * things: the place has to answer a value, and it has to stand where a row can get to. So the arms
+ * an author writes and the arms a run can be observed in are different collections, and the ones
+ * with no probe are exactly the ones a claim is about — an arm answering {@code unreachable}
+ * answers no value, so it never had a number, and the reading that judges what the author declared
+ * there was looking for it under one.
  *
- * <p>Made together and here only. Derived apart, the halves would answer for different collections
- * of places: a claim is judged at the place, a branch denominator counts the arms that carry a
- * probe, and a line drawn on a comparison asks about the outcome that leads into an arm rather than
- * about the arm.
+ * <p>The two halves are made together and here only. Derived apart, they would answer for different
+ * collections of places: a claim is judged at the place, a branch denominator counts the arms that
+ * carry a probe, and a line drawn on a comparison asks about the outcome that leads into an arm
+ * rather than about the arm.
+ *
+ * <p><b>One of these is of one plan, and nothing in it says which.</b> An arm a run cannot be
+ * recorded in carries no numbering at all, so a place cannot be asked what plan it is of. What
+ * holds two readings apart is the pairing rather than the place: a reader that has both a plan and
+ * a reading of it says so once, at the seam where they meet
+ * ({@link souther.compiler.check.PathReachability.Answers#requireNumbering}). Asked of each place
+ * instead, the question would be one an unprobed arm has no answer to, and giving it one would put
+ * the plan's own address back inside the identity.
  */
-public sealed interface ControlPointId {
+public sealed interface ControlPlace {
 
     /**
      * One arm, as it stands in the tree that runs.
@@ -42,10 +52,10 @@ public sealed interface ControlPointId {
      *               the two a reader is shown turns on what the position the walk had in hand was
      *               in — and that is the last moment anything here has one
      */
-    record ArmPoint(ArmOccurrence arm, Optional<ArmProbe> probe, ArmReportAnchor anchor)
-            implements ControlPointId {
+    record Arm(ArmOccurrence arm, Optional<ArmProbe> probe, ArmReportAnchor anchor)
+            implements ControlPlace {
 
-        public ArmPoint {
+        public Arm {
             if (arm == null) {
                 throw new IllegalArgumentException("a place an arm is is some arm");
             }
@@ -104,25 +114,44 @@ public sealed interface ControlPointId {
      * reached both by a value that made {@code B} false and by one that never reached {@code B} —
      * the arm cannot say which comparison came out which way, and a line is drawn on the comparison.
      *
-     * <p>What a plan may claim, written in the plan's own vocabulary: the address this numbering
-     * issued for the comparison, and the way it came out. A running class records the number
-     * instead, having no numbering to ask what it addresses, and putting the two together is the
-     * boundary between a recording and a numbering rather than anything this holds.
+     * <p><b>Which comparison, and separately where a run through it is written down.</b> The
+     * comparison is a construct of the tree that runs and stands there whether anything instruments
+     * it or not; the site is an address the emitter issued, and its own account of itself is that it
+     * is an address and not an identity. Held by the site alone, this said which comparison it was
+     * about only for as long as every comparison anyone asked after was one the emitter had
+     * numbered — which is the reading the arm side stopped making when an arm came to name its fork
+     * rather than its probe.
      *
-     * <p>One place and one way, so there is nothing here for a caller to pair wrongly. Two halves
-     * carrying a place each — an address beside a recorded number — would be a control point saying
-     * where it is twice.
+     * <p>One place and one way, so there is nothing here for a caller to pair wrongly. What pairs
+     * the comparison with the site is {@link CoverageSites.Plan#outcomeOf}, which is the only maker
+     * of one of these and takes the site from the plan that holds the comparison.
      *
-     * @param at   where this numbering records a run through the comparison
-     * @param held the way it came out
+     * <p><b>Only where a run through the comparison could be recorded.</b> The plan numbers a
+     * comparison standing where a row can get to and where what it stands in answers a value, so a
+     * comparison with no site is one in a position no run reaches. There is no place here for it and
+     * no claim to make about it, which is the same rule an arm with no probe is refused a claim by.
+     *
+     * @param comparison which comparison of the tree that runs
+     * @param at         where this plan records a run through it
+     * @param held       the way it came out
      */
-    record ComparisonPoint(ComparisonEmissionSite at, boolean held) implements ControlPointId {
+    record Outcome(ConstructOccurrence comparison, ComparisonEmissionSite at, boolean held)
+            implements ControlPlace {
 
-        public ComparisonPoint {
+        public Outcome {
+            if (comparison == null) {
+                throw new IllegalArgumentException(
+                        "a comparison coming out one way is some comparison");
+            }
             if (at == null) {
                 throw new IllegalArgumentException(
                         "a place a comparison comes out one way is a place");
             }
+        }
+
+        @Override
+        public String toString() {
+            return comparison + (held ? " holds" : " fails");
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -204,7 +204,7 @@ public final class CoverageSites {
      * one is wanted.
      */
     public record ArmSite(String behavior, SourceOutcome.Arm outcome,
-                          ControlPointId.ArmPoint place, int ordinal,
+                          ControlPlace.Arm place, int ordinal,
                           Obligation obligation) implements Site {
 
         public ArmSite {
@@ -308,7 +308,7 @@ public final class CoverageSites {
         private final List<GuardRef> guards;
         private final IdentityHashMap<Core, int[]> byNode;
         private final Map<ConstructOccurrence, ComparisonEmissionSite> byComparison;
-        private final IdentityHashMap<Core, ControlPointId.ArmPoint[]> armsByNode;
+        private final IdentityHashMap<Core, ControlPlace.Arm[]> armsByNode;
         private final java.util.Set<Core> mayRepeat;
         private final Map<Integer, Citation> reachedAt;
         private final ComparisonCatalog comparisons;
@@ -330,7 +330,7 @@ public final class CoverageSites {
          */
         Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
              Map<ConstructOccurrence, ComparisonEmissionSite> byComparison,
-             IdentityHashMap<Core, ControlPointId.ArmPoint[]> armsByNode,
+             IdentityHashMap<Core, ControlPlace.Arm[]> armsByNode,
              java.util.Set<Core> mayRepeat,
              Map<Integer, Citation> reachedAt,
              ComparisonCatalog comparisons,
@@ -420,7 +420,7 @@ public final class CoverageSites {
             return byComparison;
         }
 
-        IdentityHashMap<Core, ControlPointId.ArmPoint[]> armsByNode() {
+        IdentityHashMap<Core, ControlPlace.Arm[]> armsByNode() {
             return armsByNode;
         }
 
@@ -472,16 +472,22 @@ public final class CoverageSites {
          * owed wants the probed ones and can ask each; a reader judging what an arm declares wants
          * the arm, which is the one this has and the other does not.
          */
-        public ControlPointId.ArmPoint[] armsOf(Core node) {
+        public ControlPlace.Arm[] armsOf(Core node) {
             return armsByNode.get(node);
         }
 
-        /** Which way {@code comparison} coming out {@code result} is, or empty where this plan
-         *  numbered no comparison there. */
-        public java.util.Optional<ControlPointId.ComparisonPoint> outcomeOf(
+        /**
+         * Which way {@code which} coming out {@code result} is, or empty where this plan numbered
+         * no comparison there.
+         *
+         * <p>The only maker of one of these, and what pairs the comparison with the address a run
+         * through it is recorded at. The two are separate questions and one plan answers both, so a
+         * caller never holds an outcome whose site was issued for some other comparison.
+         */
+        public java.util.Optional<ControlPlace.Outcome> outcomeOf(
                 ConstructOccurrence which, boolean result) {
             return emissionSiteOf(which)
-                    .map(site -> new ControlPointId.ComparisonPoint(site, result));
+                    .map(site -> new ControlPlace.Outcome(which, site, result));
         }
 
         /**
@@ -636,7 +642,7 @@ public final class CoverageSites {
         // One occurrence per arm the walk made, whoever asks for it. A site of an arm and the arms
         // of its fork are the same place, and they are the same value: made twice, the two would be
         // two answers about one arm, and every reader below would be free to have either.
-        IdentityHashMap<DraftArm, ControlPointId.ArmPoint> issued = new IdentityHashMap<>();
+        IdentityHashMap<DraftArm, ControlPlace.Arm> issued = new IdentityHashMap<>();
         List<Site> sites = new ArrayList<>();
         for (DraftSite draft : walk.sites) {
             sites.add(switch (draft) {
@@ -658,9 +664,9 @@ public final class CoverageSites {
         Map<ConstructOccurrence, ComparisonEmissionSite> byComparison = new LinkedHashMap<>();
         walk.byComparison.forEach((which, raw) ->
                 byComparison.put(which, numbering.comparison(raw)));
-        IdentityHashMap<Core, ControlPointId.ArmPoint[]> armsByNode = new IdentityHashMap<>();
+        IdentityHashMap<Core, ControlPlace.Arm[]> armsByNode = new IdentityHashMap<>();
         walk.armsByNode.forEach((node, arms) -> {
-            ControlPointId.ArmPoint[] here = new ControlPointId.ArmPoint[arms.length];
+            ControlPlace.Arm[] here = new ControlPlace.Arm[arms.length];
             for (int i = 0; i < arms.length; i++) {
                 here[i] = placeOf(arms[i], numbering, issued);
             }
@@ -683,10 +689,10 @@ public final class CoverageSites {
      * places, and what is wanted here is the occurrence this draft became rather than the one some
      * draft equal to it did.
      */
-    private static ControlPointId.ArmPoint placeOf(
+    private static ControlPlace.Arm placeOf(
             DraftArm draft, SiteNumbering numbering,
-            IdentityHashMap<DraftArm, ControlPointId.ArmPoint> issued) {
-        return issued.computeIfAbsent(draft, each -> new ControlPointId.ArmPoint(
+            IdentityHashMap<DraftArm, ControlPlace.Arm> issued) {
+        return issued.computeIfAbsent(draft, each -> new ControlPlace.Arm(
                 each.arm(), armAt(numbering, each.raw()), each.anchor()));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -41,7 +41,7 @@ package souther.compiler.partition;
  * lit is read where the reading is, before anything is folded.
  *
  * <p>Four identities and not one, the way {@link souther.compiler.coverage.CoverageSites.Obligation}
- * and {@link souther.compiler.coverage.ControlPointId} are on the arm side.
+ * and {@link souther.compiler.coverage.ControlPlace} are on the arm side.
  * {@link LineOrigin#rule()} answers which rule of the model this came from and is provenance; this
  * answers which debt it is; {@link BoundaryLine} answers which readings are one line; {@link Border}
  * answers where one of them was read. A narrowing moves the debt without moving the rule:

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3,7 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleKey;
@@ -1497,7 +1497,7 @@ public final class Generator {
             List<ControlClaim> claims) {
         List<ArmProbe> out = new ArrayList<>();
         for (ControlClaim claim : claims) {
-            if (claim.at() instanceof ControlPointId.ArmPoint arm
+            if (claim.at() instanceof ControlPlace.Arm arm
                     && arm.probe().isPresent()) {
                 out.add(arm.probe().get());
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -176,6 +176,11 @@ public final class GuardThresholds {
         if (states == null) {
             return Guards.NONE;
         }
+        // The reading below is asked what arrives at comparisons this plan names, so the two are
+        // held to being one plan's. Both are handed in, which is where a reader can put two
+        // modules' together — and a reading of another plan answers that nothing is known about
+        // every comparison here, which restricts nothing and is what an unread body looks like.
+        arrives.requireNumbering(plan.identity());
         InputDomain inputs = read.domain();
         List<RuleEvidence> found = new ArrayList<>();
         RulesWithNoLine.Gathered withoutALine = new RulesWithNoLine.Gathered();

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -2,7 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.core.Core;
 import souther.compiler.check.PathReachability;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeSymbol;
@@ -51,6 +51,11 @@ public final class ProducedCases {
      */
     public static Set<TypeSymbol> of(Core body, CoverageSites.Plan plan, PathReachability.Answers arrives,
                                    Set<TypeSymbol> declared) {
+        // The arms this walks are the plan's and the reading is asked about them by place, so the
+        // two are held to being one another's before either is read. Asked before the shortcut
+        // below, because a reading of another module's plan proves nothing unreached and would take
+        // that way out rather than be found.
+        arrives.requireNumbering(plan.identity());
         // Nothing proven is nothing to take away: what this returns is `declared` less the cases whose
         // every producer is behind a proven arm, and with no such arm there are none. Skipped rather
         // than walked to the same answer.
@@ -90,7 +95,7 @@ public final class ProducedCases {
      * value a {@code let} binds — is not what the behavior answers with, and counting it would keep a
      * case owed because the body happened to build one on its way past.
      */
-    private static void walk(Core e, List<ControlPointId.ArmPoint> under,
+    private static void walk(Core e, List<ControlPlace.Arm> under,
                              CoverageSites.Plan plan,
                              PathReachability.Answers arrives, Set<TypeSymbol> declared, Seen seen) {
         if (seen.anythingUnreadable) {
@@ -100,19 +105,19 @@ public final class ProducedCases {
             case Core.Unreachable _ -> { }   // answers nothing, so it produces nothing
             case Core.LetIn li -> walk(li.body(), under, plan, arrives, declared, seen);
             case Core.If iff -> {
-                ControlPointId.ArmPoint[] arms = plan.armsOf(iff);
+                ControlPlace.Arm[] arms = plan.armsOf(iff);
                 walk(iff.then(), beneath(under, arms, 0), plan, arrives, declared, seen);
                 walk(iff.els(), beneath(under, arms, 1), plan, arrives, declared, seen);
             }
             case Core.Match m -> {
-                ControlPointId.ArmPoint[] arms = plan.armsOf(m);
+                ControlPlace.Arm[] arms = plan.armsOf(m);
                 for (int i = 0; i < m.cases().size(); i++) {
                     walk(m.cases().get(i).body(), beneath(under, arms, i), plan, arrives, declared,
                             seen);
                 }
             }
             case Core.IfConstructed ic -> {
-                ControlPointId.ArmPoint[] arms = plan.armsOf(ic);
+                ControlPlace.Arm[] arms = plan.armsOf(ic);
                 walk(ic.then(), beneath(under, arms, 0), plan, arrives, declared, seen);
                 for (int i = 0; i < ic.els().size(); i++) {
                     walk(ic.els().get(i).body(), beneath(under, arms, i + 1), plan, arrives,
@@ -128,7 +133,7 @@ public final class ProducedCases {
     }
 
     /** Where one producer puts the case it answers with. */
-    private static void produce(TypeSymbol built, List<ControlPointId.ArmPoint> under,
+    private static void produce(TypeSymbol built, List<ControlPlace.Arm> under,
                                 PathReachability.Answers arrives,
                                 Set<TypeSymbol> declared, Seen seen) {
         boolean proven = under.stream().anyMatch(arm ->
@@ -153,14 +158,14 @@ public final class ProducedCases {
      * is instrumented for, and what this asks is whether anything arrives — a place with no probe
      * is a place all the same, and the reading answers about it like any other.
      */
-    private static List<ControlPointId.ArmPoint> beneath(
-            List<ControlPointId.ArmPoint> under,
-            ControlPointId.ArmPoint[] arms, int index) {
+    private static List<ControlPlace.Arm> beneath(
+            List<ControlPlace.Arm> under,
+            ControlPlace.Arm[] arms, int index) {
         if (arms == null || index >= arms.length || arms[index] == null
                 || !takesAProducerAway(arms[index])) {
             return under;
         }
-        List<ControlPointId.ArmPoint> out = new ArrayList<>(under);
+        List<ControlPlace.Arm> out = new ArrayList<>(under);
         out.add(arms[index]);
         return List.copyOf(out);
     }
@@ -179,7 +184,7 @@ public final class ProducedCases {
      * for, this would hold a place to more than what makes one: an occurrence names an origin where
      * it has one, and a reader wanting a construct is a reader that can be told there is none.
      */
-    private static boolean takesAProducerAway(ControlPointId.ArmPoint arm) {
+    private static boolean takesAProducerAway(ControlPlace.Arm arm) {
         SourceConstructOrigin origin = arm.origin();
         if (origin == null) {
             return false;   // nothing here says what wrote it, which is not a construct either

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -8,6 +8,7 @@ import souther.compiler.inputs.TermPath;
 
 
 import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.reach.Reachability;
@@ -1006,7 +1007,7 @@ public final class Adequacy {
                         // one: it is the author saying what this reading proves, and telling them
                         // to take it out is telling them off for being right. The denominator
                         // counts the probed arms, and this reports the probed arms.
-                        if (where instanceof souther.compiler.coverage.ControlPointId.ArmPoint
+                        if (where instanceof ControlPlace.Arm
                                 arm && arm.isMeasured() && arm.writtenBy(name)
                                 && said instanceof souther.compiler.reach.Reachability.Unreachable
                                         unreachable) {
@@ -1034,7 +1035,7 @@ public final class Adequacy {
          * answers and never this.
          */
         private static Report warning(
-                Db db, souther.compiler.coverage.ControlPointId.ArmPoint arm,
+                Db db, ControlPlace.Arm arm,
                 souther.compiler.reach.Proof proof) {
             return Report.of(new DeadBranchProofWords(
                     Warnings.pointedAt(Sites.placeOf(db, arm.anchor()))
@@ -1109,12 +1110,12 @@ public final class Adequacy {
         }
 
         /** One dead branch and how it was shown, before either is turned into words. */
-        private record Dead(souther.compiler.coverage.ControlPointId.ArmPoint arm,
+        private record Dead(ControlPlace.Arm arm,
                             souther.compiler.reach.Proof proof) {}
 
         /** Where a report about an arm points, read the way {@link Warnings#pointedAt} reads it. */
         private static souther.compiler.diag.SourcePos at(
-                Db db, souther.compiler.coverage.ControlPointId.ArmPoint arm) {
+                Db db, ControlPlace.Arm arm) {
             return switch (Sites.placeOf(db, arm.anchor())) {
                 case Citation.Written written -> written.at();
                 case Citation.Unplaced unplaced -> unplaced.at();
@@ -2537,6 +2538,17 @@ public final class Adequacy {
                 souther.compiler.check.PathReachability.Answers.AsRun arrives =
                         reachable == null ? NOTHING_PROVEN
                                 : reachable.getOrDefault(behavior.name(), NOTHING_PROVEN);
+                // The arms are this plan's and the reading is asked about them by place, so the two
+                // are held to being one another's here, where they are put together. A reading of
+                // another module's plan answers "nothing reached it" about every one of these arms,
+                // which is the same shape as a behavior that owes nothing.
+                //
+                // Only where the bodies came back. What stands here otherwise is the plan of
+                // nothing, which is no module's, and what this behavior is owed is answered by the
+                // gate below saying the bodies were not read.
+                if (bodiesRead) {
+                    arrives.answers().requireNumbering(plan.identity());
+                }
                 BranchEvidence absent = whyNoArms(name, prepared.value().writesItsOwnBody(behavior),
                         bodiesRead, arms, arrives, instrumented, observed);
                 if (absent != null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2538,17 +2538,6 @@ public final class Adequacy {
                 souther.compiler.check.PathReachability.Answers.AsRun arrives =
                         reachable == null ? NOTHING_PROVEN
                                 : reachable.getOrDefault(behavior.name(), NOTHING_PROVEN);
-                // The arms are this plan's and the reading is asked about them by place, so the two
-                // are held to being one another's here, where they are put together. A reading of
-                // another module's plan answers "nothing reached it" about every one of these arms,
-                // which is the same shape as a behavior that owes nothing.
-                //
-                // Only where the bodies came back. What stands here otherwise is the plan of
-                // nothing, which is no module's, and what this behavior is owed is answered by the
-                // gate below saying the bodies were not read.
-                if (bodiesRead) {
-                    arrives.answers().requireNumbering(plan.identity());
-                }
                 BranchEvidence absent = whyNoArms(name, prepared.value().writesItsOwnBody(behavior),
                         bodiesRead, arms, arrives, instrumented, observed);
                 if (absent != null) {

--- a/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
@@ -3,7 +3,7 @@ package souther.compiler.reading;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 
 import java.util.LinkedHashMap;
@@ -45,7 +45,7 @@ final class Arms {
      * row to.
      */
     void at(Core fork, int part, Reach reach) {
-        ControlPointId.ArmPoint[] arms = plan.armsOf(fork);
+        ControlPlace.Arm[] arms = plan.armsOf(fork);
         if (arms == null || part < 0 || part >= arms.length || arms[part] == null) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
@@ -3,7 +3,7 @@ package souther.compiler.reading;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.flow.Naming;
 import souther.compiler.inputs.ComparedNumber;
@@ -121,7 +121,7 @@ final class CoverageNaming implements Naming<Outcome> {
      *  null where no run through the arm could be recorded. */
     @Override
     public Outcome matchCase(Core.Match match, int part) {
-        ControlPointId.ArmPoint place = armPoint(match, part);
+        ControlPlace.Arm place = armPoint(match, part);
         ControlClaim claim = claimAt(place);
         if (claim == null) {
             return null;
@@ -155,7 +155,7 @@ final class CoverageNaming implements Naming<Outcome> {
      */
     @Override
     public Outcome forkArm(Core fork, int part) {
-        ControlPointId.ArmPoint place = armPoint(fork, part);
+        ControlPlace.Arm place = armPoint(fork, part);
         ControlClaim claim = claimAt(place);
         if (claim == null) {
             return null;
@@ -185,13 +185,13 @@ final class CoverageNaming implements Naming<Outcome> {
      * position names it off the place it has already asked for. Asked again of the fork, the answer
      * would be this plan's arms read a second time to say what the first read already said.
      */
-    private ControlPointId.ArmPoint armPoint(Core fork, int part) {
-        ControlPointId.ArmPoint[] arms = plan.armsOf(fork);
+    private ControlPlace.Arm armPoint(Core fork, int part) {
+        ControlPlace.Arm[] arms = plan.armsOf(fork);
         return arms == null || part >= arms.length ? null : arms[part];
     }
 
     /** What a run through {@code place} would be seen doing, and null where nothing records one. */
-    private static ControlClaim claimAt(ControlPointId.ArmPoint place) {
+    private static ControlClaim claimAt(ControlPlace.Arm place) {
         return place == null ? null : ControlClaim.of(place).orElse(null);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
@@ -110,10 +110,18 @@ final class CoverageNaming implements Naming<Outcome> {
             return null;
         }
         NumericTerm at = drawn.term();
-        return plan.outcomeOf(site, held)
-                .flatMap(ControlClaim::of)
+        ControlPlace.Outcome outcome = plan.outcomeOf(site, held).orElse(null);
+        if (outcome == null) {
+            return null;
+        }
+        // The condition and the claim are about one comparison, so they are read off one value. The
+        // place the claim is made at says which comparison it is a way out of; asked of the node
+        // instead, the two halves of this decision would be two answers, and a decision whose
+        // condition named one comparison and whose claim was recorded at another is one nothing
+        // here reads both halves of to notice.
+        return ControlClaim.of(outcome)
                 .map(claim -> one(new Decision(
-                        new Condition.Side(at, comparison.occurrence(), held), claim)))
+                        new Condition.Side(at, outcome.comparison(), held), claim)))
                 .orElse(null);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonIsReadWhereverItStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonIsReadWhereverItStandsTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -72,9 +72,9 @@ class AComparisonIsReadWhereverItStandsTest {
                 .ask(new Adequacy.PathReached("d")).value();
         assertNotNull(answers, "the model under test compiles");
         return answers.get("charge").found().entrySet().stream()
-                .filter(each -> each.getKey() instanceof ControlPointId.ComparisonPoint)
+                .filter(each -> each.getKey() instanceof ControlPlace.Outcome)
                 .filter(each -> each.getValue() instanceof Reachability.Unreachable)
-                .map(each -> ((ControlPointId.ComparisonPoint) each.getKey()).held())
+                .map(each -> ((ControlPlace.Outcome) each.getKey()).held())
                 .toList();
     }
 
@@ -105,7 +105,7 @@ class AComparisonIsReadWhereverItStandsTest {
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");
         CoverageSites.Plan plan = checked.plan();
-        Map<ControlPointId, Reachability> found = compilation.db()
+        Map<ControlPlace, Reachability> found = compilation.db()
                 .ask(new Adequacy.PathReached(module)).value().get(behavior).found();
         List<String> out = new ArrayList<>();
         unanswered(checked.behaviorBodies().get(behavior), plan, found, out);
@@ -114,7 +114,7 @@ class AComparisonIsReadWhereverItStandsTest {
 
     /** The traversal is this test's and which nodes are comparisons is the plan's. */
     private static void unanswered(Core e, CoverageSites.Plan plan,
-                                   Map<ControlPointId, Reachability> found, List<String> out) {
+                                   Map<ControlPlace, Reachability> found, List<String> out) {
         if (e instanceof Core.Binary node) {
             plan.comparisons().occurrenceAt(node).ifPresent(which -> {
                 for (boolean result : new boolean[] {true, false}) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AGuardTheGuardsAboveItRuleOutIsProvenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGuardTheGuardsAboveItRuleOutIsProvenTest.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
@@ -102,7 +102,7 @@ class AGuardTheGuardsAboveItRuleOutIsProvenTest {
         assertTrue(byBehavior != null && byBehavior.containsKey(behavior),
                 "the module answers nothing about `" + behavior + "`");
         return byBehavior.get(behavior).found().entrySet().stream()
-                .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint)
+                .filter(each -> each.getKey() instanceof ControlPlace.Arm)
                 .map(Map.Entry::getValue)
                 .toList();
     }
@@ -237,11 +237,11 @@ class AGuardTheGuardsAboveItRuleOutIsProvenTest {
         Compilation c = Compilation.ofSource(A_LIBRARY_FORK, "d");
         Map<String, PathReachability.Answers> byBehavior =
                 c.db().ask(new Adequacy.PathReached("d")).value();
-        List<ControlPointId.ArmPoint> proven = byBehavior.get("mk").found().entrySet().stream()
+        List<ControlPlace.Arm> proven = byBehavior.get("mk").found().entrySet().stream()
                 .filter(each -> each.getValue() instanceof Reachability.Unreachable)
                 .map(each -> each.getKey())
-                .filter(ControlPointId.ArmPoint.class::isInstance)
-                .map(ControlPointId.ArmPoint.class::cast)
+                .filter(ControlPlace.Arm.class::isInstance)
+                .map(ControlPlace.Arm.class::cast)
                 .toList();
         assertTrue(!proven.isEmpty(),
                 "the argument makes one side of the library's fork unreachable, and that is proven");

--- a/souther-compiler/src/test/java/souther/compiler/check/AGuardsArmsAreNotItsThresholdTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGuardsArmsAreNotItsThresholdTest.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.reach.Reachability;
@@ -55,9 +55,9 @@ class AGuardsArmsAreNotItsThresholdTest {
         // of a guard is one a run can be recorded in, so the probe numbers put all four in that
         // order and there is nothing here for the reading's own answer to decide.
         List<Reachability> arms = byBehavior.get("pick").found().entrySet().stream()
-                .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint)
+                .filter(each -> each.getKey() instanceof ControlPlace.Arm)
                 .sorted(java.util.Comparator.comparingInt(each ->
-                        ((ControlPointId.ArmPoint) each.getKey()).probe().orElseThrow().raw()))
+                        ((ControlPlace.Arm) each.getKey()).probe().orElseThrow().raw()))
                 .map(Map.Entry::getValue)
                 .toList();
         assertEquals(4, arms.size(), "two guards, two arms each");

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlPlace;
+import souther.compiler.claims.Claims;
+import souther.compiler.claims.UnreachableClaims;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.partition.GuardThresholds;
 import souther.compiler.partition.ProducedCases;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -18,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,6 +83,57 @@ class AReadingAnswersAboutThePlacesOfOnePlanTest {
                 | On      -> Yes
                 | Pending -> Yes
                 | Off     -> No
+
+            example pick
+                | "on" : (Active(On)) -> Yes
+            """;
+
+    /**
+     * A guard under a guard that rules it out: both lines are ones the declarations allow, and
+     * nothing arrives at the inner one. What drops it is the reading of what arrives and nothing
+     * else, which is the lookup under test.
+     */
+    private static final String SHADOWED = """
+            module example.shadowed
+
+            data Count = Int
+                invariant lower = value >= 0
+                invariant cap = value <= 100
+            data Small
+            data Large
+            data Under
+
+            behavior pick : (c: Count) -> Small | Large | Under
+
+            let pick (c) =
+                if c.value >= 50
+                    then if c.value <= 10
+                        then Small
+                        else Large
+                    else Under
+
+            example pick
+                | "big" : (Count(60)) -> Large
+                | "under" : (Count(1)) -> Under
+            """;
+
+    /** A body that declares a case cannot arrive, which is what a claim is made of. */
+    private static final String DECLARED = """
+            module example.declared
+
+            data On
+            data Off
+            data Pending
+            data Flag = On | Off | Pending
+            data Active = Flag invariant value /= Off
+            data Yes
+
+            behavior pick : (f: Active) -> Yes
+
+            let pick (f) = match f.value with
+                | On      -> Yes
+                | Pending -> Yes
+                | Off     -> unreachable "an Active never carries Off"
 
             example pick
                 | "on" : (Active(On)) -> Yes
@@ -155,6 +211,57 @@ class AReadingAnswersAboutThePlacesOfOnePlanTest {
                 () -> "the refusal names the two numberings: " + refusal.getMessage());
     }
 
+    /**
+     * The rules read off a behavior's guards refuse the pair rather than reading it.
+     *
+     * <p>The other lookup a reading holds, and the one an absence is widest at. What a comparison
+     * this reading has nothing filed under comes back as is that nothing is known about it, which
+     * restricts nothing — so a reading of another module would leave every line of this body drawn
+     * exactly as the declarations leave it, and say nothing about having been the wrong reading.
+     *
+     * <p>What that costs here, measured with the pair let through: the inner line comes back
+     * alongside the outer one, and a row is asked for at a boundary nothing can arrive at.
+     */
+    @Test
+    void theRulesReadOffTheGuardsRefuseAReadingOfAnotherPlan() {
+        Read shadowed = read(SHADOWED);
+        Read refused = read(REFUSED);
+
+        assertEquals(1, shadowed.guardsWith(shadowed.arrives).thresholds().size(),
+                "read against its own plan, the inner line is dropped: nothing arrives at it");
+
+        IllegalArgumentException refusal = assertThrows(IllegalArgumentException.class,
+                () -> shadowed.guardsWith(refused.arrives));
+
+        assertTrue(refusal.getMessage().contains("was made under"),
+                () -> "the refusal names the two numberings: " + refusal.getMessage());
+    }
+
+    /**
+     * Judging what a body declares cannot arrive refuses the pair rather than reading it.
+     *
+     * <p>The seam the whole question was found at. A claim is judged by looking its arm up in a
+     * reading, and a reading of another plan has nothing filed under any of them — so every claim
+     * an author wrote comes back unproven, which is what a claim about a place this compiler did
+     * not walk to comes back as.
+     */
+    @Test
+    void judgingWhatABodyDeclaresCannotArriveRefusesAReadingOfAnotherPlan() {
+        Read declared = read(DECLARED);
+        Read refused = read(REFUSED);
+
+        UnreachableClaims claims = declared.claims();
+        assertFalse(claims.isEmpty(), "the body declares that a case cannot arrive");
+        assertEquals(claims.all().size(), Claims.of(claims, declared.arrives).all().size(),
+                "read against its own plan, every claim it makes is judged");
+
+        IllegalArgumentException refusal = assertThrows(IllegalArgumentException.class,
+                () -> Claims.of(claims, refused.arrives));
+
+        assertTrue(refusal.getMessage().contains("was made under"),
+                () -> "the refusal names the two numberings: " + refusal.getMessage());
+    }
+
     /** A reading that was never made goes with any plan, because it says nothing about one. */
     @Test
     void noReadingAtAllIsReadAgainstWhicheverPlanTheReaderHolds() {
@@ -166,8 +273,28 @@ class AReadingAnswersAboutThePlacesOfOnePlanTest {
                 "nothing was proven, so nothing is taken away — and the pair is not refused");
     }
 
-    /** One module compiled, with the three things a reader of it puts together. */
-    private record Read(Core body, CoverageSites.Plan plan, PathReachability.Answers arrives) {
+    /** One module compiled, with what the readers under test put together. */
+    private record Read(Compilation compilation, String module, Bodies.Elaborated checked,
+                        Core body, CoverageSites.Plan plan, PathReachability.Answers arrives) {
+
+        /** What this behavior's guards state, read against {@code against}. */
+        GuardThresholds.Guards guardsWith(PathReachability.Answers against) {
+            RuleReadingSource rules = RuleReadings.of(compilation, module);
+            InputDomain inputs = compilation.db()
+                    .ask(new Adequacy.Inputs(module)).value().get("pick");
+            AnalysisBody analysis = checked.analysisBodies().get("pick");
+            return GuardThresholds.of("pick", analysis, body, plan, inputs.reading(rules),
+                    ElementBindings.of(analysis.core(), analysis.elements(), rules.symbols()),
+                    against);
+        }
+
+        /** What this behavior's body declares cannot arrive. */
+        UnreachableClaims claims() {
+            RuleReadingSource rules = RuleReadings.of(compilation, module);
+            InputDomain inputs = compilation.db()
+                    .ask(new Adequacy.Inputs(module)).value().get("pick");
+            return UnreachableClaims.of(body, inputs, rules.symbols(), plan);
+        }
 
         /** The arm this module's own reading proves nothing arrives at. */
         ControlPlace.Arm armProvenDead() {
@@ -196,7 +323,8 @@ class AReadingAnswersAboutThePlacesOfOnePlanTest {
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         Map<String, PathReachability.Answers> answers =
                 compilation.db().ask(new Adequacy.PathReached(module)).value();
-        return new Read(checked.behaviorBodies().get("pick"), checked.plan(), answers.get("pick"));
+        return new Read(compilation, module, checked, checked.behaviorBodies().get("pick"),
+                checked.plan(), answers.get("pick"));
     }
 
     private static void gather(Core e, Set<TypeSymbol> out) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.core.Core;
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.partition.ProducedCases;
@@ -125,6 +126,32 @@ class AReadingAnswersAboutThePlacesOfOnePlanTest {
 
         assertTrue(refusal.getMessage().contains("was made under")
                         && refusal.getMessage().contains("is being read against"),
+                () -> "the refusal names the two numberings: " + refusal.getMessage());
+    }
+
+    /**
+     * Taking the rows in refuses probes of another numbering rather than correcting nothing.
+     *
+     * <p>The same invariant met from the other side. What a run corrects is read by looking each
+     * arm's probe up among the probes a row was recorded at, so probes of another numbering answer
+     * to no arm here — every proof stands, and a reading shown wrong by a run goes on saying
+     * nothing arrives.
+     */
+    @Test
+    void takingTheRowsInRefusesProbesOfAnotherNumbering() {
+        Read capped = read(CAPPED);
+        Read refused = read(REFUSED);
+
+        ArmProbe elsewhere = refused.armProvenDead().probe().orElseThrow();
+
+        assertEquals(Set.of(),
+                capped.arrives.asRunWith(Set.of()).provedWrong(),
+                "no row ran, so this reading is shown wrong nowhere");
+
+        IllegalArgumentException refusal = assertThrows(IllegalArgumentException.class,
+                () -> capped.arrives.asRunWith(Set.of(elsewhere)));
+
+        assertTrue(refusal.getMessage().contains("was made under"),
                 () -> "the refusal names the two numberings: " + refusal.getMessage());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReadingAnswersAboutThePlacesOfOnePlanTest.java
@@ -1,0 +1,191 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ControlPlace;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.partition.ProducedCases;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.reach.Reachability;
+import souther.compiler.reach.WhyUnsettled;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A reading and the plan whose places it is asked about are one plan's, and are held to it.
+ *
+ * <p>A place this reading has nothing filed under is one the walk did not get to, and every reader
+ * takes that as unsettled and goes on. That is the right answer for a body this walk stopped short
+ * in, and it is the same answer for every place of another module — where nothing was asked and
+ * nothing is being said. Under one answer, a reader handed the wrong reading is told that nothing
+ * arrives anywhere, which is the shape of a behavior with nothing to measure.
+ *
+ * <p><b>Asked of the pairing and not of the place.</b> A place cannot say which plan it is of: an
+ * arm no run can be recorded in carries no numbering at all, and giving it one would put the plan's
+ * own address inside the identity the plan is supposed to be reading. So the two halves are held to
+ * each other where a reader puts them together, and once.
+ */
+class AReadingAnswersAboutThePlacesOfOnePlanTest {
+
+    /** Nothing at or above the cap reaches the arm that answers {@code No}. */
+    private static final String CAPPED = """
+            module example.capped
+
+            data Count = Int
+                invariant lower = value >= 0
+                invariant cap = value <= 10
+            data Yes
+            data No
+
+            behavior pick : (c: Count) -> Yes | No
+
+            let pick (c) =
+                if c.value >= 50
+                    then No
+                    else Yes
+
+            example pick
+                | "small" : (Count(1)) -> Yes
+            """;
+
+    /** Another module, whose reading also proves an arm dead — so it is not an empty reading that
+     *  would be turned away for saying nothing. */
+    private static final String REFUSED = """
+            module example.refused
+
+            data On
+            data Off
+            data Pending
+            data Flag = On | Off | Pending
+            data Active = Flag invariant value /= Off
+            data Yes
+            data No
+
+            behavior pick : (f: Active) -> Yes | No
+
+            let pick (f) = match f.value with
+                | On      -> Yes
+                | Pending -> Yes
+                | Off     -> No
+
+            example pick
+                | "on" : (Active(On)) -> Yes
+            """;
+
+    /**
+     * What the reading of one module says about a place of another, which is nothing, said the way
+     * "the walk did not get there" is said.
+     *
+     * <p>The reason the pairing is checked at all. Both readings here prove an arm dead, so neither
+     * is turned away by a reader that skips a reading with nothing to say.
+     */
+    @Test
+    void aReadingHasNothingFiledUnderAnotherPlansPlaceAndSaysSoLikeAWalkThatStoppedShort() {
+        Read capped = read(CAPPED);
+        Read refused = read(REFUSED);
+
+        Reachability said = refused.arrives.at(capped.armProvenDead());
+
+        WhyUnsettled why = assertInstanceOf(Reachability.Unsettled.class, said).why();
+        assertEquals(WhyUnsettled.theWalkDidNotReachIt(), why,
+                "the arm one module proved dead is, to the other module's reading, a place its own"
+                        + " walk never came to — and a reader cannot tell the two apart");
+    }
+
+    /**
+     * The walk over what a body can answer with refuses the pair rather than reading it.
+     *
+     * <p>What it would answer instead is the whole of the harm: the arm that takes {@code No} away
+     * is proven dead in {@code capped}'s own reading, and is a place {@code refused}'s reading has
+     * nothing filed under — so the case only that arm answers with comes back owed, and a row is
+     * asked for at a branch nothing can reach.
+     */
+    @Test
+    void theWalkOverWhatABodyAnswersWithRefusesAReadingOfAnotherPlan() {
+        Read capped = read(CAPPED);
+        Read refused = read(REFUSED);
+
+        assertEquals(Set.of("example.capped.Yes"), namesOf(ProducedCases.of(
+                        capped.body, capped.plan, capped.arrives, capped.answersWith())),
+                "read against its own plan, the case only the dead arm answers with is taken away");
+
+        IllegalArgumentException refusal = assertThrows(IllegalArgumentException.class,
+                () -> ProducedCases.of(capped.body, capped.plan, refused.arrives,
+                        capped.answersWith()));
+
+        assertTrue(refusal.getMessage().contains("was made under")
+                        && refusal.getMessage().contains("is being read against"),
+                () -> "the refusal names the two numberings: " + refusal.getMessage());
+    }
+
+    /** A reading that was never made goes with any plan, because it says nothing about one. */
+    @Test
+    void noReadingAtAllIsReadAgainstWhicheverPlanTheReaderHolds() {
+        Read capped = read(CAPPED);
+
+        assertEquals(capped.answersWith(),
+                ProducedCases.of(capped.body, capped.plan, PathReachability.Answers.NONE,
+                        capped.answersWith()),
+                "nothing was proven, so nothing is taken away — and the pair is not refused");
+    }
+
+    /** One module compiled, with the three things a reader of it puts together. */
+    private record Read(Core body, CoverageSites.Plan plan, PathReachability.Answers arrives) {
+
+        /** The arm this module's own reading proves nothing arrives at. */
+        ControlPlace.Arm armProvenDead() {
+            return arrives.found().entrySet().stream()
+                    .filter(each -> each.getValue() instanceof Reachability.Unreachable)
+                    .map(Map.Entry::getKey)
+                    .filter(ControlPlace.Arm.class::isInstance)
+                    .map(ControlPlace.Arm.class::cast)
+                    .findFirst().orElseThrow(() ->
+                            new AssertionError("this module proves no arm dead, so there is"
+                                    + " nothing here for a foreign reading to answer about"));
+        }
+
+        /** The cases the body names, which is what the walk takes from. */
+        Set<TypeSymbol> answersWith() {
+            Set<TypeSymbol> out = new LinkedHashSet<>();
+            gather(body, out);
+            return out;
+        }
+    }
+
+    private static Read read(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        Map<String, PathReachability.Answers> answers =
+                compilation.db().ask(new Adequacy.PathReached(module)).value();
+        return new Read(checked.behaviorBodies().get("pick"), checked.plan(), answers.get("pick"));
+    }
+
+    private static void gather(Core e, Set<TypeSymbol> out) {
+        if (e == null) {
+            return;
+        }
+        switch (e) {
+            case Core.UnitValue value -> out.add(value.data());
+            case Core.Construct built -> out.add(built.typeName());
+            default -> { }
+        }
+        Core.forEachChild(e, child -> gather(child, out));
+    }
+
+    private static Set<String> namesOf(Set<TypeSymbol> types) {
+        return types.stream().map(TypeSymbol::toString)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
@@ -3,7 +3,7 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 import souther.compiler.Compiler;
 import souther.compiler.coverage.ArmProbe;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.diag.CompileException;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
@@ -36,7 +36,7 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
                 c.db().ask(new Adequacy.PathReached(module)).value();
         return byBehavior == null || byBehavior.get(behavior) == null ? List.of()
                 : byBehavior.get(behavior).found().entrySet().stream()
-                        .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint)
+                        .filter(each -> each.getKey() instanceof ControlPlace.Arm)
                         .map(Map.Entry::getValue)
                         .toList();
     }
@@ -186,14 +186,14 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
                 c.db().ask(new Adequacy.PathReached("demo")).value().get("charge");
         ArmProbe probe = answers.found().entrySet().stream()
                 .filter(each -> each.getValue() instanceof Reachability.Unreachable)
-                .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint)
-                .map(each -> (ControlPointId.ArmPoint) each.getKey())
+                .filter(each -> each.getKey() instanceof ControlPlace.Arm)
+                .map(each -> (ControlPlace.Arm) each.getKey())
                 .findFirst().orElseThrow().probe().orElseThrow();
         PathReachability.Answers.AsRun ran = answers.asRunWith(Set.of(probe));
         assertEquals(Set.of(probe), ran.provedWrong(),
                 "a row through it is what takes the proof back");
         assertEquals(List.of(), ran.answers().found().entrySet().stream()
-                        .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint)
+                        .filter(each -> each.getKey() instanceof ControlPlace.Arm)
                         .map(Map.Entry::getValue)
                         .filter(Reachability.Unreachable.class::isInstance).toList(),
                 "so no arm is left for the diagnostic to be about");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoAsksAReadingAboutAPlaceSaysWhichPlanItIsOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoAsksAReadingAboutAPlaceSaysWhichPlanItIsOfTest.java
@@ -1,0 +1,136 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Who asks a reading what arrives somewhere, written down with what says the reading is of the plan
+ * the place came from.
+ *
+ * <p>A reading files its answers under the places of one plan. Asked about a place of another, it
+ * has nothing filed and says so the way it says a place its own walk never came to — unsettled for
+ * an arm, and nothing known for a comparison. Both are the fail-open answer every reader below acts
+ * on, so a reader handed the wrong reading is told that nothing arrives anywhere and that nothing
+ * is known about any comparison, which is what a body with nothing to measure looks like.
+ *
+ * <p><b>The pairing is what is held, and it is held by the reader.</b> A place cannot be asked which
+ * plan it is of: an arm no run can be recorded in carries no numbering, and giving it one would put
+ * the plan's own address inside the identity the reading exists to keep apart from it. So
+ * {@link PathReachability.Answers#requireNumbering} is asked once where a reader puts a plan and a
+ * reading together — not at each lookup, which would make an instrument that works in proportion to
+ * what it measures.
+ *
+ * <p><b>Which is why this list exists.</b> The invariant is the reading's and the check is the
+ * reader's, so nothing in the reading says who the readers are. Found by searching, the population
+ * is whatever the search turned up — and a reader added afterwards is a plan and a reading put
+ * together with nothing holding them to each other. This is the population, taken off the compiled
+ * classes, and a new reader arriving in it is one to look at rather than one this can decide about.
+ *
+ * <p>{@code asRunWith} is not here. What it is handed is a set of probes rather than a place, and it
+ * holds them to this reading's numbering itself — one pass over what it was given, which is a set it
+ * already walks.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it. The tests are not in {@code target/classes}, and what is read
+ * is this module's classes.
+ */
+class WhoAsksAReadingAboutAPlaceSaysWhichPlanItIsOfTest {
+
+    private static final String A_READING =
+            "souther/compiler/check/PathReachability$Answers";
+
+    /** The two ways a reading is asked about a place of a plan. Both answer an absence as an
+     *  ordinary fact, so neither can tell a caller it was handed the wrong reading. */
+    private static final Set<String> ASKS_ABOUT_A_PLACE = Set.of("at", "arrivalAt");
+
+    /** A method that asks, how many times it does, and what says the reading is the plan's. */
+    private record Licence(String who, int asks, String why) { }
+
+    private static final List<Licence> MAY_ASK = List.of(
+            new Licence("souther.compiler.claims.Claims.of -> at", 1,
+                    "the claims name arms of one plan and say which, and this holds the reading to"
+                            + " being that plan's before it looks any of them up. Both halves are"
+                            + " handed in, so a caller is what could put two modules' together"),
+            new Licence("souther.compiler.partition.ProducedCases.produce -> at", 1,
+                    "a private step of a walk whose way in takes the plan and the reading together"
+                            + " and holds them to each other there — before the shortcut for a"
+                            + " reading that proves nothing unreached, which a foreign reading"
+                            + " would otherwise leave by"),
+            new Licence("souther.compiler.partition.GuardThresholds.of -> arrivalAt", 1,
+                    "a step of the walk over one behavior's guards, whose way in takes the plan and"
+                            + " the reading together and holds them to each other there. What an"
+                            + " absence means here is that nothing is known about the comparison,"
+                            + " which restricts nothing — the widest answer there is, and the one a"
+                            + " reading of another module would give about every comparison"),
+            new Licence("souther.compiler.query.Adequacy.BranchEvidence.owed -> at", 1,
+                    "the arms and the reading both come out of the store under one module name,"
+                            + " inside the one method that asks for either. Nothing hands this pair"
+                            + " over, so there is no pair for a caller to get wrong and nothing"
+                            + " here for a check to be asked about"));
+
+    @Test
+    void everyReaderThatAsksAReadingAboutAPlaceIsWrittenDownWithWhatMakesItSafe() {
+        assertEquals(declared(), asked(),
+                "a reading asked about a place of another plan answers that nothing arrives there,"
+                        + " which is the answer it gives about a place its own walk never came to."
+                        + " So a reader arriving here is one to look at rather than one this can"
+                        + " decide about. Who asks today, and what makes each safe: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_ASK.forEach(each -> out.put(each.who(), each.asks()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_ASK.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /**
+     * The method a person wrote, for a name javac may have made up.
+     *
+     * <p>A lambda is compiled to a method named after the one it was written inside and numbered by
+     * where it fell among that class's lambdas. The number moves when a lambda is added anywhere in
+     * the class, which has nothing to do with who asks a reading about a place — and a list that
+     * went stale for that would be one people learned to re-fit rather than read.
+     */
+    private static String wroteIt(String compiled) {
+        if (!compiled.startsWith("lambda$")) {
+            return compiled;
+        }
+        return compiled.substring("lambda$".length(), compiled.lastIndexOf('$'));
+    }
+
+    /** How many times each method of the compiler asks a reading about a place. */
+    private static Map<String, Integer> asked() {
+        Map<String, Integer> calls = new TreeMap<>();
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(A_READING)
+                            && ASKS_ABOUT_A_PLACE.contains(call.name().stringValue())) {
+                        calls.merge(from + "." + wroteIt(method.methodName().stringValue())
+                                + " -> " + call.name().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        return calls;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AModuleHasOnePlanAndOneMakerOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AModuleHasOnePlanAndOneMakerOfItTest.java
@@ -132,14 +132,14 @@ class AModuleHasOnePlanAndOneMakerOfItTest {
                     + " souther.compiler.coverage.ComparisonEmissionSite",
             "method outcomeOf(souther.compiler.types.ConstructOccurrence,boolean) :"
                     + " java.util.Optional<"
-                    + "souther.compiler.coverage.ControlPointId$ComparisonPoint>",
+                    + "souther.compiler.coverage.ControlPlace$Outcome>",
             // What a number means, which is the half of a plan that outlives the graph.
             "method numbering() : souther.compiler.coverage.SiteNumbering",
             "method identity() : souther.compiler.coverage.NumberingIdentity",
             // Asked about a node the caller is already holding, which is the emitter's question.
             "method mayRepeat(souther.compiler.core.Core) : boolean",
             "method armsOf(souther.compiler.core.Core) :"
-                    + " souther.compiler.coverage.ControlPointId$ArmPoint[]",
+                    + " souther.compiler.coverage.ControlPlace$Arm[]",
             "method probesOf(souther.compiler.core.Core) : int[]",
             // Where the fork of each place this plan reached is written.
             "method whereEachArmsForkIsWritten() :"

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnArmsSiteAndItsPlaceAreOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnArmsSiteAndItsPlaceAreOneValueTest.java
@@ -73,7 +73,7 @@ class AnArmsSiteAndItsPlaceAreOneValueTest {
     @Test
     void aSiteHoldsThePlaceOfTheArmItIsASiteOf() {
         CoverageSites.Plan plan = planOf(MODEL);
-        ControlPointId.ArmPoint[] arms = plan.armsByNode().values().stream().findFirst()
+        ControlPlace.Arm[] arms = plan.armsByNode().values().stream().findFirst()
                 .orElseThrow(() -> new AssertionError("the model writes a fork"));
         assertEquals(1, plan.armsByNode().size(),
                 "one fork, so which arms a site is to be found among is not in question");
@@ -129,9 +129,9 @@ class AnArmsSiteAndItsPlaceAreOneValueTest {
     @Test
     void aRealPlaceWithNoProbeCarriesTheProofAboutIt() {
         PathReachability.Answers answers = arrivalsOf(SILENT_REFUSED_ARM);
-        List<ControlPointId.ArmPoint> silent = answers.found().keySet().stream()
-                .filter(ControlPointId.ArmPoint.class::isInstance)
-                .map(ControlPointId.ArmPoint.class::cast)
+        List<ControlPlace.Arm> silent = answers.found().keySet().stream()
+                .filter(ControlPlace.Arm.class::isInstance)
+                .map(ControlPlace.Arm.class::cast)
                 .filter(arm -> arm.probe().isEmpty()).toList();
 
         assertEquals(1, silent.size(),
@@ -152,11 +152,11 @@ class AnArmsSiteAndItsPlaceAreOneValueTest {
     @Test
     void aPlaceTheWalkDidNotReachIsUnsettledRatherThanAbsent() {
         PathReachability.Answers answers = arrivalsOf(MODEL);
-        ControlPointId.ArmPoint any = answers.found().keySet().stream()
-                .filter(ControlPointId.ArmPoint.class::isInstance)
-                .map(ControlPointId.ArmPoint.class::cast)
+        ControlPlace.Arm any = answers.found().keySet().stream()
+                .filter(ControlPlace.Arm.class::isInstance)
+                .map(ControlPlace.Arm.class::cast)
                 .findFirst().orElseThrow();
-        ControlPointId.ArmPoint never = new ControlPointId.ArmPoint(
+        ControlPlace.Arm never = new ControlPlace.Arm(
                 new ArmOccurrence(any.arm().fork(), Integer.MAX_VALUE),
                 Optional.empty(), any.anchor());
 

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
@@ -56,9 +56,9 @@ public final class Numberings {
      * tree's answer and a probe number is the emitter's, so a fixture that let one stand for the
      * other would be writing down a correspondence nothing makes.
      */
-    public static ControlPointId.ArmPoint armPlace(ArmOccurrence arm, ArmProbe probe,
+    public static ControlPlace.Arm armPlace(ArmOccurrence arm, ArmProbe probe,
                                                    ArmReportAnchor anchor) {
-        return new ControlPointId.ArmPoint(arm, Optional.of(probe), anchor);
+        return new ControlPlace.Arm(arm, Optional.of(probe), anchor);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Plans.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Plans.java
@@ -63,11 +63,11 @@ public final class Plans {
      * ones.
      */
     public static CoverageSites.Plan withArmRenamed(CoverageSites.Plan plan,
-                                                    ControlPointId.ArmPoint was,
-                                                    ControlPointId.ArmPoint now) {
-        IdentityHashMap<Core, ControlPointId.ArmPoint[]> arms = new IdentityHashMap<>();
+                                                    ControlPlace.Arm was,
+                                                    ControlPlace.Arm now) {
+        IdentityHashMap<Core, ControlPlace.Arm[]> arms = new IdentityHashMap<>();
         plan.armsByNode().forEach((node, held) -> {
-            ControlPointId.ArmPoint[] out = held.clone();
+            ControlPlace.Arm[] out = held.clone();
             for (int at = 0; at < out.length; at++) {
                 if (out[at].equals(was)) {
                     out[at] = now;

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
@@ -28,8 +28,8 @@ public final class Runs {
         Set<SeenComparison> ways = new LinkedHashSet<>();
         for (ControlClaim claim : claims) {
             switch (claim.at()) {
-                case ControlPointId.ArmPoint arm -> arm.probe().ifPresent(arms::add);
-                case ControlPointId.ComparisonPoint point ->
+                case ControlPlace.Arm arm -> arm.probe().ifPresent(arms::add);
+                case ControlPlace.Outcome point ->
                         ways.add(new SeenComparison(point.at(), point.held()));
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoMakesAControlPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoMakesAControlPlaceTest.java
@@ -1,0 +1,117 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A control place is made by the plan whose answer it is, and by nothing else.
+ *
+ * <p>Both halves of one of these are the plan's: which alternative of the tree it is, and what the
+ * plan worked out about observing it and reporting on it. Nothing checks the two against each other
+ * afterwards, and nothing could — the arm's fork and the arm's probe are answered by different
+ * things, and so are the comparison and the address a run through it is recorded at. What holds
+ * them together is that one walk settles both at once.
+ *
+ * <p><b>The docs say so and the types cannot.</b> {@code ControlPlace} is public and its arms are
+ * records, so their canonical constructors are public and a caller can put any comparison beside
+ * any address. Downstream reads the pair as the plan's answer: a claim is made at the address and a
+ * condition is written about the comparison, so a pair nothing issued together sends a run to be
+ * recorded at one comparison and reported about another. {@link ComparisonEmissionSite} keeps its
+ * own constructor to its package for this reason; a record cannot, so the maker is counted here
+ * instead.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it — and a place built through a method reference is a call like
+ * any other, which no reading of the text would have found. The tests are not in
+ * {@code target/classes}, and what is read is this module's classes.
+ */
+class WhoMakesAControlPlaceTest {
+
+    private static final Set<String> A_CONTROL_PLACE = Set.of(
+            "souther/compiler/coverage/ControlPlace$Arm",
+            "souther/compiler/coverage/ControlPlace$Outcome");
+
+    /** A method that may make one, how many it makes, and what says the halves go together. */
+    private record Licence(String who, int makes, String why) { }
+
+    private static final List<Licence> MAY_MAKE = List.of(
+            new Licence("souther.compiler.coverage.CoverageSites.placeOf"
+                            + " -> ControlPlace$Arm", 1,
+                    "the one place an arm the walk drafted becomes a place, made once per draft so"
+                            + " that a site of an arm and the arms of its fork are the same value."
+                            + " The probe and the anchor come off that draft, so there is no pair"
+                            + " here for a caller to have assembled"),
+            new Licence("souther.compiler.coverage.CoverageSites.Plan.outcomeOf"
+                            + " -> ControlPlace$Outcome", 1,
+                    "the address is taken from this plan for the comparison being asked about, so"
+                            + " the two are the one answer. Handed in separately they would be two,"
+                            + " and a claim recorded at one comparison would carry a condition"
+                            + " written about another"));
+
+    @Test
+    void everyMakerOfAControlPlaceIsWrittenDownWithWhatSaysItsHalvesGoTogether() {
+        assertEquals(declared(), made(),
+                "a control place holds what one walk settled together, and nothing downstream reads"
+                        + " both halves to notice a pair that was assembled instead. So a maker"
+                        + " arriving here is one to look at rather than one this can decide about."
+                        + " What makes one today, and what says its halves go together: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_MAKE.forEach(each -> out.put(each.who(), each.makes()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_MAKE.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many control places each method of the compiler makes. */
+    private static Map<String, Integer> made() {
+        Map<String, Integer> calls = new TreeMap<>();
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.name().stringValue().equals("<init>")
+                            && A_CONTROL_PLACE.contains(call.owner().asInternalName())) {
+                        String which = call.owner().asInternalName();
+                        calls.merge(from + "." + wroteIt(method.methodName().stringValue())
+                                        + " -> " + which.substring(which.lastIndexOf('/') + 1),
+                                1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        return calls;
+    }
+
+    /**
+     * The method a person wrote, for a name javac may have made up.
+     *
+     * <p>A lambda is compiled to a method named after the one it was written inside and numbered by
+     * where it fell among that class's lambdas. The number moves when a lambda is added anywhere in
+     * the class, which has nothing to do with who makes a control place.
+     */
+    private static String wroteIt(String compiled) {
+        if (!compiled.startsWith("lambda$")) {
+            return compiled;
+        }
+        return compiled.substring("lambda$".length(), compiled.lastIndexOf('$'));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
@@ -30,6 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * of the bodies it holds; a reader reaching for any other plan is one branch away from the stand-in,
  * and where the bodies are there is no answer at all rather than an empty one.
  *
+ * <p><b>Two things a taker does with one, and the stand-in is dangerous to one of them.</b> A
+ * numbering read as an address space says a run happened at these places, and taken off the
+ * stand-in it says that of nowhere. A numbering read as a name says which plan a value is of, and
+ * is only ever compared with another taken the same way — two readers of the plan of nothing agree
+ * they hold the plan of nothing, which is true. The reason beside each entry says which of the two
+ * it is doing.
+ *
  * <p><b>What this holds is the population, and not that each of them is right.</b> A walk over the
  * compiled classes sees which method takes a numbering off a plan; it does not see which plan, so
  * it cannot tell a reader holding the checked bodies from one holding the stand-in. That is what
@@ -63,7 +70,34 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
                             + " holds for the bodies it is emitting — and taken only where coverage"
                             + " was asked for, so it is never the stand-in's. The emission answers"
                             + " with it, rather than a caller working out a numbering of its own"
-                            + " beside the one the probes were written from"));
+                            + " beside the one the probes were written from"),
+            // The four below take one for the other reason there is to take one. None of them
+            // aligns a recording against it: each stamps or compares a reading of a plan with the
+            // plan it is being read against, so what a numbering says here is "these two are the
+            // same plan's" and never "this run happened at these places". The stand-in cannot make
+            // one of them answer about somewhere else — two readers of the plan of nothing agree
+            // that they hold the plan of nothing, which is what they hold.
+            new Licence("souther.compiler.check.PathReachability.of -> identity", 1,
+                    "the reading stamps itself with the plan whose places it files its answers"
+                            + " under, taken off the plan it was handed and walked. Absent, a"
+                            + " reading would be a map of places with nothing saying whose, and a"
+                            + " reader pairing it with another plan would be told every place of"
+                            + " the body is one nothing reached"),
+            new Licence("souther.compiler.claims.UnreachableClaims.of -> identity", 1,
+                    "the claims name arms of the plan they were read against, and say so, taken"
+                            + " off that same plan. What judges them looks each arm up in a"
+                            + " reading, and this is what says which reading answers about them"),
+            new Licence("souther.compiler.partition.ProducedCases.of -> identity", 1,
+                    "the walk asks a reading about the arms of the plan it was handed, so the two"
+                            + " are held to being one plan's before either is read. Both are"
+                            + " parameters of one call, which is where a caller could put two"
+                            + " modules' together"),
+            new Licence("souther.compiler.query.Adequacy.BranchCoverage.lambda$compute$0"
+                            + " -> identity", 1,
+                    "the arms of one behavior and the reading that says what arrives at them are"
+                            + " put together here, and are held to being one plan's. Taken only"
+                            + " where the checked bodies came back, so the plan is theirs and never"
+                            + " the stand-in this file is about"));
 
     @Test
     void everyReaderOfAPlansNumberingIsWrittenDownWithWhatMakesItSafe() {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
@@ -71,7 +71,7 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
                             + " was asked for, so it is never the stand-in's. The emission answers"
                             + " with it, rather than a caller working out a numbering of its own"
                             + " beside the one the probes were written from"),
-            // The four below take one for the other reason there is to take one. None of them
+            // The ones below take one for the other reason there is to take one. None of them
             // aligns a recording against it: each stamps or compares a reading of a plan with the
             // plan it is being read against, so what a numbering says here is "these two are the
             // same plan's" and never "this run happened at these places". The stand-in cannot make
@@ -92,12 +92,10 @@ class WhoTakesAPlansNumberingHasItsBodiesTest {
                             + " are held to being one plan's before either is read. Both are"
                             + " parameters of one call, which is where a caller could put two"
                             + " modules' together"),
-            new Licence("souther.compiler.query.Adequacy.BranchCoverage.lambda$compute$0"
-                            + " -> identity", 1,
-                    "the arms of one behavior and the reading that says what arrives at them are"
-                            + " put together here, and are held to being one plan's. Taken only"
-                            + " where the checked bodies came back, so the plan is theirs and never"
-                            + " the stand-in this file is about"));
+            new Licence("souther.compiler.partition.GuardThresholds.of -> identity", 1,
+                    "the rules read off the guards are asked what arrives at comparisons this plan"
+                            + " names, so the two are held to being one plan's. Both are handed in,"
+                            + " which is where a caller could put two modules' together"));
 
     @Test
     void everyReaderOfAPlansNumberingIsWrittenDownWithWhatMakesItSafe() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -408,7 +408,7 @@ class AGroupTooWideToWalkSaysSoTest {
     private static List<ArmProbe> armsIn(InteractionCells.NotOffered held) {
         List<ArmProbe> out = new java.util.ArrayList<>();
         for (souther.compiler.coverage.ControlClaim claim : held.claims()) {
-            if (claim.at() instanceof souther.compiler.coverage.ControlPointId.ArmPoint arm
+            if (claim.at() instanceof souther.compiler.coverage.ControlPlace.Arm arm
                     && arm.probe().isPresent()) {
                 out.add(arm.probe().get());
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
@@ -3,7 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 import souther.compiler.check.PathReachability;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.Plans;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -132,15 +132,15 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
                 .ask(new Adequacy.PathReached(module)).value().get("pick");
         Set<TypeSymbol> answersWith = casesNamedIn(body);
 
-        ControlPointId.ArmPoint refused = arrives.found().entrySet().stream()
+        ControlPlace.Arm refused = arrives.found().entrySet().stream()
                 .filter(each -> each.getValue() instanceof souther.compiler.reach.Reachability.Unreachable)
                 .map(Map.Entry::getKey)
-                .filter(ControlPointId.ArmPoint.class::isInstance)
-                .map(ControlPointId.ArmPoint.class::cast)
+                .filter(ControlPlace.Arm.class::isInstance)
+                .map(ControlPlace.Arm.class::cast)
                 .findFirst().orElseThrow();
         assertTrue(refused.probe().isPresent(), "the compiler numbered the arm it proved dead");
 
-        ControlPointId.ArmPoint silent = new ControlPointId.ArmPoint(
+        ControlPlace.Arm silent = new ControlPlace.Arm(
                 refused.arm(), java.util.Optional.empty(), refused.anchor());
 
         assertEquals(ProducedCases.of(body, checked.plan(), arrives, answersWith),
@@ -156,11 +156,11 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
 
     /** The same answers, filed under {@code now} where they were filed under {@code was}. */
     private static PathReachability.Answers arrivalsWith(PathReachability.Answers answers,
-                                                         ControlPointId.ArmPoint was,
-                                                         ControlPointId.ArmPoint now) {
-        Map<ControlPointId, souther.compiler.reach.Reachability> found = new LinkedHashMap<>();
+                                                         ControlPlace.Arm was,
+                                                         ControlPlace.Arm now) {
+        Map<ControlPlace, souther.compiler.reach.Reachability> found = new LinkedHashMap<>();
         answers.found().forEach((where, said) -> found.put(where.equals(was) ? now : where, said));
-        return new PathReachability.Answers(found, answers.arriving());
+        return new PathReachability.Answers(answers.numbering(), found, answers.arriving());
     }
 
     /**
@@ -196,7 +196,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
         Map<String, PathReachability.Answers> answers = compilation.db()
                 .ask(new Adequacy.PathReached(compilation.modules().get(0))).value();
         return answers.get("pick").found().entrySet().stream()
-                .filter(each -> each.getKey() instanceof ControlPointId.ArmPoint arm
+                .filter(each -> each.getKey() instanceof ControlPlace.Arm arm
                         && arm.origin().kind() == kind)
                 .map(Map.Entry::getValue)
                 .filter(souther.compiler.reach.Reachability.Unreachable.class::isInstance)

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
@@ -10,7 +10,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.coverage.Runs;
@@ -73,7 +73,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
             for (WayIn way : ((PathAccess.Ways) each.getValue()).ways()) {
                 assertTrue(way.claims().stream()
                                 .noneMatch(claim -> claim.at() instanceof
-                                        ControlPointId.ArmPoint),
+                                        ControlPlace.Arm),
                         "and nothing on the way names the arm it leads to: " + way.claims());
             }
         }
@@ -149,8 +149,8 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
             for (WayIn way : found.ways()) {
                 for (ControlClaim claim : way.claims()) {
                     switch (claim.at()) {
-                        case ControlPointId.ArmPoint arm -> taken.add(arm.probe().get());
-                        case ControlPointId.ComparisonPoint point ->
+                        case ControlPlace.Arm arm -> taken.add(arm.probe().get());
+                        case ControlPlace.Outcome point ->
                                 ways.add(new SeenComparison(point.at(), point.held()));
                     }
                 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -10,7 +10,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.inputs.InputDomain;
@@ -275,7 +275,7 @@ class ARowNothingRanFillsNoCombinationTest {
     private static Set<ArmProbe> claimedBy(CellSelection selection) {
         Set<ArmProbe> out = new LinkedHashSet<>();
         for (ControlClaim claim : selection.claims()) {
-            if (claim.at() instanceof ControlPointId.ArmPoint arm && arm.probe().isPresent()) {
+            if (claim.at() instanceof ControlPlace.Arm arm && arm.probe().isPresent()) {
                 out.add(arm.probe().get());
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -5,7 +5,7 @@ import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.Numberings;
 import souther.compiler.coverage.Runs;
 import souther.compiler.coverage.SiteNumbering;
@@ -55,7 +55,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
 
     /** A place a run can be recorded at, told from its neighbours by the probe it carries. */
     private static ControlClaim at(int probe) {
-        return ControlClaim.of(new ControlPointId.ArmPoint(Numberings.armOfForkAt(probe),
+        return ControlClaim.of(new ControlPlace.Arm(Numberings.armOfForkAt(probe),
                         java.util.Optional.of(probe(probe)), null))
                 .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
@@ -5,7 +5,7 @@ import souther.compiler.coverage.Numberings;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +44,7 @@ class WhatACombinationAsksIsItsOwnToSayTest {
 
     private static CellSelection over(boolean[]... positions) {
         return new CellSelection(new InteractionCells.Cell(positions),
-                List.of(ControlClaim.of(new ControlPointId.ArmPoint(Numberings.armOfForkAt(1),
+                List.of(ControlClaim.of(new ControlPlace.Arm(Numberings.armOfForkAt(1),
                                 Optional.of(Numberings.arm(2, 1)), null))
                         .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"))));
     }

--- a/souther-compiler/src/test/java/souther/compiler/reading/TwoCopiesOfOneForkAreTwoDecisionsARowMaySettleApartTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/TwoCopiesOfOneForkAreTwoDecisionsARowMaySettleApartTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.ControlPlace;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -60,8 +60,8 @@ class TwoCopiesOfOneForkAreTwoDecisionsARowMaySettleApartTest {
 
         List<Core> copies = theForkTheOperationCopies(checked.behaviorBodies().get("pick"));
 
-        ControlPointId.ArmPoint[] first = plan.armsOf(copies.get(0));
-        ControlPointId.ArmPoint[] second = plan.armsOf(copies.get(1));
+        ControlPlace.Arm[] first = plan.armsOf(copies.get(0));
+        ControlPlace.Arm[] second = plan.armsOf(copies.get(1));
         assertTrue(first[0].isMeasured() && first[1].isMeasured() && second[1].isMeasured(),
                 "a run through any arm of this fork can be recorded");
 
@@ -73,7 +73,7 @@ class TwoCopiesOfOneForkAreTwoDecisionsARowMaySettleApartTest {
                 "and one copy going both ways is one decision settled twice");
     }
 
-    private static Decision decision(ControlPointId.ArmPoint arm) {
+    private static Decision decision(ControlPlace.Arm arm) {
         return new Decision(new Condition.Arm(arm.arm()),
                 ControlClaim.of(arm).orElseThrow(
                         () -> new AssertionError("an arm with a probe can be claimed")));


### PR DESCRIPTION
`ControlPointId` was defined by what the walk handed out: a numbered control point per plan, whose
only member was that number. The number went when an arm came to name its fork, and the name stayed
on a type that no longer declares anything. This gives the type back a definition taken from its
readers.

An arm already said which arm it is. A comparison coming out one way said only where the emitter
records it — and that value's own account of itself is that it is an address and not an identity,
true about which comparison it is for exactly as long as every comparison anyone asks after is one
the emitter numbered. It now carries the comparison beside the site. That is the division the arm
side already makes, and the one the conditions of a reading make between what a condition is and
where a report about it points.

A reading and the plan whose places it answers about are now held to being one another's. Absent
from a reading means the walk did not get there, which every reader takes as unsettled and goes on
from — and it was the same answer for every place of another module's plan, where nothing was asked
and nothing is being said. A place cannot be asked which plan it is of: an arm no run can be
recorded in carries no numbering, and giving it one would put the plan's own address back inside the
identity. So the pairing is what is checked, once, where a reader puts the two halves together.

What refuses a claim about a comparison is now the rule that refuses one about an arm — a place no
run could be recorded at. The reason written beside it named a condition on the fork's arms, which
is not what decides whether a comparison is numbered: the plan numbers a comparison standing where a
row can get to and where what it stands in answers a value.

A decision's condition and its claim are now read off the one place they are both about, rather than
the claim coming from the plan and the comparison beside it from the node.

Closes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)