### PR TITLE
Ask a value what stands for it, and let the one it keeps a number over answer once

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
@@ -13,11 +14,13 @@ import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.classfile.instruction.LoadInstruction;
 import java.lang.classfile.instruction.ReturnInstruction;
+import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -32,9 +35,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * finishing happens matters as much as that it happens — finishing a total after the sum has been
  * taken finishes a number the pairing has already left.
  *
- * <p>Which is why this is asked of the package rather than left to each value. Every one of these
+ * <p>Which is why this is asked of the packages rather than left to each value. Every one of these
  * hashes was written by somebody deciding afresh how to gather two things symmetrically, and the
  * one that decided on the plainest answer — the ends added — was the one that lost the pairing.
+ *
+ * <p><b>And of more than one package, because where a value is written says nothing about how it is
+ * hashed.</b> A relation between positions and the identity of a binding are both handed to
+ * something that adds hashes up. A rule the values of one package keep and the values of the next
+ * do not would be two answers to one question, and the second of them is the one that has the
+ * defect. What is left outside is a value written somewhere else again, and this says nothing about
+ * one.
  *
  * <p><b>Asked of the number the hash hands back, and not of what the class mentions.</b> A class
  * that names the algebra somewhere and gathers its own parts in {@code hashCode} is the defect this
@@ -50,11 +60,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * what this is about, and never its own equality: the generated one is over every component it has
  * and over every component it is given.
  */
