### PR TITLE
Read a rule about the strings off what its subject is made of

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -12,10 +12,10 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.StringPredicates;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.FilingCoordinate;
-import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.PathResolution;
+import souther.compiler.inputs.StandingQuestion;
 import souther.compiler.regex.PatternPlan;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
@@ -89,18 +89,20 @@ public final class BehaviorSetStatements {
      *                   holds, which is settled where those are known and not here
      * @param blocked the distinctions of a position this compiler did not get, which is what keeps
      *                its classes from being composed out of the ones it did
-     * @param saying  the rules that reached here and divide no position, which a reader is owed and
-     *                which hold nothing open. A rule about a value an operation made from a
-     *                position is one of these: it is about that value, and a denominator held open
-     *                by it would be held open by a rule that never reached the position
+     * @param nothingClassifies the rules that reached here and whose subject this reading could not
+     *                place at a position, each as the question standing where it was filed. Nothing
+     *                works out what such a rule states of the values there — reading it back
+     *                through the operation that made them is a capability this has not — so what is
+     *                undecided is what the rule does at all, which is what the question says
      */
     public record Read(List<RuleEvidence> statements, List<ClassingBlocker> blocked,
-                       List<RuleWithoutALine> saying, List<ForkOfItsOwn> forks) {
+                       List<StandingQuestion.NothingClassifiesIt> nothingClassifies,
+                       List<ForkOfItsOwn> forks) {
 
         public Read {
             statements = List.copyOf(statements);
             blocked = List.copyOf(blocked);
-            saying = List.copyOf(saying);
+            nothingClassifies = List.copyOf(nothingClassifies);
             forks = List.copyOf(forks);
         }
     }
@@ -212,17 +214,22 @@ public final class BehaviorSetStatements {
                    RuleReachNumbering reaches) {
         List<Asked> asked = new ArrayList<>();
         List<ClassingBlocker> blocked = new ArrayList<>();
-        List<RuleWithoutALine> saying = new ArrayList<>();
+        List<StandingQuestion.NothingClassifiesIt> nothingClassifies = new ArrayList<>();
         for (PredicateReadings.Reading each : read.predicates()) {
             switch (ask(each, symbols)) {
                 case Outcome.OfADistinction(Asked it) -> asked.add(it);
                 case Outcome.NotGot(var at, var why) ->
                         blocked.add(new ClassingBlocker(at, each.origin(), why));
-                // At every place it may be about. A rule said to divide nothing is one sentence,
-                // and where the reading could not settle which position it was of, each of the
-                // places it may have been of is owed it.
+                // At every place it may be about. A rule this could not place is one sentence, and
+                // where the reading could not settle which position it was of, each of the places
+                // it may have been of is owed it.
+                //
+                // As a question and not as a finding. What such a rule states of the values there
+                // is what nothing worked out, so a measure that closed over it would be closing
+                // over a reading that stopped — while the report went on naming the rule.
                 case Outcome.SayingNothing(var at, var why) -> at.forEach(where ->
-                        saying.add(RuleWithoutALine.of(each.origin().cited(), where, why)));
+                        nothingClassifies.add(StandingQuestion.NothingClassifiesIt
+                                .of(each.origin().cited(), where, why)));
                 // Nothing places it, so there is nobody to say it to. Which is the answer the
                 // reading of a comparison gives the same shape, and not this walk being quiet.
                 case Outcome.Nowhere _ -> { }
@@ -244,7 +251,7 @@ public final class BehaviorSetStatements {
         for (Asked each : asked) {
             state(each, answers.get(each.term()), statements, blocked);
         }
-        return new Read(statements, blocked, saying,
+        return new Read(statements, blocked, nothingClassifies,
                 ofTheirOwn(behavior, read, symbols, forks, reaches));
     }
 
@@ -253,14 +260,13 @@ public final class BehaviorSetStatements {
      *
      * <p><b>Named outcomes and not what a walk had left over.</b> Three things can be true of such a
      * rule and they are not one another: it states a distinction of this position, it states one
-     * this compiler did not get, or it states nothing about this position at all. Only the second
-     * keeps a position's classes from being composed — the first is one of them, and the third is
-     * not about the position, so a denominator held open by it would be held open by a rule that
-     * never reached it.
+     * this compiler did not get, or its subject stands at no position this reading can place. Only
+     * the second keeps a position's classes from being composed — the first is one of them, and the
+     * third is a reading that stopped before it reached a position, so a denominator held open by
+     * it would be held open by a rule that never got there.
      *
      * <p>Filled from the branches a reading fell through, the three were one list: everything that
-     * did not become a statement kept the position's classes shut, and a rule read to the end that
-     * says nothing took its siblings down with it.
+     * did not become a statement kept the position's classes shut.
      */
     private sealed interface Outcome {
 
@@ -278,20 +284,25 @@ public final class BehaviorSetStatements {
                       BlockReason.RuleWithoutLineReason why) implements Outcome {}
 
         /**
-         * A rule of the model that divides no position here, and where to say so.
+         * A rule of the model whose subject this could not place at a position, and where to say
+         * so.
          *
-         * <p>A reader is owed the sentence and the classes are not held open by it: a rule about a
-         * value an operation made from a position is about that value, and a rule read to the end
-         * that tells nothing apart has been read. Neither is a distinction gone missing.
+         * <p>A reading that stopped, and the reason says which way. A value an operation made out
+         * of what stands somewhere is about that value, and what the rule says about the values it
+         * was made from would take reading the operation backwards; a value that is what stands at
+         * one of several places is about the input at whichever of them this run is. Neither is a
+         * distinction gone missing, and neither is a rule read to the end — so what stands where
+         * this is filed is a question, and what a measure there rests on is that nothing worked out
+         * what the rule states.
          */
         record SayingNothing(List<FilingCoordinate> at,
-                             BlockReason.RuleWithoutLineReason why) implements Outcome {
+                             BlockReason.RuleReadingStopped why) implements Outcome {
 
             public SayingNothing {
                 at = List.copyOf(at);
                 if (at.isEmpty()) {
                     throw new IllegalArgumentException(
-                            "a rule said to divide nothing is said somewhere: " + why);
+                            "a rule this could not place is said somewhere: " + why);
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -10,12 +10,14 @@ import souther.compiler.check.PredicateStatement;
 import souther.compiler.check.StatedContract;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.StringPredicates;
+import souther.compiler.check.ValueOrigin;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.FilingCoordinate;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.StandingQuestion;
+import souther.compiler.inputs.TermPath;
 import souther.compiler.regex.PatternPlan;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
@@ -357,25 +359,93 @@ public final class BehaviorSetStatements {
     private static Outcome saidWithoutADenominator(PredicateReadings.Reading each,
                                                    PathResolution stands, Symbols symbols) {
         return switch (stands) {
-            case PathResolution.MayStandAt(var among) -> new Outcome.SayingNothing(
-                    among.stream().map(FilingCoordinate::at).toList(),
-                    new BlockReason.RuleAboutAnElementOfSeveralSequences());
-            case PathResolution.NotAPosition _ ->
-                    switch (each.reads().cameFrom(each.subject(), symbols)) {
-                        case PathResolution.At(var from) -> new Outcome.SayingNothing(
-                                List.of(FilingCoordinate.at(from)),
-                                new BlockReason.RuleAboutADerivedValue());
-                        case PathResolution.MayStandAt(var among) -> new Outcome.SayingNothing(
-                                among.stream().map(FilingCoordinate::at).toList(),
-                                new BlockReason.RuleAboutAnElementOfSeveralSequences());
-                        // And a rule about a value that came from no position the reading can name,
-                        // which has nowhere to be said.
-                        case PathResolution.NotAPosition _ -> new Outcome.Nowhere();
-                    };
+            case PathResolution.MayStandAt(var among) -> mayStandAt(among);
+            case PathResolution.NotAPosition _ -> whereItsValueCameFrom(each, symbols);
             // The caller asks this only where the subject stands at no one place.
             case PathResolution.At at -> throw new IllegalArgumentException(
                     "a rule whose subject stands at " + at.path() + " has a denominator");
         };
+    }
+
+    /**
+     * The same for a subject that is at no one position, read out of what its value is made of.
+     *
+     * <p>Asked of {@link ValueOrigin}, which is where what an expression is made of is worked out
+     * for every reader of a body, and read off the arms of it that say where a value came from
+     * ({@link #positionsItCameFrom}). A subject an operation answered names no position and came
+     * from the ones its arguments name; a walk that stopped at the operation reported a model
+     * stating nothing where an author wrote a rule.
+     *
+     * <p>At every position the value came from. {@code String.append(a, b)} is made out of both,
+     * and an author who wrote a rule about the joined string is owed the sentence at each — filed
+     * at one of them, the other comes back as a position the model says nothing about.
+     *
+     * <p>A subject that <em>is</em> what stands at more than one place is asked first, and of the
+     * reading rather than of what the value is made of. That is the other sentence — nothing was
+     * made out of it and there is no operation to read backwards — and what an expression is made
+     * of has no way to say it: a value that is one of several places is not one built out of all
+     * of them.
+     */
+    private static Outcome whereItsValueCameFrom(PredicateReadings.Reading each, Symbols symbols) {
+        if (each.reads().cameFrom(each.subject(), symbols)
+                instanceof PathResolution.MayStandAt(var among)) {
+            return mayStandAt(among);
+        }
+        Set<TermPath> from = positionsItCameFrom(
+                GuardThresholds.originOf(each.subject(), each.reads(), symbols));
+        // And a rule about a value that came from no position the reading can name, which has
+        // nowhere to be said.
+        return from.isEmpty() ? new Outcome.Nowhere()
+                : new Outcome.SayingNothing(from.stream().map(FilingCoordinate::at).toList(),
+                        new BlockReason.RuleAboutADerivedValue());
+    }
+
+    /**
+     * Every position {@code origin}'s value came from, out of the arms that say where a value came
+     * from.
+     *
+     * <p>Read here and not asked of what an expression is made of as a whole, because that answer
+     * does not hold the question. What is made out of several things and what is one of several
+     * things arrive in one arm: the parts of a choice are the values it chooses between and what it
+     * turns on, side by side. A union over that arm files a rule at what decided which value the
+     * subject is, and a reader sent there is sent to a position the rule says nothing about.
+     *
+     * <p>So the arms that do state where a value came from are read, and the one that does not is
+     * left. What that costs is a rule under a choice shown nowhere, which is what such a rule comes
+     * to already; what reading it would cost is a rule shown at the wrong position, which is worse
+     * and is the thing an author cannot tell from a rule their model states.
+     *
+     * <p>A switch with no default, so an arm added to what an expression is made of is one somebody
+     * says the provenance of before this compiles.
+     */
+    private static Set<TermPath> positionsItCameFrom(ValueOrigin<TermPath> origin) {
+        return switch (origin) {
+            case ValueOrigin.IsAPosition<TermPath> it -> Set.of(it.at());
+            case ValueOrigin.MadeFromAPosition<TermPath> it -> Set.of(it.at());
+            // What an operation answered came from whatever its arguments came from, each of them:
+            // a string joined out of two positions is made out of both, and an author who wrote a
+            // rule about the joined value is owed the sentence at each.
+            case ValueOrigin.Applied<TermPath> it -> across(it.arguments());
+            // A value written where it stands came from no position, and one nothing here can name
+            // came from none this can name.
+            case ValueOrigin.Written<TermPath> _, ValueOrigin.Unnameable<TermPath> _ -> Set.of();
+            case ValueOrigin.Composed<TermPath> _ -> Set.of();
+        };
+    }
+
+    /** The positions everything in {@code of} came from, in the order they were met. */
+    private static Set<TermPath> across(List<ValueOrigin<TermPath>> of) {
+        Set<TermPath> out = new LinkedHashSet<>();
+        for (ValueOrigin<TermPath> each : of) {
+            out.addAll(positionsItCameFrom(each));
+        }
+        return out;
+    }
+
+    /** A rule about a value that is what stands at one of {@code among}, said at each of them. */
+    private static Outcome mayStandAt(List<TermPath> among) {
+        return new Outcome.SayingNothing(among.stream().map(FilingCoordinate::at).toList(),
+                new BlockReason.RuleAboutAnElementOfSeveralSequences());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -186,18 +186,18 @@ final class Coverages {
             EnsuresThresholds.Clauses clauses, GuardThresholds.Guards guards,
             LinesWhereTheyFall.Filed filed,
             souther.compiler.partition.BehaviorSetStatements.Read sets) {
-        // And the rules about the strings that divided no position, which are findings of the same
-        // kind. Left out, a rule an author wrote would reach the measure, come to nothing, and be
-        // shown to nobody — while the position it names came back as one the model says nothing
-        // about.
+        // Every producer's answer in one gathering. Left out of it, a rule an author wrote would
+        // reach the measure, come to nothing, and be shown to nobody — while the position it names
+        // came back as one the model says nothing about.
         souther.compiler.inputs.RulesWithNoLine.Gathered found =
                 new souther.compiler.inputs.RulesWithNoLine.Gathered();
+        // The lines that had nowhere to fall, as the findings whoever could not place them made.
         filed.blocked().forEach(each -> found.add(each.reported()));
-        // And the rules that reached the measure and divide no position. They hold nothing open —
-        // a rule read to the end that tells nothing apart has been read, and one about a value an
-        // operation made from a position is about that value — so they are said and nothing waits
-        // on them.
-        sets.saying().forEach(found::add);
+        // And the rules about the strings whose subject this reading could not place at a position.
+        // A question each and no finding: what a report is owed about such a rule is that nothing
+        // worked out what it states there, which the question says, and a measure that closed over
+        // it would be closing over a reading that stopped.
+        sets.nothingClassifies().forEach(found::asked);
         // And the forks whose condition no reader took in. A question for each and no finding: what
         // a report is owed about such a rule is that nothing worked out what it states, which the
         // question says, and where it says it is what the reading got to rather than what the fork

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -1,0 +1,220 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleCitation;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.query.Sites;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule an author wrote about the strings of a value an operation made is named at every position
+ * that value came from.
+ *
+ * <p>Not measured there. What {@code String.uppercase} answers is made from what stands at a
+ * position and is not those strings, so a line drawn there would be at values the rule is not about.
+ * What it must not be is silent: the author wrote a rule, and a reading that placed it nowhere
+ * reported a model that states nothing at the position — which is the answer a body with no rule in
+ * it gives.
+ *
+ * <p><b>At every position and not the first.</b> A value joined out of two positions is made out of
+ * both, and an author who wrote a rule about the joined string is owed the sentence at each of them.
+ * Filed at one, the other comes back as a position the model says nothing about.
+ *
+ * <p>What the value is made of is {@link souther.compiler.check.ValueOrigin}'s answer, which is the
+ * same answer the reading of a comparison beside this one is filed from. Asked of where a subject's
+ * value came from instead, a rule about anything an operation stands over is a rule about nothing:
+ * that question is answered for a leaf, and an application is not one.
+ */
+class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
+
+    private static final String MODULE = "example.codes";
+
+    private static final String ONE_POSITION = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (code: String) -> Answer
+            let f (code) =
+                if String.startsWith("JP", String.uppercase(code)) then Yes else No
+            """;
+
+    private static final String TWO_POSITIONS = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (a: String, b: String) -> Answer
+            let f (a, b) =
+                if String.startsWith("JP", String.append(a, b)) then Yes else No
+            """;
+
+    private static final String NO_POSITION = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (code: String) -> Answer
+            let f (code) =
+                if String.startsWith("JP", "written") then Yes else No
+            """;
+
+    private static final String A_VALUE_CHOSEN_BETWEEN = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (flag: Bool, a: String, b: String) -> Answer
+            let f (flag, a, b) =
+                if String.startsWith("JP", if flag then a else b) then Yes else No
+            """;
+
+    private static final String AN_ELEMENT_IT_CAME_FROM = """
+            module example.codes
+
+            data Person = { code: String }
+            data Count = Int
+
+            behavior f : (people: List<Person>) -> Count
+                constructs Count
+            let f (people) =
+                Count(List.length(
+                    List.filter(s -> String.startsWith("JP", s),
+                        List.map(q -> q.code, people))))
+            """;
+
+    private static PartitionEvidence measured(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        PartitionEvidence f = compilation.db()
+                .ask(new Adequacy.Coverage(MODULE)).value().get("f");
+        assertNotNull(f, "the model under test compiles");
+        return f;
+    }
+
+    /** Where a rule that came to nothing was said, once per position. */
+    private static List<String> derived(PartitionEvidence measured) {
+        return measured.notRead().stream()
+                .filter(each -> each.reason()
+                        == UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE)
+                .map(PartitionEvidence.NotRead::at).toList();
+    }
+
+    /** The rule is named, at the position the strings it is about were made from. */
+    @Test
+    void aValueMadeFromOnePositionIsNamedThere() {
+        assertEquals(List.of("code"), derived(measured(ONE_POSITION)),
+                () -> "said where the strings came from: " + measured(ONE_POSITION).notRead());
+    }
+
+    /** And at every position it was made from, since the rule is about what all of them came to. */
+    @Test
+    void aValueMadeFromTwoPositionsIsNamedAtBoth() {
+        assertEquals(List.of("a", "b"), derived(measured(TWO_POSITIONS)),
+                () -> "said at each: " + measured(TWO_POSITIONS).notRead());
+    }
+
+    /** A rule about a string written where it stands is about no position, and is said nowhere. */
+    @Test
+    void aValueWrittenWhereItStandsIsNamedNowhere() {
+        assertEquals(List.of(), derived(measured(NO_POSITION)));
+    }
+
+    /**
+     * And a rule about a value chosen between two is said nowhere, for want of a reading that
+     * tells a choice from a composition.
+     *
+     * <p>Not what such a rule is owed. The value is what {@code a} is or what {@code b} is, and
+     * each of them is a position an author who wrote a rule about it has something to be told
+     * about — but what an expression is made of holds the arms of a choice and what it turns on in
+     * one arm, side by side with everything a value was built out of. Read as where the value came
+     * from, the rule would be filed at {@code flag} as well, which decided which value the subject
+     * is and holds none of the strings the rule is about.
+     *
+     * <p>So this is the reading falling short rather than the model saying nothing, and it is what
+     * the day a choice is told from a composition has to come back to.
+     */
+    @Test
+    void aValueChosenBetweenTwoIsNamedNowhereForNow() {
+        assertEquals(List.of(), derived(measured(A_VALUE_CHOSEN_BETWEEN)),
+                () -> "nothing is filed, and least of all what the choice turned on: "
+                        + measured(A_VALUE_CHOSEN_BETWEEN).notRead());
+    }
+
+    /**
+     * And a value handed out by an operation is named at the position it was taken from.
+     *
+     * <p>Beside the three above and reached the other way: nothing was applied to what the rule is
+     * about, and what says where it came from is the edge an expansion wrote. Left out, the day
+     * filing is read off the positions a walk <em>named</em> — which is not what any of these are —
+     * this case is the one that goes quiet.
+     */
+    @Test
+    void anElementAnOperationHandedOutIsNamedWhereItCameFrom() {
+        assertEquals(List.of("people[*]"), derived(measured(AN_ELEMENT_IT_CAME_FROM)),
+                () -> "said where the elements came from: "
+                        + measured(AN_ELEMENT_IT_CAME_FROM).notRead());
+    }
+
+    /**
+     * And each of them names the rule, as the question standing there.
+     *
+     * <p>These are not positions nothing was written at, and they are not rules read to the end
+     * either: what the rule states of the values here is what nothing worked out, so the measure at
+     * the position rests on the question rather than closing over it.
+     */
+    @Test
+    void everyOneOfThemNamesTheRuleAsAQuestionStandingThere() {
+        for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM)) {
+            PartitionEvidence measured = measured(model);
+            assertTrue(measured.notRead().stream()
+                            .filter(each -> each.reason()
+                                    == UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE)
+                            .allMatch(each -> each instanceof PartitionEvidence.NotRead
+                                    .AnUnclassifiedRule),
+                    () -> "a rule was read, so the finding has one to name: " + measured.notRead());
+        }
+    }
+
+    /**
+     * And the document writes a handle for it, which is a place this compilation worked out.
+     *
+     * <p>The other half of what such a finding is owed. A reader told a rule was written and not
+     * where it is has been sent nowhere, and the handle a document writes is what this compilation
+     * already worked out about where the rule stands.
+     */
+    @Test
+    void theDocumentWritesAHandleForTheRule() {
+        Compilation compilation = Compilation.ofSource(ONE_POSITION, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        List<RuleCitation.Written> cited = compilation.db()
+                .ask(new Adequacy.Coverage(MODULE)).value().get("f").notRead().stream()
+                .flatMap(each -> each.cited().stream())
+                .filter(RuleCitation.Written.class::isInstance)
+                .map(RuleCitation.Written.class::cast).toList();
+        assertEquals(1, cited.size(), () -> "one rule to place: " + cited);
+
+        assertNotNull(Sites.placeOf(compilation.db(), cited.getFirst()),
+                "where the rule the report names is written");
+    }
+
+    /** No line is drawn at any of them, since the strings the rule is about are not the ones
+     *  there. */
+    @Test
+    void noLineIsDrawnAtAnyOfThem() {
+        for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM)) {
+            assertEquals(List.of(), measured(model).axes().stream()
+                    .map(PartitionEvidence.AxisCoverage::path).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
@@ -29,14 +29,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p><b>Asked of every reader that can file one.</b> Which of them owes a question is a decision
  * each of them makes where it files: the accounting of a declaration's clauses raises it, and a
- * body's comparison and a clause of an {@code ensures} say instead that nothing classifies them.
+ * body's comparison, a clause of an {@code ensures} and a predicate over the strings say instead
+ * that nothing classifies them.
  * Nothing in the types holds them to the same answer, so this does — a reader added, or one that
  * starts filing a stop where it used to file a statement, fails here rather than taking a measure
  * quietly with it.
  *
- * <p>Over the models this repository carries and over two written for the readers the corpora do
- * not exercise, since what is being checked is a property of the readers rather than of any one
- * model.
+ * <p>Over the models this repository carries and over the ones written here for the readers the
+ * corpora do not exercise, since what is being checked is a property of the readers rather than of
+ * any one model.
  */
 @Tag("population")
 class ARuleWhoseReadingStoppedLeavesAQuestionTest {
@@ -65,6 +66,22 @@ class ARuleWhoseReadingStoppedLeavesAQuestionTest {
 
             behavior look : (item: Item) -> Ok
                 ensures Bool.not(item.price > 100)
+            """;
+
+    /** A predicate over the strings of a value an operation handed out, which is about those
+     *  strings and not the ones at the position they came from. */
+    private static final String A_PREDICATE_OVER_A_MADE_VALUE = """
+            module probe.codes
+
+            data Person = { code: String }
+            data Count = Int
+
+            behavior seen : (people: List<Person>) -> Count
+                constructs Count
+            let seen (people) =
+                Count(List.length(
+                    List.filter(s -> String.startsWith("JP", s),
+                        List.map(q -> q.code, people))))
             """;
 
     @Test
@@ -103,10 +120,11 @@ class ARuleWhoseReadingStoppedLeavesAQuestionTest {
         assertTrue(stopped > 0, "no reading stopped anywhere, so this checked nothing");
     }
 
-    /** The models this repository carries, and the two readers they do not exercise. */
+    /** The models this repository carries, and the readers they do not exercise. */
     private static List<Compilation> every() {
         List<Compilation> out = new ArrayList<>(RepositoryModels.all());
-        for (String each : List.of(A_COMPARISON_NOBODY_READS, AN_ENSURES_NOBODY_READS)) {
+        for (String each : List.of(A_COMPARISON_NOBODY_READS, AN_ENSURES_NOBODY_READS,
+                A_PREDICATE_OVER_A_MADE_VALUE)) {
             Compilation one = Compilation.ofSource(each, "Main");
             one.measure(Adequacy.Asked.fullReport());
             one.answerEverything();

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest.java
@@ -100,13 +100,6 @@ class EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest {
      * the line saying nothing does is the thing that has to go.
      */
     private static final Map<String, String> NO_BATCH_CONSUMER = Map.of(
-            Sites.ApplicationsWrittenIn.class.getName(),
-            "where a module wrote each of its applications, which is what places a rule about the"
-                    + " strings at a position. A batch run reads the rule — the walk of a body makes"
-                    + " one and says what it comes to — and the answer stops there: what such a rule"
-                    + " came to is lost on the way to the array a document writes rules under, so no"
-                    + " result of a run holds a handle for one and nothing asks where it is. The"
-                    + " question is answerable and the dependency does not reach it",
             Sites.Authored.class.getName(),
             "where a module's source was written, occurrence by occurrence — a projection for a"
                     + " reader outside the compiler, and no answer of a batch compilation reads it");

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/codes.sou
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/codes.sou
@@ -1,0 +1,15 @@
+// A rule about the strings of a value an operation made out of a position.
+//
+// The author wrote a rule about the code, and what it is applied to is what `String.uppercase`
+// answered rather than what stands at the position. Reading the rule back through the operation is
+// a capability this compiler has not, so no line is drawn here — and the position is not one the
+// model says nothing about. What a reader is owed is that a rule was written, that it is about
+// something made from here, and where it is written.
+module conformance.codes exposing ( Origin, originOf )
+
+data Origin = Domestic | Overseas
+
+behavior originOf : (code: String) -> Origin
+
+let originOf (code) =
+    if String.startsWith("JP", String.uppercase(code)) then Domestic else Overseas

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
@@ -2,7 +2,7 @@
   "schemaVersion" : 17,
   "compilerVersion" : "<version>",
   "status" : "partial",
-  "weakening" : [ "bodies_not_elaborated" ],
+  "weakening" : [ "bodies_not_elaborated", "rule_unread" ],
   "adequacy" : "not_satisfied",
   "keptOpenBy" : [ ],
   "modules" : [ {
@@ -3033,9 +3033,130 @@
     "incompleteness" : [ ],
     "declarations" : [ ],
     "behaviors" : [ ]
+  }, {
+    "module" : "conformance.codes",
+    "status" : "partial",
+    "weakening" : [ "rule_unread" ],
+    "incompleteness" : [ ],
+    "declarations" : [ ],
+    "behaviors" : [ {
+      "name" : "originOf",
+      "implementation" : "implemented",
+      "rows" : 0,
+      "pending" : 0,
+      "status" : "partial",
+      "weakening" : [ "rule_unread" ],
+      "signature" : {
+        "status" : "unavailable",
+        "reason" : "no_rows",
+        "output" : {
+          "declared" : [ "Domestic", "Overseas" ],
+          "status" : "unavailable",
+          "reason" : "no_rows"
+        },
+        "inputs" : [ {
+          "declared" : [ ],
+          "excluded" : [ ],
+          "status" : "unavailable",
+          "reason" : "not_a_sum"
+        } ]
+      },
+      "partition" : {
+        "axesMeasure" : {
+          "status" : "unavailable",
+          "reason" : "the_reading_did_not_run_out",
+          "weakening" : [ "rule_unread" ]
+        },
+        "boundariesMeasure" : {
+          "status" : "unavailable",
+          "reason" : "the_reading_did_not_run_out",
+          "weakening" : [ "rule_unread" ]
+        },
+        "axes" : [ ],
+        "unanswered" : [ {
+          "at" : "code",
+          "rule" : "predicate@5:15:8",
+          "ruleId" : {
+            "kind" : "predicate",
+            "declaredIn" : "conformance.codes",
+            "writtenIn" : "body",
+            "definition" : "originOf",
+            "behavior" : "originOf",
+            "ordinal" : 2,
+            "lowered" : 0
+          },
+          "question" : "notDetermined",
+          "subject" : {
+            "kind" : "filedAt",
+            "path" : "code"
+          },
+          "stopped" : [ {
+            "reason" : "rule_about_a_derived_value"
+          } ]
+        } ],
+        "claimsOffAxis" : [ ],
+        "boundaries" : [ ],
+        "obligations" : [ ],
+        "pairs" : {
+          "total" : 0,
+          "between" : [ ],
+          "status" : "complete",
+          "covered" : 0,
+          "unknown" : 0
+        },
+        "notDerivable" : [ ],
+        "notRead" : [ {
+          "position" : "code",
+          "reason" : "rule_about_a_derived_value",
+          "rule" : "predicate@5:15:8",
+          "ruleId" : {
+            "kind" : "predicate",
+            "declaredIn" : "conformance.codes",
+            "writtenIn" : "body",
+            "definition" : "originOf",
+            "behavior" : "originOf",
+            "ordinal" : 2,
+            "lowered" : 0
+          }
+        } ]
+      },
+      "branch" : {
+        "status" : "unavailable",
+        "reason" : "no_rows"
+      },
+      "findings" : [ {
+        "kind" : "partition_not_read",
+        "disposition" : "reported",
+        "subject" : "code",
+        "ruleId" : {
+          "kind" : "predicate",
+          "declaredIn" : "conformance.codes",
+          "writtenIn" : "body",
+          "definition" : "originOf",
+          "behavior" : "originOf",
+          "ordinal" : 2,
+          "lowered" : 0
+        },
+        "reason" : "rule_about_a_derived_value"
+      }, {
+        "kind" : "rule_unaccounted",
+        "disposition" : "reported",
+        "subject" : "predicate@5:15:8 — what this rule states about code",
+        "ruleId" : {
+          "kind" : "predicate",
+          "declaredIn" : "conformance.codes",
+          "writtenIn" : "body",
+          "definition" : "originOf",
+          "behavior" : "originOf",
+          "ordinal" : 2,
+          "lowered" : 0
+        }
+      } ]
+    } ]
   } ],
   "sources" : {
     "1" : "vouchers.sou",
-    "2" : "waitlist.sou"
+    "2" : "waitlist.sou",
+    "5" : "codes.sou"
   }
 }

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/sources.txt
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/sources.txt
@@ -3,3 +3,4 @@ vouchers.sou
 waitlist.sou
 holds.sou
 deposits.sou
+codes.sou


### PR DESCRIPTION
A rule an author writes about the strings of a value an operation answered
reached the measure, came to nothing, and was shown to nobody — while the
position it names came back as one the model says nothing about. Where the
subject's value came from is answered for a leaf, and an application is not
one, so nothing placed such a rule anywhere.

It is read off what the expression is made of instead, which is where the
reading of a comparison beside it already asks. Every position the value
came from is one the author is owed the sentence at: a string joined out of
two of them is made out of both, and filed at one the other comes back
silent. The place such a rule is written is asked of the module that wrote
it, and a run of the corpus reaches that question now, so the line saying
nothing reads it goes.

What an expression is made of holds the arms of a choice and what the
choice turns on side by side with everything a value was built out of. So
that arm is not read here as where a value came from, and the reading of it
is a projection in the one reader that needs it rather than an answer the
type gives about every arm. A rule under a choice stays shown nowhere,
which is what it comes to already; read the other way it would be shown at
the position that decided which value the subject is, which an author
cannot tell from a rule their model states. A regression pins that, and it
is what has to be come back to the day a choice is told from a composition.

The first commit is a defect this exposed rather than one it introduced.
A predicate whose subject the reading could not place was filed as a
finding with nothing standing where it was filed, so the measures there
closed over a rule nobody had worked out while the report went on naming
it. Its regression is red on develop as it stands.

Two things this leaves alone, each its own finding. What an expression is
made of folds a fork's condition in with the values it chooses between, so
a value's data origin and what it turns on come back as one set. And where
a report gathers the rules it may name, a rule that did divide its position
is never gathered — the handle for it is written nowhere.

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)