### PR TITLE
Spend a clause's denial where its comparison is read

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Comparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Comparison.java
@@ -65,6 +65,21 @@ public final class Comparison {
         return right;
     }
 
+    /**
+     * The statement this comparison makes, which is what it placed and the two values it placed it
+     * on.
+     *
+     * <p>What a reader wants where the recognition itself decides nothing it asks. A reading that
+     * works out what a rule does to a quantity is the same reading whether the comparison was
+     * spelled by an author or arrived at from what the rules proved, so it is written against the
+     * statement; this is the way over from the one that was spelled. Nothing is dropped that such a
+     * reader had a use for — the node it was recognised from is what a report about the clause
+     * holds, and a report holds it already.
+     */
+    public StatedComparison stated() {
+        return new StatedComparison(claim, left, right);
+    }
+
     /** Everything this holds, which is what an identity is of. The claim is read off the operator
      *  the sides were written with, so two of these over one binary carry one claim — and it is
      *  read here all the same, because a field left out of an identity is a field a reader of the

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
@@ -577,18 +578,27 @@ public final class FieldDomains {
      * happened to have a sentence for, and a rule this reading owes nothing about could not be
      * passed along at all.
      *
-     * <p>The conjunct as it was written. Which number it is about, and what it does to that
-     * number, are the next reading's to establish in its own vocabulary — said here, this would be
-     * the reading that placed no end answering the question it just failed to answer.
+     * <p>What the conjunct states, and not the node it was written as. Which number it is about,
+     * and what it does to that number, are the next reading's to establish in its own vocabulary —
+     * said here, this would be the reading that placed no end answering the question it just failed
+     * to answer. What it compares, though, is not that question: it is what this reading was handed
+     * and had to establish to get this far, and a reader given the node instead reads the operator
+     * again — which, for a rule written under a denial, is the comparison that holds exactly where
+     * the rule does not.
      *
-     * @param part which part of which rule it is, as the split that wrote the parts down named it
-     * @param read the part itself
+     * @param part   which part of which rule it is, as the split that wrote the parts down named it
+     * @param states what the conjunct compares and what it claims of the two sides
+     * @param wrote  where the author wrote it, for whoever reports about the clause. A position and
+     *               not the expression, so there is nothing here to read a meaning off a second
+     *               time
      */