-class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
+class AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest {
 
-    private static final String WHERE = "souther/compiler/values/";
+    private static final List<String> WHERE =
+            List.of("souther/compiler/values/", "souther/compiler/types/");
 
-    private static final String THE_ALGEBRA = WHERE + "ValueHash";
+    private static final String THE_ALGEBRA = "souther/compiler/hash/ValueHash";
+
+    /** What a value implements where it names the value standing for it. */
+    private static final String NAMES_ONE = "souther/compiler/hash/SaysWhatStandsForIt";
 
     /** What a record's own equality and hash are left to, which is nobody here deciding anything. */
     private static final String DERIVED = "java/lang/runtime/ObjectMethods";
@@ -68,7 +82,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
     @Test
     void everyValueThereThatWorksOutItsOwnHashTakesItFromTheAlgebra() {
         List<String> gatheringItThemselves = new ArrayList<>();
-        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
+        for (ClassModel read : theValues()) {
             Optional<MethodModel> spelled = spelledOut(read, "hashCode", "()I");
             if (spelled.isPresent() && !fromTheAlgebra(read, spelled.get())) {
                 gatheringItThemselves.add(read.thisClass().name().stringValue());
@@ -94,7 +108,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
     @Test
     void andARecordThereSpellsItsOwnEqualityWhereAndOnlyWhereTheGeneratedOneWouldSayAnother() {
         List<String> disagreeing = new ArrayList<>();
-        for (ClassModel read : COMPILED.inTheClassesOf(WHERE)) {
+        for (ClassModel read : theValues()) {
             if (read.findAttribute(Attributes.record()).isEmpty()) {
                 continue;
             }
@@ -122,7 +136,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
      */
     @Test
     void andTheValuesThoseRulesAreAboutWereRead() {
-        List<ClassModel> read = COMPILED.inTheClassesOf(WHERE);
+        List<ClassModel> read = theValues();
 
         assertTrue(read.size() > 1, "the classes about relations were not built here");
         assertTrue(read.stream().anyMatch(each -> spelledOut(each, "hashCode", "()I").isPresent()),
@@ -130,6 +144,183 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
         assertTrue(read.stream().anyMatch(
                         each -> each.findAttribute(Attributes.record()).isPresent()),
                 "no value there is a record, which is not what these hold either");
+    }
+
+    /**
+     * And a number a value keeps is over the value it says stands for it.
+     *
+     * <p>A value asked its number far more often than one is made works it out once and hands back
+     * what it kept, and the algebra is then in the making rather than in the answer. What that
+     * leaves open is which number was kept: a class can ask the algebra about anything at all and
+     * put that away, and every rule above reads a hash that hands back a field as settled.
+     *
+     * <p>So what is followed here is where the number handed to the algebra came from. Between the
+     * value putting away what stands for it and putting away its number, nothing of the value is
+     * read but that one thing, and what is put away is what the algebra answered. A number gathered
+     * from something else — a part held beside what stands for the value, a number handed in — is
+     * one the equality does not read, and two values equal by what stands for them would be two
+     * numbers.
+     */
+    @Test
+    void andANumberAValueKeepsIsOverWhatItSaysStandsForIt() {
+        List<String> read = new ArrayList<>();
+        List<String> gatheringElsewhere = new ArrayList<>();
+        for (ClassModel value : theValues()) {
+            if (!namesWhatStandsForIt(value)) {
+                continue;
+            }
+            Optional<MethodModel> hash = spelledOut(value, "hashCode", "()I");
+            Optional<String> kept = hash.flatMap(spelled -> handedBack(value, spelled));
+            if (kept.isEmpty()) {
+                continue;
+            }
+            read.add(value.thisClass().name().stringValue());
+            String named = fieldNamed(value).orElseThrow(() -> new AssertionError(
+                    value.thisClass().name().stringValue() + " says something stands for it and"
+                            + " does not hand back a value it holds, which is a shape this cannot"
+                            + " follow"));
+            if (!keptOverWhatStandsForIt(value, named, kept.get())) {
+                gatheringElsewhere.add(value.thisClass().name().stringValue());
+            }
+        }
+
+        assertEquals(List.of(), gatheringElsewhere,
+                "a number kept over anything but what stands for the value is one two values equal"
+                        + " by what stands for them can differ in");
+        assertFalse(read.isEmpty(), "no value here keeps a number it works out once, which is not"
+                + " what these hold");
+    }
+
+    /**
+     * And such a value holds what stands for it, the number it worked out, and nothing else.
+     *
+     * <p>What a record gave away when one of these stopped being one is the compiler's guarantee
+     * that a component it is given is part of what it is. Held in one value again, that guarantee
+     * is back — a component joins what stands for the value and the equality, the number and the
+     * walk all read it — but only for as long as what stands for the value is where a part is put.
+     * A field beside it is a part of the value that its equality does not read and its number is
+     * not over, and nothing about writing one would say so.
+     */
+    @Test
+    void andItHoldsWhatStandsForItAndTheNumberAndNothingElse() {
+        List<String> holdingMore = new ArrayList<>();
+        List<String> read = new ArrayList<>();
+        for (ClassModel value : theValues()) {
+            if (!namesWhatStandsForIt(value)) {
+                continue;
+            }
+            Optional<MethodModel> hash = spelledOut(value, "hashCode", "()I");
+            Optional<String> kept = hash.flatMap(spelled -> handedBack(value, spelled));
+            Optional<String> named = fieldNamed(value);
+            if (kept.isEmpty() || named.isEmpty()) {
+                continue;
+            }
+            read.add(value.thisClass().name().stringValue());
+            for (FieldModel field : value.fields()) {
+                String held = field.fieldName().stringValue();
+                if (!field.flags().has(AccessFlag.STATIC) && !held.equals(kept.get())
+                        && !held.equals(named.get())) {
+                    holdingMore.add(value.thisClass().name().stringValue() + " holds " + held);
+                }
+            }
+        }
+
+        assertEquals(List.of(), holdingMore,
+                "a part held beside what stands for the value is one the equality does not read,"
+                        + " which is what putting the parts in a value of their own is against");
+        assertFalse(read.isEmpty(), "no value here holds its parts in a value of their own, which"
+                + " is not what these hold");
+    }
+
+    /** Whether the value names what stands for it. */
+    private static boolean namesWhatStandsForIt(ClassModel value) {
+        return value.interfaces().stream()
+                .anyMatch(each -> NAMES_ONE.equals(each.name().stringValue()));
+    }
+
+    /** The value it hands back as standing for it, where that is something it holds. */
+    private static Optional<String> fieldNamed(ClassModel value) {
+        for (MethodModel method : value.methods()) {
+            if (!"standsFor".equals(method.methodName().stringValue())) {
+                continue;
+            }
+            List<Instruction> body = instructionsOf(method);
+            if (body.size() == 3 && body.get(0) instanceof LoadInstruction
+                    && body.get(1) instanceof FieldInstruction field
+                    && field.opcode() == Opcode.GETFIELD
+                    && value.thisClass().name().equals(field.owner().name())
+                    && body.get(2) instanceof ReturnInstruction) {
+                return Optional.of(field.name().stringValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Whether every number put into {@code kept} was worked out from {@code named} and nothing
+     * else.
+     *
+     * <p>Read as the stretch between the two puts. What a value does before it has what stands for
+     * it is making that, and what it does after is not this; in between it reads one thing and
+     * hands what it read to the algebra. A read of anything else there is a part of the number that
+     * the equality does not read.
+     */
+    private static boolean keptOverWhatStandsForIt(ClassModel value, String named, String kept) {
+        boolean put = false;
+        for (MethodModel method : value.methods()) {
+            List<Instruction> body = instructionsOf(method);
+            int from = -1;
+            for (int at = 0; at < body.size(); at++) {
+                if (!(body.get(at) instanceof FieldInstruction field)
+                        || field.opcode() != Opcode.PUTFIELD
+                        || !value.thisClass().name().equals(field.owner().name())) {
+                    continue;
+                }
+                if (named.equals(field.name().stringValue())) {
+                    from = at;
+                } else if (kept.equals(field.name().stringValue())) {
+                    put = true;
+                    if (from < 0 || !overNothingElse(value, body.subList(from + 1, at), named)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return put;
+    }
+
+    /** Whether the stretch reads {@code named}, reads nothing else the value holds, and hands the
+     *  algebra's answer over. */
+    private static boolean overNothingElse(ClassModel value, List<Instruction> stretch,
+            String named) {
+        boolean readIt = false;
+        for (int at = 0; at < stretch.size(); at++) {
+            Instruction instruction = stretch.get(at);
+            if (instruction instanceof FieldInstruction field
+                    && value.thisClass().name().equals(field.owner().name())) {
+                if (!named.equals(field.name().stringValue())) {
+                    return false;
+                }
+                readIt = true;
+            }
+            if (instruction instanceof InvokeInstruction call
+                    && !"hashCode".equals(call.name().stringValue())
+                    && !THE_ALGEBRA.equals(call.owner().name().stringValue())) {
+                return false;
+            }
+        }
+        return readIt && !stretch.isEmpty()
+                && stretch.getLast() instanceof InvokeInstruction handing
+                && THE_ALGEBRA.equals(handing.owner().name().stringValue());
+    }
+
+    /** The values these rules are about, wherever they are written. */
+    private static List<ClassModel> theValues() {
+        List<ClassModel> found = new ArrayList<>();
+        for (String where : WHERE) {
+            found.addAll(COMPILED.inTheClassesOf(where));
+        }
+        return found;
     }
 
     /**
@@ -144,7 +335,7 @@ class AValueSpellsItsHashWithTheAlgebraThePackageHasTest {
             if (named.equals(method.methodName().stringValue())
                     && taking.equals(method.methodType().stringValue())) {
                 boolean handedOver = instructionsOf(method).stream().anyMatch(
-                        AValueSpellsItsHashWithTheAlgebraThePackageHasTest::handedOver);
+                        AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest::handedOver);
                 return handedOver ? Optional.empty() : Optional.of(method);
             }
         }

--- a/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest.java
@@ -9,6 +9,7 @@ import java.lang.classfile.FieldModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
+import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.instruction.FieldInstruction;
 import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
@@ -69,6 +70,9 @@ class AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest {
 
     /** What a value implements where it names the value standing for it. */
     private static final String NAMES_ONE = "souther/compiler/hash/SaysWhatStandsForIt";
+
+    /** And where the number it is asked for is one it worked out once and kept. */
+    private static final String KEEPS_ONE = "souther/compiler/hash/KeepsTheNumberItIsAskedFor";
 
     /** What a record's own equality and hash are left to, which is nobody here deciding anything. */
     private static final String DERIVED = "java/lang/runtime/ObjectMethods";
@@ -163,32 +167,31 @@ class AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest {
      */
     @Test
     void andANumberAValueKeepsIsOverWhatItSaysStandsForIt() {
-        List<String> read = new ArrayList<>();
-        List<String> gatheringElsewhere = new ArrayList<>();
-        for (ClassModel value : theValues()) {
-            if (!namesWhatStandsForIt(value)) {
-                continue;
-            }
-            Optional<MethodModel> hash = spelledOut(value, "hashCode", "()I");
-            Optional<String> kept = hash.flatMap(spelled -> handedBack(value, spelled));
+        List<String> failing = new ArrayList<>();
+        List<ClassModel> keeping = implementers(KEEPS_ONE);
+        for (ClassModel value : keeping) {
+            String what = value.thisClass().name().stringValue();
+            Optional<String> kept = spelledOut(value, "hashCode", "()I")
+                    .flatMap(spelled -> handedBack(value, spelled));
+            Optional<String> named = fieldNamed(value);
             if (kept.isEmpty()) {
+                failing.add(what + " says it keeps a number and hands one back it worked out");
                 continue;
             }
-            read.add(value.thisClass().name().stringValue());
-            String named = fieldNamed(value).orElseThrow(() -> new AssertionError(
-                    value.thisClass().name().stringValue() + " says something stands for it and"
-                            + " does not hand back a value it holds, which is a shape this cannot"
-                            + " follow"));
-            if (!keptOverWhatStandsForIt(value, named, kept.get())) {
-                gatheringElsewhere.add(value.thisClass().name().stringValue());
+            if (named.isEmpty()) {
+                failing.add(what + " hands back what stands for it without holding it");
+                continue;
+            }
+            if (!keptOverWhatStandsForIt(value, named.get(), kept.get())) {
+                failing.add(what + " keeps a number over something else it read");
             }
         }
 
-        assertEquals(List.of(), gatheringElsewhere,
+        assertEquals(List.of(), failing,
                 "a number kept over anything but what stands for the value is one two values equal"
                         + " by what stands for them can differ in");
-        assertFalse(read.isEmpty(), "no value here keeps a number it works out once, which is not"
-                + " what these hold");
+        assertFalse(keeping.isEmpty(), "no value says it keeps the number it is asked for, which is"
+                + " not what this compiler holds");
     }
 
     /**
@@ -204,18 +207,15 @@ class AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest {
     @Test
     void andItHoldsWhatStandsForItAndTheNumberAndNothingElse() {
         List<String> holdingMore = new ArrayList<>();
-        List<String> read = new ArrayList<>();
-        for (ClassModel value : theValues()) {
-            if (!namesWhatStandsForIt(value)) {
-                continue;
-            }
-            Optional<MethodModel> hash = spelledOut(value, "hashCode", "()I");
-            Optional<String> kept = hash.flatMap(spelled -> handedBack(value, spelled));
+        List<ClassModel> keeping = implementers(KEEPS_ONE);
+        for (ClassModel value : keeping) {
+            Optional<String> kept = spelledOut(value, "hashCode", "()I")
+                    .flatMap(spelled -> handedBack(value, spelled));
             Optional<String> named = fieldNamed(value);
             if (kept.isEmpty() || named.isEmpty()) {
+                // What each of those is is the rule above, which reports it.
                 continue;
             }
-            read.add(value.thisClass().name().stringValue());
             for (FieldModel field : value.fields()) {
                 String held = field.fieldName().stringValue();
                 if (!field.flags().has(AccessFlag.STATIC) && !held.equals(kept.get())
@@ -228,14 +228,69 @@ class AValueSpellsItsHashWithTheOneAlgebraThereIsForItTest {
         assertEquals(List.of(), holdingMore,
                 "a part held beside what stands for the value is one the equality does not read,"
                         + " which is what putting the parts in a value of their own is against");
-        assertFalse(read.isEmpty(), "no value here holds its parts in a value of their own, which"
-                + " is not what these hold");
+        assertFalse(keeping.isEmpty(), "no value says it keeps the number it is asked for, which is"
+                + " not what this compiler holds");
     }
 
-    /** Whether the value names what stands for it. */
-    private static boolean namesWhatStandsForIt(ClassModel value) {
-        return value.interfaces().stream()
-                .anyMatch(each -> NAMES_ONE.equals(each.name().stringValue()));
+    /**
+     * And what a value says stands for it is a value it holds, whether or not it keeps a number.
+     *
+     * <p>Asked of every value that names one, and not only of the ones a number is kept by. A value
+     * is asked this once for every number a term takes of it — far more often than one is made — so
+     * one worked out at the ask puts back the walk that naming it is for. And it hands a different
+     * object out each time, to a reader with no way to know that the two are one answer.
+     */
+    @Test
+    void andWhatStandsForAValueIsSomethingItHolds() {
+        List<String> built = new ArrayList<>();
+        List<ClassModel> naming = implementers(NAMES_ONE);
+        for (ClassModel value : naming) {
+            if (fieldNamed(value).isEmpty()) {
+                built.add(value.thisClass().name().stringValue());
+            }
+        }
+
+        assertEquals(List.of(), built,
+                "what stands for a value is worked out there rather than held, so a reader asking"
+                        + " twice is answered twice and pays the walk that naming it is against");
+        assertFalse(naming.isEmpty(), "no value names what stands for it, which is not what this"
+                + " compiler holds");
+    }
+
+    /**
+     * Every class this repository publishes that reaches {@code named}, through its own interfaces
+     * or through one of theirs.
+     *
+     * <p>The population of a rule about these values comes from what they declare and not from the
+     * shape the rule is about: a value found by looking for a number handed back out of a field is
+     * a value that leaves the rule by no longer handing one back, which is the defect the rule is
+     * against.
+     *
+     * <p>Classes, since what is asked of them is what their code does. An interface that carries
+     * one of these on to another says which values are held to it and does nothing itself.
+     */
+    private static List<ClassModel> implementers(String named) {
+        List<ClassModel> found = new ArrayList<>();
+        for (ClassModel each : COMPILED.all()) {
+            if (!each.flags().has(AccessFlag.INTERFACE) && reaches(each, named)) {
+                found.add(each);
+            }
+        }
+        return found;
+    }
+
+    /** Whether {@code read} declares {@code named} or declares something that reaches it. */
+    private static boolean reaches(ClassModel read, String named) {
+        for (ClassEntry each : read.interfaces()) {
+            String spelled = each.name().stringValue();
+            if (spelled.equals(named)) {
+                return true;
+            }
+            if (COMPILED.find(spelled).filter(above -> reaches(above, named)).isPresent()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** The value it hands back as standing for it, where that is something it holds. */

--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.hash.SaysWhatStandsForIt;
 
 /**
  * One evaluation the check reads, told apart from every other.
@@ -20,46 +21,57 @@ import souther.compiler.diag.SourcePos;
  *
  * <p>What a term carrying one of these is hashed from is not which object it is. {@code Object}'s
  * hash is drawn afresh each run, and a term filed under one would be filed somewhere else the next
- * time — so the term algebra reads what was written and which occurrence of the reading this is
- * ({@code Term.STANDS_FOR}), which agrees with equality the one way a hash has to: two that are one
- * hash alike.
+ * time — so what stands for one here is what was written and which occurrence of the reading it is,
+ * which agrees with equality the one way a hash has to: two that are one hash alike.
  *
- * <p>Named there rather than answered here. A type answering with a hash of its own is where the
- * walk that proves a term is hashed from values has to stop, and what that hash reads is then the
- * one thing nothing checks; a type naming what stands for it is walked through like everything
- * else. Which is why the position is not among what is named: it stands on a {@link
- * souther.compiler.diag.Placement}, and what that reads is a tree, not a value this can answer for.
+ * <p>Which is less than what tells two of these apart, and that is allowed of what stands for a
+ * value: two of them are one only when they are the same object, so any two that are equal name the
+ * same thing whatever else is true. The position is left out for a reason of its own. It stands on
+ * a {@link souther.compiler.diag.Placement}, and what that reads is a tree rather than a value this
+ * can answer for.
  */
-final class EvaluationId {
+final class EvaluationId implements SaysWhatStandsForIt {
+
+    /**
+     * What stands for an evaluation where a number is wanted of it.
+     *
+     * @param what       what was written where it stands
+     * @param occurrence which one it is of the evaluations its reading has named, in the order it
+     *                   named them
+     */
+    record Named(String what, int occurrence) {
+    }
 
     private final SourcePos where;
-    private final String what;
 
-    /** Which one this is of the evaluations its reading has named, in the order it named them. */
-    private final int occurrence;
+    private final Named named;
 
     EvaluationId(String what, SourcePos where, int occurrence) {
-        this.what = what;
+        this.named = new Named(what, occurrence);
         this.where = where;
-        this.occurrence = occurrence;
     }
 
     /** What was written where this stands. */
     String what() {
-        return what;
+        return named.what();
     }
 
     /** Which one this is of the evaluations its reading has named. */
     int occurrence() {
-        return occurrence;
+        return named.occurrence();
     }
 
     SourcePos where() {
         return where;
     }
 
+    @Override
+    public Named standsFor() {
+        return named;
+    }
+
     String rendered() {
-        return "<" + what + " at "
+        return "<" + named.what() + " at "
                 + (where == null ? "?" : where.line() + ":" + where.column()) + ">";
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.hash.SaysWhatStandsForIt;
 import souther.compiler.types.BinOp;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -253,7 +254,7 @@ final class Term {
         ITS_ELEMENTS,
         /** Each of its elements, in no order — what a set's own equality reads. */
         ITS_UNORDERED_ELEMENTS,
-        /** The parts it says stand for it ({@link #STANDS_FOR}). */
+        /** The value it says stands for it ({@link SaysWhatStandsForIt}). */
         THE_PARTS_IT_NAMES,
         /** Nothing here takes a value of this class. */
         NONE_HERE
@@ -277,24 +278,6 @@ final class Term {
         return RULES.get(type);
     }
 
-    /**
-     * What stands for a value of a class that is neither a scalar nor a record given its equality.
-     *
-     * <p>Named parts and not a hash. A class answering "here is my hash" is a place the walk that
-     * proves a term is hashed from values has to stop, and what such a hash reads is then the one
-     * thing nothing checks — which is how a set of type symbols came to be hashed by the identity of
-     * an enum two levels under it. A class answering "here is what stands for me" is one the walk
-     * goes through, so what it reads is proved like everything else.
-     *
-     * <p>Both of these are told apart by less than what they hold. A type symbol is its address, and
-     * an evaluation is told apart from every other by which object it is — so what is named here is
-     * what may be hashed without giving two equal values two hashes, which for the second is
-     * anything that is a function of the value.
-     */
-    private static final Map<Class<?>, List<String>> STANDS_FOR = Map.of(
-            TypeSymbol.AtModule.class, List.of("key"),
-            EvaluationId.class, List.of("what", "occurrence"));
-
     private static Rule ruleOf(Class<?> type) {
         if (Enum.class.isAssignableFrom(type)) {
             return Rule.AN_ENUM_BY_NAME;
@@ -308,7 +291,11 @@ final class Term {
         if (java.util.Set.class.isAssignableFrom(type)) {
             return Rule.ITS_UNORDERED_ELEMENTS;
         }
-        if (STANDS_FOR.containsKey(type)) {
+        // Asked before the question about records, because a value that keeps the number it is
+        // asked for is a class here and may hold its parts in a record all the same: what it says
+        // stands for it is the answer either way, and its own components are the field it keeps
+        // them in and the number it worked out.
+        if (SaysWhatStandsForIt.class.isAssignableFrom(type)) {
             return Rule.THE_PARTS_IT_NAMES;
         }
         // A record given its equality holds it over everything it carries, so its components are
@@ -326,14 +313,16 @@ final class Term {
      * value is made of or to which object it is.
      *
      * <p>Read off the modifier, since the hash a record is given is final and one written by hand is
-     * not. What it decides is who is taken at their word. A record stating none is what it holds, and
-     * following its components is following its hash; a record stating one states it over some of
-     * what it holds, so following the rest would give two equal values two hashes.
+     * not. What it decides is what is left of a record that has not said what stands for it: one
+     * stating no hash is what it holds, and following its components is following its hash; one
+     * stating a hash states it over some of what it holds, so following the rest would give two
+     * equal values two hashes, and nothing here takes it.
      *
-     * <p>Taken at their word and no further: what such a hash is itself taken from is not walked, so
-     * a type saying what it hashes to answers for the whole of what it reads. Which is why what is
-     * said here is about the hash and not about the equality — {@link EvaluationId} tells two apart
-     * by which object each is and still says what it hashes to, and it is the hash this asks about.
+     * <p>Which is why a value that keeps the number it is asked for says what stands for it. A hash
+     * is not walked into — what such a number is taken from would be the one thing nothing here
+     * reads — and naming the value it is over puts that back inside the walk. Asked about the hash
+     * and not about the equality: {@link EvaluationId} tells two apart by which object each is, and
+     * it is the number a term is built from that this is about.
      */
     private static boolean statesAHashOfItsOwn(Class<?> type) {
         for (java.lang.reflect.Method method : type.getDeclaredMethods()) {
@@ -369,16 +358,19 @@ final class Term {
         }
     };
 
-    /** How each of what stands for a value of {@code type} is read: the parts it names, or its
-     *  record components where it names none. */
+    /**
+     * How each of what stands for a value of {@code type} is read: the one value it says stands for
+     * it, or its record components where it says nothing.
+     *
+     * <p>A value that names one is read through that one and not through what it holds beside it.
+     * Which is what the naming is for: a value keeping the number it is asked for holds that number
+     * too, and a number is the one thing a walk proving where numbers come from must not read.
+     */
     static List<java.lang.reflect.Method> readersOf(Class<?> type) {
-        List<String> named = STANDS_FOR.get(type);
         List<java.lang.reflect.Method> read = new ArrayList<>();
         try {
-            if (named != null) {
-                for (String part : named) {
-                    read.add(type.getDeclaredMethod(part));
-                }
+            if (SaysWhatStandsForIt.class.isAssignableFrom(type)) {
+                read.add(type.getMethod("standsFor"));
                 return read;
             }
             for (java.lang.reflect.RecordComponent component : type.getRecordComponents()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -663,7 +663,12 @@ public final class TypeOps {
             return Type.tuple(elements);
         }
         if (isDataLike(a) && isDataLike(b)) {
-            Set<TypeSymbol> names = new HashSet<>(namesOf(a));
+            // In the order the cases were met, because a report quotes this type back to the author
+            // and a set that hands its members over in the order their hashes fall would quote it
+            // in an order nothing about the program decides. Two unions holding alike are one value
+            // whatever order either walks in, so the order is the rendering's to read and nothing
+            // else's.
+            Set<TypeSymbol> names = new LinkedHashSet<>(namesOf(a));
             names.addAll(namesOf(b));
             return caseSetType(names);
         }

--- a/souther-compiler/src/main/java/souther/compiler/hash/KeepsTheNumberItIsAskedFor.java
+++ b/souther-compiler/src/main/java/souther/compiler/hash/KeepsTheNumberItIsAskedFor.java
@@ -1,0 +1,27 @@
+package souther.compiler.hash;
+
+/**
+ * A value whose own number is worked out once, from what stands for it, and kept.
+ *
+ * <p>For a value asked its number far more often than one of it is made — one used as a key, whose
+ * parts are values of the same kind, so that working the number out walks everything under it. What
+ * is walked cannot change while the value exists, so it is walked once.
+ *
+ * <p><b>Said here rather than read off the shape of a {@code hashCode}.</b> A rule about these
+ * values that found them by looking for a number handed back out of a field would let a value that
+ * stopped keeping one leave the rule without a word — and a value that stopped keeping one is the
+ * whole of what the rule is against. So the value declares that it is one of these, and dropping
+ * the declaration is an edit somebody makes on purpose.
+ *
+ * <p>What is held to it, and checked against what the class file does:
+ *
+ * <ul>
+ *   <li>its {@code hashCode} hands back a number it holds;
+ *   <li>nothing puts a number there but {@link ValueHash}, over what {@link #standsFor} answers and
+ *       over nothing else it holds;
+ *   <li>it holds what stands for it, that number, and nothing more — which is what a record gave
+ *       for nothing and what a class of this kind has to say for itself.
+ * </ul>
+ */
+public interface KeepsTheNumberItIsAskedFor extends SaysWhatStandsForIt {
+}

--- a/souther-compiler/src/main/java/souther/compiler/hash/SaysWhatStandsForIt.java
+++ b/souther-compiler/src/main/java/souther/compiler/hash/SaysWhatStandsForIt.java
@@ -1,25 +1,32 @@
 package souther.compiler.hash;
 
 /**
- * A value that names the value standing for it: what its own number is taken from, and what a walk
- * proving a number is taken from values reads in its place.
+ * A value that names the value a walk may follow in its place.
+ *
+ * <p>What the walk is is the one that proves a number is taken from values and never from which
+ * object something is. It stops at a class that answers a number of its own, so a class that has to
+ * answer one names what it is over instead, and the walk goes through that.
  *
  * <p>Said by the value and not about it. A table of class names and part names kept somewhere else
  * is a second writing of what a value holds, and the two come apart the first time a value is given
- * a part: the class compiles, the hash is over what it was, and the walk proves something about a
+ * a part: the class compiles, the number is over what it was, and the walk proves something about a
  * value nobody builds. What is named here is named where the parts are, so a part joins both at
  * once or neither.
  *
  * <p><b>What may be named is anything the value's equality already agrees with.</b> Two values that
- * are equal name things that are equal — that is the whole of what a hash owes an equality — and a
- * value told apart by more than what stands for it is free to name the less. So this is not a
- * second spelling of the equality: it is what may be hashed without giving two equal values two
- * numbers, and where a value is told apart by which object it is, that is anything about the value
- * that does not move.
+ * are equal name things that are equal — that is the whole of what a number owes an equality — and a
+ * value told apart by more than what stands for it is free to name the less. So this is not a second
+ * spelling of the equality, and it is not a statement about what the value's own
+ * {@code hashCode} reads: an evaluation is told apart by which object it is, answers the number
+ * {@code Object} gives it, and still names what may be walked in its place.
  *
- * <p><b>Held, not worked out when asked.</b> A value is asked this once for every number taken of
- * it, which for a value used as a key is far more often than one is made. One built at the ask
- * would put the walk back that naming it is for.
+ * <p><b>Nor is it a statement that the value keeps a number.</b> A value that does is a
+ * {@link KeepsTheNumberItIsAskedFor}, which says so and is held to it.
+ *
+ * <p><b>Held, not worked out when asked.</b> A value is asked this once for every number a term
+ * takes of it, which is far more often than one is made. One built at the ask would put back the
+ * walk that naming it is for, and would hand out a different object each time to a reader that has
+ * no way to know it.
  */
 public interface SaysWhatStandsForIt {
 

--- a/souther-compiler/src/main/java/souther/compiler/hash/SaysWhatStandsForIt.java
+++ b/souther-compiler/src/main/java/souther/compiler/hash/SaysWhatStandsForIt.java
@@ -1,0 +1,34 @@
+package souther.compiler.hash;
+
+/**
+ * A value that names the value standing for it: what its own number is taken from, and what a walk
+ * proving a number is taken from values reads in its place.
+ *
+ * <p>Said by the value and not about it. A table of class names and part names kept somewhere else
+ * is a second writing of what a value holds, and the two come apart the first time a value is given
+ * a part: the class compiles, the hash is over what it was, and the walk proves something about a
+ * value nobody builds. What is named here is named where the parts are, so a part joins both at
+ * once or neither.
+ *
+ * <p><b>What may be named is anything the value's equality already agrees with.</b> Two values that
+ * are equal name things that are equal — that is the whole of what a hash owes an equality — and a
+ * value told apart by more than what stands for it is free to name the less. So this is not a
+ * second spelling of the equality: it is what may be hashed without giving two equal values two
+ * numbers, and where a value is told apart by which object it is, that is anything about the value
+ * that does not move.
+ *
+ * <p><b>Held, not worked out when asked.</b> A value is asked this once for every number taken of
+ * it, which for a value used as a key is far more often than one is made. One built at the ask
+ * would put the walk back that naming it is for.
+ */
+public interface SaysWhatStandsForIt {
+
+    /**
+     * The value that stands for this one.
+     *
+     * <p>Answered with a type of its own rather than with {@code Object}, so that what a walk over
+     * types reads is the same thing the walk over values will meet. A value holding its parts in a
+     * record of its own answers with that record.
+     */
+    Object standsFor();
+}

--- a/souther-compiler/src/main/java/souther/compiler/hash/ValueHash.java
+++ b/souther-compiler/src/main/java/souther/compiler/hash/ValueHash.java
@@ -1,7 +1,7 @@
-package souther.compiler.values;
+package souther.compiler.hash;
 
 /**
- * How a value here is hashed from what it holds.
+ * How a value is hashed from what it holds.
  *
  * <p>A value whose hash is worked out from its parts is nearly always handed to something that adds
  * hashes up: a set of them sums what it holds, a map sums its entries, and a record built over one
@@ -32,10 +32,20 @@ package souther.compiler.values;
  * from itself and a block left no value name the same block and claim different things.
  *
  * <p><b>How many parts a value has is not asked here.</b> There are as many of these as there are
- * values here to write, and a value of five parts is a fifth one written when there is one. What
+ * values to write, and a value of five parts is a fifth one written when there is one. What
  * they are for is the shape of an equality, and the shapes are what the shapes are.
+ *
+ * <p><b>A package holding this and nothing else, which the packages of values depend on.</b> Where
+ * a value is written says nothing about how it is hashed: a relation between positions and the
+ * identity of a binding are both handed to something that adds hashes up, and the sum above
+ * cancels an affine number either way. A discipline one package keeps and the next does not is two
+ * answers to one question, and the second of them is the one carrying the defect.
+ *
+ * <p>Which is what the members being public says, and the whole of it. Crossing a package boundary
+ * in Java is what the word is for here; nothing outside this compiler is offered a hash of a value
+ * of its own.
  */
-final class ValueHash {
+public final class ValueHash {
 
     /** What a part already gathered is multiplied by before the next joins it, so that the parts
      *  keep their places. Odd, so no bit of what is already there is lost in the multiplication. */
@@ -58,7 +68,7 @@ final class ValueHash {
      * is that one, and what that one is made of is that one's own question. So this is where such
      * a value comes, and not because it is simple.
      */
-    static int ofOnePart(Class<?> kind, int part) {
+    public static int ofOnePart(Class<?> kind, int part) {
         return finished(GATHER * seed(kind) + part);
     }
 
@@ -72,17 +82,17 @@ final class ValueHash {
      * it. Where a value <em>is</em> a collection, how many it holds is part of the number
      * ({@link #ofWhatItHolds}), because there is nothing else there to tell two of them apart.
      */
-    static int ofItsParts(Class<?> kind, int first, int second) {
+    public static int ofItsParts(Class<?> kind, int first, int second) {
         return finished(GATHER * (GATHER * seed(kind) + first) + second);
     }
 
     /** A value of {@code kind} holding three, each in its own place. */
-    static int ofItsParts(Class<?> kind, int first, int second, int third) {
+    public static int ofItsParts(Class<?> kind, int first, int second, int third) {
         return finished(GATHER * (GATHER * (GATHER * seed(kind) + first) + second) + third);
     }
 
     /** A value of {@code kind} holding four, each in its own place. */
-    static int ofItsParts(Class<?> kind, int first, int second, int third, int fourth) {
+    public static int ofItsParts(Class<?> kind, int first, int second, int third, int fourth) {
         int gathered = GATHER * (GATHER * (GATHER * seed(kind) + first) + second) + third;
         return finished(GATHER * gathered + fourth);
     }
@@ -99,7 +109,7 @@ final class ValueHash {
      * {@code 4} and {@code 1} with {@code 3} add to one number and exclusive-or to two, and a
      * relation's pairs are drawn from few blocks, so pairs adding alike is what it has.
      */
-    static int ofAnUnorderedPair(Class<?> kind, int one, int other) {
+    public static int ofAnUnorderedPair(Class<?> kind, int one, int other) {
         return finished(GATHER * (GATHER * seed(kind) + (one + other)) + (one ^ other));
     }
 
@@ -112,7 +122,7 @@ final class ValueHash {
      * one value and have to be one number. The count joins it so that two of them whose contents
      * sum alike are still told apart where they hold different numbers of things.
      */
-    static int ofWhatItHolds(Class<?> kind, int summed, int size) {
+    public static int ofWhatItHolds(Class<?> kind, int summed, int size) {
         return finished(GATHER * (GATHER * seed(kind) + summed) + size);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
@@ -1,5 +1,8 @@
 package souther.compiler.types;
 
+import souther.compiler.hash.SaysWhatStandsForIt;
+import souther.compiler.hash.ValueHash;
+
 /**
  * Which binding a name is. A parameter, a {@code let}, a lambda's parameter, a {@code match} arm's
  * binding: each is one of these, and two of them are the same binding when they are equal.
@@ -17,17 +20,64 @@ package souther.compiler.types;
  * <p>{@code ordinal} counts the bindings of {@code owner} in the order they are written. It is not
  * stable against an edit — binding something ahead of it moves it — but the movement stops at the
  * definition, which is the unit the queries already ask in.
+ *
+ * <p><b>Its number is worked out when it is made and kept.</b> Nearly everything a compilation asks
+ * about a name is filed under one of these, so a value of this kind is asked its number tens of
+ * times for every one that is made — and an owner is a thing standing inside another, so working
+ * one out walks the whole chain the copy is under, the call it was expanded at, and the construct
+ * beneath that. What is walked is the same every time, because none of it can change.
  */
-public record BindingId(BindingOwner owner, int ordinal) {
+public final class BindingId implements SaysWhatStandsForIt {
 
-    public BindingId {
+    /**
+     * The whole of what a binding identity is, in one value.
+     *
+     * <p>Written once, and read by the equality, by the number and by the walk that proves the
+     * number is taken from values. A component given to a binding identity is given to it here,
+     * which is what leaves the three unable to disagree about what one holds.
+     */
+    record Parts(BindingOwner owner, int ordinal) {
+    }
+
+    private final Parts parts;
+
+    private final int hash;
+
+    public BindingId(BindingOwner owner, int ordinal) {
         if (owner == null) {
             throw new IllegalArgumentException("a binding belongs to something: " + ordinal);
         }
+        this.parts = new Parts(owner, ordinal);
+        this.hash = ValueHash.ofOnePart(BindingId.class, parts.hashCode());
+    }
+
+    /** What the binding belongs to. */
+    public BindingOwner owner() {
+        return parts.owner();
+    }
+
+    /** Which binding of that owner this is. */
+    public int ordinal() {
+        return parts.ordinal();
+    }
+
+    @Override
+    public Parts standsFor() {
+        return parts;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof BindingId that && hash == that.hash && parts.equals(that.parts);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
     }
 
     @Override
     public String toString() {
-        return owner + "." + ordinal;
+        return parts.owner() + "." + parts.ordinal();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
@@ -1,6 +1,6 @@
 package souther.compiler.types;
 
-import souther.compiler.hash.SaysWhatStandsForIt;
+import souther.compiler.hash.KeepsTheNumberItIsAskedFor;
 import souther.compiler.hash.ValueHash;
 
 /**
@@ -27,7 +27,7 @@ import souther.compiler.hash.ValueHash;
  * one out walks the whole chain the copy is under, the call it was expanded at, and the construct
  * beneath that. What is walked is the same every time, because none of it can change.
  */
-public final class BindingId implements SaysWhatStandsForIt {
+public final class BindingId implements KeepsTheNumberItIsAskedFor {
 
     /**
      * The whole of what a binding identity is, in one value.

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -127,7 +127,7 @@ public sealed interface BindingOwner {
         record Parts(BindingOwner within, ValueName expanded, ApplicationOrigin.Identified at) {
         }
 
-        private final Parts parts;
+        private final Expansion.Parts parts;
 
         private final int hash;
 
@@ -136,7 +136,7 @@ public sealed interface BindingOwner {
                 throw new IllegalArgumentException(
                         "an expansion is of something, somewhere, at some call");
             }
-            this.parts = new Parts(within, expanded, at);
+            this.parts = new Expansion.Parts(within, expanded, at);
             this.hash = ValueHash.ofOnePart(Expansion.class, parts.hashCode());
         }
 
@@ -156,7 +156,7 @@ public sealed interface BindingOwner {
         }
 
         @Override
-        public Parts standsFor() {
+        public Expansion.Parts standsFor() {
             return parts;
         }
 
@@ -188,12 +188,12 @@ public sealed interface BindingOwner {
         record Parts(BindingOwner within, Pass pass, int ordinal) {
         }
 
-        private final Parts parts;
+        private final Synthesized.Parts parts;
 
         private final int hash;
 
         public Synthesized(BindingOwner within, Pass pass, int ordinal) {
-            this.parts = new Parts(within, pass, ordinal);
+            this.parts = new Synthesized.Parts(within, pass, ordinal);
             this.hash = ValueHash.ofOnePart(Synthesized.class, parts.hashCode());
         }
 
@@ -213,7 +213,7 @@ public sealed interface BindingOwner {
         }
 
         @Override
-        public Parts standsFor() {
+        public Synthesized.Parts standsFor() {
             return parts;
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -1,6 +1,6 @@
 package souther.compiler.types;
 
-import souther.compiler.hash.SaysWhatStandsForIt;
+import souther.compiler.hash.KeepsTheNumberItIsAskedFor;
 import souther.compiler.hash.ValueHash;
 
 /**
@@ -120,7 +120,7 @@ public sealed interface BindingOwner {
      * That walk answers the same thing every time, and an owner is asked its number once for every
      * name filed under a binding it owns.
      */
-    final class Expansion implements BindingOwner, SaysWhatStandsForIt {
+    final class Expansion implements BindingOwner, KeepsTheNumberItIsAskedFor {
 
         /** The whole of what one expansion is, read by its equality, by its number and by the walk
          *  that proves the number is taken from values. */
@@ -182,7 +182,7 @@ public sealed interface BindingOwner {
      * <p>Its number is kept for the reason an expansion's is: what it stands inside is an owner,
      * and asking it for a number walks whatever is above it.
      */
-    final class Synthesized implements BindingOwner, SaysWhatStandsForIt {
+    final class Synthesized implements BindingOwner, KeepsTheNumberItIsAskedFor {
 
         /** The whole of what one pass's bindings inside one owner are. */
         record Parts(BindingOwner within, Pass pass, int ordinal) {

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -1,5 +1,8 @@
 package souther.compiler.types;
 
+import souther.compiler.hash.SaysWhatStandsForIt;
+import souther.compiler.hash.ValueHash;
+
 /**
  * What a binding belongs to — the definition whose text introduced it, or the copy of a body that a
  * pass placed inside one.
@@ -111,29 +114,123 @@ public sealed interface BindingOwner {
      * <p>And {@code within}, which is what tells copies apart. One call written inside a helper
      * that is itself expanded twice is one site and two expansions, and the two are inside different
      * owners.
+     *
+     * <p><b>Its number is worked out when it is made and kept.</b> What it stands inside is one of
+     * these too, so working one out walks every copy above it and the call each was expanded at.
+     * That walk answers the same thing every time, and an owner is asked its number once for every
+     * name filed under a binding it owns.
      */
-    record Expansion(BindingOwner within, ValueName expanded, ApplicationOrigin.Identified at)
-            implements BindingOwner {
+    final class Expansion implements BindingOwner, SaysWhatStandsForIt {
 
-        public Expansion {
+        /** The whole of what one expansion is, read by its equality, by its number and by the walk
+         *  that proves the number is taken from values. */
+        record Parts(BindingOwner within, ValueName expanded, ApplicationOrigin.Identified at) {
+        }
+
+        private final Parts parts;
+
+        private final int hash;
+
+        public Expansion(BindingOwner within, ValueName expanded, ApplicationOrigin.Identified at) {
             if (within == null || expanded == null || at == null) {
                 throw new IllegalArgumentException(
                         "an expansion is of something, somewhere, at some call");
             }
+            this.parts = new Parts(within, expanded, at);
+            this.hash = ValueHash.ofOnePart(Expansion.class, parts.hashCode());
+        }
+
+        /** What this copy stands inside. */
+        public BindingOwner within() {
+            return parts.within();
+        }
+
+        /** What was expanded here. */
+        public ValueName expanded() {
+            return parts.expanded();
+        }
+
+        /** The call it was expanded at. */
+        public ApplicationOrigin.Identified at() {
+            return parts.at();
+        }
+
+        @Override
+        public Parts standsFor() {
+            return parts;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Expansion that && hash == that.hash && parts.equals(that.parts);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
         }
 
         @Override
         public String toString() {
-            return within + "/" + expanded + "@" + at;
+            return parts.within() + "/" + parts.expanded() + "@" + parts.at();
         }
     }
 
-    /** Bindings {@code pass} made inside {@code within}, which no source wrote. */
-    record Synthesized(BindingOwner within, Pass pass, int ordinal) implements BindingOwner {
+    /**
+     * Bindings {@code pass} made inside {@code within}, which no source wrote.
+     *
+     * <p>Its number is kept for the reason an expansion's is: what it stands inside is an owner,
+     * and asking it for a number walks whatever is above it.
+     */
+    final class Synthesized implements BindingOwner, SaysWhatStandsForIt {
+
+        /** The whole of what one pass's bindings inside one owner are. */
+        record Parts(BindingOwner within, Pass pass, int ordinal) {
+        }
+
+        private final Parts parts;
+
+        private final int hash;
+
+        public Synthesized(BindingOwner within, Pass pass, int ordinal) {
+            this.parts = new Parts(within, pass, ordinal);
+            this.hash = ValueHash.ofOnePart(Synthesized.class, parts.hashCode());
+        }
+
+        /** What these bindings stand inside. */
+        public BindingOwner within() {
+            return parts.within();
+        }
+
+        /** Which pass made them. */
+        public Pass pass() {
+            return parts.pass();
+        }
+
+        /** Which of that pass's bindings inside that owner this is. */
+        public int ordinal() {
+            return parts.ordinal();
+        }
+
+        @Override
+        public Parts standsFor() {
+            return parts;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Synthesized that && hash == that.hash
+                    && parts.equals(that.parts);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
 
         @Override
         public String toString() {
-            return within + "/" + pass + "#" + ordinal;
+            return parts.within() + "/" + parts.pass() + "#" + parts.ordinal();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
@@ -1,5 +1,7 @@
 package souther.compiler.types;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.List;
 
 /**
@@ -106,7 +108,7 @@ public final class ResolvedCase {
 
     @Override
     public int hashCode() {
-        return 31 * selector.hashCode() + atoms.hashCode();
+        return ValueHash.ofItsParts(ResolvedCase.class, selector.hashCode(), atoms.hashCode());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/types/TypeSymbol.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/TypeSymbol.java
@@ -1,6 +1,8 @@
 package souther.compiler.types;
 
 import souther.compiler.Reserved;
+import souther.compiler.hash.SaysWhatStandsForIt;
+import souther.compiler.hash.ValueHash;
 
 /**
  * A data type's identity: which declaration this is, told apart by who declared it.
@@ -33,7 +35,7 @@ public sealed interface TypeSymbol extends Comparable<TypeSymbol> {
      * where it stands for the declaration in the compiler's own reasoning, and one is minted from
      * the other only in {@link TypeSymbols}.
      */
-    final class AtModule implements TypeSymbol {
+    final class AtModule implements TypeSymbol, SaysWhatStandsForIt {
 
         private final TypeKey key;
 
@@ -69,6 +71,12 @@ public sealed interface TypeSymbol extends Comparable<TypeSymbol> {
             return key.name();
         }
 
+        /** The address, which is the whole of what tells one of these from another. */
+        @Override
+        public TypeKey standsFor() {
+            return key;
+        }
+
         @Override
         public boolean equals(Object other) {
             return other instanceof AtModule at && key.equals(at.key);
@@ -76,7 +84,7 @@ public sealed interface TypeSymbol extends Comparable<TypeSymbol> {
 
         @Override
         public int hashCode() {
-            return key.hashCode();
+            return ValueHash.ofOnePart(AtModule.class, key.hashCode());
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1,5 +1,6 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
 import souther.compiler.reading.StateOfAReading;
 
 import java.util.ArrayList;

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Lacks.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;

--- a/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Provenance.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/souther-compiler/src/main/java/souther/compiler/values/Realized.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Realized.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalEvidence.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalLack.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sameness.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/souther-compiler/src/main/java/souther/compiler/values/Shown.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Shown.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.function.Function;
 
 /**

--- a/souther-compiler/src/main/java/souther/compiler/values/Standing.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Standing.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;

--- a/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
@@ -23,6 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>{@code ++} reaches the same join from two written operands, one level in from what it compares.
  * Both of them have their element type labelled, because both of them have one.
+ *
+ * <p><b>An accumulator naming several cases names them in the order the join met them</b>, which for
+ * an {@code else} is the {@code then} branch and then the arms as they are written, and for a
+ * {@code match} is the arms as they are written. What is quoted back to an author is then a function
+ * of what the author wrote; a set handing its members over in the order their numbers fall would
+ * quote an order nothing about the program decides, and moving any one of those numbers would move
+ * the report.
  */
 class AJoinFailureNamesTheOperandItRefusedTest {
 
@@ -132,7 +139,7 @@ class AJoinFailureNamesTheOperandItRefusedTest {
         Diagnostic report = only(source);
 
         assertEquals("1", underlined(source, report));
-        assertTrue(values(report).contains("Blue | Red"), values(report).toString());
+        assertTrue(values(report).contains("Red | Blue"), values(report).toString());
     }
 
     /**
@@ -177,7 +184,7 @@ class AJoinFailureNamesTheOperandItRefusedTest {
 
         assertEquals("| Guest -> 1", line(source, report).trim());
         assertEquals(List.of(), report.secondary());
-        assertTrue(values(report).contains("Blue | Red"), values(report).toString());
+        assertTrue(values(report).contains("Red | Blue"), values(report).toString());
     }
 
     private static final String BOUNDED = """

--- a/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.values;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.hash.ValueHash;
 
 import java.util.List;
 import java.util.Set;

--- a/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AValueIsHashedAtItsOwnBoundaryTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.values;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.hash.ValueHash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;


### PR DESCRIPTION
Closes #1539.

A binding identity is what nearly everything about a name is filed under, and an
owner is a thing standing inside another — so asking one for its number walked
every copy above it, the call each was expanded at and the construct beneath
that, once per lookup rather than once per value. Nothing on that walk can change
while the value exists, so the walk happens when the value is made and the number
is kept.

## What stands for a value is said where its parts are

The walk that proves a term is hashed from values stops at a class answering
"here is my number", and the table naming the parts of the classes it had to stop
at was a second writing of what a value holds: a part given to one of them joined
the class and its equality, and neither the number nor the table. So a value says
what stands for it, and the number, the equality and the walk all read that one
answer.

What may be named is anything the equality already agrees with, which is not the
same as the equality's own state — an evaluation is told apart by which object it
is and names less than it holds, and a type symbol names its address. Unifying the
list of components is the point; the two are not one concept.

The parts of a value that keeps a number live in a value of their own, which is
what a record gave for nothing and what is now stated: a check follows the number
back to the field the value says stands for it, and refuses a part held anywhere
else. The number a term is built from is still walked rather than taken from what
the value kept, because what lies under this chain includes an enum, and what an
enum answers is drawn afresh each run.

## One algebra for every value

Where a value is written says nothing about how it is hashed: the numbers of a
relation between positions and of a binding's identity are handed to the same
sums, and those cancel an affine number either way. So the algebra that finishes
a number moves to a package of its own that the packages of values depend on, and
the rule that a value takes its number from it is asked of both.

## An order that reached an author came from a hash

Moving these numbers made three reports change what they quoted. A join built its
case set in a collection that hands its members over in the order their numbers
fall, so what an author read was an order nothing about the program decides — the
join beside it that takes an expected type already gathers them in the order it
meets them. The producer is fixed and the order is now the accumulator's: the
`then` branch, and then the arms as they are written.

## What was measured

The profile no longer shows this family of values under hashing at all, and the
population for converting anything further was derived from the branch's own
profile and is empty: with the owner keeping its number, what hangs below it is
walked once per value rather than once per lookup.

A warm compile is faster, and by about what the profile said this family cost. It
was measured against the commit this branch is cut from, alternating the two in
both orders so a drift over the run cannot land on one side, and the branch was
ahead in every pair. An earlier run of the same measurement said the opposite, and
what it had measured was another worktree's test run and a baseline that had moved.

Every rule added is checked against a mutation: a number worked out from
something other than what stands for the value, a part held beside it, and a part
of a kind nothing here knows how to hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

