### PR TITLE
Put the names a position wears on the classes its body draws

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClass.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClass.java
@@ -1,8 +1,11 @@
 package souther.compiler.partition;
 
 import souther.compiler.inputs.Refinement;
+import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
+
+import java.util.List;
 
 /**
  * One equivalence class of an input position: a set of values expected to behave the same way.
@@ -91,6 +94,22 @@ public record PartitionClass(String id, String label, Recognition recognises,
                     + " and cannot be made a class of " + number);
         }
         return new PartitionClass(id, label, recognises, representatives, denotes, selects, number);
+    }
+
+    /**
+     * The same class, asked of the value inside the names the position writes it under.
+     *
+     * <p>What the class means is about the values the position holds, and a row writes one of them
+     * under whatever names the position wears — so the two are one class and the names are how a
+     * row spells it. Said by whoever assembles the measure, which is where the position's type is
+     * read; a class made from the rules alone has no way of knowing what wears it.
+     *
+     * <p>Nothing said where the position wears nothing ({@link Recognition.Under#of}), so a class
+     * of a bare position stays the class it was rather than becoming a second spelling of it.
+     */
+    public PartitionClass under(List<TypeSymbol> worn) {
+        return new PartitionClass(id, label, Recognition.Under.of(worn, recognises),
+                representatives, denotes, selects, of);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -678,8 +678,14 @@ public final class Partitions {
             // lies — so a position whose classes are sets has none, and a value singled out is in
             // them rather than beside them. Published as both, one distinction would be stated
             // twice in two algebras and every line would fall in no class ({@link Axis}).
+            // Under the names the position wears, which is where they are put on: the rules divided
+            // the values the position holds and knew nothing of what is written over them, and a
+            // row writes one of those values under every name the type puts on it. Left off, a
+            // class drawn over strings is asked about a construction and holds none of them —
+            // which is the classes of a position holding nothing the position holds.
             case Classing.Classed.Composed(List<PartitionClass> it) ->
-                    new Composition(it, composedFrom(dividing), false, null);
+                    new Composition(it.stream().map(each -> each.under(view.wrappers())).toList(),
+                            composedFrom(dividing), false, null);
             // No classes and nothing they were composed from, and the cuts stand: they are
             // observations of their own rather than a projection of the classes.
             case Classing.Classed.NotComposed(var why) ->

--- a/souther-compiler/src/test/java/souther/compiler/AValueWrittenUnderANameIsInTheClassesOfWhatTheNameHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AValueWrittenUnderANameIsInTheClassesOfWhatTheNameHoldsTest.java
@@ -1,0 +1,146 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row's value at a position divided into sets of strings falls in one of them, whether or not the
+ * position's type is a name over the string.
+ *
+ * <p>A name over one value is not a step in a path, so a walk to the position leaves the
+ * construction and the string is one inside it — while the rules that divided the position divided
+ * the strings it wraps. Read as the case it is, such a value is in none of the sets those rules
+ * stated, and the classes of the position turn out to hold none of what the position holds. That is
+ * the partition's own exhaustiveness broken, and it is raised rather than reported, so a build over
+ * a model of this shape stops.
+ *
+ * <p>Asked of what a run left and not of the classes alone. The classes are exclusive and exhaustive
+ * over the strings either way — the reading that drew them never saw the name — so a test that read
+ * them would have passed throughout.
+ */
+class AValueWrittenUnderANameIsInTheClassesOfWhatTheNameHoldsTest {
+
+    /**
+     * A string a body divides, under a name.
+     *
+     * <p>No invariant on {@code Ticket}: a rule bounding some other number of the position takes
+     * these classes off the measures altogether, and then nothing asks which class anything is in.
+     */
+    private static final String UNDER_A_NAME = """
+            module example.prefix
+
+            data Ticket = String
+            data Seated = { ticket: Ticket }
+
+            behavior seat : (t: Ticket) -> Seated | NotOnTheList
+                constructs Seated
+
+            let seat (t) = {
+                guard String.startsWith("w-", t.value) else NotOnTheList
+                Seated { ticket = t }
+            }
+
+            example seat
+                | "one that is on the list" : (Ticket("w-1")) -> Seated { ticket = Ticket("w-1") }
+            """;
+
+    /**
+     * The same body over a record whose one field happens to be called {@code value}.
+     *
+     * <p>A name over a value and a record with one field are two declarations and not two spellings
+     * of one (spec §data), and the difference is what a reader of an observation cannot see: both
+     * are observed as a construction carrying a field called {@code value}. So the difference has
+     * to be settled from the declarations, and it is — here it is settled before any of this, by
+     * the record being given up in favour of the position under it.
+     */
+    private static final String IN_A_RECORD = """
+            module example.boxed
+
+            data Ticket = { value: String }
+            data Seated = { ticket: Ticket }
+
+            behavior seat : (t: Ticket) -> Seated | NotOnTheList
+                constructs Seated
+
+            let seat (t) = {
+                guard String.startsWith("w-", t.value) else NotOnTheList
+                Seated { ticket = t }
+            }
+
+            example seat
+                | "one that is on the list" :
+                    (Ticket { value = "w-1" }) -> Seated { ticket = Ticket { value = "w-1" } }
+            """;
+
+    private static PartitionEvidence.AxisCoverage axis(String source, String path) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        PartitionEvidence partition = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value().get("seat");
+        assertNotNull(partition, "the model under test compiles");
+        return partition.axes().stream().filter(each -> each.path().equals(path))
+                .findFirst().orElseThrow();
+    }
+
+    /**
+     * The row is in the class its string belongs to.
+     *
+     * <p>Which class, and not that some class was reached: the point is that the value the name
+     * holds is what places it, so the assertion names the side of the prefix the row's string is
+     * on. A row placed in the other one would be a value read as something it is not.
+     */
+    @Test
+    void aRowIsPlacedByTheStringItsNameHolds() {
+        PartitionEvidence.AxisCoverage at = axis(UNDER_A_NAME, "t");
+
+        PartitionEvidence.AxisCoverage.Reached reached = at.reached().made().orElseThrow();
+        assertEquals(0, reached.unclassifiedRows(),
+                "a row whose value the classes were drawn over was read for it");
+        assertTrue(reached.covered().contains("t/String.startsWith(\"w-\", x)"),
+                () -> "the class the row's string is in, among " + at.classes()
+                        + ", reached " + reached.covered());
+    }
+
+    /** And the classes it is placed among are the ones the body drew. */
+    @Test
+    void theClassesAreTheSidesTheBodyDrew() {
+        assertEquals(
+                java.util.List.of("t/String.startsWith(\"w-\", x)",
+                        "t/not String.startsWith(\"w-\", x)"),
+                axis(UNDER_A_NAME, "t").classes());
+    }
+
+    /**
+     * And a record with a field of that name divides the field, not the record.
+     *
+     * <p>Which is where the two declarations part, and the reason nothing downstream has to tell
+     * them apart from what a row wrote: a name over a value is one position and the classes are of
+     * it, a record is given up in favour of the positions under it and the classes are of the field.
+     *
+     * <p>What this holds is that separation and not the absence of a reader that would guess at it.
+     * Nothing here hands a construction to a class at all — the position is the field, so what
+     * arrives is the string — so a reader that read the two constructions alike would pass this as
+     * readily. What refuses one is that the names a class is written under are the ones the
+     * position's type view read, and taking them off asks for those names.
+     */
+    @Test
+    void aRecordIsDividedAtItsFieldAndNotAsANameOverIt() {
+        PartitionEvidence.AxisCoverage at = axis(IN_A_RECORD, "t.value");
+
+        assertEquals(
+                java.util.List.of("t.value/String.startsWith(\"w-\", x)",
+                        "t.value/not String.startsWith(\"w-\", x)"),
+                at.classes());
+        assertTrue(at.reached().made().orElseThrow().covered()
+                        .contains("t.value/String.startsWith(\"w-\", x)"),
+                "the row is placed at the field the classes are of");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorDividesAPositionByWhatItsRulesTellApartTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorDividesAPositionByWhatItsRulesTellApartTest.java
@@ -172,7 +172,7 @@ class ABehaviorDividesAPositionByWhatItsRulesTellApartTest {
         assertTrue(!axis.classes().isEmpty(),
                 "the two rules are sayable together, so the position has classes");
         assertTrue(axis.classes().stream().allMatch(
-                        each -> each.recognises() instanceof Recognition.OfASet),
+                        each -> isOfASet(each.recognises())),
                 "and they are the values on either side of what the two rules come to: "
                         + axis.classes().stream().map(PartitionClass::label).toList());
     }
@@ -316,15 +316,32 @@ class ABehaviorDividesAPositionByWhatItsRulesTellApartTest {
 
         for (Axis each : divided.axes()) {
             if (each.classes().stream()
-                    .anyMatch(one -> one.recognises() instanceof Recognition.OfASet)) {
+                    .anyMatch(one -> isOfASet(one.recognises()))) {
                 assertEquals(List.of(), each.cuts(),
                         "a class that is a set has no place on the order for a cut to be at: "
                                 + each);
             }
         }
         assertTrue(divided.axes().stream().anyMatch(each -> each.classes().stream()
-                        .anyMatch(one -> one.recognises() instanceof Recognition.OfASet)),
+                        .anyMatch(one -> isOfASet(one.recognises()))),
                 "and the rule does divide the position into sets: " + divided.axes());
+    }
+
+    /**
+     * Whether a class means a set of the position's values, under whatever names a row writes one
+     * of them under.
+     *
+     * <p>Asked through the wearing rather than of the arm in hand. A class of a position that
+     * wears a name is written down under it, so the outermost arm is the wearing and the meaning
+     * is one inside — and a model whose position wears one would read here as a position divided
+     * nowhere.
+     */
+    private static boolean isOfASet(Recognition recognition) {
+        return switch (recognition) {
+            case Recognition.OfASet _ -> true;
+            case Recognition.Under under -> isOfASet(under.inner());
+            default -> false;
+        };
     }
 
     /** The one measure the model under test makes of its position. */


### PR DESCRIPTION
Closes #1559.

Reworked after review. The first attempt fixed this at `Recognitions`, by reading
a construction that carries one field called `value` as the value inside it. That
was wrong at the root, and the review was right to refuse it: whether a
declaration is a name over a value is settled by the declaration and never by the
shape of what a row wrote, and `data X = Y` and `data X = { value: Y }` are two
declarations (spec §data). The one reader that takes names off an observation
already takes them off by name — it walks the wrappers the position's type view
read and strips only where the construction's type is the name it expected — so a
record whose own field is called `value` is never mistaken for a name over one.
That patch went around that guarantee and put a second name-stripping beside it,
deciding from the runtime shape what the declarations had already decided.

## Where it actually goes wrong

Every kind of class made from a position's own declarations is published under
the names the position wears: the type view is read once, and what it says is put
on the truths, the presences, the cases and the values singled out.

The classes composed from a body's rules are not. `String.startsWith("w-", x)`
comes back as the bare set of strings, and nothing on it says a row writes one of
those under a name. So a value written under one arrived at a class drawn over
what the name holds, was read as the declaration it is, and was in none of the
sets those rules stated. Every class read it and none held it, which is what
`Axis` declares cannot happen — raised, and rightly, because it is the
partition's own exhaustiveness broken rather than a measurement coming up short.

The fix puts the names on where the measure is assembled, which is the one place
the position's type is read. The rules that composed the classes go on knowing
what they divided and nothing about what is written over it.

## The question that was asked of the arm

Fixing that turned an existing test red, and the test was right to go: it asked
whether a class is a set with an `instanceof` on the arm in hand. A class of a
position that wears a name is written down under the wearing, so the outermost
arm is the wearing and the meaning is one inside it. Asked that way, a position
divided into sets reads as one divided nowhere.

So the question moves onto the meaning, beside the two that were already asked
that way. Main code never asked the bare arm — everything about a recognition
goes through the one reader — and this was the only place that did.

One place asserts an arm and stays: its model gives the position no name, so
nothing is worn and the assertion is exact for what it tests.

## What the tests hold

A model whose body divides a string under a name, with a row on one side. It
asserts which class the row landed in rather than that some class was reached,
and that no row went unread.

Beside it, the same body over a record whose one field is called `value`. That is
where the two declarations part and why nothing downstream has to tell them apart
from what a row wrote: a name over a value is one position and the classes are of
it; a record is given up in favour of the positions under it and the classes are
of the field. Taking the names back off leaves that one green and raises on the
other, with the sentence the issue was filed about.

## What this does not fix

#1565 is beside this one: where a rule bounds some other number of the position,
these classes are dropped from the measures altogether and nothing asks which
class anything is in. That is why the booking corpus does not reach this. It is
not a prerequisite — the corpus is measured exactly as it was and the checked-in
answers are unchanged.

## What was run

`mvn -o test` is green, and the whole `population` group is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)