### PR TITLE
Say where an origin's makers are held to what this says of them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/types/SourceConstructOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/SourceConstructOrigin.java
@@ -34,8 +34,9 @@ package souther.compiler.types;
  * comprehension rather than of when the lowering ran. Nothing else makes one — an origin minted after
  * expansion would give two copies of one fork two origins, which is the thing this exists to prevent.
  * A record's constructor is public and takes every component, so that last sentence is held against
- * the compiled classes rather than left to be read: what settles an origin is written down, with who
- * calls it.
+ * the compiled classes rather than left to be read: what may settle an origin, and every compiled
+ * class of this repository that names one of those makers, is written down in {@code
+ * WhoMaySettleASourceConstructOriginTest}.
  *
  * <p>Not a name anything outside one compilation can be matched by. {@code ordinal} is the builder's
  * own count over what {@link #owner} names, and the builder does not take the numbers in the order


### PR DESCRIPTION
`SourceConstructOrigin` says that nothing but the reading that first meets a construct mints one, and that the sentence is held against the compiled classes rather than left to be read. It named nowhere that does it.

The enforcement described there already existed in `WhoMaySettleASourceConstructOriginTest` before #1530 was opened. What was missing was the path from the type to it. That absence is what the issue is: a reader who wants to know whether a pass may mint an origin of its own was told the question is settled somewhere they can look, and was not told where — and looking is what the issue records having done.

So the doc names the check, and says what the check holds. It also stops saying `who calls it`. What is read there is the constant pool of every class this repository publishes, which is why a name reached through a method reference is found and why the rows are a class and the maker it names; a caller method is not among what a pool entry can say. Left as it was, the sentence leaves the next reader room to expect a call site.

Nothing else changes. The check is untouched.

Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)