-    public record WithoutAnEnd(PartId<RuleRef.Invariant> part, Core read) {
+    public record WithoutAnEnd(PartId<RuleRef.Invariant> part, StatedComparison states,
+                               SourcePos wrote) {
 
         public WithoutAnEnd {
-            if (part == null || read == null) {
-                throw new IllegalArgumentException("a conjunct handed on is some clause's text");
+            if (part == null || states == null || wrote == null) {
+                throw new IllegalArgumentException(
+                        "a conjunct handed on is some clause's comparison, written somewhere");
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1466,6 +1466,36 @@ public final class InvariantChecker {
     }
 
     /**
+     * What a conjunct handed to the next reading is one of: which part of which rule, and where in
+     * that part the comparison stands.
+     *
+     * <p><b>The occurrence, because one authored part states more than one comparison.</b> A denial
+     * is carried to the leaves as a clause is read, so a conjunction an author wrote as a denied
+     * choice is one part and two comparisons — and both are handed on, because each is a rule the
+     * reading that draws lines has something to do with. Named by the part alone, the second is the
+     * first said again and the reading below never sees it.
+     *
+     * <p><b>And the place is not here, because one conjunct read twice is one conjunct.</b> A rule
+     * is read once per place the walk opens a value at, so a record holding two of a type is two
+     * readings of that type's clause — one written rule, and a row is owed for it once. Named by
+     * the place as well, each reading would hand on its own and the model would owe a row per
+     * place it happens to be carried to.
+     *
+     * <p>Which is why this is neither {@link ReadingPlace} nor {@link PartId} but the pair that
+     * says what a hand-over is: one per comparison the reading arrived at inside a conjunct,
+     * however many places that conjunct was read at.
+     */
+    record HandOver(PartId<RuleRef.Invariant> part, ClauseExpr.Occurrence at) {
+
+        HandOver {
+            if (part == null || at == null) {
+                throw new IllegalArgumentException(
+                        "a conjunct handed on is part of some rule, somewhere in it");
+            }
+        }
+    }
+
+    /**
      * One clause reaching a value, rebased onto the positions of that value, which clause it is,
      * and the parts its author wrote it in.
      *
@@ -1861,7 +1891,7 @@ public final class InvariantChecker {
                                    ReadingEvidence took, RulesRead rules) {
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
-        List<FieldDomains.WithoutAnEnd> withoutAnEnd = new ArrayList<>();
+        SequencedMap<HandOver, FieldDomains.WithoutAnEnd> withoutAnEnd = new LinkedHashMap<>();
         List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
@@ -1882,7 +1912,8 @@ public final class InvariantChecker {
                         raised, took, typeAt, rules, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
-        return new Reading(List.copyOf(out), List.copyOf(noLines), List.copyOf(withoutAnEnd),
+        return new Reading(List.copyOf(out), List.copyOf(noLines),
+                List.copyOf(withoutAnEnd.values()),
                 List.copyOf(aboutOneCoordinate),
                 Map.copyOf(narrowers),
                 Collections.unmodifiableMap(new LinkedHashMap<>(raised)),
@@ -1992,7 +2023,7 @@ public final class InvariantChecker {
                         Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
                         List<FieldDomains.NoLine> noLines,
-                        List<FieldDomains.WithoutAnEnd> withoutAnEnd,
+                        SequencedMap<HandOver, FieldDomains.WithoutAnEnd> withoutAnEnd,
                         List<FieldDomains.AboutOneCoordinate> naming,
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
@@ -2111,8 +2142,8 @@ public final class InvariantChecker {
             // out places no end and is no failure of this reading, so there is nothing here for an
             // author to lift and there is a conjunct for the reading that draws lines to make what
             // it can of.
-            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, comparison,
-                    said.written().pos()));
+            withoutAnEnd.putIfAbsent(new HandOver(part, said.at()),
+                    new FieldDomains.WithoutAnEnd(part, comparison, said.written().pos()));
             return;
         }
         // An end where the other side is a constant, and a relation everywhere else. Which it is
@@ -2190,8 +2221,8 @@ public final class InvariantChecker {
             // The hand-over beside the finding, and not read off it. Both come of this conjunct
             // having no end, and they answer different questions: what an author is owed a word
             // about, and what the next reading is given to read.
-            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, comparison,
-                    said.written().pos()));
+            withoutAnEnd.putIfAbsent(new HandOver(part, said.at()),
+                    new FieldDomains.WithoutAnEnd(part, comparison, said.written().pos()));
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2004,11 +2004,12 @@ public final class InvariantChecker {
         // Which rule this is a part of, asked of the part. Carried beside it, a reading could be
         // given a part of one rule and told it was reading another.
         RuleRef.Invariant from = part.rule();
-        // A binding this reading was handed as itself, which is where the environment changes. One
-        // written under a denial is not: what this reader is given there is the denial, and a
-        // denial is a form it has no word for.
-        if (saidAs instanceof ClauseExpr.Scoped scoped
-                && scoped.spelled().get(0) == scoped.binding()) {
+        // A binding, which is where the environment changes and the one shape that is not a part.
+        // Whether a denial stands above it decides nothing here: the denial is carried to the
+        // leaves as the clause is read, so the body under a binding already states what the binding
+        // states, and a helper's rule denied is read as the rule it denies rather than left as a
+        // form this reader has no word for.
+        if (saidAs instanceof ClauseExpr.Scoped scoped) {
             direct(scoped.body(), of, part, terms.inside(scoped.binding(), at), byName, out,
                     noLines, withoutAnEnd, naming, narrowers, raised, took, typeAt, rules,
                     raisedByPart, standing);
@@ -2022,22 +2023,31 @@ public final class InvariantChecker {
         // Asked of the shape and never of the operator, so that what a connective composes is
         // recognised in one place ({@link ClauseExpr}).
         //
-        // Stated, and composing both. What a connective composes and how the whole of it stands are
-        // two answers, and both are wanted here: a choice denied composes both of its parts denied,
-        // so a conjunction is what is left when the shape says both and says it is stated. What is
-        // under a denial states the opposite of what it reads as, and the reading below has no word
-        // for that.
+        // And asked of what the connective composes alone. How the whole of it stands is a separate
+        // answer, and it is already inside this one: the denial a clause was read under is applied
+        // to what the connective composes where the shape is made, so a choice denied arrives here
+        // saying it composes both, and both of the parts it hands over are the denied ones. Asked
+        // together with how the whole stands, the denial is applied a second time and a conjunction
+        // an author wrote as a denied choice is a part this reading never descends into.
         if (saidAs instanceof ClauseExpr.Joined joined
-                && joined.how() == ConditionJoin.BOTH && joined.positive()) {
+                && joined.how() == ConditionJoin.BOTH) {
             direct(joined.left(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
                     narrowers, raised, took, typeAt, rules, raisedByPart, standing);
             direct(joined.right(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
                     narrowers, raised, took, typeAt, rules, raisedByPart, standing);
             return;
         }
-        // The node the author wrote this as, which is the outermost of what the shape is spelled
-        // as: a rule under a denial is read as the denial and not as what it denies.
-        Core clause = saidAs.spelled().get(0);
+        // A binding is crossed above and a conjunction is descended into, so what is left is a part
+        // of the clause: a leaf, or a choice this reading takes whole.
+        ClauseExpr.Part said = (ClauseExpr.Part) saidAs;
+        // The rule this part states, which is what every reading below is of. Under a denial that
+        // is what the denial denies, and the denial itself is spent where the comparison is read
+        // ({@link StatedComparison#of}) rather than carried down as a flag each reader applies.
+        // Taken as the outermost of what the shape was spelled as, this is the {@code not} an
+        // author wrote, which is no comparison — and a rule written under one placed no end, drew
+        // no line and was about no number, while the reading that turns clauses into sets read it
+        // perfectly well.
+        Core clause = said.of();
         // What a rule about the strings at a position says about where they stop, which is a rule
         // of this conjunct as much as an ordering written here is. Beside the reading of
         // comparisons and not inside it: what such a rule states is not a comparison and has no
@@ -2045,62 +2055,56 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(new ReadingPlace(of.opened(), saidAs.at()), of, part, byName, out);
-        restricting(clause, saidAs.at(), from, of, part, byName, rules, noLines, runs);
-        aChoiceAboutOneCoordinate(clause, part, at, byName, naming);
-        if (!(clause instanceof Core.Binary bin)) {
-            // Nothing but a binary is written as a comparison, so there is no reading of one for
-            // the classification to be handed.
-            settle(clause, from, of, part, saidAs.at(), states(clause, at, byName, null, runs),
-                    new InvariantBound.Read.NoEnd(),
-                    byName, raised, took, raisedByPart);
-            return;
-        }
+        RunsRead runs = runsOf(new ReadingPlace(of.opened(), said.at()), of, part, byName, out);
+        // What an author wrote and where, which is what a sentence about the rule points at. A rule
+        // written under a denial is shown as the denial: that is what is on the line.
+        restricting(said.written(), said.at(), from, of, part, byName, rules, noLines, runs);
+        aChoiceAboutOneCoordinate(said, part, at, byName, naming);
         // Where this clause is recognised as a comparison, and the one place it is. What each
         // reader below wants is what the recognition established — the two sides to walk, and what
         // the rule states of them — so each is handed that rather than the node it was read off.
         // Asked again below, the question is answered a second time and every reader has a case to
         // invent an answer for: the one where the operator compares nothing, which the recognition
         // here already took out.
-        Comparison comparison = Comparison.of(bin).orElse(null);
-        // And the one reading of the arithmetic over it, handed to each of the questions asked of
-        // it: what the clause states, and what a reader is left with where no end came of it.
-        CanonicalForm read =
-                comparison == null ? null : canonicalFormOf(comparison, at, byName);
-        // A rule that orders the values, or one that says which value they take. A rule that only
-        // rules a value out is read no further here, and neither is an operator that compares
-        // nothing: what is below reads a clause for the end it places on a position and for which
-        // declarations narrowed that position, and neither of those is a thing a denial of one
-        // value states.
-        ComparisonClaim asWritten = comparison == null ? null : comparison.claim();
-        if (asWritten == null) {
-            settle(bin, from, of, part, saidAs.at(), states(bin, at, byName, read, runs),
+        //
+        // Of the part and its polarity together, so what comes back is the comparison the clause
+        // states. A reader handed the operator and told separately how the clause stands is a
+        // reader that has to remember to put the two together, which is the one thing this walk
+        // was not doing.
+        StatedComparison comparison = StatedComparison.of(said);
+        if (comparison == null) {
+            // Nothing written as a comparison, so there is no reading of one for the classification
+            // to be handed: what is below reads a clause for the end it places on a position and
+            // for which declarations narrowed that position, and neither is a thing another shape
+            // of rule states.
+            settle(clause, from, of, part, said.at(), states(clause, at, byName, null, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             return;
         }
+        Core.Binary bin = (Core.Binary) clause;
+        // And the one reading of the arithmetic over it, handed to each of the questions asked of
+        // it: what the clause states, and what a reader is left with where no end came of it.
+        CanonicalForm read = canonicalFormOf(comparison, at, byName);
+        // What the rule states, with the denial already in it.
+        ComparisonClaim asWritten = comparison.claim();
         // Which number this conjunct is about, written down before anything is asked about what it
         // did to it. Every shape of rule alike: whether an end is read from it below decides which
         // reader states where the values stop, and decides nothing about which conjuncts account
         // for where they stop.
         aboutOneCoordinate(read, part, naming);
-        // The coordinate-bearing side read as the left one, as `0 <= value` says what `value >= 0`
-        // says.
+        // What the comparison states of the coordinate it names, read from whichever side bears
+        // one, as `0 <= value` says what `value >= 0` says. The turn is spent making this, so no
+        // reader below holds a claim beside a note about which way round it was written.
         //
         // Above what the claim is, because which number the rule is about does not turn on that. A
         // rule that names a value is about the number it names as plainly as one that orders the
         // values around it, and the lookup done under the ordering alone was one every other
         // reading of the clause had to do again for itself.
-        Coordinate found = byName.get(nameOf(bin.left(), at));
-        Core bound = bin.right();
-        ComparisonClaim said = asWritten;
-        if (found == null) {
-            found = byName.get(nameOf(bin.right(), at));
-            bound = bin.left();
-            said = said.turned();
-        }
+        StatedComparison.Numbered<Coordinate> numbered =
+                comparison.at(each -> byName.get(nameOf(each, at)));
         if (asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
-            settle(bin, from, of, part, saidAs.at(), states(bin, at, byName, read, runs),
+            settle(bin, from, of, part, said.at(), states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             // And handed on, which is not the same as being reported. A rule that rules one value
@@ -2118,10 +2122,12 @@ public final class InvariantChecker {
         // the order places none — there is no value to draw a line at — and it is not a relation
         // either: what it compares the coordinate to is a constant this read perfectly. So it falls
         // out here rather than being filed as a clause that could have moved an edge.
-        InvariantBound.Read end = found != null && said instanceof ComparisonClaim.Cut cut
-                ? InvariantBound.at(cut, Terms.asWrittenValue(bound, at), found.carrier())
+        InvariantBound.Read end = numbered != null
+                && numbered.claim() instanceof ComparisonClaim.Cut cut
+                ? InvariantBound.at(cut, Terms.asWrittenValue(numbered.other(), at),
+                        numbered.number().carrier())
                 : new InvariantBound.Read.NoEnd();
-        Coordinate about = found;
+        Coordinate about = numbered == null ? null : numbered.number();
         // What the clause is about, asked of the comparison and not of what `end` came to. A
         // coordinate compared for order against something naming no other coordinate states where
         // the values stop, whether or not the number on the other side is one this could fold.
@@ -2132,8 +2138,8 @@ public final class InvariantChecker {
         // `width` stops that no reading can ever answer, because a rule relating two positions
         // places no end (ADR-0090). The reader already knows: the reason it records for such a
         // comparison is `ComparisonBetweenPositions`.
-        if (about != null && said instanceof ComparisonClaim.Cut
-                && coordinatesIn(bound, at, byName).isEmpty()
+        if (about != null && numbered.claim() instanceof ComparisonClaim.Cut
+                && coordinatesIn(numbered.other(), at, byName).isEmpty()
                 && shape instanceof ClauseStates.SomethingElse named) {
             Set<RuleKey> names = new LinkedHashSet<>(named.named());
             // The name the bound sits at, which the walk over the comparison writes anyway. Added
@@ -2165,7 +2171,7 @@ public final class InvariantChecker {
                                             List.of(part))
                                     : had.and(part)));
         }
-        settle(bin, from, of, part, saidAs.at(), shape, end, byName, raised, took,
+        settle(bin, from, of, part, said.at(), shape, end, byName, raised, took,
                 raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
             // A rule saying where the values stop that no end came out of, said as that. Here,
@@ -2191,8 +2197,8 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(found.at(), part, placed.bound(),
-                    new ReadingPlace(of.opened(), saidAs.at())));
+            out.add(new Direct(about.at(), part, placed.bound(),
+                    new ReadingPlace(of.opened(), said.at())));
         }
     }
 
@@ -2215,10 +2221,13 @@ public final class InvariantChecker {
      * candidate costs a counterfactual and claims nothing, and a rule saying which of them may be
      * one would be a second place deciding what a choice does.
      */
-    private void aChoiceAboutOneCoordinate(Core clause, PartId<RuleRef.Invariant> part,
+    private void aChoiceAboutOneCoordinate(ClauseExpr.Part said, PartId<RuleRef.Invariant> part,
                                            Denotations at, Map<FactSubject, Coordinate> byName,
                                            List<FieldDomains.AboutOneCoordinate> naming) {
-        if (!(ClauseExpr.of(clause, true) instanceof ClauseExpr.Joined joined)
+        // The shape the walk is already holding. Read again from the node, this would be a second
+        // reading of the clause's structure, and one made under a polarity of its own: a choice an
+        // author wrote as a denied conjunction is a choice, and the shape says so.
+        if (!(said instanceof ClauseExpr.Joined joined)
                 || joined.how() != ConditionJoin.EITHER) {
             return;
         }
@@ -2379,12 +2388,12 @@ public final class InvariantChecker {
         if (!(leaf instanceof Core.Binary bin)) {
             return NO_LINE;
         }
-        Comparison read = Comparison.of(bin).orElse(null);
+        StatedComparison read = StatedComparison.of(bin, positive);
         if (read == null) {
             return NO_LINE;
         }
-        ComparisonClaim said = positive ? read.claim() : read.claim().denied();
-        if (said instanceof ComparisonClaim.Singled singled && !singled.holdsAtTheValue()) {
+        if (read.claim() instanceof ComparisonClaim.Singled singled
+                && !singled.holdsAtTheValue()) {
             return NO_LINE;
         }
         // Whether the rule holds one of this value's positions to another, which is a fact about
@@ -2412,11 +2421,12 @@ public final class InvariantChecker {
                 Coordinate against = heldAgainstAConstant(bin, at, byName);
                 yield against == null ? ELSEWHERE : statedOn(against);
             }
-            // The positions cancelled, and what is left is a number against a number. Read as
-            // written, which is what the residue is a residue of: under a denial the same form
-            // states the opposite of what it reads as, and both answers are here.
+            // The positions cancelled, and what is left is a number against a number. Asked of the
+            // comparison the clause states, which already holds the denial, so a rule admitting
+            // nothing and one restricting nothing are told apart here and not by a reader pairing
+            // this with a polarity of its own.
             case CanonicalForm.CutsNothing form ->
-                    form.holdsOfEveryRow() == positive ? NO_LINE : ADMITS_NOTHING;
+                    form.holdsOfEveryRow() ? NO_LINE : ADMITS_NOTHING;
             // Over one number, which is the line's. Over several, and holding no position to a
             // position, the rule stops the values somewhere on one of them and which is what
             // reading further would say — the same answer as a number with no name at all.
@@ -2619,7 +2629,7 @@ public final class InvariantChecker {
      * the sides are what there is to walk. Read off a node holding both, this would be the same
      * walk reached through a value the readers below have no reason to hold.
      */
-    private List<Coordinate> coordinatesIn(Comparison comparison, Denotations at,
+    private List<Coordinate> coordinatesIn(StatedComparison comparison, Denotations at,
                                            Map<FactSubject, Coordinate> byName) {
         List<Coordinate> out = new ArrayList<>(coordinatesIn(comparison.left(), at, byName));
         out.addAll(coordinatesIn(comparison.right(), at, byName));
@@ -2729,7 +2739,7 @@ public final class InvariantChecker {
         if (!(read.comparison().claim() instanceof ComparisonClaim.Cut)) {
             return;
         }
-        Comparison comparison = read.comparison();
+        StatedComparison comparison = read.comparison();
         Places left = placesIn(comparison.left(), at, byName);
         Places right = placesIn(comparison.right(), at, byName);
         Predicate<RuleKey> ordered = place -> carrierAt(place, left, right) != null;
@@ -3164,8 +3174,9 @@ public final class InvariantChecker {
      */
     private sealed interface CanonicalForm {
 
-        /** The comparison this is the reading of. */
-        Comparison comparison();
+        /** The comparison this is the reading of, as the clause states it — the denial the clause
+         *  was read under is already inside the claim, so nothing below applies one. */
+        StatedComparison comparison();
 
         /**
          * The canonical form has no position left in it, and this is what {@code left - right} came
@@ -3176,7 +3187,8 @@ public final class InvariantChecker {
          * position at all — asked by the one authority for that question, which is the walk over
          * the clause, and not by this.
          */
-        record CutsNothing(Comparison comparison, BigDecimal residue) implements CanonicalForm {
+        record CutsNothing(StatedComparison comparison, BigDecimal residue)
+                implements CanonicalForm {
 
             /**
              * Whether the comparison holds of every row there is.
@@ -3193,6 +3205,11 @@ public final class InvariantChecker {
              * may stand at {@code lo} is a question nothing answered. What the comparison decides
              * is what the residue has to be, and which way the residue has to stand is what the
              * relation it states is answered at.
+             *
+             * <p>Of the comparison the clause states, which is where the denial has already gone.
+             * Asked of the one an author spelled, this answers about {@code 0 >= 0} for a clause
+             * stating {@code 0 < 0}, and a reader has to pair it with a polarity to get back what
+             * the rule says — which is the pairing being remembered once per reader.
              */
             boolean holdsOfEveryRow() {
                 return comparison.claim().statedRelation().holds(residue.signum());
@@ -3206,7 +3223,7 @@ public final class InvariantChecker {
          * what a reader downstream makes of them: which subject that expression is about is an
          * answer, and holding it here would put an answer inside what a classification is asked of.
          */
-        record NotRead(Comparison comparison, Core stoppedAt, Denotations under)
+        record NotRead(StatedComparison comparison, Core stoppedAt, Denotations under)
                 implements CanonicalForm {}
 
         /**
@@ -3228,7 +3245,7 @@ public final class InvariantChecker {
          * ({@code UnreadComparison.over}). Typed as a sequence, this would promise an order that is
          * whatever a hash of the atoms happened to give.
          */
-        record Over(Comparison comparison, java.util.Set<Coordinate> numbers)
+        record Over(StatedComparison comparison, java.util.Set<Coordinate> numbers)
                 implements CanonicalForm {
 
             public Over {
@@ -3298,7 +3315,7 @@ public final class InvariantChecker {
      * of the same shape in a body two declarations away is described in the same words — which is
      * what {@code invariant Int.add(length.value, width.value) <= 150} and the guard beside it are.
      */
-    private CanonicalForm canonicalFormOf(Comparison recognised, Denotations at,
+    private CanonicalForm canonicalFormOf(StatedComparison recognised, Denotations at,
                                           Map<FactSubject, Coordinate> byName) {
         // Named against this reader's own coordinates rather than against every number the
         // discharge procedure can identify. A value that is a number and is no coordinate of the

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2111,7 +2111,8 @@ public final class InvariantChecker {
             // out places no end and is no failure of this reading, so there is nothing here for an
             // author to lift and there is a conjunct for the reading that draws lines to make what
             // it can of.
-            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, bin));
+            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, comparison,
+                    said.written().pos()));
             return;
         }
         // An end where the other side is a constant, and a relation everywhere else. Which it is
@@ -2189,7 +2190,8 @@ public final class InvariantChecker {
             // The hand-over beside the finding, and not read off it. Both come of this conjunct
             // having no end, and they answer different questions: what an author is owed a word
             // about, and what the next reading is given to read.
-            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, bin));
+            withoutAnEnd.add(new FieldDomains.WithoutAnEnd(part, comparison,
+                    said.written().pos()));
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedLeaf.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedLeaf.java
@@ -14,8 +14,8 @@ import java.util.function.Function;
  *
  * <p>One procedure and two readings of it. Where the values at a position stop is one order and how
  * long the string standing there is is another, and each is read by whoever owns it — but what a
- * comparison does to an order does not change with which order it is: the side naming the number is
- * found, the claim is turned to match, a denial swaps what it states, and an end is read against the
+ * comparison does to an order does not change with which order it is: what the comparison states of
+ * the number it names is asked once ({@link StatedComparison}), and an end is read against the
  * carrier. Written once per reading, the two would be one algorithm with two accounts, and the
  * reading that was not kept in step would answer about a comparison this compiler reads.
  *
@@ -113,22 +113,16 @@ final class OrderedLeaf {
      */
     static <K> Read<K> of(Core.Binary bin, boolean positive, Denotations at, Terms terms,
                           Function<Core, K> named, Function<K, Carrier> carrierOf) {
-        Comparison read = Comparison.of(bin).orElse(null);
-        if (read == null) {
+        StatedComparison stated = StatedComparison.of(bin, positive);
+        if (stated == null) {
             // Written with an operator and not a comparison. The same as a rule of another shape.
             return notFollowed();
         }
-        // The side bearing the number read as the left one, as `0 <= value` says what `value >= 0`
-        // says.
-        K number = named.apply(bin.left());
-        Core bound = bin.right();
-        ComparisonClaim claim = read.claim();
-        if (number == null) {
-            number = named.apply(bin.right());
-            bound = bin.left();
-            claim = claim.turned();
-        }
-        Carrier carrier = number == null ? null : carrierOf.apply(number);
+        // What the comparison states of the number it names, with the denial and the side it was
+        // written on both already spent ({@link StatedComparison#at}). Nothing below applies either
+        // of them, so there is nothing below for either to be forgotten at.
+        StatedComparison.Numbered<K> said = stated.at(named);
+        Carrier carrier = said == null ? null : carrierOf.apply(said.number());
         if (carrier == null) {
             // Neither side is a number this reading has. The rule may still be about one — a
             // length, an absolute value, a reversal — and what it holds that number to is then
@@ -140,15 +134,14 @@ final class OrderedLeaf {
         // hand and before either is read for what it leaves: put inside what one claim does with
         // its side, the same rule written with a different operator is a rule nobody read
         // ({@code n == m} beside {@code n < m}).
-        boolean against = named.apply(bound) != null;
-        Hir.Expr written = Terms.asWrittenValue(bound, at);
-        ComparisonClaim said = positive ? claim : claim.denied();
-        return new Read<>(switch (said) {
+        boolean against = named.apply(said.other()) != null;
+        Hir.Expr written = Terms.asWrittenValue(said.other(), at);
+        return new Read<>(switch (said.claim()) {
             case ComparisonClaim.Singled singled -> singled.holdsAtTheValue()
-                    ? onlyTheValue(number, carrier, written)
+                    ? onlyTheValue(said.number(), carrier, written)
                     : new Left.PlacesNoEnd<>();
             case ComparisonClaim.Cut cut ->
-                    ends(number, carrier, InvariantBound.at(cut, written, carrier));
+                    ends(said.number(), carrier, InvariantBound.at(cut, written, carrier));
         }, against);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedComparison.java
@@ -3,6 +3,8 @@ package souther.compiler.check;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Rel;
 
+import java.util.function.Function;
+
 /**
  * A comparison a reading arrived at: what it places, and the two values it places it on.
  *
@@ -38,4 +40,63 @@ record StatedComparison(ComparisonClaim claim, Core left, Core right) {
     Rel relationUnder(boolean positive) {
         return (positive ? claim : claim.denied()).statedRelation();
     }
+
+    /**
+     * What the part states, or null where it states no comparison.
+     *
+     * <p>The one way from a part of a clause to what its comparison says. How the part stands is
+     * the shape's answer ({@link ClauseExpr#positive}) and what the part is is the shape's too
+     * ({@link ClauseExpr.Part#of}), so a reader that takes a part through here is reading the
+     * comparison the clause states rather than the one an author happened to spell — and the
+     * denial is spent here, once, instead of arriving at each reader as a flag it has to remember
+     * to apply.
+     */
+    static StatedComparison of(ClauseExpr.Part part) {
+        return part.of() instanceof Core.Binary bin ? of(bin, part.positive()) : null;
+    }
+
+    /** The same of a comparison held under {@code positive} by a reader whose polarity did not come
+     *  from a clause's shape. */
+    static StatedComparison of(Core.Binary bin, boolean positive) {
+        Comparison read = Comparison.of(bin).orElse(null);
+        return read == null ? null
+                : new StatedComparison(positive ? read.claim() : read.claim().denied(),
+                        read.left(), read.right());
+    }
+
+    /**
+     * The same read from the side {@code named} recognises a number on, or null where it names one
+     * on neither.
+     *
+     * <p>The second half of the crossing from an operator to a statement, and it is spent here for
+     * the same reason the denial is. {@code 0 <= n} says what {@code n >= 0} says, and a reader
+     * handed the two sides and told which of them bore the number is a reader that has to turn the
+     * claim itself — where forgetting to states the comparison that holds exactly where this one
+     * does not, which is the denial's failure again one step further on.
+     *
+     * <p>Which expressions are numbers is the reading's, and arrives as {@code named}. Nothing here
+     * decides what a number is, so a reader holding the positions and one holding the lengths reach
+     * this the same way and neither can reach the other's.
+     */
+    <K> Numbered<K> at(Function<Core, K> named) {
+        K found = named.apply(left);
+        if (found != null) {
+            return new Numbered<>(claim, found, right);
+        }
+        K other = named.apply(right);
+        return other == null ? null : new Numbered<>(claim.turned(), other, left);
+    }
+
+    /**
+     * What one comparison states of one of a reading's numbers.
+     *
+     * <p>Neither the polarity the clause held it under nor which side it was written on is left
+     * here: both are spent making it, and what is left is a claim about {@code number} and
+     * {@code other} in that order. A reader below has nothing to apply and nothing to forget.
+     *
+     * @param other what the number is held against, which may be a constant, a number of the same
+     *              reading, or something with no number in it at all — telling those apart is the
+     *              reader's and not this
+     */
+    record Numbered<K>(ComparisonClaim claim, K number, Core other) {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedComparison.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  * instead of. Whoever reports about a clause holds the expression the source wrote and reports about
  * that.
  */
-record StatedComparison(ComparisonClaim claim, Core left, Core right) {
+public record StatedComparison(ComparisonClaim claim, Core left, Core right) {
 
     /**
      * The relation this states, asserted with polarity {@code positive}.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
@@ -2,7 +2,8 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
-import souther.compiler.core.Core;
+import souther.compiler.check.StatedComparison;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeSymbol;
 
 /**
@@ -22,7 +23,11 @@ import souther.compiler.types.TypeSymbol;
  * @param part     which part of which rule this is, as the split that wrote the parts down named
  *                 it. What tells one authored line from another is this name, and a reader holding
  *                 the expression alone cannot tell two identical conjuncts apart
- * @param read     the conjunct itself
+ * @param states   what the conjunct compares and what it claims of the two sides, as the clause
+ *                 states it. The comparison and not the node it was written as: a rule written
+ *                 under a denial reads off its operator as the comparison that holds exactly where
+ *                 the rule does not, and a reader handed the node reads the operator
+ * @param wrote    where the author wrote it, for the sentence a line carries
  * @param at       where the value the clause is written about stands. The clause binds each field of
  *                 the declaration that wrote it, and a field an include brought in keeps that
  *                 declaration's binding, so the names under this path are what the clause reads
@@ -33,11 +38,11 @@ import souther.compiler.types.TypeSymbol;
  *                 is that name's — matched against the writing declaration's bindings alone, a
  *                 clause under a name names no position at all
  */
-public record ClauseWithoutAnEnd(PartId<RuleRef.Invariant> part, Core read, TermPath at,
-                                 TypeSymbol.AtModule readUnder) {
+public record ClauseWithoutAnEnd(PartId<RuleRef.Invariant> part, StatedComparison states,
+                                 SourcePos wrote, TermPath at, TypeSymbol.AtModule readUnder) {
 
     public ClauseWithoutAnEnd {
-        if (part == null || read == null || at == null || readUnder == null) {
+        if (part == null || states == null || wrote == null || at == null || readUnder == null) {
             throw new IllegalArgumentException(
                     "a clause is one of a declaration's, is written, and is about a value somewhere");
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
@@ -1,7 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.Carrier;
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.ComparisonPlacement;
 import souther.compiler.core.Core;
@@ -110,7 +110,8 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlac
      * would be about one position for a reader that came this way and another for one that came the
      * other.
      */
-    public static DrawnLine lineOf(Comparison comparison, InputReading read, InputReads reads) {
+    public static DrawnLine lineOf(StatedComparison comparison, InputReading read,
+                                   InputReads reads) {
         OnASide side = sideOf(comparison.left(), comparison.right(), read, reads);
         NumericTerm.FromOnePosition position =
                 side == null ? null : side.named().term().atOnePosition();

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -2,8 +2,6 @@ package souther.compiler.inputs;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.NumberAt;
-import souther.compiler.check.PartId;
-import souther.compiler.check.RuleRef;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.DeclarationReadings;
 import souther.compiler.check.FieldDomains;
@@ -640,10 +638,13 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
      * part — so it is handed over as a clause, with the path the value it is written about stands
      * at, and read there in the vocabulary a line is drawn in.
      *
-     * <p>Once per conjunct, not once per coordinate. The same conjunct is filed at each coordinate
-     * it names, which is what a reader after a position wants and what a reader after a rule must
-     * not have: taken as they are filed, {@code lo <= hi} would draw its line twice and owe two
-     * rows where the model states one thing.
+     * <p>One per comparison the reading arrived at, which is what it is handed. A conjunct read at
+     * several places of one value is one conjunct and is handed on once; a conjunct stating several
+     * comparisons — which is what a conjunction an author wrote as a denied choice is — states each
+     * of them, and each is a rule this reading has something to do with. Both are settled where the
+     * conjuncts are read and arrive that way, so there is nothing to work out again here: counted
+     * by the rule alone, the second comparison of one conjunct was the first said again and never
+     * reached the reading below.
      *
      * <p>Not what any of them came to. Which of these is a line is the drawing reading's answer,
      * and this reading's word for why it drew none is no part of the question — the two read the
@@ -654,17 +655,11 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
      * which places no end and is nothing anyone has to lift, could not be passed along at all.
      */
     List<ClauseWithoutAnEnd> clausesWithoutAnEnd() {
-        java.util.Map<Key, ClauseWithoutAnEnd> once = new java.util.LinkedHashMap<>();
-        for (FieldDomains.WithoutAnEnd each : bounds().withoutAnEnd()) {
-            once.putIfAbsent(new Key(each.part()),
-                    new ClauseWithoutAnEnd(each.part(), each.states(), each.wrote(), root,
-                            bounds().named()));
-        }
-        return List.copyOf(once.values());
+        return bounds().withoutAnEnd().stream()
+                .map(each -> new ClauseWithoutAnEnd(each.part(), each.states(), each.wrote(), root,
+                        bounds().named()))
+                .toList();
     }
-
-    /** What makes two of them one: which part of which rule it is. */
-    private record Key(PartId<RuleRef.Invariant> part) {}
 
     /**
      * The declaration a value of {@code type} is read under: the name the signature wrote where it

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -657,7 +657,8 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
         java.util.Map<Key, ClauseWithoutAnEnd> once = new java.util.LinkedHashMap<>();
         for (FieldDomains.WithoutAnEnd each : bounds().withoutAnEnd()) {
             once.putIfAbsent(new Key(each.part()),
-                    new ClauseWithoutAnEnd(each.part(), each.read(), root, bounds().named()));
+                    new ClauseWithoutAnEnd(each.part(), each.states(), each.wrote(), root,
+                            bounds().named()));
         }
         return List.copyOf(once.values());
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.AffineForms;
 import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
 import souther.compiler.check.RuleReadingSource;
@@ -51,8 +52,8 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
      */
     static AffineReading of(Comparison comparison, InputDomain inputs, InputReads reads,
                             RuleReadingSource ruleSource) {
-        return read(comparison, inputs, reads, ruleSource) instanceof OfAComparison.Cuts cuts
-                ? cuts.read() : null;
+        return read(comparison.stated(), inputs, reads, ruleSource) instanceof OfAComparison.Cuts
+                cuts ? cuts.read() : null;
     }
 
     /**
@@ -108,7 +109,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
     }
 
     /** The same, saying which of the three it is. */
-    static OfAComparison read(Comparison comparison, InputDomain inputs, InputReads reads,
+    static OfAComparison read(StatedComparison comparison, InputDomain inputs, InputReads reads,
                               RuleReadingSource ruleSource) {
         // What this reading names as it goes, kept so that a reading which ran to the end can say
         // what it was about without anybody reading the comparison again.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -1,6 +1,6 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.inputs.ComparedNumber;
 import souther.compiler.inputs.InputReading;
@@ -64,7 +64,7 @@ record ComparedLine(NumericTerm.FromOnePosition term, Place value,
      * nothing, and there is nothing else for a spelling to try: which quantity a rule cuts is the
      * arithmetic's answer, and this reading is reached only where the arithmetic had none.
      */
-    static ComparedLine asWritten(Comparison comparison,
+    static ComparedLine asWritten(StatedComparison comparison,
                                   InputReading read, InputReads reads) {
         // What the rule placed comes from the comparison and is carried as what it placed, so
         // nothing on the way here has a side to fill in for a rule that has none — and nothing on

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
@@ -1,7 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
@@ -84,7 +84,7 @@ record ComparedTerms(TermOrders on, TermOrders against, Count stepsApart) {
      * nothing here has taken apart at all — the canonical form is what says a pair is a pair, and
      * it had no answer.
      */
-    static ComparedTerms asWritten(Comparison comparison,
+    static ComparedTerms asWritten(StatedComparison comparison,
                                    InputReading read, InputReads reads) {
         // A distance is what an order between the two sides states. A rule that names a value
         // orders nothing, and what tells the two apart is the claim the comparison carries — an

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -1,6 +1,6 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
@@ -241,7 +241,7 @@ sealed interface ComparisonAssessment {
      * form written two ways agree as arithmetic and are made of different things, so the rule they
      * state would come back as one about no input at all.
      */
-    static ComparisonAssessment of(String behavior, Comparison comparison, Citation at,
+    static ComparisonAssessment of(String behavior, StatedComparison comparison, Citation at,
                                    InputReading read, InputReads reads,
                                    BindingId answer,
                                    boolean drawnByAnInvariant) {
@@ -370,8 +370,8 @@ sealed interface ComparisonAssessment {
      * the second went out as a rule about nothing, and the position it plainly concerns came back
      * as one the model states nothing about.
      */
-    private static ComparisonAssessment aboutNoPosition(Comparison comparison, InputReads reads,
-                                                        Symbols symbols) {
+    private static ComparisonAssessment aboutNoPosition(StatedComparison comparison,
+                                                        InputReads reads, Symbols symbols) {
         SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> why =
                 new LinkedHashMap<>();
         GuardThresholds.cameFrom(comparison, reads, symbols, why);

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -230,7 +230,7 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
             BoundaryPolicy.Standing standing = BoundaryPolicy.refuses(live)
                     .<BoundaryPolicy.Standing>map(BoundaryPolicy.Standing.Refused::new)
                     .orElseGet(() -> new BoundaryPolicy.Standing.Admitted(
-                            ComparisonAssessment.of(in.behavior(), comparison, where,
+                            ComparisonAssessment.of(in.behavior(), comparison.stated(), where,
                                     in.read(), reads, null, false)));
             out.add(new Reading(stands, comparison, where, reads, assumed, standing));
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -1,6 +1,6 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
@@ -137,7 +137,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * over the comparison and answered about the shape rather than about what this reading could do
      * with it.
      */
-    static Read read(String behavior, Comparison comparison,
+    static Read read(String behavior, StatedComparison comparison,
                      InputReading read, InputReads reads) {
         AffineReading.OfAComparison canonical =
                 AffineReading.read(comparison, read.domain(), reads, read.rules());
@@ -271,7 +271,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * a case of an enumeration, one string against another. Reached only from a reading that
      * stopped, so a spelling never answers a question the canonical form has already answered.
      */
-    private static Read asWritten(String behavior, Comparison comparison,
+    private static Read asWritten(String behavior, StatedComparison comparison,
                                   AffineReading.OfAComparison.Stopped canonical,
                                   InputReading read, InputReads reads) {
         Quantities quantities = read.quantities();

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -1,12 +1,10 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.types.Type;
-import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
 import souther.compiler.inputs.ClauseWithoutAnEnd;
 import souther.compiler.inputs.InputReading;
@@ -67,13 +65,6 @@ public final class DeclaredThresholds {
     private static void drawn(String behavior, ClauseWithoutAnEnd clause,
                               InputReading read, List<LineDrawn> out) {
         Symbols symbols = read.symbols();
-        if (!(clause.read() instanceof Core.Binary binary)) {
-            return;
-        }
-        Comparison comparison = Comparison.of(binary).orElse(null);
-        if (comparison == null) {
-            return;
-        }
         Map<BindingId, TermPath> roots = rootsOf(clause, symbols);
         if (roots.isEmpty()) {
             return;
@@ -82,8 +73,8 @@ public final class DeclaredThresholds {
         // there is nothing a behavior answered for it to be about.
         // And no arrival: a declaration's clause stands in no body for anything to be on the way
         // to, which reads as an arrival that restricts nothing.
-        ComparisonAssessment assessed = ComparisonAssessment.of(behavior, comparison,
-                Citation.of(binary.pos()), read,
+        ComparisonAssessment assessed = ComparisonAssessment.of(behavior, clause.states(),
+                Citation.of(clause.wrote()), read,
                 InputReads.ofADeclaredClause(roots), null, true);
         // Only the quantity that is on no position. Why this drew no line where it drew none is not
         // said here: the reading of ends already answered for this clause at each position it names,

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -214,7 +214,7 @@ public final class EnsuresThresholds {
         // No arrival either: a clause stands in no body, it is checked whenever the behavior
         // answers, so there is nothing on the way to it and what arrives is the declarations'
         // whole domain — which is what an arrival that restricts nothing reads as.
-        ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison,
+        ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison.stated(),
                 Citation.of(e.pos()), read,
                 reads, rule.value(), false);
         // What the positions this names are left with, where the reading of lines drew none. Asked

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -3,7 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.check.AnalysisBody;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.Comparison;
+import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleAt;
 import souther.compiler.check.RuleCitation;
@@ -309,7 +309,7 @@ public final class GuardThresholds {
      * be. Answered alike, a rule about an element of a sequence would be reported as one about a
      * value somebody computed, and an author would go looking for the operation to invert.
      */
-    static void cameFrom(Comparison comparison, InputReads reads, Symbols symbols,
+    static void cameFrom(StatedComparison comparison, InputReads reads, Symbols symbols,
                          SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> out) {
         for (Core side : List.of(comparison.left(), comparison.right())) {
             // Where a side's values came from, and nothing where they came from nowhere.
@@ -434,7 +434,7 @@ public final class GuardThresholds {
      * whatever the caller happens to hold.
      */
     static java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped>
-            whatEachPlaceIsLeftWith(Comparison comparison,
+            whatEachPlaceIsLeftWith(StatedComparison comparison,
                                     AffineReading.OfAComparison.Stopped stopped,
                                     InputReading read, InputReads reads) {
         Symbols symbols = read.symbols();
@@ -503,7 +503,7 @@ public final class GuardThresholds {
      * the position's own values — which number of it the rule is about is exactly the part that was
      * not read.
      */
-    static List<FilingCoordinate> filedAt(Comparison comparison,
+    static List<FilingCoordinate> filedAt(StatedComparison comparison,
                                                InputReading read,
                                                InputReads reads) {
         Symbols symbols = read.symbols();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
@@ -51,6 +51,25 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
         assertEquals(readingOf("n /= 3"), readingOf("Bool.not(n == 3)"));
     }
 
+    /**
+     * And a rule named through a helper, denied.
+     *
+     * <p>A helper's expansion is a binding, and what a reading meets under a denial there is the
+     * binding with the denial above it. Crossed only where nothing stood above it, a rule an author
+     * named and denied was a form this reading had no word for — and since almost every binding it
+     * meets is one an expansion made, that is most of the rules stated through a helper.
+     */
+    @Test
+    void aRuleNamedThroughAHelperAndDeniedIsTheRuleItDenies() {
+        assertEquals(readingOf("n <= 3"), readingOf("Bool.not(aboveThree(n))", HELPER));
+        assertEquals(readingOf("n > 3"), readingOf("aboveThree(n)", HELPER));
+    }
+
+    /** A helper naming the rule the fixtures above deny. */
+    private static final String HELPER = """
+            let aboveThree (n: Int): Bool = n > 3
+            """;
+
     /** The pair the tier above would pass without: a rule and its denial are different rules. */
     @Test
     void aRuleAndItsDenialAreNotOneReading() {
@@ -102,7 +121,11 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
                            List<ComparisonClaim> handedOn, String bounds, String accounting) {}
 
     private static Reading readingOf(String clause) {
-        FieldDomains domains = domainsOf(clause);
+        return readingOf(clause, "");
+    }
+
+    private static Reading readingOf(String clause, String helpers) {
+        FieldDomains domains = domainsOf(clause, helpers);
         return new Reading(domains.placed(), domains.stated(), domains.aboutOneCoordinate(),
                 domains.withoutAnEnd().stream().map(each -> each.states().claim()).toList(),
                 String.valueOf(domains.at(RuleKey.of("n"))),
@@ -121,14 +144,19 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
     }
 
     private static FieldDomains domainsOf(String clause) {
+        return domainsOf(clause, "");
+    }
+
+    private static FieldDomains domainsOf(String clause, String helpers) {
         String source = """
                 module example.spelling
 
+                %s
                 data Box =
                     { n: Int
                     }
                     invariant capped = %s
-                """.formatted(clause);
+                """.formatted(helpers, clause);
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         assertEquals(List.of(), compilation.diagnostics().values().stream()

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
@@ -87,21 +87,19 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
      */
     @Test
     void aConjunctionWrittenAsADeniedChoiceLeavesWhatTheConjunctionLeaves() {
-        assertEquals(endsOf("n <= 3 && n >= 0"), endsOf("Bool.not(n > 3 || n < 0)"));
-        assertEquals(boundsOf("n <= 3 && n >= 0"), boundsOf("Bool.not(n > 3 || n < 0)"));
+        assertEquals(leavesOf("n <= 3 && n >= 0"), leavesOf("Bool.not(n > 3 || n < 0)"));
     }
 
     /** And a choice written as a denied conjunction. */
     @Test
     void aChoiceWrittenAsADeniedConjunctionLeavesWhatTheChoiceLeaves() {
-        assertEquals(endsOf("n <= 3 || n >= 10"), endsOf("Bool.not(n > 3 && n < 10)"));
-        assertEquals(boundsOf("n <= 3 || n >= 10"), boundsOf("Bool.not(n > 3 && n < 10)"));
+        assertEquals(leavesOf("n <= 3 || n >= 10"), leavesOf("Bool.not(n > 3 && n < 10)"));
     }
 
     /** The pair that tier would pass without: a conjunction and a choice leave different things. */
     @Test
     void aConjunctionAndAChoiceDoNotLeaveTheSameThing() {
-        assertNotEquals(boundsOf("n <= 3 && n >= 0"), boundsOf("n <= 3 || n >= 10"));
+        assertNotEquals(leavesOf("n <= 3 && n >= 0"), leavesOf("n <= 3 || n >= 10"));
     }
 
     /**
@@ -132,15 +130,22 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
                 String.valueOf(domains.accounting()));
     }
 
-    /** The ends the rules leave, with the conjunct each is filed against dropped. */
-    private static Set<String> endsOf(String clause) {
-        return domainsOf(clause).placed().stream()
-                .map(each -> each.at() + (each.lower() ? " from " : " to ") + each.end())
-                .collect(java.util.stream.Collectors.toSet());
-    }
+    /**
+     * What the rules leave the position, with the conjunct each end is filed against dropped.
+     *
+     * <p>What the tier below holds. One reading, projected twice: asked as two questions of two
+     * readings, the two spellings are each read again for the second half, and a test that reads a
+     * model twice is a test that could be comparing two of them.
+     */
+    private record Leaves(Set<String> ends, String bounds) {}
 
-    private static String boundsOf(String clause) {
-        return String.valueOf(domainsOf(clause).at(RuleKey.of("n")));
+    private static Leaves leavesOf(String clause) {
+        FieldDomains domains = domainsOf(clause);
+        return new Leaves(
+                domains.placed().stream()
+                        .map(each -> each.at() + (each.lower() ? " from " : " to ") + each.end())
+                        .collect(java.util.stream.Collectors.toSet()),
+                String.valueOf(domains.at(RuleKey.of("n"))));
     }
 
     private static FieldDomains domainsOf(String clause) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
@@ -1,0 +1,142 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What a declaration's rules leave a position is the same however the boolean was spelt.
+ *
+ * <p>A denial is one of the language's ways of saying a thing and not a rule of its own. {@code not
+ * (n > 3)}, {@code (n > 3) == false} and {@code if n > 3 then false else true} state what {@code n
+ * <= 3} states, and a reading that answers about the spelling answers about a clause nobody wrote.
+ *
+ * <p><b>Two tiers, because the two questions have different owners.</b> Where the spellings differ
+ * only in how one leaf was written, everything a reading of the declaration comes to is the same —
+ * the ends, which conjunct placed them, what accounts for the rule, and what the position is left
+ * with. Where the spellings differ by a De Morgan law, the rules are the same rules and the
+ * conjuncts an author wrote are not: {@code a && b} is two authored parts and {@code not (a || b)}
+ * is one. Which of them a line belongs to is the split's answer and not this one's, so what is held
+ * here is what the rules leave and not how it is filed.
+ *
+ * <p>Each tier carries the pair that makes it say something. A property over a projection that lost
+ * the distinction holds whatever the projection does, so the spellings that state different rules
+ * are asserted to come out different.
+ */
+class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
+
+    /** One leaf, said four ways. Everything a reading comes to is the same. */
+    @Test
+    void oneLeafSaidFourWaysIsOneReading() {
+        Reading held = readingOf("n <= 3");
+        assertEquals(held, readingOf("Bool.not(n > 3)"));
+        assertEquals(held, readingOf("(n > 3) == false"));
+        assertEquals(held, readingOf("if n > 3 then false else true"));
+    }
+
+    /** And the two shapes that name a value, which a denial exchanges. */
+    @Test
+    void aValueNamedAndTheValueRuledOutAreEachOneReading() {
+        assertEquals(readingOf("n == 3"), readingOf("Bool.not(n /= 3)"));
+        assertEquals(readingOf("n /= 3"), readingOf("Bool.not(n == 3)"));
+    }
+
+    /** The pair the tier above would pass without: a rule and its denial are different rules. */
+    @Test
+    void aRuleAndItsDenialAreNotOneReading() {
+        assertNotEquals(readingOf("n <= 3"), readingOf("n > 3"));
+        assertNotEquals(readingOf("n == 3"), readingOf("n /= 3"));
+    }
+
+    /**
+     * And a conjunction written as a denied choice leaves what the conjunction leaves.
+     *
+     * <p>What the rules leave, and not which authored conjunct each end belongs to. The split that
+     * wrote the parts down reads the {@code &&} an author typed, so one of these is two parts and
+     * the other is one; whether that is the filing these ends deserve is a question about the split
+     * and is asked where the split is.
+     */
+    @Test
+    void aConjunctionWrittenAsADeniedChoiceLeavesWhatTheConjunctionLeaves() {
+        assertEquals(endsOf("n <= 3 && n >= 0"), endsOf("Bool.not(n > 3 || n < 0)"));
+        assertEquals(boundsOf("n <= 3 && n >= 0"), boundsOf("Bool.not(n > 3 || n < 0)"));
+    }
+
+    /** And a choice written as a denied conjunction. */
+    @Test
+    void aChoiceWrittenAsADeniedConjunctionLeavesWhatTheChoiceLeaves() {
+        assertEquals(endsOf("n <= 3 || n >= 10"), endsOf("Bool.not(n > 3 && n < 10)"));
+        assertEquals(boundsOf("n <= 3 || n >= 10"), boundsOf("Bool.not(n > 3 && n < 10)"));
+    }
+
+    /** The pair that tier would pass without: a conjunction and a choice leave different things. */
+    @Test
+    void aConjunctionAndAChoiceDoNotLeaveTheSameThing() {
+        assertNotEquals(boundsOf("n <= 3 && n >= 0"), boundsOf("n <= 3 || n >= 10"));
+    }
+
+    /**
+     * Everything a reading of one declaration comes to, less where it was written.
+     *
+     * <p>What the spellings must agree about. Where each of them was written is what they must not:
+     * a report about {@code not (n > 3)} points at the denial, which is what is on the line, and
+     * the same report about {@code n <= 3} points somewhere else — so a position is no part of this.
+     *
+     * <p>A conjunct handed on is compared by what it claims of its two sides and not by the sides.
+     * The sides are expressions, and an expression carries where it was written; what a denial can
+     * exchange is the claim, and it exchanges nothing else — the two sides of a comparison are put
+     * the other way round by turning it towards a number, which is not on this path.
+     */
+    private record Reading(List<FieldDomains.Placed> placed, List<FieldDomains.Placed> stated,
+                           List<FieldDomains.AboutOneCoordinate> about,
+                           List<ComparisonClaim> handedOn, String bounds, String accounting) {}
+
+    private static Reading readingOf(String clause) {
+        FieldDomains domains = domainsOf(clause);
+        return new Reading(domains.placed(), domains.stated(), domains.aboutOneCoordinate(),
+                domains.withoutAnEnd().stream().map(each -> each.states().claim()).toList(),
+                String.valueOf(domains.at(RuleKey.of("n"))),
+                String.valueOf(domains.accounting()));
+    }
+
+    /** The ends the rules leave, with the conjunct each is filed against dropped. */
+    private static Set<String> endsOf(String clause) {
+        return domainsOf(clause).placed().stream()
+                .map(each -> each.at() + (each.lower() ? " from " : " to ") + each.end())
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    private static String boundsOf(String clause) {
+        return String.valueOf(domainsOf(clause).at(RuleKey.of("n")));
+    }
+
+    private static FieldDomains domainsOf(String clause) {
+        String source = """
+                module example.spelling
+
+                data Box =
+                    { n: Int
+                    }
+                    invariant capped = %s
+                """.formatted(clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model under test is a program that can be written: " + clause);
+        String module = compilation.modules().get(0);
+        RuleReadingSource rules = RuleReadings.of(compilation, module);
+        TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Box"));
+        return FieldDomains.of(named, rules, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
@@ -76,11 +76,12 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
     /**
      * And the fixtures are held to being programs somebody could write.
      *
-     * <p>The control on how these models are built. A property over spellings is worth what its
-     * fixtures are worth, and a spelling this compiler refuses reads as a declaration with no rule
-     * at all — which agrees with every other spelling about a great deal. What each fixture is
-     * driven far enough to answer is the structure alone, so what is asserted here is that far
-     * enough is far enough.
+     * <p>The control on how these models are built, and it is over the driving rather than beside
+     * it. A property over spellings is worth what its fixtures are worth, and a spelling this
+     * compiler refuses reads as a declaration with no rule at all — which agrees with every other
+     * spelling about everything. The reading these rows are of makes a leaf of an ill-typed clause
+     * and says nothing about it, so what refuses one is somewhere else entirely, and how far a
+     * fixture is driven is the whole of whether it is refused at all.
      */
     @Test
     void aModelThatCannotBeWrittenIsRefused() {
@@ -200,14 +201,18 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
 
     private static FieldDomains read(String source, String clause) {
         Compilation compilation = Compilation.ofSource(source, "Main");
-        // What a fixture has to clear, and no more. Answering everything there is to answer runs
-        // the code this compiler writes, the constant constructions, the examples and every warning
-        // — none of which a rule about what a declaration's clauses leave is read from, and all of
-        // which a fixture pays for once per model it names. What a model that cannot be written is
-        // refused by is held below.
-        compilation.structuralReports();
-        assertEquals(List.of(), compilation.diagnostics().values().stream()
-                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+        // Everything there is to answer, which is what holding a fixture to being writable costs
+        // and not what these rows read.
+        //
+        // Driven as far as the rows read, an ill-typed clause reads perfectly well: what refuses
+        // `Bool.not(n)` is not the reading of ends, which makes a leaf of it, but the typing the
+        // code this compiler writes goes through — so a fixture stopped short of that comes back a
+        // declaration with no rule, and a declaration with no rule agrees with every spelling here
+        // about everything. Which is the one way a property over spellings passes while saying
+        // nothing, so the fixtures are held first and read afterwards.
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.reports().stream()
+                        .map(each -> each.report().diagnostic().code()).toList(),
                 "the model under test is a program that can be written: " + clause);
         String module = compilation.modules().get(0);
         RuleReadingSource rules = RuleReadings.of(compilation, module);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest.java
@@ -8,11 +8,14 @@ import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * What a declaration's rules leave a position is the same however the boolean was spelt.
@@ -69,6 +72,23 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
     private static final String HELPER = """
             let aboveThree (n: Int): Bool = n > 3
             """;
+
+    /**
+     * And the fixtures are held to being programs somebody could write.
+     *
+     * <p>The control on how these models are built. A property over spellings is worth what its
+     * fixtures are worth, and a spelling this compiler refuses reads as a declaration with no rule
+     * at all — which agrees with every other spelling about a great deal. What each fixture is
+     * driven far enough to answer is the structure alone, so what is asserted here is that far
+     * enough is far enough.
+     */
+    @Test
+    void aModelThatCannotBeWrittenIsRefused() {
+        for (String clause : List.of("n > \"three\"", "nope > 3", "Bool.not(n)")) {
+            assertThrows(AssertionError.class, () -> domainsOf(clause),
+                    () -> "a fixture this compiler refuses is no fixture: " + clause);
+        }
+    }
 
     /** The pair the tier above would pass without: a rule and its denial are different rules. */
     @Test
@@ -152,6 +172,19 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
         return domainsOf(clause, "");
     }
 
+    /**
+     * The reading of each model this test names, built once.
+     *
+     * <p>A property held over spellings names the same spelling from several of its rows — one
+     * spelling is the thing another is being held against, and the row that says two of them differ
+     * names both again. Built per naming, a model is built as many times as it is mentioned, and
+     * which reading of it a row was about is decided by the order the rows ran in.
+     *
+     * <p>The model and not the reading, because building it is what costs: what a reading projects
+     * out of one is a walk over what is already in hand.
+     */
+    private static final Map<String, FieldDomains> READ = new HashMap<>();
+
     private static FieldDomains domainsOf(String clause, String helpers) {
         String source = """
                 module example.spelling
@@ -162,8 +195,17 @@ class WhatARuleLeavesDoesNotTurnOnHowItsAuthorSpeltTheBooleanTest {
                     }
                     invariant capped = %s
                 """.formatted(helpers, clause);
+        return READ.computeIfAbsent(source, each -> read(each, clause));
+    }
+
+    private static FieldDomains read(String source, String clause) {
         Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
+        // What a fixture has to clear, and no more. Answering everything there is to answer runs
+        // the code this compiler writes, the constant constructions, the examples and every warning
+        // — none of which a rule about what a declaration's clauses leave is read from, and all of
+        // which a fixture pays for once per model it names. What a model that cannot be written is
+        // refused by is held below.
+        compilation.structuralReports();
         assertEquals(List.of(), compilation.diagnostics().values().stream()
                         .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
                 "the model under test is a program that can be written: " + clause);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAClauseIsReadIntoItsShapeIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAClauseIsReadIntoItsShapeIsWrittenDownTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Who reads a clause's tree into its shape, and where such a reading may happen.
+ *
+ * <p>What a clause is written out of — a conjunction, a choice, a denial — is read out of the tree
+ * once ({@link ClauseExpr}), and everything downstream is an evaluator over what that left. A reader
+ * that starts a second one is deciding for itself what the author wrote, and it decides it under a
+ * polarity of its own: read afresh from a node, a clause the walk was holding as denied comes back
+ * stated, and the occurrences under it are numbered from wherever the node begins rather than from
+ * the clause.
+ *
+ * <p>Which is what a reading of ends did. It held the shape, went back to the node it was spelled
+ * as, and asked for the shape again with the polarity written in as {@code true} — so a conjunction
+ * an author wrote as a denied choice was a choice to that second reading, and the answer it filed
+ * was about a clause nobody wrote.
+ *
+ * <p>Read off the compiled classes, and by the type the call is made with rather than by the name
+ * alone: the reading that walks a clause into its shape calls itself, and a licence keyed by the
+ * name would licence the entry point and the recursion together, so a caller reaching for the entry
+ * point could take the recursion's place in the table and pass.
+ */
+class WhereAClauseIsReadIntoItsShapeIsWrittenDownTest {
+
+    private static final String SHAPE = "souther/compiler/check/ClauseExpr";
+
+    /** The way in, which takes a tree and how it stands and nothing else. What the walk calls
+     *  itself with carries where it has got to, and is a different descriptor. */
+    private static final String THE_WAY_IN =
+            "(Lsouther/compiler/core/Core;Z)Lsouther/compiler/check/ClauseExpr;";
+
+    /** A method that may read a clause into its shape, how many times it does, and why. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_READ = List.of(
+            new Licence("souther.compiler.check.ClauseReading.read", 1,
+                    "the fold every reading of a clause is written as, which reads the shape and"
+                            + " hands each reading its parts"),
+            new Licence("souther.compiler.check.Clauses.statedAt", 1,
+                    "the shape a world of rules is described against, made where the parts a"
+                            + " caller reads are chosen"),
+            new Licence("souther.compiler.check.InvariantChecker.seedFieldsFresh", 1,
+                    "the same, for the reading a declaration's rules are gathered by"),
+            new Licence("souther.compiler.check.StatedByClauses.mirrors", 1,
+                    "the shape of a clause a caller holds only as a tree, compared against one"
+                            + " already read"));
+
+    @Test
+    void onlyTheReadingsThatMakeAShapeReadOne() {
+        assertEquals(declared(), callsTo(SHAPE, "of", THE_WAY_IN),
+                "a clause read into its shape anywhere else is a second answer to what its author"
+                        + " wrote, arrived at under whatever polarity that reader wrote down."
+                        + " What may read one, and why: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_READ.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new TreeMap<>();
+        MAY_READ.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler calls {@code owner.name} with {@code descriptor}. */
+    private static Map<String, Integer> callsTo(String owner, String name, String descriptor) {
+        Map<String, Integer> calls = new TreeMap<>();
+        for (ClassModel model : WhatWasCompiled.compiled().all()) {
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(owner)
+                            && call.name().stringValue().equals(name)
+                            && call.type().stringValue().equals(descriptor)) {
+                        calls.merge(from + "." + method.methodName().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        return calls;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
@@ -126,10 +126,10 @@ class ADeniedComparisonDrawsTheLineItStatesTest {
                 let take (r) = Taken
                 """.formatted(clause);
         Compilation compilation = Compilation.ofSource(source, "Main");
-        // The structure alone, which is what a fixture has to clear. What this test reads is asked
-        // for below and pulls what answering it needs; answering everything there is to answer
-        // besides is work no row here is read from.
-        compilation.structuralReports();
+        // Everything there is to answer, which is what holding a fixture to being writable costs
+        // and not what these rows read. An ill-typed clause reads perfectly well as far as the rows
+        // go and comes back a rule that draws no line, which every spelling here would agree with.
+        compilation.answerEverything();
         assertEquals(List.of(), compilation.diagnostics().values().stream()
                         .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
                 "the model under test is a program that can be written");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
@@ -9,9 +9,11 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * A rule written under a denial draws the line the rule states, not the one its operator does.
@@ -62,12 +64,44 @@ class ADeniedComparisonDrawsTheLineItStatesTest {
                 "the two keep opposite ends of the number the positions stand apart");
     }
 
+    /**
+     * And a conjunct stating two comparisons hands on both of them.
+     *
+     * <p>A denial is carried to the leaves, so a conjunction an author wrote as a denied choice is
+     * one authored conjunct stating two rules. Both are rules this reading draws a line for, and
+     * both have to reach it: counted by the rule they are a conjunct of, the second is the first
+     * said again and the line it would have drawn is not drawn at all.
+     *
+     * <p>The cuts and not the lines, because which authored conjunct each is filed against is what
+     * the two spellings differ about and is #1583's question. What is held here is that the reading
+     * below is given the same rules.
+     */
+    @Test
+    void aConjunctStatingTwoComparisonsHandsOnBoth() {
+        assertEquals(cutsOf("lo <= hi && lo2 <= hi2"),
+                cutsOf("Bool.not(lo > hi || lo2 > hi2)"),
+                "both halves of a denied choice are rules the reading of lines is given");
+    }
+
+    /** The pair that would pass without it: one comparison is not two. */
+    @Test
+    void oneComparisonIsNotTwo() {
+        assertNotEquals(cutsOf("lo <= hi && lo2 <= hi2"), cutsOf("lo <= hi"),
+                "a conjunct stating one rule hands on one");
+    }
+
+    /** What the lines cut, with the conjunct each is filed against dropped. */
+    private static Set<String> cutsOf(String clause) {
+        return linesOf(clause).stream().map(each -> String.valueOf(each.cuts()))
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
     /** What the reading that draws lines makes of a declaration whose rule is {@code clause}. */
     private static List<LineDrawn> linesOf(String clause) {
         String source = """
                 module example.denied
 
-                data R = { lo: Int, hi: Int }
+                data R = { lo: Int, hi: Int, lo2: Int, hi2: Int }
                     invariant same = %s
 
                 data Taken

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
@@ -8,7 +8,9 @@ import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,8 +98,22 @@ class ADeniedComparisonDrawsTheLineItStatesTest {
                 .collect(java.util.stream.Collectors.toSet());
     }
 
+    /**
+     * The lines each model this test names draws, worked out once.
+     *
+     * <p>A property held over spellings names the same spelling from several of its rows — one
+     * spelling is the thing another is being held against, and the row that says two of them differ
+     * names both again. Built per naming, a model is built as many times as it is mentioned, and
+     * which reading of it a row was about is decided by the order the rows ran in.
+     */
+    private static final Map<String, List<LineDrawn>> DRAWN = new HashMap<>();
+
     /** What the reading that draws lines makes of a declaration whose rule is {@code clause}. */
     private static List<LineDrawn> linesOf(String clause) {
+        return DRAWN.computeIfAbsent(clause, ADeniedComparisonDrawsTheLineItStatesTest::drawnFor);
+    }
+
+    private static List<LineDrawn> drawnFor(String clause) {
         String source = """
                 module example.denied
 
@@ -110,7 +126,10 @@ class ADeniedComparisonDrawsTheLineItStatesTest {
                 let take (r) = Taken
                 """.formatted(clause);
         Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
+        // The structure alone, which is what a fixture has to clear. What this test reads is asked
+        // for below and pulls what answering it needs; answering everything there is to answer
+        // besides is work no row here is read from.
+        compilation.structuralReports();
         assertEquals(List.of(), compilation.diagnostics().values().stream()
                         .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
                 "the model under test is a program that can be written");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeniedComparisonDrawsTheLineItStatesTest.java
@@ -1,0 +1,92 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A rule written under a denial draws the line the rule states, not the one its operator does.
+ *
+ * <p>A conjunct that placed no end is handed to this reading, which reads what it compares and what
+ * it claims of the two sides. Handed the expression instead, this reading recognised the comparison
+ * again off the operator — and the operator of a rule written under a denial states the comparison
+ * that holds exactly where the rule does not, so {@code not (lo /= hi)} would draw the line of
+ * {@code lo /= hi}: the values it parts are the ones the rule admits.
+ *
+ * <p>An ordering between two positions, because that is the shape this reading draws a line for. A
+ * rule naming a value of the number two positions stand apart parts that number from every other
+ * one and keeps no end of it, so a denial exchanged there leaves nothing for a line to be the wrong
+ * way round about.
+ *
+ * <p>Read through to the lines rather than at the hand-over, because the hand-over is not where the
+ * two readings could differ — it is where one of them stops and the other starts, and a value
+ * carried across correctly and read for the wrong thing is a defect this would not see.
+ */
+class ADeniedComparisonDrawsTheLineItStatesTest {
+
+    /** The same rule written twice: as itself, and as the denial of the comparison that holds
+     *  exactly where it does not. */
+    @Test
+    void anOrderWrittenAsADeniedOppositeDrawsOneLine() {
+        assertEquals(linesOf("lo <= hi"), linesOf("Bool.not(lo > hi)"),
+                "the denial of an order is the order that holds where it does not, and it keeps"
+                        + " that order's end");
+    }
+
+    @Test
+    void andTheSameForTheOrderThatRefusesItsOwnValue() {
+        assertEquals(linesOf("lo < hi"), linesOf("Bool.not(lo >= hi)"),
+                "and the same where the rule refuses the value it names");
+    }
+
+    /**
+     * And an order is not its opposite, which is what makes the pairs above say something.
+     *
+     * <p>A metamorphic pair over a projection that lost the distinction passes whatever the
+     * projection does with it. What is asserted here is that the projection has not lost it: the
+     * line {@code lo <= hi} draws and the line {@code lo > hi} draws are different lines, so a
+     * reading that took one for the other would have to show up above.
+     */
+    @Test
+    void anOrderAndItsOppositeDoNotDrawTheSameLine() {
+        assertFalse(linesOf("lo <= hi").equals(linesOf("lo > hi")),
+                "the two keep opposite ends of the number the positions stand apart");
+    }
+
+    /** What the reading that draws lines makes of a declaration whose rule is {@code clause}. */
+    private static List<LineDrawn> linesOf(String clause) {
+        String source = """
+                module example.denied
+
+                data R = { lo: Int, hi: Int }
+                    invariant same = %s
+
+                data Taken
+
+                behavior take : (r: R) -> Taken
+                let take (r) = Taken
+                """.formatted(clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model under test is a program that can be written");
+        String module = compilation.modules().get(0);
+        RuleReadingSource rules = RuleReadings.of(compilation, module);
+        InputDomain inputs =
+                compilation.db().ask(new Adequacy.Inputs(module)).value().get("take");
+        List<LineDrawn> drawn = DeclaredThresholds.between("take", inputs.reading(rules));
+        assertFalse(drawn.isEmpty(),
+                "a rule relating two positions reaches the reading that draws lines: " + clause);
+        return drawn;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
@@ -239,7 +239,8 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
 
         ReadComparisons read = ReadComparisons.of(source, "classify");
         ComparisonReadings.Reading against = read.only();
-        return switch (AffineReading.read(against.comparison(), read.inputs(), against.reads(),
+        return switch (AffineReading.read(against.comparison().stated(), read.inputs(),
+                against.reads(),
                 read.rules())) {
             case AffineReading.OfAComparison.Stopped _ -> "stopped";
             case AffineReading.OfAComparison.CutsNothing _ -> "cuts nothing";

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -79,7 +79,7 @@ class WhatAComparisonIsARuleAboutTest {
         for (Contract.Param param : stated.params()) {
             roots.putIfAbsent(param.binding(), param.name());
         }
-        return ComparisonAssessment.of("f", comparison, Citation.of(binary.pos()),
+        return ComparisonAssessment.of("f", comparison.stated(), Citation.of(binary.pos()),
                 inputs.reading(rules),
                 InputReads.ofWhatIsDeclared(roots), rule.value(), false);
     }


### PR DESCRIPTION
Addresses #1520.

The walk that reads a conjunct for the end it places was handed the clause's shape and went back to the node it was spelled as, taking the outermost of them — which is the denial, not what it denies. The polarity beside it was then spent on the only thing a loose boolean can do at a walk: deciding whether to descend into a conjunction.

Both halves of the issue follow from that. A rule written under a denial reached this reading as a node that is no comparison, so it placed no end, drew no line and was about no number, while the reading that turns clauses into sets read it perfectly well. And because what a connective composes already has the denial applied to it, asking for that *and* for how the whole stands applied the denial twice, so a conjunction an author wrote as a denied choice was a part this reading never descended into.

## What is here

The crossing from an operator to what a clause states is asked once, of the part and its polarity together, and the side bearing the number is resolved in the same step. What comes back holds neither the polarity nor a note about which way round the comparison was written, so no reader below has either to apply. The reading that holds an order and the reading that reads ends now cross over at the same place instead of each writing that crossing out for itself. The canonical form is of the comparison the clause states, so whether a form holds of every row is answered without a reader pairing it with a polarity of its own — one of the two readers of that answer was not pairing it.

A conjunct that placed no end is handed on to the reading that draws lines, and it was handed over as its own expression, which that reading recognised as a comparison again off the operator. Under a denial the operator states the comparison that holds exactly where the rule does not, so the line drawn there would be the opposite rule's. What is handed over now is the comparison the clause states, with where the author wrote it beside it as a position rather than an expression, and the arm that dropped whatever was no comparison goes with it — what is handed on is one, and the type says so.

## What holds it

A licence for reading a clause into its shape, so a reader holding one cannot start a second. It is keyed by the descriptor rather than the name, because the walk calls itself and a table keyed by the name would licence the way in and the recursion together.

A metamorphic property over what a declaration's rules leave, in two tiers. Spellings that differ in one leaf must agree about everything a reading comes to; spellings that differ by a De Morgan law must agree about what the rules leave and not about which authored conjunct each end is filed against, which is the split's answer and not this reading's. Each tier carries the pair that would pass without it.

And the line a denied order draws, read through to where lines are drawn, since a comparison carried across correctly could still be read there for the wrong thing.

## Found on the way

#1583 — one authored conjunct can state several lines, and what pairs them is implicit in a shape that reads as one-to-one. The De Morgan tier above stops short of asserting the filing for that reason.

#1582 — a newtype's own bound is not read when the rule is written under a denial. The same family, in the reader that works on the source-level tree, where there is no shape and no way in that takes a polarity. It predates this change and is not exposed by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)