### PR TITLE
Write down the two places a walk of a store reaches and the declarations already allow

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -436,6 +436,14 @@ final class AnswerClosure {
             new Known(at(Q + "Bodies$Expanding", "souther.compiler.stdlib.Stdlib",
                     m(ANSWER, "value"), m("souther.compiler.query.Bodies$Expanding$Of", "table"), m("souther.compiler.check.HelperTable", "stdlib")),
                     STDLIB, ONLY_WALKED),
+            // What the declarations a reading of an input reached have already been made into,
+            // borrowed by the reading for the readers of those declarations that come after it. The
+            // walk of the declarations stops at the way of asking, which nothing closes; this is
+            // the object a compile put there, which is the same allowance one step further down.
+            new Known(at(Q + "Adequacy$Inputs", "souther.compiler.check.LentReadings",
+                    m(ANSWER, "value"), VALUE,
+                    m("souther.compiler.inputs.InputDomain", "machines")),
+                    A_LENDING_OF_READINGS, ONLY_WALKED),
             narrowedEnd(Q + "Adequacy$Inputs", walked(Scenario.THE_CORPORA),
                     m(ANSWER, "value"), VALUE,
                     m("souther.compiler.inputs.InputDomain", "byPath"), VALUE,
@@ -453,6 +461,16 @@ final class AnswerClosure {
             // has — and the walk that asks each object what it is meets the end on the way.
             narrowedEnd(Q + "Adequacy$Divided", walked(Scenario.THE_CORPORA),
                     m(ANSWER, "value"),
+                    m("souther.compiler.partition.Partitions$Partitioning", "measurements"),
+                    ELEMENT, m("souther.compiler.partition.PositionMeasurements", "axes"), ELEMENT,
+                    m("souther.compiler.partition.Axis", "narrowed"),
+                    m("souther.compiler.check.NarrowedBounds$Reading", "lower")),
+            // And the same end again through the reading the geometry is a projection of. Two
+            // questions are asked of one reading of a body — what the model divides, and where that
+            // reading met each condition it places itself — so a walk arrives at everything the
+            // geometry holds by both names. One thing to fix, met twice.
+            narrowedEnd(Q + "Adequacy$Dividing", walked(Scenario.THE_CORPORA),
+                    m(ANSWER, "value"), m(Q + "Adequacy$BodyDivided", "geometry"),
                     m("souther.compiler.partition.Partitions$Partitioning", "measurements"),
                     ELEMENT, m("souther.compiler.partition.PositionMeasurements", "axes"), ELEMENT,
                     m("souther.compiler.partition.Axis", "narrowed"),


### PR DESCRIPTION
Closes #1558.

## The issue had the diagnosis half wrong

It read the two places as unjudged, and asked whether a capability under
`Adequacy$Inputs` should be accepted at all. It is already accepted. Both places
are written down where the declarations are walked, with the reason each is
allowed:

- `A_LENDING_OF_READINGS` covers `Adequacy$Inputs` at
  `InputDomain#machines`, stopped at `DeclarationReadings` because nothing
  closes a way of asking.
- The ends of a narrowed range under `Adequacy$Dividing`, reached through the
  geometry a body's reading leaves.

`AnswerClosure` keeps a register per detector, and only the walk of the
declarations had been extended. The walk of a store reaches the same two places
and had nothing beside them, which is what the class was saying.

So the work is the register the other detector reads, and the readings the
entries take are the ones already written.

## Why a walk of a store reaches further

This is the pattern the scope already follows. The declarations stop at
`Resolve$Elsewhere`, the way of asking; a walk of what was built goes on through
it to the store, and both are written down under one reading. The lending is the
same shape: the declarations stop at the interface, and a compile put a
`LentReadings` there.

The geometry is the other kind. Two questions are asked of one reading of a
body — what the model divides, and where that reading met each condition it
places itself — so everything under the geometry is met once under each name.
The declared side says exactly that about the machines under it; the end of a
range hangs there too and had not been said.

## What was mutated

Each entry was checked by breaking it and watching the right assertion go. A
wrong member name in the path takes the place out of the register and both
assertions fail. Widening the detectors and scenarios beside the lending leaves
the place registered and fails only the one that holds provenance, naming the
lending and what actually met it.

## What was run

The class is tagged `population`, so the build on a push leaves it out and the
job for it is skipped.

    mvn -o test -Dtest=EverythingAnAnswerHoldsMeansSomethingTest

is green, the whole `population` group is green, and `mvn -o test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)