### PR TITLE
Keep the absence of a reading rather than answering that it found nothing

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -914,20 +914,22 @@ public final class Adequacy {
             if (!prepared.present() || !scope.present() || !reading.present()) {
                 return Answer.absent();
             }
-            souther.compiler.query.Bodies.Elaborated checked =
-                    db.ask(new Bodies.Checked(name)).value();
-            Map<String, souther.compiler.core.Core> bodies =
-                    checked == null ? Map.of() : checked.behaviorBodies();
+            Answer<Bodies.Elaborated> checked = db.ask(new Bodies.Checked(name));
+            if (!checked.present()) {
+                // The bodies this would be about were not elaborated, so there is nothing here to
+                // read them off. Answered rather than absent, the places nobody could look for read
+                // as places the model does not have — a fact about this compile having stopped,
+                // said in the words of a fact about the model.
+                return Answer.absent();
+            }
+            Map<String, souther.compiler.core.Core> bodies = checked.value().behaviorBodies();
             if (bodies.isEmpty()) {
-                // Nothing checked, so there are no places to be about. Asked further, the reading
-                // of the input is derived over types that did not check — which is a position the
-                // partition refuses outright, and rightly: what would be answered there is about
-                // this compile having stopped and not about the model.
+                // Elaborated, and holding no body: there are no places to be about, and that is
+                // what the model says. Which is why this stays a present answer and the one above
+                // does not.
                 return Answer.of(Ordered.map(Map.of()));
             }
-            souther.compiler.coverage.CoverageSites.Plan plan =
-                    checked == null
-                            ? souther.compiler.coverage.CoverageSites.Plan.NONE : checked.plan();
+            souther.compiler.coverage.CoverageSites.Plan plan = checked.value().plan();
             // Asked here and not above, because this is where one is needed: what a behavior's
             // boundary came to is asked of the signatures and the readings together, and the
             // answer above is about there being no places to ask it of. Asked at the way in, a

--- a/souther-compiler/src/test/java/souther/compiler/query/AnAbsentDerivationIsNotAProofAboutTheModelTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnAbsentDerivationIsNotAProofAboutTheModelTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.check.PathReachability;
 import souther.compiler.report.AdequacyReport;
 
 import tools.jackson.databind.JsonNode;
@@ -266,5 +267,55 @@ class AnAbsentDerivationIsNotAProofAboutTheModelTest {
         Measure.NotApplicable<?> none = assertInstanceOf(Measure.NotApplicable.class, measured,
                 () -> "the body is here and decides nothing: " + measured);
         assertEquals(Adequacy.BranchEvidence.NoArms.NO_ARM_OBLIGATIONS, none.why());
+    }
+
+    /**
+     * The reading of what the guards above each place leave is not made where the bodies were not.
+     *
+     * <p>The same rule the arm measure is held to, one derivation over. The reading is read off the
+     * elaborated bodies; a module the compile stopped in has none, and the answer that came back was
+     * a map with nothing in it — which is what a module whose bodies hold no place answers too.
+     * Nothing between the two, so a reader that walked the reading and found nowhere was told the
+     * model divides nowhere, on a compile that never looked.
+     */
+    @Test
+    void thePlacesOfABodyThatWasNotElaboratedAreNotReadAsNoPlaces() {
+        Compilation compilation = measured(STOPPED);
+
+        assertFalse(compilation.errors().isEmpty(), "this model is one the compile stops in");
+        assertFalse(compilation.db().ask(new Bodies.Checked("example.rooms")).present(),
+                "and stops before the bodies are elaborated, which is what this is about");
+
+        assertFalse(compilation.db().ask(new Adequacy.PathReached("example.rooms")).present(),
+                "so there is no reading of its places, rather than a reading that found none");
+    }
+
+    /**
+     * And a module whose bodies were elaborated and hold no place is read as holding none.
+     *
+     * <p>The other direction, and the reason the answer above is absent rather than the reading
+     * being made absent whenever it is empty: a module of injected behaviors has been read to the
+     * end, and what it holds is nothing.
+     */
+    @Test
+    void thePlacesOfAModuleThatDeclaresNoBodyAreNone() {
+        Compilation compilation = measured("""
+                module example.injected
+
+                data A = { n: Int }
+                data B = { n: Int }
+
+                behavior asked : (a: A) -> B
+                """);
+
+        assertTrue(compilation.errors().isEmpty(), () -> "this one compiles: "
+                + compilation.errors());
+        assertTrue(compilation.db().ask(new Bodies.Checked("example.injected")).present(),
+                "its bodies were elaborated");
+
+        Answer<Map<String, PathReachability.Answers>> read =
+                compilation.db().ask(new Adequacy.PathReached("example.injected"));
+        assertTrue(read.present(), "so the reading was made");
+        assertEquals(Map.of(), read.value(), "and what it found is nothing");
     }
 }


### PR DESCRIPTION
The reading of what the guards above each place leave is read off the elaborated bodies. A module the compile stopped in has none, and `Adequacy.PathReached` asked for them, substituted an empty map where there was no answer, and returned that as its own — indistinguishable from a reading that ran and found no place. The comment on that branch already said that what would be answered there is about this compile having stopped and not about the model.

So the absence is kept, asked as `present()` rather than as a null value so the code says why the two differ, and the present empty answer stays for the case it is really about: a module that was elaborated and holds no body.

The same fact already has a name and a reporter. `Adequacy.BranchCoverage` answers `FailedToMeasure(BODIES_NOT_ELABORATED)` carrying `Weakening.BodiesNotElaborated`, and `AnAbsentDerivationIsNotAProofAboutTheModelTest` states the rule for that measure in both directions. This is that rule one derivation over, so the two new checks live in that class: the stopped module's reading is absent, and a module of injected behaviors still gets a settled nothing. Each was mutated against the branch it is about before being kept.

Both keys the sweep turned up beside this one were read. The derived one follows this one and needed nothing. The map of every class the compilation generates keeps its empty answer: its doc says a module that did not check contributes none, so that an example reaching it fails to load rather than running against something never checked, and it asserts nothing about the model.

#1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
