### PR TITLE
Name a line of a declaration by which statement of its conjunct drew it

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -13,6 +13,9 @@ import souther.compiler.coverage.SiteAddress;
 import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
@@ -96,10 +99,12 @@ final class AReportOfOneBorder {
      */
     static Border aBoundedBorder() {
         LineOrigin origin = new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                        java.util.Optional.of(new ClauseName("cap")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.rate", "Amount")), 0),
+                                java.util.Optional.of(new ClauseName("cap")))), 0),
+                        0)),
                 souther.compiler.numeric.EndSide.LOWER, true);
         return Border.at(
                 BoundaryTarget.at(
@@ -145,10 +150,12 @@ final class AReportOfOneBorder {
     /** The same border a rule leaves at 100 and up, where the ON point is the whole of what it owes. */
     static Border aBorderAtTheEdgeOfItsDomain() {
         LineOrigin origin = new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                        java.util.Optional.of(new ClauseName("cap")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.rate", "Amount")), 0),
+                                java.util.Optional.of(new ClauseName("cap")))), 0),
+                        0)),
                 souther.compiler.numeric.EndSide.LOWER, true);
         return Border.at(
                 BoundaryTarget.at(

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -65,41 +65,7 @@ sealed interface ClauseExpr {
      * occurrences for itself would be a second answer to how many there are, and two answers to
      * that is what reading the connectives twice came to.
      */
-    Occurrence at();
-
-    /**
-     * One occurrence of a clause's structure, counted from the outside in.
-     *
-     * <p>A position among the occurrences of one clause and not a name, so it means something only
-     * beside the clause it is of — two clauses each have an occurrence numbered nought, and they
-     * are two occurrences. What pairs it with the clause is the reader's, which holds the rule and
-     * the part it is reading.
-     *
-     * <p>Independent of how the clause stands. A denial changes what a connective composes and
-     * changes nothing about which occurrences there are, so a clause read as stated and the same
-     * clause read as denied number their occurrences alike — and an answer filed about one is an
-     * answer about the other.
-     */
-    record Occurrence(int ordinal) {
-
-        /** The clause itself, which takes the first number before anything under it does — see
-         *  {@link ClauseExpr#under}. */
-        static Occurrence ofTheClause() {
-            return new Occurrence(0);
-        }
-
-        public Occurrence {
-            if (ordinal < 0) {
-                throw new IllegalArgumentException(
-                        "an occurrence of a clause is counted from zero: " + ordinal);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "#" + ordinal;
-        }
-    }
+    ClauseOccurrence at();
 
     /**
      * Whether what this stands for is stated, or denied where it is not.
@@ -145,7 +111,7 @@ sealed interface ClauseExpr {
     }
 
     /** One part of no connective, stated where {@code positive} and denied where it is not. */
-    record Leaf(List<Core> spelled, boolean positive, Occurrence at) implements Part {
+    record Leaf(List<Core> spelled, boolean positive, ClauseOccurrence at) implements Part {
 
         public Leaf {
             spelled = named(spelled);
@@ -167,7 +133,7 @@ sealed interface ClauseExpr {
      *            stands are two answers: a choice denied composes both of its parts denied, so
      *            {@code BOTH} beside {@code positive} being false is a choice and not a conjunction
      */
-    record Joined(List<Core> spelled, boolean positive, Occurrence at, ConditionJoin how,
+    record Joined(List<Core> spelled, boolean positive, ClauseOccurrence at, ConditionJoin how,
                   ClauseExpr left, ClauseExpr right) implements Part {
 
         public Joined {
@@ -213,7 +179,7 @@ sealed interface ClauseExpr {
      * @param binding the binding as the tree holds it, which the fold hands to {@link ClauseScope}
      *                — the shape says a binding stands here, and what it means is settled elsewhere
      */
-    record Scoped(List<Core> spelled, boolean positive, Occurrence at, Core.LetIn binding,
+    record Scoped(List<Core> spelled, boolean positive, ClauseOccurrence at, Core.LetIn binding,
                   ClauseExpr body) implements ClauseExpr {
 
         public Scoped {
@@ -249,10 +215,10 @@ sealed interface ClauseExpr {
      * stated and read as denied hands out the same numbers.
      */
     private static ClauseExpr under(Core clause, boolean positive, int[] counted) {
-        return of(clause, positive, List.of(), new Occurrence(counted[0]++), counted);
+        return of(clause, positive, List.of(), new ClauseOccurrence(counted[0]++), counted);
     }
 
-    private static ClauseExpr of(Core clause, boolean positive, List<Core> above, Occurrence at,
+    private static ClauseExpr of(Core clause, boolean positive, List<Core> above, ClauseOccurrence at,
                                  int[] counted) {
         List<Core> spelled = new ArrayList<>(above);
         spelled.add(clause);
@@ -310,7 +276,7 @@ sealed interface ClauseExpr {
      * that learned one spelling at a time would answer for the ones somebody had got to.
      */
     private static ClauseExpr restating(Core clause, boolean positive, List<Core> spelled,
-                                        Occurrence at, int[] counted) {
+                                        ClauseOccurrence at, int[] counted) {
         if (clause instanceof Core.PreservedCall call && call.operation().equals(DischargeRules.NOT)
                 && call.args().size() == 1) {
             return of(call.args().get(0), !positive, spelled, at, counted);
@@ -333,7 +299,7 @@ sealed interface ClauseExpr {
      * added.
      */
     private static ClauseExpr againstATruthValue(Core clause, boolean positive,
-                                                 List<Core> spelled, Occurrence at, int[] counted) {
+                                                 List<Core> spelled, ClauseOccurrence at, int[] counted) {
         if (!(clause instanceof Core.Binary bin)
                 || (bin.op() != BinOp.EQ && bin.op() != BinOp.NE)) {
             return null;

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseOccurrence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseOccurrence.java
@@ -1,0 +1,42 @@
+package souther.compiler.check;
+
+/**
+ * One occurrence of a clause's structure, counted from the outside in.
+ *
+ * <p>A position among the occurrences of one clause and not a name, so it means something only
+ * beside the clause it is of — two clauses each have an occurrence numbered nought, and they are two
+ * occurrences. What pairs it with the clause is the reader's, which holds the rule and the part it
+ * is reading ({@link InvariantStatementId}).
+ *
+ * <p>Independent of how the clause stands. A denial changes what a connective composes and changes
+ * nothing about which occurrences there are, so a clause read as stated and the same clause read as
+ * denied number their occurrences alike — and an answer filed about one is an answer about the
+ * other.
+ *
+ * <p>Which occurrences a clause has is decided where the clause is read into its shape
+ * ({@link ClauseExpr}) and nowhere else: a reader that numbered them for itself would be a second
+ * answer to how many there are, and two answers to that is what reading the connectives twice came
+ * to. That is a rule about who assigns the numbers of a clause being read, and not about who may
+ * name one — a coordinate of a clause is said in the vocabulary of everything that files an answer
+ * about a clause, so it is written here rather than inside the shape.
+ */
+public record ClauseOccurrence(int ordinal) {
+
+    /** The clause itself, which takes the first number before anything under it does — see
+     *  {@link ClauseExpr#under}. */
+    static ClauseOccurrence ofTheClause() {
+        return new ClauseOccurrence(0);
+    }
+
+    public ClauseOccurrence {
+        if (ordinal < 0) {
+            throw new IllegalArgumentException(
+                    "an occurrence of a clause is counted from zero: " + ordinal);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "#" + ordinal;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseView.java
@@ -44,10 +44,10 @@ final class ClauseView {
     private final List<Clauses.StatedPart> present;
     /** And where in the clause the ones it does not are: two conjuncts spelled alike stand at two
      *  places, and a set comparing them by what they say would leave out both. */
-    private final Set<ClauseExpr.Occurrence> omitted;
+    private final Set<ClauseOccurrence> omitted;
 
     private ClauseView(List<Clauses.StatedPart> authored, List<Clauses.StatedPart> present,
-                       Set<ClauseExpr.Occurrence> omitted) {
+                       Set<ClauseOccurrence> omitted) {
         this.authored = authored;
         this.present = present;
         this.omitted = omitted;
@@ -96,7 +96,7 @@ final class ClauseView {
     static ClauseView without(List<Clauses.StatedPart> authored,
                               Set<PartId<RuleRef.Invariant>> left) {
         List<Clauses.StatedPart> here = new ArrayList<>(authored.size());
-        Set<ClauseExpr.Occurrence> omitted = new LinkedHashSet<>();
+        Set<ClauseOccurrence> omitted = new LinkedHashSet<>();
         for (Clauses.StatedPart each : authored) {
             if (left.contains(each.id())) {
                 omitted.add(each.of().at());

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * comes back for a name nothing declares is then one answer and not two, because there was one
  * lookup.
  *
- * <p>Nothing here is an identity. What tells one authored line from another is the clause and which
- * of its conjuncts drew the end ({@link souther.compiler.partition.AuthoredLine}), and that is what
+ * <p>Nothing here is an identity. What tells one authored line from another is which line of the
+ * clause it is ({@link souther.compiler.partition.AuthoredLine}), and that is what
  * this is keyed by; what it hands back is what to call the line. Held as part of the identity,
  * the frames above would make one line two.
  */

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -1,9 +1,12 @@
 package souther.compiler.check;
 
 import souther.compiler.diag.Citation;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.types.TypeSymbol;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -54,6 +57,20 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
      */
     public record Key(DeclaredLine line) {}
 
+    /**
+     * One end of one of a declaration's numbers, which is what the evidence about it is gathered
+     * under.
+     *
+     * <p>All three, because an end is where a number stops on one side: two rules stopping one
+     * number at one value are evidence about one end, and the same rules stopping it at two values
+     * are not.
+     *
+     * @param on    which number of the declaration
+     * @param lower whether this is where its values start; otherwise where they stop
+     * @param at    the value the end sits at
+     */
+    private record AnEnd(NumberAt<RuleKey> on, boolean lower, Endpoint at) {}
+
     public DeclaredBorders {
         if (at == null) {
             throw new IllegalArgumentException("a declaration is written somewhere");
@@ -91,16 +108,25 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
                     "there is no declaration of " + declaredOn.name() + " to read");
         }
         Citation at = citations.of(named.key());
-        Map<Key, NumberAt<RuleKey>> forms = new LinkedHashMap<>();
+        // The evidence gathered by the end it is about, because which lines an end is owed to is a
+        // question about the end and not about one piece of what was established there
+        // ({@link DeclaredBounds.End#drawn}). Asked of each piece as it arrives, this named lines
+        // the reading of cuts does not draw, and a report would hold words for one of them.
+        Map<AnEnd, List<LineProvenance>> byEnd = new LinkedHashMap<>();
         for (FieldDomains.Placed placed
                 : Rules.of(declaredOn, source, policy, machines).bounds().placed()) {
             // A clause reaching this declaration through a spread is written on another one and is
             // that one's to name, the way a line is named by the rule that drew it (ADR-0090). Its
             // own reading answers for it.
-            if (placed.part().rule().clause().id().declaredOn().equals(declaredOn)) {
-                forms.put(new Key(placed.from().line()), placed.at());
+            if (!placed.part().rule().clause().id().declaredOn().equals(declaredOn)) {
+                continue;
             }
+            byEnd.computeIfAbsent(new AnEnd(placed.at(), placed.lower(), placed.end()),
+                    _ -> new ArrayList<>()).add(placed.from());
         }
+        Map<Key, NumberAt<RuleKey>> forms = new LinkedHashMap<>();
+        byEnd.forEach((end, found) -> new DeclaredBounds.End(end.at(), found).drawn()
+                .forEach(line -> forms.put(new Key(line), end.on())));
         return new DeclaredBorders(at, forms);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -39,15 +39,20 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
                               Map<Key, NumberAt<RuleKey>> forms) {
 
     /**
-     * Which authored line: the part of the clause that placed the end.
+     * Which authored line: what the reading knows about the clause that placed the end.
      *
      * <p>A part of a {@code data}'s clause and of nothing else. These are the lines a declaration
      * wrote in its own terms, and a behavior's {@code ensures} writes none of them — so the kind of
      * clause is in the type rather than asked of a part that arrives. Written over parts of any
      * clause, this would take a behavior's and answer null, which is the word it has for a
      * declaration that drew no such line.
+     *
+     * <p>The line and not the conjunct alone, because this is a pairing key and a conjunct does not
+     * name one line. A conjunct written under a denial places an end on each of two numbers, and
+     * keyed by the conjunct the second overwrites the first — leaving one of the two lines named
+     * after the other's number.
      */
-    public record Key(PartId<RuleRef.Invariant> part) {}
+    public record Key(DeclaredLine line) {}
 
     public DeclaredBorders {
         if (at == null) {
@@ -93,7 +98,7 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
             // that one's to name, the way a line is named by the rule that drew it (ADR-0090). Its
             // own reading answers for it.
             if (placed.part().rule().clause().id().declaredOn().equals(declaredOn)) {
-                forms.put(new Key(placed.part()), placed.at());
+                forms.put(new Key(placed.from().line()), placed.at());
             }
         }
         return new DeclaredBorders(at, forms);
@@ -106,8 +111,8 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
      * not read is a clause with no form to print, and a caller handed one has nothing to call the
      * line but the rule's own name.
      */
-    public NumberAt<RuleKey> at(PartId<RuleRef.Invariant> part) {
-        return at(new Key(part));
+    public NumberAt<RuleKey> at(DeclaredLine line) {
+        return at(new Key(line));
     }
 
     /** The same, for a caller holding the key the rule handed it
@@ -137,8 +142,8 @@ public record DeclaredBorders(souther.compiler.diag.Citation at,
                 ? taken.operation() + "(" + where + ")" : where;
     }
 
-    /** The same, for a caller holding the part that drew the line. */
-    public String nameOf(PartId<RuleRef.Invariant> part) {
-        return nameOf(new Key(part));
+    /** The same, for a caller holding the line as the clause drew it. */
+    public String nameOf(DeclaredLine line) {
+        return nameOf(new Key(line));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -36,24 +36,40 @@ public final class DeclaredBounds {
      * character says nothing about {@code code}. Held as the rule, the two came out as one thing to
      * write a row for, which is the mistake issue #1062 is about with the halves the other way round.
      *
-     * <p><b>The conjunct and not the number it was written about.</b> Which coordinate a clause
-     * bounded is read from whatever value the reading started at — {@code Day}'s own clause is about
-     * {@code value} read from {@code Day} and about {@code d} read from the {@code Span} holding it
-     * — so two readings of one line spell the coordinate two ways, and an identity built on it calls
-     * one authored line two. The conjunct is the clause's own text: it is the same number whichever
-     * value the reading started at, and it is what tells the ends of {@code value >= 0 && value <=
-     * 10} apart.
+     * <p><b>The clause's own text and not the number it was written about.</b> Which coordinate a
+     * clause bounded is read from whatever value the reading started at — {@code Day}'s own clause
+     * is about {@code value} read from {@code Day} and about {@code d} read from the {@code Span}
+     * holding it — so two readings of one line spell the coordinate two ways, and an identity built
+     * on it calls one authored line two.
+     *
+     * <p><b>And not the conjunct alone.</b> A conjunct states as many comparisons as the reading
+     * arrives at inside it: a denial is carried to the leaves, so {@code Bool.not(String.length(name)
+     * < 1 || String.length(code) < 1)} is one conjunct placing an end on each of two numbers. Held
+     * as the conjunct, those two are one line, and a reader naming either of them names whichever
+     * was written down last.
+     *
+     * <p><b>The statement and not how it was arrived at.</b> Two readings reach one end of one
+     * statement — a comparison places it, and a counterfactual finds the conjunct accounts for it —
+     * and that is one line owed one row, which is what {@link End#tighter} folds them into. Held
+     * with the evidence in it, the same line came back twice because two readers had found it, and
+     * every report counted it twice. What each reading knew stays where it was established
+     * ({@link LineProvenance}) and is spent on the way here.
      *
      * <p>Counted over every conjunct and not over the ones a line came out of, so that a reading
      * that could make nothing of one conjunct still numbers the next the same as a reading that
      * could.
      */
-    public record Drawn(PartId<RuleRef.Invariant> part) {
+    public record Drawn(DeclaredLine line) {
 
         public Drawn {
-            if (part == null) {
+            if (line == null) {
                 throw new IllegalArgumentException("a rule put an end here, and this is which");
             }
+        }
+
+        /** Which conjunct of which rule put the end here, which is what a report names it by. */
+        public PartId<RuleRef.Invariant> part() {
+            return line.part();
         }
     }
 
@@ -117,6 +133,12 @@ public final class DeclaredBounds {
             return min == null && max == null;
         }
 
+        /** Where the value stops, with the lines left behind — for a caller asking how wide the
+         *  value is rather than what the model draws through it. */
+        public Range range() {
+            return new Range(min == null ? null : min.at(), max == null ? null : max.at(), carrier);
+        }
+
         /**
          * The end on one side, or null where nothing stops the values that way.
          *
@@ -131,9 +153,30 @@ public final class DeclaredBounds {
         }
     }
 
+    /**
+     * Where the rules a value wears stop it, with nothing about which of them said so.
+     *
+     * <p>Two numbers and no line. What a caller asking how wide a value is wants is where it stops;
+     * which rule stopped it there is a line of the model, and a line is owed a row. Held as ends
+     * with names on them, this reading's names met the reading of lines' names at the same value and
+     * the model owed two rows for one line.
+     *
+     * <p>Which is what this reading has to give. It hands a whole authored conjunct to the reading
+     * of one comparison, so a conjunct written under a denial arrives as a shape it makes nothing
+     * of — the statements inside it are not reached here and there is nothing to name a line by.
+     * The reading that does reach them is the one lines are read from
+     * ({@link FieldDomains#placed}).
+     */
+    public record Range(Endpoint min, Endpoint max, Carrier carrier) {
+
+        public boolean saysNothing() {
+            return min == null && max == null;
+        }
+    }
+
     /** What a numeric newtype's own rules leave its value between, for a caller that is asking about
      * the value and not about anything taken of it. */
-    public static Bounds of(TypeView view, RuleReadingSource source) {
+    public static Range of(TypeView view, RuleReadingSource source) {
         return of(view, source, Carrier.ofValue(view.declared(), source.symbols()), null);
     }
 
@@ -148,15 +191,13 @@ public final class DeclaredBounds {
      * @param measure the operation the number is taken by, or null where the number is the value
      *                itself
      */
-    public static Bounds of(TypeView view, RuleReadingSource source, Carrier carrier,
-                            ValueName measure) {
+    public static Range of(TypeView view, RuleReadingSource source, Carrier carrier,
+                           ValueName measure) {
         if (carrier == null) {
             return null;
         }
-        End min = null;
-        End max = null;
-        // The ends of the clauses, which is one projection of them and not the reading of them.
-        // Every layer that put an end where it is is kept, because each is a rule a row is owed.
+        Endpoint min = null;
+        Endpoint max = null;
         for (DeclaredClauses.Conjunct each : DeclaredClauses.allOf(view.wrappers(), source)) {
             // An end and nothing else. A rule this reads no end from narrows nothing here, and a
             // rule stepping past the last value of the order states an end no value is at — which
@@ -168,14 +209,13 @@ public final class DeclaredBounds {
                 continue;
             }
             InvariantBound read = placed.bound();
-            End end = new End(read.end(), List.of(new Drawn(each.part())));
             if (read.lower()) {
-                min = End.tighter(min, end, false);
+                min = Endpoint.lower(min, read.end());
             } else {
-                max = End.tighter(max, end, true);
+                max = Endpoint.upper(max, read.end());
             }
         }
-        return new Bounds(min, max, carrier);
+        return new Range(min, max, carrier);
     }
 
     /**
@@ -200,7 +240,7 @@ public final class DeclaredBounds {
             if (!each.at().of().equals(kind)) {
                 continue;
             }
-            End end = new End(each.end(), List.of(new Drawn(each.part())));
+            End end = new End(each.end(), List.of(new Drawn(each.from().line())));
             if (each.lower()) {
                 min = End.tighter(min, end, false);
             } else {
@@ -307,9 +347,9 @@ public final class DeclaredBounds {
     public static CountRange countsHeld(TypeView view, RuleReadingSource source,
                                         FieldDomains.Held held) {
         ValueName.Stdlib counts = NumericMeasures.takenOf(view.declared(), source.symbols());
-        Bounds sized = counts == null ? null : of(view, source, Carrier.WHOLE, counts);
-        Endpoint least = sized == null || sized.min() == null ? null : sized.min().at();
-        Endpoint most = sized == null || sized.max() == null ? null : sized.max().at();
+        Range sized = counts == null ? null : of(view, source, Carrier.WHOLE, counts);
+        Endpoint least = sized == null ? null : sized.min();
+        Endpoint most = sized == null ? null : sized.max();
         return new CountRange(
                 Math.max(CountDomain.leastFrom(least),
                         held == null ? 0 : CountDomain.leastFrom(held.bounds().min())),

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -166,12 +166,7 @@ public final class DeclaredBounds {
      * The reading that does reach them is the one lines are read from
      * ({@link FieldDomains#placed}).
      */
-    public record Range(Endpoint min, Endpoint max, Carrier carrier) {
-
-        public boolean saysNothing() {
-            return min == null && max == null;
-        }
-    }
+    public record Range(Endpoint min, Endpoint max, Carrier carrier) {}
 
     /** What a numeric newtype's own rules leave its value between, for a caller that is asking about
      * the value and not about anything taken of it. */

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -56,39 +56,41 @@ public final class DeclaredBounds {
         /**
          * The lines this end is owed to, read off everything established about it.
          *
-         * <p>A statement's line wherever the evidence is about one statement, whichever reading
-         * established it: a comparison that placed the end, and a conjunct whose one statement on
-         * this number accounts for it, are the same line found two ways and one row to write.
+         * <p>A statement's line where a comparison placed the end, which is the one reading that
+         * establishes a statement placed anything. What the other reading takes away is a whole
+         * conjunct, so the line it establishes is the conjunct's however few of its statements are
+         * on this number.
          *
-         * <p>And a line of several statements together only where none of them is a line here
-         * already. Taking a conjunct away takes away every statement it made, so where one of them
-         * placed this end on its own the intervention was bound to move it — what the coarser
+         * <p>And the conjunct's line only where none of the statements it is paired with is a line
+         * here already. Taking a conjunct away takes away every statement it made, so where one of
+         * them placed this end on its own the intervention was bound to move it — what the coarser
          * reading established is the line that is already here, and nothing beside it. Read as a
          * line of its own, {@code n >= 0 && n /= 100} written into one conjunct owes two rows at the
          * bottom of its range, where the author drew one.
          *
          * <p>Not a rule about which reading wins. Where the ends are apart there is no such
          * subsumption to make and both are lines: {@code n >= 0 && n /= 0} places one at nought and
-         * leaves the values starting at one, and the second is a line neither statement drew.
+         * leaves the values starting at one, and the second is a line no statement of the conjunct
+         * drew.
          */
         public List<DeclaredLine> drawn() {
             Set<InvariantStatementId> here = new LinkedHashSet<>();
             for (LineProvenance each : found) {
-                InvariantStatementId one = each.aboutOneStatement();
-                if (one != null) {
-                    here.add(one);
+                InvariantStatementId placed = each.placedBy();
+                if (placed != null) {
+                    here.add(placed);
                 }
             }
             List<DeclaredLine> out = new ArrayList<>();
             here.forEach(each -> out.add(new DeclaredLine.OfAStatement(each)));
             for (LineProvenance each : found) {
-                if (each.aboutOneStatement() != null
+                if (each.placedBy() != null
                         || each.statements().stream().anyMatch(here::contains)) {
                     continue;
                 }
-                DeclaredLine together = new DeclaredLine.OfStatementsTogether(each.statements());
-                if (!out.contains(together)) {
-                    out.add(together);
+                DeclaredLine conjunct = new DeclaredLine.OfAConjunct(each.statements());
+                if (!out.contains(conjunct)) {
+                    out.add(conjunct);
                 }
             }
             return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -6,7 +6,9 @@ import souther.compiler.numeric.Place;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * What the rules written on a type leave a value of it between, and which of the names it wears
@@ -28,71 +30,68 @@ import java.util.List;
 public final class DeclaredBounds {
 
     /**
-     * One rule that put an end here, and which number of the declaration it was written about.
+     * One end of a range, and everything the readings established about what put it there.
      *
-     * <p>The pair and not the rule alone. One clause can bound two numbers of one declaration —
-     * {@code invariant both = String.length(name) >= 1 && String.length(code) >= 1} places two ends
-     * at one value — and they are two lines an author drew: a row whose {@code name} is one
-     * character says nothing about {@code code}. Held as the rule, the two came out as one thing to
-     * write a row for, which is the mistake issue #1062 is about with the halves the other way round.
-     *
-     * <p><b>The clause's own text and not the number it was written about.</b> Which coordinate a
-     * clause bounded is read from whatever value the reading started at — {@code Day}'s own clause
-     * is about {@code value} read from {@code Day} and about {@code d} read from the {@code Span}
-     * holding it — so two readings of one line spell the coordinate two ways, and an identity built
-     * on it calls one authored line two.
-     *
-     * <p><b>And not the conjunct alone.</b> A conjunct states as many comparisons as the reading
-     * arrives at inside it: a denial is carried to the leaves, so {@code Bool.not(String.length(name)
-     * < 1 || String.length(code) < 1)} is one conjunct placing an end on each of two numbers. Held
-     * as the conjunct, those two are one line, and a reader naming either of them names whichever
-     * was written down last.
-     *
-     * <p><b>The statement and not how it was arrived at.</b> Two readings reach one end of one
-     * statement — a comparison places it, and a counterfactual finds the conjunct accounts for it —
-     * and that is one line owed one row, which is what {@link End#tighter} folds them into. Held
-     * with the evidence in it, the same line came back twice because two readers had found it, and
-     * every report counted it twice. What each reading knew stays where it was established
-     * ({@link LineProvenance}) and is spent on the way here.
-     *
-     * <p>Counted over every conjunct and not over the ones a line came out of, so that a reading
-     * that could make nothing of one conjunct still numbers the next the same as a reading that
-     * could.
-     */
-    public record Drawn(DeclaredLine line) {
-
-        public Drawn {
-            if (line == null) {
-                throw new IllegalArgumentException("a rule put an end here, and this is which");
-            }
-        }
-
-        /** Which conjunct of which rule put the end here, which is what a report names it by. */
-        public PartId<RuleRef.Invariant> part() {
-            return line.part();
-        }
-    }
-
-    /**
-     * One end of a range, and every rule that put it there.
-     *
-     * <p>Rules, plural. Two layers can state the same bound — a wrapper repeating what it wraps — and
-     * they are two rules a row could be owed to, which is the accounting a cut already keeps. Holding
-     * one would drop an obligation rather than a line of text.
+     * <p>Evidence, plural. Two layers can state the same bound — a wrapper repeating what it wraps —
+     * and they are two rules a row could be owed to, which is the accounting a cut already keeps.
+     * Holding one would drop an obligation rather than a line of text.
      *
      * <p>The clauses and not the declarations they are written on. Held as declarations, two clauses
      * of one declaration at one value came out as one rule, and a report owed one line for a
      * boundary two rules had drawn ({@link Clause}).
      *
-     * <p>Each as the rule a report names it by. An end here is read by the measure that turns it
-     * into lines to write rows at, and that measure names the rule that drew it — handed the clause
-     * reference, it built the identity back for itself, which is a decision about what a rule is
-     * being taken by whoever happened to consume one.
+     * <p><b>What was established, and not the lines it comes to.</b> Which lines an end is owed to
+     * is a question about the end: a conjunct taken away moves an end that one of its own statements
+     * placed, and what that shows is the statement's line found a second way rather than a line
+     * beside it. Answered where each piece of evidence is made, that reading has only its own piece
+     * in hand and there is no answer to give — so it is answered here, where every piece about this
+     * end is ({@link #drawn}).
      */
-    public record End(Endpoint at, List<Drawn> from) {
+    public record End(Endpoint at, List<LineProvenance> found) {
 
         public Place value() {
             return at.at();
+        }
+
+        /**
+         * The lines this end is owed to, read off everything established about it.
+         *
+         * <p>A statement's line wherever the evidence is about one statement, whichever reading
+         * established it: a comparison that placed the end, and a conjunct whose one statement on
+         * this number accounts for it, are the same line found two ways and one row to write.
+         *
+         * <p>And a line of several statements together only where none of them is a line here
+         * already. Taking a conjunct away takes away every statement it made, so where one of them
+         * placed this end on its own the intervention was bound to move it — what the coarser
+         * reading established is the line that is already here, and nothing beside it. Read as a
+         * line of its own, {@code n >= 0 && n /= 100} written into one conjunct owes two rows at the
+         * bottom of its range, where the author drew one.
+         *
+         * <p>Not a rule about which reading wins. Where the ends are apart there is no such
+         * subsumption to make and both are lines: {@code n >= 0 && n /= 0} places one at nought and
+         * leaves the values starting at one, and the second is a line neither statement drew.
+         */
+        public List<DeclaredLine> drawn() {
+            Set<InvariantStatementId> here = new LinkedHashSet<>();
+            for (LineProvenance each : found) {
+                InvariantStatementId one = each.aboutOneStatement();
+                if (one != null) {
+                    here.add(one);
+                }
+            }
+            List<DeclaredLine> out = new ArrayList<>();
+            here.forEach(each -> out.add(new DeclaredLine.OfAStatement(each)));
+            for (LineProvenance each : found) {
+                if (each.aboutOneStatement() != null
+                        || each.statements().stream().anyMatch(here::contains)) {
+                    continue;
+                }
+                DeclaredLine together = new DeclaredLine.OfStatementsTogether(each.statements());
+                if (!out.contains(together)) {
+                    out.add(together);
+                }
+            }
+            return List.copyOf(out);
         }
 
         /**
@@ -114,8 +113,8 @@ public final class DeclaredBounds {
             if (had.value().compareTo(one.value()) != 0) {
                 return at == had.at() ? had : one;
             }
-            List<Drawn> both = new ArrayList<>(had.from());
-            one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
+            List<LineProvenance> both = new ArrayList<>(had.found());
+            one.found().stream().filter(n -> !both.contains(n)).forEach(both::add);
             return new End(at, List.copyOf(both));
         }
     }
@@ -240,7 +239,7 @@ public final class DeclaredBounds {
             if (!each.at().of().equals(kind)) {
                 continue;
             }
-            End end = new End(each.end(), List.of(new Drawn(each.from().line())));
+            End end = new End(each.end(), List.of(each.from()));
             if (each.lower()) {
                 min = End.tighter(min, end, false);
             } else {

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
@@ -7,16 +7,24 @@ import java.util.Set;
  *
  * <p>Two grains and not one, because a clause draws lines at both. A comparison inside a conjunct
  * draws its own — {@code Bool.not(String.length(name) < 1 || String.length(code) < 1)} states one
- * per leaf, on two numbers, and a row at either says nothing about the other. A choice draws one
- * between them all: {@code value == "a" || value == "b"} leaves the value running from one string to
- * the other, and neither side of it places that end. Held at one grain, the first kind is a line per
- * conjunct and the second is a line named after whichever branch was written first.
+ * per leaf, on two numbers, and a row at either says nothing about the other. And a conjunct can
+ * leave the values somewhere none of its statements does: {@code n /= 0 && n /= 1} written into one
+ * conjunct stops nothing on its own and leaves the number starting at two. Held at one grain, the
+ * first kind is a line per conjunct and the second is a line named after whichever statement was
+ * written first.
  *
- * <p><b>And not how the end was found.</b> A comparison places an end and a counterfactual finds the
- * conjunct accounts for one, and where they are about the same statement they are one line owed one
- * row ({@link DeclaredBounds.End#tighter}). What each reading established stays with the reading
- * ({@link LineProvenance}) and is spent on the way here — carried into the line, one line came back
- * twice because two readers had found it.
+ * <p><b>The conjunct's own text and not the number it was written about.</b> Which coordinate a
+ * clause bounded is read from whatever value the reading started at — {@code Day}'s own clause is
+ * about {@code value} read from {@code Day} and about {@code d} read from the {@code Span} holding
+ * it — so two readings of one line spell the coordinate two ways, and an identity built on it calls
+ * one authored line two.
+ *
+ * <p><b>And not how the end was found.</b> A comparison places an end and a counterfactual finds
+ * that a conjunct accounts for one, and where they are about the same statement they are one line
+ * owed one row. What each reading established stays with the reading ({@link LineProvenance}) and is
+ * spent where the lines at one end are read off the evidence gathered there
+ * ({@link DeclaredBounds.End#drawn}) — carried into the line, one line came back twice because two
+ * readings had found it.
  */
 public sealed interface DeclaredLine {
 
@@ -43,12 +51,19 @@ public sealed interface DeclaredLine {
     }
 
     /**
-     * The line a conjunct draws between its own statements, which is no one of them.
+     * The line several statements of one conjunct leave together, which is no one of them.
      *
-     * <p>What a choice leaves. {@code value == "a" || value == "b"} stops the value at "a" and at
-     * "b", and neither branch stops it anywhere: each of them names a value and orders nothing, and
-     * what places the ends is the two of them together. So the line is the conjunct's, and the
-     * statements are what tells it from the line the same conjunct draws on another number.
+     * <p>What the reading established, and no more. {@code n /= 0 && n /= 1} written into one
+     * conjunct places no end at all — each side names a value and orders nothing — and what the
+     * values are left running from is the two of them together, found by taking the conjunct away.
+     * So the line is the conjunct's, and which of its statements are about this number is what
+     * tells it from the line the same conjunct leaves on another.
+     *
+     * <p><b>Together, and not what the author wrote between them.</b> These reach this reading from
+     * a conjunction as readily as from a choice: what is known is that the conjunct was taken away
+     * and the end moved, which says nothing about the connective. Named for one of the two, the type
+     * would be stating something the reading never established, and every reader of a line would be
+     * told a connective by a value that never saw one.
      *
      * <p>Which conjunct it is is read off them. Held beside them, the pair would be a second way to
      * the rule this line is about, and a line with two of those can be built about two rules.
@@ -57,9 +72,9 @@ public sealed interface DeclaredLine {
      *              line — none of them did — and not left out either, since two lines of one
      *              conjunct on two numbers are told apart by nothing else
      */
-    record OfAChoice(Set<InvariantStatementId> among) implements DeclaredLine {
+    record OfStatementsTogether(Set<InvariantStatementId> among) implements DeclaredLine {
 
-        public OfAChoice {
+        public OfStatementsTogether {
             among = Set.copyOf(among);
             if (among.size() < 2) {
                 throw new IllegalArgumentException(

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
@@ -51,45 +51,47 @@ public sealed interface DeclaredLine {
     }
 
     /**
-     * The line several statements of one conjunct leave together, which is no one of them.
+     * The line an authored conjunct draws, which is no statement of it.
      *
-     * <p>What the reading established, and no more. {@code n /= 0 && n /= 1} written into one
-     * conjunct places no end at all — each side names a value and orders nothing — and what the
-     * values are left running from is the two of them together, found by taking the conjunct away.
-     * So the line is the conjunct's, and which of its statements are about this number is what
-     * tells it from the line the same conjunct leaves on another.
+     * <p>What taking a conjunct away establishes. {@code n /= 0 && n /= 1} written into one conjunct
+     * places no end at all — each side names a value and orders nothing — and what the values are
+     * left running from is found by taking the conjunct away. So the line is the conjunct's.
      *
-     * <p><b>Together, and not what the author wrote between them.</b> These reach this reading from
-     * a conjunction as readily as from a choice: what is known is that the conjunct was taken away
-     * and the end moved, which says nothing about the connective. Named for one of the two, the type
-     * would be stating something the reading never established, and every reader of a line would be
-     * told a connective by a value that never saw one.
+     * <p><b>However few of its statements are on this number.</b> The intervention is the same one
+     * whether the conjunct states one thing here or several: it removes everything the conjunct
+     * stated, so what moved the end is the conjunct. A conjunct stating {@code a /= 100} about one
+     * number and {@code b >= 1} about another pairs one statement with the first number, and a line
+     * read from that as the statement's would be saying that {@code a /= 100} placed an end which
+     * {@code b >= 1} is why.
+     *
+     * <p><b>The statements pair the line, and did not draw it.</b> Which of the conjunct's
+     * statements are about this number is what tells this line from the line the same conjunct draws
+     * on another number, and it is nothing more than that: they reach this reading from a
+     * conjunction as readily as from a choice, and what is known is that the conjunct was taken away
+     * and the end moved.
      *
      * <p>Which conjunct it is is read off them. Held beside them, the pair would be a second way to
      * the rule this line is about, and a line with two of those can be built about two rules.
      *
-     * @param among the conjunct's statements which are about this number. Not the one that drew the
-     *              line — none of them did — and not left out either, since two lines of one
-     *              conjunct on two numbers are told apart by nothing else
+     * @param pairedWith the conjunct's statements which are about this number
      */
-    record OfStatementsTogether(Set<InvariantStatementId> among) implements DeclaredLine {
+    record OfAConjunct(Set<InvariantStatementId> pairedWith) implements DeclaredLine {
 
-        public OfStatementsTogether {
-            among = Set.copyOf(among);
-            if (among.size() < 2) {
+        public OfAConjunct {
+            pairedWith = Set.copyOf(pairedWith);
+            if (pairedWith.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "a line between a conjunct's statements is drawn by more than one of them: "
-                                + among);
+                        "a conjunct's line is paired by something the conjunct states");
             }
-            if (among.stream().map(InvariantStatementId::part).distinct().count() != 1) {
+            if (pairedWith.stream().map(InvariantStatementId::part).distinct().count() != 1) {
                 throw new IllegalArgumentException(
-                        "a conjunct draws its line between statements of its own: " + among);
+                        "a conjunct draws its line paired with statements of its own: " + pairedWith);
             }
         }
 
         @Override
         public PartId<RuleRef.Invariant> part() {
-            return among.iterator().next().part();
+            return pairedWith.iterator().next().part();
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredLine.java
@@ -1,0 +1,80 @@
+package souther.compiler.check;
+
+import java.util.Set;
+
+/**
+ * Which line of a declaration's clause an end is, at the grain the clause draws it.
+ *
+ * <p>Two grains and not one, because a clause draws lines at both. A comparison inside a conjunct
+ * draws its own — {@code Bool.not(String.length(name) < 1 || String.length(code) < 1)} states one
+ * per leaf, on two numbers, and a row at either says nothing about the other. A choice draws one
+ * between them all: {@code value == "a" || value == "b"} leaves the value running from one string to
+ * the other, and neither side of it places that end. Held at one grain, the first kind is a line per
+ * conjunct and the second is a line named after whichever branch was written first.
+ *
+ * <p><b>And not how the end was found.</b> A comparison places an end and a counterfactual finds the
+ * conjunct accounts for one, and where they are about the same statement they are one line owed one
+ * row ({@link DeclaredBounds.End#tighter}). What each reading established stays with the reading
+ * ({@link LineProvenance}) and is spent on the way here — carried into the line, one line came back
+ * twice because two readers had found it.
+ */
+public sealed interface DeclaredLine {
+
+    /** Which conjunct of which clause drew it, which is what a rule is named by. */
+    PartId<RuleRef.Invariant> part();
+
+    /**
+     * The line one statement of a conjunct drew.
+     *
+     * @param statement the statement, which is the finest a clause is decomposed into
+     */
+    record OfAStatement(InvariantStatementId statement) implements DeclaredLine {
+
+        public OfAStatement {
+            if (statement == null) {
+                throw new IllegalArgumentException("a line a statement drew is some statement's");
+            }
+        }
+
+        @Override
+        public PartId<RuleRef.Invariant> part() {
+            return statement.part();
+        }
+    }
+
+    /**
+     * The line a conjunct draws between its own statements, which is no one of them.
+     *
+     * <p>What a choice leaves. {@code value == "a" || value == "b"} stops the value at "a" and at
+     * "b", and neither branch stops it anywhere: each of them names a value and orders nothing, and
+     * what places the ends is the two of them together. So the line is the conjunct's, and the
+     * statements are what tells it from the line the same conjunct draws on another number.
+     *
+     * <p>Which conjunct it is is read off them. Held beside them, the pair would be a second way to
+     * the rule this line is about, and a line with two of those can be built about two rules.
+     *
+     * @param among the conjunct's statements which are about this number. Not the one that drew the
+     *              line — none of them did — and not left out either, since two lines of one
+     *              conjunct on two numbers are told apart by nothing else
+     */
+    record OfAChoice(Set<InvariantStatementId> among) implements DeclaredLine {
+
+        public OfAChoice {
+            among = Set.copyOf(among);
+            if (among.size() < 2) {
+                throw new IllegalArgumentException(
+                        "a line between a conjunct's statements is drawn by more than one of them: "
+                                + among);
+            }
+            if (among.stream().map(InvariantStatementId::part).distinct().count() != 1) {
+                throw new IllegalArgumentException(
+                        "a conjunct draws its line between statements of its own: " + among);
+            }
+        }
+
+        @Override
+        public PartId<RuleRef.Invariant> part() {
+            return among.iterator().next().part();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -555,13 +555,20 @@ public final class FieldDomains {
      *              place, and no other kind of rule reaches this reading
      * @param lower whether this bounds the coordinate below; otherwise above
      */
-    public record Placed(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part, boolean lower,
+    public record Placed(NumberAt<RuleKey> at, LineProvenance from, boolean lower,
                          Endpoint end) {
 
         /** What the value's rules call where the end sits. Never which number it is on: that is
          *  {@link #at}, and reading one off the other is what the pair exists to stop. */
         public RuleKey path() {
             return at.position();
+        }
+
+        /** Which conjunct is behind the end, which is what a rule is named by. Both answers have
+         *  one, and which of the two this is is what says how much is known about the statements
+         *  under it. */
+        public PartId<RuleRef.Invariant> part() {
+            return from.part();
         }
     }
 
@@ -586,20 +593,28 @@ public final class FieldDomains {
      * again — which, for a rule written under a denial, is the comparison that holds exactly where
      * the rule does not.
      *
-     * @param part   which part of which rule it is, as the split that wrote the parts down named it
-     * @param states what the conjunct compares and what it claims of the two sides
-     * @param wrote  where the author wrote it, for whoever reports about the clause. A position and
-     *               not the expression, so there is nothing here to read a meaning off a second
-     *               time
+     * @param statement which statement of which conjunct it is, as the reading that arrived at it
+     *                  names it. The statement and not the conjunct: a conjunct written under a
+     *                  denial states one comparison per leaf, and named by the conjunct the second
+     *                  of them is the first handed on again
+     * @param states    what the conjunct compares and what it claims of the two sides
+     * @param wrote     where the author wrote it, for whoever reports about the clause. A position
+     *                  and not the expression, so there is nothing here to read a meaning off a
+     *                  second time
      */
-    public record WithoutAnEnd(PartId<RuleRef.Invariant> part, StatedComparison states,
+    public record WithoutAnEnd(InvariantStatementId statement, StatedComparison states,
                                SourcePos wrote) {
 
         public WithoutAnEnd {
-            if (part == null || states == null || wrote == null) {
+            if (statement == null || states == null || wrote == null) {
                 throw new IllegalArgumentException(
                         "a conjunct handed on is some clause's comparison, written somewhere");
             }
+        }
+
+        /** Which conjunct the statement is of, which is what a rule is named by. */
+        public PartId<RuleRef.Invariant> part() {
+            return statement.part();
         }
     }
 
@@ -635,26 +650,48 @@ public final class FieldDomains {
      * and a reading asked without either of them was asked without the part they share, which named
      * the same part twice as holding an end it holds once.
      *
-     * @param at   the number its quantity is over
-     * @param part which part of which rule it is
+     * <p><b>And the statements of it that reached this number, kept beside the part.</b> They are
+     * not what the counterfactual intervenes on and they are what an answer about this number is
+     * told apart by: a conjunct reaching two numbers is one candidate at each of them, and the two
+     * are one thing said twice unless each says which of the conjunct's statements it is about.
+     *
+     * <p>Which part it is is read off them rather than held beside them, so that a candidate has one
+     * way to the rule it is about and cannot be built naming two.
+     *
+     * @param at         the number its quantity is over
+     * @param statements the statements of one part which reached this number
      */
-    public record AboutOneCoordinate(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part) {
+    public record AboutOneCoordinate(NumberAt<RuleKey> at,
+                                     Set<InvariantStatementId> statements) {
 
         public AboutOneCoordinate {
-            if (at == null || part == null) {
+            if (at == null) {
                 throw new IllegalArgumentException("a quantity over one number is some rule's");
+            }
+            statements = Set.copyOf(statements);
+            if (statements.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a candidate is something one part of a rule states");
+            }
+            if (statements.stream().map(InvariantStatementId::part).distinct().count() != 1) {
+                throw new IllegalArgumentException(
+                        "a candidate is the statements of one part: " + statements);
             }
         }
 
-        /** Which authored line this is a part of, which is what tells a candidate from an end
-         *  the reading of comparisons already placed. */
-        Line line() {
-            return new Line(part);
+        /** Which part of which rule it is, which every one of its statements is of. */
+        public PartId<RuleRef.Invariant> part() {
+            return statements.iterator().next().part();
+        }
+
+        /** The same candidate with one more of the part's statements written into it, for the walk
+         *  that meets them one at a time. */
+        public AboutOneCoordinate and(InvariantStatementId statement) {
+            Set<InvariantStatementId> both = new LinkedHashSet<>(statements);
+            both.add(statement);
+            return new AboutOneCoordinate(at, both);
         }
     }
-
-    /** One authored line: which part of which rule drew it. */
-    record Line(PartId<RuleRef.Invariant> part) {}
 
     /**
      * A rule about where one coordinate's values stop that this reading placed no end from, and
@@ -1320,7 +1357,8 @@ public final class FieldDomains {
      */
     public List<Placed> stated() {
         return directs.stream()
-                .map(each -> new Placed(each.at(), each.part(),
+                .map(each -> new Placed(each.at(),
+                        new LineProvenance.Direct(each.statement()),
                         each.bound().lower(), each.bound().end()))
                 .toList();
     }
@@ -1392,10 +1430,15 @@ public final class FieldDomains {
      * answer for themselves is left with them.
      */
     private boolean needsAttributing(List<AboutOneCoordinate> candidates) {
-        Set<Line> ends = directs.stream()
-                .map(each -> new Line(each.part()))
+        // The statements the reading of comparisons placed an end from, and not the conjuncts they
+        // are of. A conjunct written under a denial states one comparison per leaf, so a leaf that
+        // placed an end says nothing about the leaf beside it — asked of the conjunct, a statement
+        // whose sibling placed an end reads as already accounted for and is never attributed at
+        // all, which is a candidate dropped where the two ends of one conjunct are on two numbers.
+        Set<InvariantStatementId> ends = directs.stream()
+                .map(InvariantChecker.Direct::statement)
                 .collect(java.util.stream.Collectors.toSet());
-        return candidates.stream().anyMatch(each -> !ends.contains(each.line()));
+        return candidates.stream().anyMatch(each -> !ends.containsAll(each.statements()));
     }
 
     /**
@@ -1421,7 +1464,8 @@ public final class FieldDomains {
         }
         for (AboutOneCoordinate each : EndNarrowing.read(end, candidates,
                 removed -> sideWithout(removed, at, lower), inWrittenOrder()).names()) {
-            out.add(new Placed(at, each.part(), lower, end));
+            out.add(new Placed(at, new LineProvenance.Counterfactual(each.statements()),
+                    lower, end));
         }
     }
 
@@ -2197,7 +2241,7 @@ public final class FieldDomains {
             RuleRef.Invariant rule = reading.from();
             // Where in the clause this reading recorded a shape, which is what a conjunction below
             // asks about its two halves.
-            Set<ClauseExpr.Occurrence> recorded = new LinkedHashSet<>();
+            Set<ClauseOccurrence> recorded = new LinkedHashSet<>();
             reading.constrained().values().forEach(byOccurrence ->
                     byOccurrence.values().forEach(one -> recorded.add(one.of().at())));
             // A part at a time, and any one of them is enough. A conjunct the bounds hold nothing of

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -685,13 +685,6 @@ public final class FieldDomains {
             return statements.iterator().next().part();
         }
 
-        /** The same candidate with one more of the part's statements written into it, for the walk
-         *  that meets them one at a time. */
-        public AboutOneCoordinate and(InvariantStatementId statement) {
-            Set<InvariantStatementId> both = new LinkedHashSet<>(statements);
-            both.add(statement);
-            return new AboutOneCoordinate(at, both);
-        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -550,9 +550,10 @@ public final class FieldDomains {
      * @param at    which number at which name the end is on. The number and not a name beside a
      *              flag: one name carries more than one, and which of them an end is on is what
      *              the operation beside the name says
-     * @param part  which part of which rule placed the end, which is what names the line. A part
-     *              of a declaration's clause: these are the ends the clauses of a declaration
-     *              place, and no other kind of rule reaches this reading
+     * @param from  what this reading established about what put the end here. The evidence and not
+     *              the line it comes to: which lines an end is owed to is a question about the end,
+     *              and this is one piece of what was found there
+     *              ({@link DeclaredBounds.End#drawn})
      * @param lower whether this bounds the coordinate below; otherwise above
      */
     public record Placed(NumberAt<RuleKey> at, LineProvenance from, boolean lower,

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1899,7 +1899,7 @@ public final class InvariantChecker {
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
         SequencedMap<HandOver, FieldDomains.WithoutAnEnd> withoutAnEnd = new LinkedHashMap<>();
-        List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate = new ArrayList<>();
+        SequencedMap<Candidate, Set<InvariantStatementId>> aboutOneCoordinate = new LinkedHashMap<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
         Map<ReadingPlace, Required> raisedByPart = new LinkedHashMap<>();
@@ -1925,7 +1925,12 @@ public final class InvariantChecker {
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines),
                 List.copyOf(withoutAnEnd.values()),
-                List.copyOf(aboutOneCoordinate),
+                // Made once each, from the statements gathered under them: a candidate rebuilt as
+                // the walk met another statement copied what it had so far every time.
+                aboutOneCoordinate.entrySet().stream()
+                        .map(each -> new FieldDomains.AboutOneCoordinate(
+                                each.getKey().at(), each.getValue()))
+                        .toList(),
                 Map.copyOf(narrowers),
                 Collections.unmodifiableMap(new LinkedHashMap<>(raised)),
                 Collections.unmodifiableMap(new LinkedHashMap<>(raisedByPart)),
@@ -2035,7 +2040,7 @@ public final class InvariantChecker {
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
                         List<FieldDomains.NoLine> noLines,
                         SequencedMap<HandOver, FieldDomains.WithoutAnEnd> withoutAnEnd,
-                        List<FieldDomains.AboutOneCoordinate> naming,
+                        SequencedMap<Candidate, Set<InvariantStatementId>> naming,
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
@@ -2280,7 +2285,7 @@ public final class InvariantChecker {
      */
     private void aChoiceAboutOneCoordinate(ClauseExpr.Part said, InvariantStatementId statement,
                                            Denotations at, Map<FactSubject, Coordinate> byName,
-                                           List<FieldDomains.AboutOneCoordinate> naming) {
+                                           SequencedMap<Candidate, Set<InvariantStatementId>> naming) {
         // The shape the walk is already holding. Read again from the node, this would be a second
         // reading of the clause's structure, and one made under a polarity of its own: a choice an
         // author wrote as a denied conjunction is a choice, and the shape says so.
@@ -3183,12 +3188,22 @@ public final class InvariantChecker {
      * ({@link FieldDomains#movedEndsOf}).
      */
     private static void aboutOneCoordinate(CanonicalForm read, InvariantStatementId statement,
-                                          List<FieldDomains.AboutOneCoordinate> out) {
+                                          SequencedMap<Candidate, Set<InvariantStatementId>> out) {
         if (!(read instanceof CanonicalForm.Over over) || over.numbers().size() != 1) {
             return;
         }
         aboutOneCoordinate(over.numbers().iterator().next().at(), statement, out);
     }
+
+    /**
+     * One conjunct's quantity over one number, as the walk gathers the statements that reach it.
+     *
+     * <p>What the candidates are being collected under while the clause is read, and no part of what
+     * a reading answers. A candidate is made once, from the statements gathered here, rather than
+     * remade with one more statement in it each time the walk meets another — which copied the set
+     * it had grown so far, once per statement, for every statement.
+     */
+    private record Candidate(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part) {}
 
     /**
      * One candidate, kept once, with the statement that reached this number written into it.
@@ -3200,15 +3215,9 @@ public final class InvariantChecker {
      * about which.
      */
     private static void aboutOneCoordinate(NumberAt<RuleKey> at, InvariantStatementId statement,
-                                           List<FieldDomains.AboutOneCoordinate> out) {
-        for (int i = 0; i < out.size(); i++) {
-            FieldDomains.AboutOneCoordinate had = out.get(i);
-            if (had.at().equals(at) && had.part().equals(statement.part())) {
-                out.set(i, had.and(statement));
-                return;
-            }
-        }
-        out.add(new FieldDomains.AboutOneCoordinate(at, Set.of(statement)));
+                                           SequencedMap<Candidate, Set<InvariantStatementId>> out) {
+        out.computeIfAbsent(new Candidate(at, statement.part()), _ -> new LinkedHashSet<>())
+                .add(statement);
     }
 
     /** One finding, kept once. A coordinate reached twice is one place with one thing to say. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -832,7 +832,7 @@ public final class InvariantChecker {
             public void gathered(RuleRef.Invariant from, Core clause,
                                  List<Clauses.StatedPart> parts,
                                  Map<PartId<RuleRef.Invariant>,
-                                         Map<ClauseExpr.Occurrence, PartAsRead>> constrained,
+                                         Map<ClauseOccurrence, PartAsRead>> constrained,
                                  Set<FactSubject> spokenFor) {
                 written.add(Written.of(new ReadingId(written.size()), clause, parts,
                         reach.withoutParts(), constrained));
@@ -906,7 +906,7 @@ public final class InvariantChecker {
             // written into a table every reading shares: a clause is read once per place the walk
             // opens a value at, and a table holding all of them together has nothing to say which
             // reading an entry came from.
-            Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>> constrained =
+            Map<PartId<RuleRef.Invariant>, Map<ClauseOccurrence, PartAsRead>> constrained =
                     new LinkedHashMap<>();
             Predicates.Owed owed = null;
             for (Clauses.StatedPart part : view.present()) {
@@ -1401,13 +1401,20 @@ public final class InvariantChecker {
      *                 once per place the walk opens a value at, so which reading placed it is the
      *                 other half of the same answer
      */
-    record Direct(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part, InvariantBound bound,
+    record Direct(NumberAt<RuleKey> at, InvariantStatementId statement, InvariantBound bound,
                   ReadingPlace stands) {
 
         /** What the value's rules call where the end was placed. Never which end it is: one name
          *  carries more than one number and {@link #at} is what says which of them this is. */
         RuleKey path() {
             return at.position();
+        }
+
+        /** Which conjunct the statement is of, which is what a rule is named by. Read off the
+         *  statement rather than carried beside it: the two would be free to disagree about which
+         *  conjunct a statement belongs to. */
+        PartId<RuleRef.Invariant> part() {
+            return statement.part();
         }
     }
 
@@ -1451,7 +1458,7 @@ public final class InvariantChecker {
      * reading walked the tree a substitution built for it, so the node was where and whose at once;
      * held apart, both halves have to be here.
      */
-    record ReadingPlace(ReadingId reading, ClauseExpr.Occurrence at) {
+    record ReadingPlace(ReadingId reading, ClauseOccurrence at) {
 
         ReadingPlace {
             if (reading == null || at == null) {
@@ -1481,14 +1488,14 @@ public final class InvariantChecker {
      * the place as well, each reading would hand on its own and the model would owe a row per
      * place it happens to be carried to.
      *
-     * <p>Which is why this is neither {@link ReadingPlace} nor {@link PartId} but the pair that
-     * says what a hand-over is: one per comparison the reading arrived at inside a conjunct,
-     * however many places that conjunct was read at.
+     * <p>Which is why this is neither {@link ReadingPlace} nor {@link PartId} but the statement:
+     * one hand-over per comparison the reading arrived at inside a conjunct, however many places
+     * that conjunct was read at.
      */
-    record HandOver(PartId<RuleRef.Invariant> part, ClauseExpr.Occurrence at) {
+    record HandOver(InvariantStatementId statement) {
 
         HandOver {
-            if (part == null || at == null) {
+            if (statement == null) {
                 throw new IllegalArgumentException(
                         "a conjunct handed on is part of some rule, somewhere in it");
             }
@@ -1508,9 +1515,9 @@ public final class InvariantChecker {
      * is its own and a rule is read once per place the walk opens a value at.
      */
     record Written(ReadingId opened, Core clause, ClauseView view,
-                   Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>>
+                   Map<PartId<RuleRef.Invariant>, Map<ClauseOccurrence, PartAsRead>>
                            constrained,
-                   Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> adopted) {
+                   Map<ClauseOccurrence, ReadByClauses.OfAPart> adopted) {
 
         Written {
             constrained = Map.copyOf(constrained);
@@ -1521,7 +1528,7 @@ public final class InvariantChecker {
         static Written of(ReadingId opened, Core clause, List<Clauses.StatedPart> authored,
                           PartsLeftOut world,
                           Map<PartId<RuleRef.Invariant>,
-                                  Map<ClauseExpr.Occurrence, PartAsRead>> constrained) {
+                                  Map<ClauseOccurrence, PartAsRead>> constrained) {
             if (authored.isEmpty()) {
                 throw new IllegalArgumentException("a clause reaching a value is written in parts");
             }
@@ -1537,8 +1544,8 @@ public final class InvariantChecker {
          * objects those substitutions happened to allocate.
          */
         Written alsoAdopting(
-                List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> account) {
-            Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> out = new LinkedHashMap<>();
+                List<Map.Entry<ClauseOccurrence, ReadByClauses.OfAPart>> account) {
+            Map<ClauseOccurrence, ReadByClauses.OfAPart> out = new LinkedHashMap<>();
             account.forEach(each -> out.put(each.getKey(), each.getValue()));
             return new Written(opened, clause, view, constrained,
                     Collections.unmodifiableMap(out));
@@ -1546,7 +1553,7 @@ public final class InvariantChecker {
 
         /** What this reading made of the part at {@code at}, or null where it read no such part —
          *  which is not the same as having read it and made nothing of it. */
-        ReadByClauses.OfAPart adoptedAt(ClauseExpr.Occurrence at) {
+        ReadByClauses.OfAPart adoptedAt(ClauseOccurrence at) {
             return adopted.get(at);
         }
 
@@ -1560,8 +1567,8 @@ public final class InvariantChecker {
          * holding all of them together has to say which reading each entry came from — and the
          * only thing that said so was which objects a substitution happened to allocate.
          */
-        PartRead read(PartId<RuleRef.Invariant> part, ClauseExpr.Occurrence at) {
-            Map<ClauseExpr.Occurrence, PartAsRead> said = constrained.get(part);
+        PartRead read(PartId<RuleRef.Invariant> part, ClauseOccurrence at) {
+            Map<ClauseOccurrence, PartAsRead> said = constrained.get(part);
             PartAsRead one = said == null ? null : said.get(at);
             return one == null ? null : one.said();
         }
@@ -1662,7 +1669,7 @@ public final class InvariantChecker {
          *                  semantics
          */
         void gathered(RuleRef.Invariant from, Core clause, List<Clauses.StatedPart> parts,
-                      Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, PartAsRead>>
+                      Map<PartId<RuleRef.Invariant>, Map<ClauseOccurrence, PartAsRead>>
                               constrained,
                       Set<FactSubject> spokenFor);
 
@@ -1907,7 +1914,11 @@ public final class InvariantChecker {
                 // again, the occurrences under one part would be numbered afresh from wherever the
                 // part begins, and an answer filed by the reading that seeded it would be asked
                 // for under a number this walk made up.
-                direct(part.of(), each, part.id(), at, byName, out, noLines,
+                //
+                // A counter apiece, because a statement is which of its own conjunct's it is: two
+                // conjuncts each have a statement numbered nought, and what pairs the number with
+                // the conjunct is the identity the two go into.
+                direct(part.of(), each, part.id(), new int[1], at, byName, out, noLines,
                         withoutAnEnd, aboutOneCoordinate, narrowers,
                         raised, took, typeAt, rules, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
@@ -1937,7 +1948,7 @@ public final class InvariantChecker {
      * >= 4` came back with nothing to say while the same two rules written apart were reported.
      */
     private void settle(Core part, RuleRef.Invariant rule, Written of,
-                        PartId<RuleRef.Invariant> its, ClauseExpr.Occurrence at,
+                        InvariantStatementId statement, ClauseOccurrence at,
                         ClauseStates states, InvariantBound.Read placed,
                         Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
@@ -1985,7 +1996,7 @@ public final class InvariantChecker {
         // the position it names. The seeding hands the whole clause to the same reader this walks,
         // so there is no such part — and if the two ever come apart, this value reads as one whose
         // rules were not gathered rather than as one whose rules were read and said nothing.
-        PartRead read = of.read(its, at);
+        PartRead read = of.read(statement.part(), at);
         Set<FactSubject> constrained = read == null ? null : read.constrained();
         if (here == null || constrained == null) {
             throw new APartNoReadingSaw(part);
@@ -2020,7 +2031,7 @@ public final class InvariantChecker {
      * What a helper's body joined is still this one part, and this reading has one end for it.
      */
     private void direct(ClauseExpr saidAs, Written of, PartId<RuleRef.Invariant> part,
-                        Denotations at,
+                        int[] statements, Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
                         List<FieldDomains.NoLine> noLines,
                         SequencedMap<HandOver, FieldDomains.WithoutAnEnd> withoutAnEnd,
@@ -2041,7 +2052,8 @@ public final class InvariantChecker {
         // states, and a helper's rule denied is read as the rule it denies rather than left as a
         // form this reader has no word for.
         if (saidAs instanceof ClauseExpr.Scoped scoped) {
-            direct(scoped.body(), of, part, terms.inside(scoped.binding(), at), byName, out,
+            direct(scoped.body(), of, part, statements, terms.inside(scoped.binding(), at),
+                    byName, out,
                     noLines, withoutAnEnd, naming, narrowers, raised, took, typeAt, rules,
                     raisedByPart, standing);
             return;
@@ -2062,15 +2074,27 @@ public final class InvariantChecker {
         // an author wrote as a denied choice is a part this reading never descends into.
         if (saidAs instanceof ClauseExpr.Joined joined
                 && joined.how() == ConditionJoin.BOTH) {
-            direct(joined.left(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, rules, raisedByPart, standing);
-            direct(joined.right(), of, part, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, rules, raisedByPart, standing);
+            direct(joined.left(), of, part, statements, at, byName, out, noLines, withoutAnEnd,
+                    naming, narrowers, raised, took, typeAt, rules, raisedByPart, standing);
+            direct(joined.right(), of, part, statements, at, byName, out, noLines, withoutAnEnd,
+                    naming, narrowers, raised, took, typeAt, rules, raisedByPart, standing);
             return;
         }
         // A binding is crossed above and a conjunction is descended into, so what is left is a part
         // of the clause: a leaf, or a choice this reading takes whole.
         ClauseExpr.Part said = (ClauseExpr.Part) saidAs;
+        // Which statement of the conjunct this is, numbered here and handed to everything below
+        // that records an answer about it. A conjunct states as many of these as the reading
+        // arrives at, so a reader naming the conjunct alone calls the second of them the first said
+        // again.
+        //
+        // Here, where a statement is recognised and before anything is made of it. A binding is
+        // crossed above and a conjunction expanded into the part is descended into, and neither is
+        // a statement: what is left is one, whatever this reading goes on to read from it. Numbered
+        // where an end or a hand-over is written down instead, the number would say which of the
+        // outcomes this was rather than which of the statements, and the same rule read by a
+        // reading that made more of it would be a different line.
+        InvariantStatementId statement = new InvariantStatementId(part, statements[0]++);
         // The rule this part states, which is what every reading below is of. Under a denial that
         // is what the denial denies, and the denial itself is spent where the comparison is read
         // ({@link StatedComparison#of}) rather than carried down as a flag each reader applies.
@@ -2086,11 +2110,11 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        RunsRead runs = runsOf(new ReadingPlace(of.opened(), said.at()), of, part, byName, out);
+        RunsRead runs = runsOf(new ReadingPlace(of.opened(), said.at()), of, statement, byName, out);
         // What an author wrote and where, which is what a sentence about the rule points at. A rule
         // written under a denial is shown as the denial: that is what is on the line.
         restricting(said.written(), said.at(), from, of, part, byName, rules, noLines, runs);
-        aChoiceAboutOneCoordinate(said, part, at, byName, naming);
+        aChoiceAboutOneCoordinate(said, statement, at, byName, naming);
         // Where this clause is recognised as a comparison, and the one place it is. What each
         // reader below wants is what the recognition established — the two sides to walk, and what
         // the rule states of them — so each is handed that rather than the node it was read off.
@@ -2108,7 +2132,7 @@ public final class InvariantChecker {
             // to be handed: what is below reads a clause for the end it places on a position and
             // for which declarations narrowed that position, and neither is a thing another shape
             // of rule states.
-            settle(clause, from, of, part, said.at(), states(clause, at, byName, null, runs),
+            settle(clause, from, of, statement, said.at(), states(clause, at, byName, null, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             return;
@@ -2123,7 +2147,7 @@ public final class InvariantChecker {
         // did to it. Every shape of rule alike: whether an end is read from it below decides which
         // reader states where the values stop, and decides nothing about which conjuncts account
         // for where they stop.
-        aboutOneCoordinate(read, part, naming);
+        aboutOneCoordinate(read, statement, naming);
         // What the comparison states of the coordinate it names, read from whichever side bears
         // one, as `0 <= value` says what `value >= 0` says. The turn is spent making this, so no
         // reader below holds a claim beside a note about which way round it was written.
@@ -2135,15 +2159,15 @@ public final class InvariantChecker {
         StatedComparison.Numbered<Coordinate> numbered =
                 comparison.at(each -> byName.get(nameOf(each, at)));
         if (asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
-            settle(bin, from, of, part, said.at(), states(bin, at, byName, read, runs),
+            settle(bin, from, of, statement, said.at(), states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             // And handed on, which is not the same as being reported. A rule that rules one value
             // out places no end and is no failure of this reading, so there is nothing here for an
             // author to lift and there is a conjunct for the reading that draws lines to make what
             // it can of.
-            withoutAnEnd.putIfAbsent(new HandOver(part, said.at()),
-                    new FieldDomains.WithoutAnEnd(part, comparison, said.written().pos()));
+            withoutAnEnd.putIfAbsent(new HandOver(statement),
+                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos()));
             return;
         }
         // An end where the other side is a constant, and a relation everywhere else. Which it is
@@ -2203,7 +2227,7 @@ public final class InvariantChecker {
                                             List.of(part))
                                     : had.and(part)));
         }
-        settle(bin, from, of, part, said.at(), shape, end, byName, raised, took,
+        settle(bin, from, of, statement, said.at(), shape, end, byName, raised, took,
                 raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
             // A rule saying where the values stop that no end came out of, said as that. Here,
@@ -2221,8 +2245,8 @@ public final class InvariantChecker {
             // The hand-over beside the finding, and not read off it. Both come of this conjunct
             // having no end, and they answer different questions: what an author is owed a word
             // about, and what the next reading is given to read.
-            withoutAnEnd.putIfAbsent(new HandOver(part, said.at()),
-                    new FieldDomains.WithoutAnEnd(part, comparison, said.written().pos()));
+            withoutAnEnd.putIfAbsent(new HandOver(statement),
+                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos()));
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -2230,7 +2254,7 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(about.at(), part, placed.bound(),
+            out.add(new Direct(about.at(), statement, placed.bound(),
                     new ReadingPlace(of.opened(), said.at())));
         }
     }
@@ -2254,7 +2278,7 @@ public final class InvariantChecker {
      * candidate costs a counterfactual and claims nothing, and a rule saying which of them may be
      * one would be a second place deciding what a choice does.
      */
-    private void aChoiceAboutOneCoordinate(ClauseExpr.Part said, PartId<RuleRef.Invariant> part,
+    private void aChoiceAboutOneCoordinate(ClauseExpr.Part said, InvariantStatementId statement,
                                            Denotations at, Map<FactSubject, Coordinate> byName,
                                            List<FieldDomains.AboutOneCoordinate> naming) {
         // The shape the walk is already holding. Read again from the node, this would be a second
@@ -2264,8 +2288,12 @@ public final class InvariantChecker {
                 || joined.how() != ConditionJoin.EITHER) {
             return;
         }
-        Set<NumberAt<RuleKey>> numbers = numbersALineIsStatedOn(joined, at, byName);
-        numbers.forEach(each -> naming.add(new FieldDomains.AboutOneCoordinate(each, part)));
+        // Of the choice's own statement, because that is the statement there is. This walk stops at
+        // a choice, so what is under it is how the choice states its rule and not a statement of
+        // the conjunct — a leaf of one is reached by no reading that files an answer about it, and
+        // naming it here would be a statement nobody issued.
+        numbersALineIsStatedOn(joined, at, byName)
+                .forEach(number -> aboutOneCoordinate(number, statement, naming));
     }
 
     /**
@@ -2280,6 +2308,7 @@ public final class InvariantChecker {
      * no line does. What each number here is is a candidate and no more — whether the part is why
      * an end is there is the counterfactual's answer ({@link FieldDomains#movedEnds}) — so a leaf
      * with no number to offer has nothing to put forward either way.
+     *
      */
     private Set<NumberAt<RuleKey>> numbersALineIsStatedOn(ClauseExpr stated, Denotations at,
                                                           Map<FactSubject, Coordinate> byName) {
@@ -2836,7 +2865,7 @@ public final class InvariantChecker {
      * beside a rule that says nothing lends the second its narrowing — and the reason goes out
      * against the one rule that holds the position to nothing.
      */
-    private void restricting(Core clause, ClauseExpr.Occurrence at, RuleRef.Invariant from,
+    private void restricting(Core clause, ClauseOccurrence at, RuleRef.Invariant from,
                              Written of, PartId<RuleRef.Invariant> part,
                              Map<FactSubject, Coordinate> byName, RulesRead rules,
                              List<FieldDomains.NoLine> noLines, RunsRead runs) {
@@ -2937,7 +2966,7 @@ public final class InvariantChecker {
      * where whole numbers are.
      */
     private RunsRead runsOf(ReadingPlace stands,
-                        Written of, PartId<RuleRef.Invariant> part,
+                        Written of, InvariantStatementId statement,
                         Map<FactSubject, Coordinate> byName, List<Direct> out) {
         ReadByClauses.OfAPart account = of.adoptedAt(stands.at());
         if (account == null) {
@@ -2959,7 +2988,7 @@ public final class InvariantChecker {
             // stop is undecided, which is not the same as its stating that they stop nowhere.
             switch (stated) {
                 case AdmittedStrings.Admitting it ->
-                        byPosition.put(position, placed(it.set(), value, part, stands, out));
+                        byPosition.put(position, placed(it.set(), value, statement, stands, out));
                 case AdmittedStrings.NotKnown it ->
                         byPosition.put(position, new Run.Undecided(it.why()));
                 // And a rule of a position that could not hand its sets on leaves the question
@@ -2987,7 +3016,7 @@ public final class InvariantChecker {
      * with no end above them has said where none of them stop — and it is a run all the same, which
      * is why what is asked of it is which of its ends the rule placed.
      */
-    private Run placed(ValueSet set, NumberAt<RuleKey> value, PartId<RuleRef.Invariant> part,
+    private Run placed(ValueSet set, NumberAt<RuleKey> value, InvariantStatementId statement,
                        ReadingPlace stands, List<Direct> out) {
         switch (extentOf(set)) {
             // A run holding one string is the rule naming a value rather than bounding a range, and
@@ -2999,12 +3028,12 @@ public final class InvariantChecker {
                 boolean placed = false;
                 if (run.holdsFromAbove()) {
                     placed = true;
-                    out.add(new Direct(value, part,
+                    out.add(new Direct(value, statement,
                             new InvariantBound(true, Endpoint.inclusive(run.first())), stands));
                 }
                 if (run.after() != null) {
                     placed = true;
-                    out.add(new Direct(value, part,
+                    out.add(new Direct(value, statement,
                             new InvariantBound(false, Endpoint.exclusive(run.after())), stands));
                 }
                 return placed ? new Run.Bounding(value) : new Run.NotBounding();
@@ -3153,24 +3182,33 @@ public final class InvariantChecker {
      * what the rules leave the coordinate without this conjunct
      * ({@link FieldDomains#movedEndsOf}).
      */
-    private static void aboutOneCoordinate(CanonicalForm read, PartId<RuleRef.Invariant> part,
+    private static void aboutOneCoordinate(CanonicalForm read, InvariantStatementId statement,
                                           List<FieldDomains.AboutOneCoordinate> out) {
         if (!(read instanceof CanonicalForm.Over over) || over.numbers().size() != 1) {
             return;
         }
-        aboutOneCoordinate(over.numbers().iterator().next().at(), part, out);
+        aboutOneCoordinate(over.numbers().iterator().next().at(), statement, out);
     }
 
     /**
-     * One candidate, kept once. A part reaching one number twice is one thing to ask a
-     * counterfactual about, because taking a part away takes away everything it stated.
+     * One candidate, kept once, with the statement that reached this number written into it.
+     *
+     * <p>A part reaching one number twice is one thing to ask a counterfactual about, because
+     * taking a part away takes away everything it stated. Which statements those were is another
+     * question and is kept: the intervention is the conjunct's, and what tells the end on this
+     * number from the end the same conjunct accounts for on another is which of its statements are
+     * about which.
      */
-    private static void aboutOneCoordinate(NumberAt<RuleKey> at, PartId<RuleRef.Invariant> part,
+    private static void aboutOneCoordinate(NumberAt<RuleKey> at, InvariantStatementId statement,
                                            List<FieldDomains.AboutOneCoordinate> out) {
-        FieldDomains.AboutOneCoordinate said = new FieldDomains.AboutOneCoordinate(at, part);
-        if (!out.contains(said)) {
-            out.add(said);
+        for (int i = 0; i < out.size(); i++) {
+            FieldDomains.AboutOneCoordinate had = out.get(i);
+            if (had.at().equals(at) && had.part().equals(statement.part())) {
+                out.set(i, had.and(statement));
+                return;
+            }
         }
+        out.add(new FieldDomains.AboutOneCoordinate(at, Set.of(statement)));
     }
 
     /** One finding, kept once. A coordinate reached twice is one place with one thing to say. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1389,12 +1389,12 @@ public final class InvariantChecker {
      *
      * @param at       where the coordinate sits, read from the value these are of, and which of the
      *                 numbers there this end is on — a count taken of the position, or its value
-     * @param part     which part of which rule placed it, which is what names the line. The clause
-     *                 and not the declaration it is on: two clauses of one declaration placing an
-     *                 end at one value are two rules a row could be owed to, and held as
-     *                 declarations they came back as one. And the part and not the clause: one part
-     *                 states as many rules as its author wrote into it, and each of them places its
-     *                 own end
+     * @param statement which statement of which conjunct placed it, which is what names the line.
+     *                 The clause and not the declaration it is on: two clauses of one declaration
+     *                 placing an end at one value are two rules a row could be owed to, and held as
+     *                 declarations they came back as one. And the statement and not the conjunct:
+     *                 one conjunct states as many rules as the reading arrives at inside it, and
+     *                 each of them places its own end
      * @param stands   where, and in which reading, the part that placed it is. One part states as
      *                 many rules as its author wrote into it and each of them stands somewhere, so
      *                 what says which of them this end came of is the place; and a rule is read

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantStatementId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantStatementId.java
@@ -1,0 +1,56 @@
+package souther.compiler.check;
+
+/**
+ * One statement of one conjunct of a declaration's clause, as the identity a statement carries
+ * wherever it is recorded.
+ *
+ * <p>A declaration's clause is decomposed twice, and this is the second of them. The first is what
+ * the author joined with {@code &&}, which {@link PartId} names. The second is what a reading
+ * arrives at inside one of those conjuncts: a denial is carried to the leaves as a clause is read,
+ * so a conjunction an author wrote as a denied choice is one conjunct and states as many
+ * comparisons as it has leaves. Named by the conjunct alone, the second of them is the first said
+ * again.
+ *
+ * <p><b>Which of the conjunct's statements, and not where in the tree it sits.</b> A rule written
+ * out and the same rule reached through a helper are one line of the model, and the trees they are
+ * read from are not alike: the helper's bindings stand between the conjunct and the comparison, so
+ * the place the comparison holds in the expanded clause ({@link ClauseOccurrence}) moves with how
+ * the author spelt it. What does not move is which of the conjunct's statements it is — bindings
+ * are how a reading gets to a statement and are no statement of their own.
+ *
+ * <p><b>Issued where a statement is recognised, before anything is made of it.</b> Counted from
+ * nought within each conjunct, over every statement the reading arrives at rather than over the
+ * ones something came of: numbered by outcome, a statement no end was read from would leave the
+ * next one holding its number, and one reading of a clause would number the statements differently
+ * from another that made more of them.
+ *
+ * <p><b>And not where it was read from.</b> A clause is read once per place a walk opens a value at,
+ * so a record holding two of a type reads that type's clause twice — one written statement, and a
+ * row is owed for it once. Which reading arrived at it is {@link InvariantChecker.ReadingPlace}'s,
+ * and a statement that held it would be a statement per position the value is carried to.
+ *
+ * @param part    the conjunct this is a statement of
+ * @param ordinal which of that conjunct's statements it is, counted from zero over all of them
+ */
+public record InvariantStatementId(PartId<RuleRef.Invariant> part, int ordinal) {
+
+    public InvariantStatementId {
+        if (part == null) {
+            throw new IllegalArgumentException("a statement is some conjunct's");
+        }
+        if (ordinal < 0) {
+            throw new IllegalArgumentException(
+                    "a statement of a conjunct is counted from zero: " + ordinal);
+        }
+    }
+
+    /** Which clause of which declaration this is a statement of. */
+    public RuleRef.Invariant rule() {
+        return part.rule();
+    }
+
+    @Override
+    public String toString() {
+        return part + "/" + ordinal;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -104,13 +103,5 @@ public sealed interface LineProvenance {
     default InvariantStatementId aboutOneStatement() {
         Set<InvariantStatementId> said = statements();
         return said.size() == 1 ? said.iterator().next() : null;
-    }
-
-    /** Every statement of every one of them, which is what a reader asking whether a set of ends
-     *  covers a candidate's statements wants. */
-    static Set<InvariantStatementId> statementsOf(Iterable<? extends LineProvenance> from) {
-        Set<InvariantStatementId> out = new LinkedHashSet<>();
-        from.forEach(each -> out.addAll(each.statements()));
-        return out;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
@@ -89,24 +89,21 @@ public sealed interface LineProvenance {
     }
 
     /**
-     * The line this end is, which is where the evidence is spent.
+     * The one statement this is about, or null where it is about several.
      *
-     * <p>One statement's where the evidence is about one of them, whichever reading established it:
-     * a comparison that placed the end names its own statement, and a counterfactual that took a
-     * conjunct away naming one statement about this number is that same line found a second way.
-     * Folded here rather than at each reader, the two came out as two lines and every report counted
-     * one line twice.
+     * <p>What a piece of evidence can say on its own, which is not which lines there are. A comparison
+     * that placed an end is about the statement it read; a counterfactual is about the statements of
+     * the conjunct it took away which are on this number, and where the conjunct stated one of them
+     * the intervention was of that statement and nothing else.
      *
-     * <p>The conjunct's where the evidence is about several. Taking a part away takes away
-     * everything it stated, so an end a conjunct accounts for through two of its statements is a
-     * line neither of them drew — which is what a choice's line is, and what it is called
-     * ({@link DeclaredLine.OfAChoice}).
+     * <p>Null rather than a statement chosen from several, because taking a part away takes away
+     * everything it stated: an answer picking one of them would be a claim the intervention never
+     * tested. What the several come to is read where every piece of evidence about one end is in
+     * hand ({@link DeclaredBounds.End#drawn}).
      */
-    default DeclaredLine line() {
+    default InvariantStatementId aboutOneStatement() {
         Set<InvariantStatementId> said = statements();
-        return said.size() == 1
-                ? new DeclaredLine.OfAStatement(said.iterator().next())
-                : new DeclaredLine.OfAChoice(said);
+        return said.size() == 1 ? said.iterator().next() : null;
     }
 
     /** Every statement of every one of them, which is what a reader asking whether a set of ends

--- a/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
@@ -25,6 +25,20 @@ public sealed interface LineProvenance {
     Set<InvariantStatementId> statements();
 
     /**
+     * The statement this establishes placed the end, or null where nothing here establishes that.
+     *
+     * <p>A question only the reading of comparisons can answer. What the other reading intervenes
+     * on is an authored conjunct, and it takes away everything that conjunct stated — so an end it
+     * moves was moved by the conjunct, whatever the conjunct states about this number. Answered
+     * from how many of the conjunct's statements are on this number, a conjunct stating one thing
+     * here and another about the number beside it says the first placed an end that the second is
+     * why: {@code a /= 100 && b >= 1} written into one conjunct pairs only {@code a /= 100} with
+     * {@code a}, and where {@code a}'s floor comes from {@code b >= 1} through a rule relating the
+     * two, taking the conjunct away moves it.
+     */
+    InvariantStatementId placedBy();
+
+    /**
      * The end a statement of the clause placed, read off that statement.
      *
      * @param statement which statement of which conjunct placed it
@@ -45,6 +59,12 @@ public sealed interface LineProvenance {
         @Override
         public Set<InvariantStatementId> statements() {
             return Set.of(statement);
+        }
+
+        /** This one, which is what reading the comparison established. */
+        @Override
+        public InvariantStatementId placedBy() {
+            return statement;
         }
     }
 
@@ -85,23 +105,18 @@ public sealed interface LineProvenance {
         public Set<InvariantStatementId> statements() {
             return pairedWith;
         }
-    }
 
-    /**
-     * The one statement this is about, or null where it is about several.
-     *
-     * <p>What a piece of evidence can say on its own, which is not which lines there are. A comparison
-     * that placed an end is about the statement it read; a counterfactual is about the statements of
-     * the conjunct it took away which are on this number, and where the conjunct stated one of them
-     * the intervention was of that statement and nothing else.
-     *
-     * <p>Null rather than a statement chosen from several, because taking a part away takes away
-     * everything it stated: an answer picking one of them would be a claim the intervention never
-     * tested. What the several come to is read where every piece of evidence about one end is in
-     * hand ({@link DeclaredBounds.End#drawn}).
-     */
-    default InvariantStatementId aboutOneStatement() {
-        Set<InvariantStatementId> said = statements();
-        return said.size() == 1 ? said.iterator().next() : null;
+        /**
+         * None, however few of the conjunct's statements are on this number.
+         *
+         * <p>What was taken away is the conjunct, so what moved the end is the conjunct. How many of
+         * its statements happen to be about this number is a fact about the pairing and not about
+         * the intervention: read as one where there is one, a statement is said to have placed an
+         * end that another statement of the same conjunct is why.
+         */
+        @Override
+        public InvariantStatementId placedBy() {
+            return null;
+        }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/LineProvenance.java
@@ -1,0 +1,119 @@
+package souther.compiler.check;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * What a reading knows about which of a declaration's rules put an end where it is.
+ *
+ * <p>Two answers and not one, because two readings answer this and they know different things. A
+ * comparison places an end of its own, and what placed it is the statement that was read. An end no
+ * comparison placed is attributed by asking what the rules leave without a conjunct, and what that
+ * establishes is about the conjunct: taking a part away takes away every statement it made, so an
+ * answer that named one of them would be a claim the counterfactual never tested.
+ *
+ * <p>Held apart in the type rather than flattened to whichever of the two every reader could take.
+ * Flattened upwards, the direct reading's answer is thrown away and two ends of one conjunct come
+ * back as one thing; flattened downwards, the counterfactual is made to name a statement, and a
+ * reader that met the two would have no way of telling a tested claim from an invented one.
+ */
+public sealed interface LineProvenance {
+
+    /** The conjunct behind the end, which both answers have and which is what a rule is named by. */
+    PartId<RuleRef.Invariant> part();
+
+    /** Every statement this answer is about, which is one where a comparison placed the end. */
+    Set<InvariantStatementId> statements();
+
+    /**
+     * The end a statement of the clause placed, read off that statement.
+     *
+     * @param statement which statement of which conjunct placed it
+     */
+    record Direct(InvariantStatementId statement) implements LineProvenance {
+
+        public Direct {
+            if (statement == null) {
+                throw new IllegalArgumentException("an end a statement placed is some statement's");
+            }
+        }
+
+        @Override
+        public PartId<RuleRef.Invariant> part() {
+            return statement.part();
+        }
+
+        @Override
+        public Set<InvariantStatementId> statements() {
+            return Set.of(statement);
+        }
+    }
+
+    /**
+     * The end a conjunct accounts for without stating it, which is what taking the conjunct away
+     * moves.
+     *
+     * <p>Which conjunct was taken away is read off them and not held beside them. The statements of
+     * one conjunct are that conjunct's, so a field for it would be a second way to the rule this is
+     * about — and a value with two of those can be built about two rules, with whoever writes from
+     * it filing an entry under one and describing the other.
+     *
+     * @param pairedWith the statements of the conjunct which are about the number this end is on.
+     *                   These are what tells two ends of one conjunct apart, and none of them is
+     *                   being said to have placed the end: the intervention was the conjunct's, and
+     *                   what it establishes is the conjunct's too
+     */
+    record Counterfactual(Set<InvariantStatementId> pairedWith) implements LineProvenance {
+
+        public Counterfactual {
+            pairedWith = Set.copyOf(pairedWith);
+            if (pairedWith.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "an end a conjunct accounts for is about something the conjunct states");
+            }
+            if (pairedWith.stream().map(InvariantStatementId::part).distinct().count() != 1) {
+                throw new IllegalArgumentException(
+                        "a conjunct accounts for an end with statements of its own: " + pairedWith);
+            }
+        }
+
+        @Override
+        public PartId<RuleRef.Invariant> part() {
+            return pairedWith.iterator().next().part();
+        }
+
+        @Override
+        public Set<InvariantStatementId> statements() {
+            return pairedWith;
+        }
+    }
+
+    /**
+     * The line this end is, which is where the evidence is spent.
+     *
+     * <p>One statement's where the evidence is about one of them, whichever reading established it:
+     * a comparison that placed the end names its own statement, and a counterfactual that took a
+     * conjunct away naming one statement about this number is that same line found a second way.
+     * Folded here rather than at each reader, the two came out as two lines and every report counted
+     * one line twice.
+     *
+     * <p>The conjunct's where the evidence is about several. Taking a part away takes away
+     * everything it stated, so an end a conjunct accounts for through two of its statements is a
+     * line neither of them drew — which is what a choice's line is, and what it is called
+     * ({@link DeclaredLine.OfAChoice}).
+     */
+    default DeclaredLine line() {
+        Set<InvariantStatementId> said = statements();
+        return said.size() == 1
+                ? new DeclaredLine.OfAStatement(said.iterator().next())
+                : new DeclaredLine.OfAChoice(said);
+    }
+
+    /** Every statement of every one of them, which is what a reader asking whether a set of ends
+     *  covers a candidate's statements wants. */
+    static Set<InvariantStatementId> statementsOf(Iterable<? extends LineProvenance> from) {
+        Set<InvariantStatementId> out = new LinkedHashSet<>();
+        from.forEach(each -> out.addAll(each.statements()));
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -668,7 +668,7 @@ final class PathEngine {
             // What this reading made of each occurrence of each part, handed over with the reading
             // it belongs to. Written into a table every reading shares instead, an entry would be
             // told from the next reading's only by which objects a substitution allocated.
-            Map<PartId<RuleRef.Invariant>, Map<ClauseExpr.Occurrence, InvariantChecker.PartAsRead>>
+            Map<PartId<RuleRef.Invariant>, Map<ClauseOccurrence, InvariantChecker.PartAsRead>>
                     constrained = new LinkedHashMap<>();
             for (TypeGuarantee.Part part : guarantee.parts()) {
                 constrained.computeIfAbsent(part.of(), _ -> new LinkedHashMap<>())

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
@@ -65,7 +65,7 @@ record RuleShortfall(FactSubject position, UnreadReason why, RuleShortfall.Site 
          *
          * <p>The identity and the place beside each other, as a choice holds them
          * ({@link ChoiceSite}). Which part of the clause this is, is what
-         * {@link ClauseExpr.Occurrence} says and a node cannot: a clause is read once for every
+         * {@link ClauseOccurrence} says and a node cannot: a clause is read once for every
          * place the walk opens a value at, over whatever tree the substitution built there, so two
          * readings of one rule meet the same written part as two objects. Told apart by the tree
          * they landed in, one thing an author wrote came back as two things to look at.
@@ -85,7 +85,7 @@ record RuleShortfall(FactSubject position, UnreadReason why, RuleShortfall.Site 
          *                  because the reader that puts these in the author's order has no clause
          *                  left to ask
          */
-        record AtALeaf(ClauseExpr.Occurrence at, SourcePos writtenAt) implements Site {
+        record AtALeaf(ClauseOccurrence at, SourcePos writtenAt) implements Site {
 
             public AtALeaf {
                 if (at == null || writtenAt == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -118,7 +118,7 @@ sealed interface StatedByClauses {
      * pushed down into the branches of a choice would be a part of each of them, and every question
      * the choice asks of an alternative would be answerable from a clause written above it.
      */
-    record CameFrom(Core node, ClauseExpr.Occurrence at, StatedByClauses of)
+    record CameFrom(Core node, ClauseOccurrence at, StatedByClauses of)
             implements StatedByClauses {
 
         public CameFrom {
@@ -1277,14 +1277,14 @@ sealed interface StatedByClauses {
             return out;
         }
 
-        private Map<ClauseExpr.Occurrence, PartAccount> partsOf(Taken took, Settlement made,
+        private Map<ClauseOccurrence, PartAccount> partsOf(Taken took, Settlement made,
                                                                Set<OpenEnd> stillOpen) {
             Set<FactSubject> unbuilt = made.made().unbuilt();
             // And what could not be built is given up on here too. What a leaf said it adopted was
             // said before any machine was made, so a position whose answer the whole reading did
             // not work out is one the account still calls taken in — while the values beside it
             // say it holds every value because nobody worked it out.
-            Map<ClauseExpr.Occurrence, PartAccount> parts = new LinkedHashMap<>();
+            Map<ClauseOccurrence, PartAccount> parts = new LinkedHashMap<>();
             took.parts().forEach((each, part) -> parts.put(each, new PartAccount(
                     part.byValues().unbuiltAt(unbuilt),
                     part.byOrder().unbuiltAt(unbuilt),
@@ -1375,11 +1375,11 @@ sealed interface StatedByClauses {
      * nothing is written under two branches of a tree — so putting two of these together is a union
      * and never a merge, which is what the tree keeping the author's shape buys.
      */
-    record Taken(Part took, Map<ClauseExpr.Occurrence, Part> parts, Set<FactSubject> opened) {
+    record Taken(Part took, Map<ClauseOccurrence, Part> parts, Set<FactSubject> opened) {
 
         /** The same, with what a written part came to filed under where in the clause it is. */
-        Taken alsoAt(ClauseExpr.Occurrence at) {
-            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>(parts);
+        Taken alsoAt(ClauseOccurrence at) {
+            Map<ClauseOccurrence, Part> out = new LinkedHashMap<>(parts);
             out.put(at, took);
             return new Taken(took, out, opened);
         }
@@ -1400,7 +1400,7 @@ sealed interface StatedByClauses {
 
         /** Every part of this, answered again — for what a settlement could not build in it. */
         Taken mapped(UnaryOperator<Part> answer) {
-            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>();
+            Map<ClauseOccurrence, Part> out = new LinkedHashMap<>();
             parts.forEach((each, part) -> out.put(each, answer.apply(part)));
             return new Taken(answer.apply(took), out, opened);
         }
@@ -1505,12 +1505,12 @@ sealed interface StatedByClauses {
                     opened(opened(opened, other.opened()), opening.byValues().positions()));
         }
 
-        private static Map<ClauseExpr.Occurrence, Part> joined(
-                Map<ClauseExpr.Occurrence, Part> these, Map<ClauseExpr.Occurrence, Part> those) {
+        private static Map<ClauseOccurrence, Part> joined(
+                Map<ClauseOccurrence, Part> these, Map<ClauseOccurrence, Part> those) {
             if (those.isEmpty()) {
                 return these;
             }
-            Map<ClauseExpr.Occurrence, Part> out = new LinkedHashMap<>(these);
+            Map<ClauseOccurrence, Part> out = new LinkedHashMap<>(these);
             out.putAll(those);
             return out;
         }
@@ -1604,7 +1604,7 @@ sealed interface StatedByClauses {
      */
     final class Asked<K> {
 
-        private final Map<K, List<ClauseExpr.Occurrence>> byPart = new LinkedHashMap<>();
+        private final Map<K, List<ClauseOccurrence>> byPart = new LinkedHashMap<>();
         private final Map<K, StatedByClauses> trees = new LinkedHashMap<>();
 
         /** One clause read from {@code at} in the world {@code view} describes
@@ -1614,7 +1614,7 @@ sealed interface StatedByClauses {
             // Where in the clause each part is, in the order the reading reached them, and once
             // however many nodes one of them was spelled as: a part written `!(x)` and read at the
             // denial and at what it denies is one part of the clause, in one place.
-            List<ClauseExpr.Occurrence> parts = new ArrayList<>();
+            List<ClauseOccurrence> parts = new ArrayList<>();
             StatedByClauses one = reader.read(clause, true, at, reader.scope(),
                     (shape, _, _) -> {
                         if (parts.isEmpty() || !parts.getLast().equals(shape.at())) {
@@ -1672,7 +1672,7 @@ sealed interface StatedByClauses {
             // written elsewhere shows dead takes what it could not read with it, and which branches
             // those are is what the settlement above answers.
             Set<FactSubject> opened = new LinkedHashSet<>();
-            Map<K, Map<ClauseExpr.Occurrence, PartAccount>> said = new LinkedHashMap<>();
+            Map<K, Map<ClauseOccurrence, PartAccount>> said = new LinkedHashMap<>();
             Map<K, Set<FactSubject>> narrowed = new LinkedHashMap<>();
             Adoption<FactSubject, ReadingLanguage.Values> byValues = Adoption.nothing();
             Adoption<FactSubject, ReadingLanguage.Order> byOrder = Adoption.nothing();
@@ -1695,7 +1695,7 @@ sealed interface StatedByClauses {
                         projected.get(each.getKey()), made, by, tally);
                 said.put(each.getKey(), mine.parts());
                 opened.addAll(mine.opened());
-                PartAccount clause = mine.parts().get(ClauseExpr.Occurrence.ofTheClause());
+                PartAccount clause = mine.parts().get(ClauseOccurrence.ofTheClause());
                 narrowed.put(each.getKey(), mine.narrowed());
                 byValues = byValues.both(clause.byValues());
                 byOrder = byOrder.both(clause.byOrder());
@@ -1722,7 +1722,7 @@ sealed interface StatedByClauses {
             // on its own, which the answer had no use for — charged to it, what a position is read
             // to admit would turn on what a reader downstream was promised, and the assertion above
             // would be true of the accounts and false of the reading as a whole.
-            Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> published =
+            Map<K, Map<ClauseOccurrence, ReadByClauses.OfAPart>> published =
                     published(said, handingOn, answered.values());
             // And the answer's allowance is where it was. What a position admits is answered under
             // the allowance for it and nothing else reaches that allowance, so what this
@@ -1734,13 +1734,13 @@ sealed interface StatedByClauses {
                             + " on spent the allowance for what they admit";
             Map<K, ReadByClauses.OfARule> clauses = new LinkedHashMap<>();
             narrowed.forEach((key, these) -> clauses.put(key, new ReadByClauses.OfARule(these,
-                    published.get(key).get(ClauseExpr.Occurrence.ofTheClause()))));
+                    published.get(key).get(ClauseOccurrence.ofTheClause()))));
             ReadByClauses read = new ReadByClauses(answered, byValues, byOrder);
-            Map<K, List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>>> parts =
+            Map<K, List<Map.Entry<ClauseOccurrence, ReadByClauses.OfAPart>>> parts =
                     new LinkedHashMap<>();
             byPart.forEach((key, these) -> {
-                Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> mine = published.get(key);
-                List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> out =
+                Map<ClauseOccurrence, ReadByClauses.OfAPart> mine = published.get(key);
+                List<Map.Entry<ClauseOccurrence, ReadByClauses.OfAPart>> out =
                         new ArrayList<>();
                 these.forEach(each -> {
                     ReadByClauses.OfAPart one = mine == null ? null : mine.get(each);
@@ -1790,8 +1790,8 @@ sealed interface StatedByClauses {
          *
          * @param answered what the positions came to, asked whether each of them is exact
          */
-        private Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> published(
-                Map<K, Map<ClauseExpr.Occurrence, PartAccount>> said,
+        private Map<K, Map<ClauseOccurrence, ReadByClauses.OfAPart>> published(
+                Map<K, Map<ClauseOccurrence, PartAccount>> said,
                 Allowance<FactSubject> handingOn,
                 AdmissibleValues<FactSubject> answered) {
             Map<FactSubject, Set<AdmittedPlan>> asked = new LinkedHashMap<>();
@@ -1809,9 +1809,9 @@ sealed interface StatedByClauses {
                     answered.speaksFor(position)
                             ? handingOn.realizeAll(answered.blockOf(position), plans)
                             : new Realizations.NotBuilt()));
-            Map<K, Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart>> out = new LinkedHashMap<>();
+            Map<K, Map<ClauseOccurrence, ReadByClauses.OfAPart>> out = new LinkedHashMap<>();
             said.forEach((key, mine) -> {
-                Map<ClauseExpr.Occurrence, ReadByClauses.OfAPart> here = new LinkedHashMap<>();
+                Map<ClauseOccurrence, ReadByClauses.OfAPart> here = new LinkedHashMap<>();
                 mine.forEach((each, part) -> here.put(each, new ReadByClauses.OfAPart(
                         part.byValues(), part.byOrder(), part.stopped(), part.aboutARule(),
                         admitted(part.aboutStrings(), answers), part.endsLeftOpen(),
@@ -1859,7 +1859,7 @@ sealed interface StatedByClauses {
      * nothing, because the work was done once and what is here is what it came to.
      */
     record Answered<K>(ReadByClauses whole, Map<K, ReadByClauses.OfARule> perClause,
-                       Map<K, List<Map.Entry<ClauseExpr.Occurrence, ReadByClauses.OfAPart>>>
+                       Map<K, List<Map.Entry<ClauseOccurrence, ReadByClauses.OfAPart>>>
                                perPart) {}
 
     /**
@@ -1874,7 +1874,7 @@ sealed interface StatedByClauses {
      *               walked ({@code AdmissibleValues.alsoOpenedAt}). The account of the rule hears
      *               the same decision as a shortfall at the choice
      */
-    record Account(Set<FactSubject> narrowed, Map<ClauseExpr.Occurrence, PartAccount> parts,
+    record Account(Set<FactSubject> narrowed, Map<ClauseOccurrence, PartAccount> parts,
                    Set<FactSubject> opened) {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
@@ -21,9 +21,9 @@ import souther.compiler.types.TypeSymbol;
  * why it placed none is no part of the question: the two read one clause with different atoms, and a
  * clause over a number one of them has no atom for is one the other names two positions in.
  *
- * @param part     which part of which rule this is, as the split that wrote the parts down named
- *                 it. What tells one authored line from another is this name, and a reader holding
- *                 the expression alone cannot tell two identical conjuncts apart
+ * @param statement which statement of which conjunct this is, as the reading that arrived at it
+ *                 named it. What tells one authored line from another is this name, and a reader
+ *                 holding the expression alone cannot tell two identical statements apart
  * @param states   what the conjunct compares and what it claims of the two sides, as the clause
  *                 states it. The comparison and not the node it was written as: a rule written
  *                 under a denial reads off its operator as the comparison that holds exactly where

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.InvariantStatementId;
 import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.StatedComparison;
@@ -38,18 +39,24 @@ import souther.compiler.types.TypeSymbol;
  *                 is that name's — matched against the writing declaration's bindings alone, a
  *                 clause under a name names no position at all
  */
-public record ClauseWithoutAnEnd(PartId<RuleRef.Invariant> part, StatedComparison states,
+public record ClauseWithoutAnEnd(InvariantStatementId statement, StatedComparison states,
                                  SourcePos wrote, TermPath at, TypeSymbol.AtModule readUnder) {
 
     public ClauseWithoutAnEnd {
-        if (part == null || states == null || wrote == null || at == null || readUnder == null) {
+        if (statement == null || states == null || wrote == null || at == null
+                || readUnder == null) {
             throw new IllegalArgumentException(
                     "a clause is one of a declaration's, is written, and is about a value somewhere");
         }
     }
 
+    /** Which conjunct of the clause this statement is of. */
+    public PartId<RuleRef.Invariant> part() {
+        return statement.part();
+    }
+
     /** Which clause of which declaration this is a part of. */
     public RuleRef.Invariant rule() {
-        return part.rule();
+        return statement.rule();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1557,22 +1557,19 @@ public final class InputDomain {
     /**
      * What the rules leave one number of one position.
      *
-     * <p>Every answer here is about {@code kind} and about no other number of the place. Three
-     * sources of ends and not one: what the type's own clauses wrote, what its conjuncts state or
-     * moved that no comparison says — a rule about the strings at a position leaves them running
-     * between two places and orders nothing — and what the value this position sits in placed. Each
-     * list holds ends of every number, and each is asked for this one's; they are intersected, and
-     * every rule that put an end where it is kept.
+     * <p>Every answer here is about {@code kind} and about no other number of the place. What its
+     * conjuncts state, and what they moved that no comparison says — a rule about the strings at a
+     * position leaves them running between two places and orders nothing. Each list holds ends of
+     * every number, and each is asked for this one's; they are intersected, and every rule that put
+     * an end where it is kept.
      *
-     * <p><b>One reading of the type's own clauses, and it is {@link #ofTheType}.</b> There is a
-     * second — the one that turns those clauses into constraints, which {@code read} holds for its
-     * own question — and it answers about more of them: it reaches the end under
-     * {@code String.length(value) * 2 >= 4}, under a disequality that moves a floor and under an
-     * equality that states both ends, where reading the comparison as written finds none. Handed
-     * both and intersected, this would take whichever answer is tighter and there would be nothing
-     * to say which of the two the position is bounded by — one clause read two ways, with the
-     * difference kept out of sight by the intersection rather than settled. So the second reading
-     * is not a parameter here.
+     * <p><b>One reading of the type's own clauses, and it is the one that reaches the statements
+     * inside them.</b> Reading each authored conjunct as one comparison answers about fewer of them
+     * — it makes nothing of a conjunction written under a denial, and nothing of
+     * {@code String.length(value) * 2 >= 4}, of a disequality that moves a floor or of an equality
+     * stating both ends — and it names its ends by the conjunct, because the statements are where
+     * it never went. Intersected with this one, its ends met these at the same value under a name
+     * of a different grain, and the model owed two rows for one line.
      */
     private static PositionBounds boundsOn(NumberAt.OfWhatNumber kind, TermPath path, Type type,
                                            ValueName.Stdlib taken, TypeView view,
@@ -1593,10 +1590,9 @@ public final class InputDomain {
         }
         Carrier on = carrierOn(kind, carried);
         DeclaredBounds.Bounds own = on == null ? null
-                : DeclaredBounds.and(ofTheType(kind, on, view, source),
-                        DeclaredBounds.and(
-                                DeclaredBounds.placed(movedHere, kind, on),
-                                DeclaredBounds.placed(stated, kind, on)));
+                : DeclaredBounds.and(
+                        DeclaredBounds.placed(movedHere, kind, on),
+                        DeclaredBounds.placed(stated, kind, on));
         // A record's rule relates the numbers its fields hold, so it reaches the term that is one of
         // them and no other: a cap on a field says nothing about how long the string beside it is.
         //
@@ -1612,7 +1608,9 @@ public final class InputDomain {
                 // term's values can be is every rule about it intersected; where it is divided is
                 // only where its own type draws a line, because a clause relating two fields is not
                 // a partition of one.
-                nothingExists ? null : TypeBounds.admissible(own, projected.bounds(), term),
+                nothingExists ? null
+                        : TypeBounds.admissible(own == null ? null : own.range(),
+                                projected.bounds(), term),
                 own, projected,
                 // Where the number actually stops, which the ends as written do not say: a clause
                 // placing one at 0 beside a clause that takes the 0 away leaves a number whose
@@ -1631,17 +1629,6 @@ public final class InputDomain {
         return switch (kind) {
             case NumberAt.OfWhatNumber.OfItsOwnValue _ -> carried;
             case NumberAt.OfWhatNumber.OfWhatAnOperationAnswers _ -> Carrier.WHOLE;
-        };
-    }
-
-    /** What the names this position wears leave {@code kind}, which each of them is read for on its
-     *  own: a name bounding the length of what it wraps says nothing about the order of it. */
-    private static DeclaredBounds.Bounds ofTheType(NumberAt.OfWhatNumber kind, Carrier on,
-                                                   TypeView view, RuleReadingSource source) {
-        return switch (kind) {
-            case NumberAt.OfWhatNumber.OfItsOwnValue _ -> DeclaredBounds.of(view, source, on, null);
-            case NumberAt.OfWhatNumber.OfWhatAnOperationAnswers it ->
-                    DeclaredBounds.of(view, source, on, it.operation());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1421,7 +1421,7 @@ public final class InputDomain {
                 placed.admits(path, souther.compiler.check.TypeOps.base(type, source.symbols()));
         List<PositionBounds> bounds = new ArrayList<>();
         for (NumberAt.OfWhatNumber kind : kinds) {
-            bounds.add(boundsOn(kind, path, type, taken, view, source, carried, placed,
+            bounds.add(boundsOn(kind, path, type, taken, source, carried, placed,
                     movedHere, stated, nothingExists));
         }
         rulesWithoutALineAt(placed, path, type, source, found);
@@ -1572,7 +1572,7 @@ public final class InputDomain {
      * of a different grain, and the model owed two rows for one line.
      */
     private static PositionBounds boundsOn(NumberAt.OfWhatNumber kind, TermPath path, Type type,
-                                           ValueName.Stdlib taken, TypeView view,
+                                           ValueName.Stdlib taken,
                                            RuleReadingSource source, Carrier carried,
                                            PlacedRules placed,
                                            List<FieldDomains.Placed> movedHere,

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -656,7 +656,8 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
      */
     List<ClauseWithoutAnEnd> clausesWithoutAnEnd() {
         return bounds().withoutAnEnd().stream()
-                .map(each -> new ClauseWithoutAnEnd(each.part(), each.states(), each.wrote(), root,
+                .map(each -> new ClauseWithoutAnEnd(each.statement(), each.states(), each.wrote(),
+                        root,
                         bounds().named()))
                 .toList();
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TypeBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TypeBounds.java
@@ -33,7 +33,7 @@ public final class TypeBounds {
      * them, so that a guard at zero is refused its neighbour below by the same intersection that
      * refuses one outside an invariant.
      */
-    public static NumericDomain.Bounds admissible(DeclaredBounds.Bounds own, NumericDomain.Bounds projected,
+    public static NumericDomain.Bounds admissible(DeclaredBounds.Range own, NumericDomain.Bounds projected,
                                            NumericTerm term) {
         // A term with nothing to guarantee and no term at all are one answer here. What this returns
         // is read by callers that take a null for a position they know nothing about, which is not
@@ -45,8 +45,8 @@ public final class TypeBounds {
         if (own == null) {
             return intrinsic;   // not a number of its own, so only what the term guarantees
         }
-        Endpoint min = own.min() == null ? null : own.min().at();
-        Endpoint max = own.max() == null ? null : own.max().at();
+        Endpoint min = own.min();
+        Endpoint max = own.max();
         NumericDomain.Bounds read = projected == null ? new NumericDomain.Bounds(min, max)
                 : new NumericDomain.Bounds(Endpoint.lower(min, projected.min()),
                         Endpoint.upper(max, projected.max()));
@@ -56,7 +56,7 @@ public final class TypeBounds {
     }
 
     /** The same, of a position no term of its own is measured at. */
-    public static NumericDomain.Bounds admissible(DeclaredBounds.Bounds own, NumericDomain.Bounds projected) {
+    public static NumericDomain.Bounds admissible(DeclaredBounds.Range own, NumericDomain.Bounds projected) {
         return admissible(own, projected, null);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -23,11 +23,16 @@ import java.util.Set;
  * is one. Said again here as "no behavior", this would be a second answer to a question the rule
  * already answers, and the two would differ for whichever kind of rule was added next.
  *
- * <p><b>Not the rule alone.</b> One clause places as many lines as it has conjuncts with an end in
- * them: {@code invariant within = value >= 1 && value <= 10} is one {@link RuleRef.Invariant} and
- * two lines, and a row at the bottom of the range is no evidence about the top. So which conjunct
- * drew it is part of this, and it is the clause's own text rather than the number it was written
- * about ({@link souther.compiler.check.DeclaredBounds.Drawn}).
+ * <p><b>Not the rule alone.</b> One clause places as many lines as the readings of it draw:
+ * {@code invariant within = value >= 1 && value <= 10} is one {@link RuleRef.Invariant} and two
+ * lines, and a row at the bottom of the range is no evidence about the top. So which line of the
+ * clause it is is part of this, and it is the clause's own text rather than the number it was
+ * written about ({@link souther.compiler.check.DeclaredLine}).
+ *
+ * <p><b>And which line of a clause is not which conjunct of it.</b> A conjunct states as many
+ * comparisons as a reading arrives at inside it, and it can leave the values somewhere none of them
+ * states: {@code Bool.not(String.length(name) < 1 || String.length(code) < 1)} is one conjunct
+ * placing an end on each of two numbers. Read as the conjunct, those two are one line.
  *
  * <p><b>And what the line is.</b> Two lines of one rule at one value are told apart by what each
  * says about its own value ({@link LineFacts}) — {@code value >= 5 && value <= 5} places a minimum
@@ -167,7 +172,7 @@ public record AuthoredLine(WhichLine which, LineFacts facts,
      * would be naming a part nobody issued.
      */
     public Optional<souther.compiler.check.DeclaredBorders.Key> declaredLine() {
-        return which instanceof WhichLine.OfAPart it
+        return which instanceof WhichLine.OfADeclarationsLine it
                 ? Optional.of(new souther.compiler.check.DeclaredBorders.Key(it.drawnBy()))
                 : Optional.empty();
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -168,7 +168,7 @@ public record AuthoredLine(WhichLine which, LineFacts facts,
      */
     public Optional<souther.compiler.check.DeclaredBorders.Key> declaredLine() {
         return which instanceof WhichLine.OfAPart it
-                ? Optional.of(new souther.compiler.check.DeclaredBorders.Key(it.part()))
+                ? Optional.of(new souther.compiler.check.DeclaredBorders.Key(it.drawnBy()))
                 : Optional.empty();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.check.DeclaredLine;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -110,8 +111,8 @@ public final class DeclaredThresholds {
             throw new IllegalStateException("which end a clause keeps, asked of one that names a"
                     + " value: " + clause.rule());
         }
-        return new LineOrigin.InvariantOrigin(clause.part(), endKept(order),
-                order.holdsAtTheValue());
+        return new LineOrigin.InvariantOrigin(new DeclaredLine.OfAStatement(clause.statement()),
+                endKept(order), order.holdsAtTheValue());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -3,6 +3,8 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.DeclaredBorders;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.RuleReportAnchor;
@@ -87,24 +89,29 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      *                        derivation gets and not one about the end, and reading the end is what
      *                        keeps the two from being confused if it ever does get further
      */
-    record InvariantOrigin(souther.compiler.check.PartId<RuleRef.Invariant> part,
+    record InvariantOrigin(DeclaredLine drawnBy,
                            souther.compiler.numeric.EndSide keeps, boolean holdsAtTheValue)
             implements LineOrigin {
 
         public InvariantOrigin {
-            if (part == null) {
+            if (drawnBy == null) {
                 throw new IllegalArgumentException("a bound drawn by no clause");
             }
             if (keeps == null) {
                 throw new IllegalArgumentException(
-                        "a bound places one of a range's two ends: " + part);
+                        "a bound places one of a range's two ends: " + drawnBy);
             }
+        }
+
+        /** Which conjunct of the clause drew it, which is what a rule is named by. */
+        public PartId<RuleRef.Invariant> part() {
+            return drawnBy.part();
         }
 
         /** Which clause of which declaration drew it. */
         @Override
         public RuleRef.Invariant rule() {
-            return part.rule();
+            return part().rule();
         }
     }
 
@@ -474,7 +481,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
         return switch (this) {
             // The part that drew it, which is what named the line where a declaration wrote it.
             case InvariantOrigin i ->
-                    new AuthoredLine(new WhichLine.OfAPart(i.part()), lineFacts(), List.of());
+                    new AuthoredLine(new WhichLine.OfAPart(i.drawnBy()), lineFacts(), List.of());
             // The rule and nothing under it. A comparison is a rule apiece — a condition holding
             // three comparisons is three rules — so there is no second line of it to tell this one
             // from, and a number here would be one this reading made up to fill a field.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -58,13 +58,13 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      * value are two rules, and a cut keeps every rule that drew it; named by the declaration and the
      * word, they are one.
      *
-     * @param part            which part of which clause drew this end. What tells one line of a
+     * @param drawnBy         which line of which clause this end is. What tells one line of a
      *                        clause from another where the clause drew several: {@code
      *                        String.length(name) >= 1 && String.length(code) >= 1} is one clause and
      *                        two lines at one value, and a row at either says nothing about the
      *                        other. The clause's own text and not the number it was written about,
      *                        which is spelled differently by every reading that reaches it
-     *                        ({@link souther.compiler.check.DeclaredBounds.Drawn})
+     *                        ({@link DeclaredLine})
      * @param keeps           which of the two ends the bound placed. Read where the end is read,
      *                        and carried for the same reason the inclusivity beside it is — a bound
      *                        orders nothing across its line, so there is no side to read off the

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -481,7 +481,8 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
         return switch (this) {
             // The part that drew it, which is what named the line where a declaration wrote it.
             case InvariantOrigin i ->
-                    new AuthoredLine(new WhichLine.OfAPart(i.drawnBy()), lineFacts(), List.of());
+                    new AuthoredLine(new WhichLine.OfADeclarationsLine(i.drawnBy()),
+                            lineFacts(), List.of());
             // The rule and nothing under it. A comparison is a rule apiece — a condition holding
             // three comparisons is three rules — so there is no second line of it to tell this one
             // from, and a number here would be one this reading made up to fill a field.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -193,9 +193,9 @@ final class LocalInspection {
         // was settled where the clause was read and arrives as it was. What is added is a
         // boundary's own answer about that rule — that a reading of it drew this cut, taken in by
         // these declarations — which is nothing the rule says about itself.
-        for (DeclaredBounds.Drawn from : end.from()) {
+        for (DeclaredBounds.Drawn drawn : end.from()) {
             put(into, carrier, end.value(),
-                    new LineOrigin.InvariantOrigin(from.part(), side, end.at().inclusive()),
+                    new LineOrigin.InvariantOrigin(drawn.line(), side, end.at().inclusive()),
                     end.at(), took);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
+import souther.compiler.check.DeclaredLine;
 import souther.compiler.check.MatchedEndAttribution;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.check.RuleReadingSource;
@@ -110,10 +111,10 @@ final class LocalInspection {
         return new DeclaredBounds.Bounds(
                 own.min() == null ? null
                         : new DeclaredBounds.End(Endpoint.lower(own.min().at(), left.min()),
-                                own.min().from()),
+                                own.min().found()),
                 own.max() == null ? null
                         : new DeclaredBounds.End(Endpoint.upper(own.max().at(), left.max()),
-                                own.max().from()),
+                                own.max().found()),
                 own.carrier());
     }
 
@@ -193,9 +194,9 @@ final class LocalInspection {
         // was settled where the clause was read and arrives as it was. What is added is a
         // boundary's own answer about that rule — that a reading of it drew this cut, taken in by
         // these declarations — which is nothing the rule says about itself.
-        for (DeclaredBounds.Drawn drawn : end.from()) {
+        for (DeclaredLine drawn : end.drawn()) {
             put(into, carrier, end.value(),
-                    new LineOrigin.InvariantOrigin(drawn.line(), side, end.at().inclusive()),
+                    new LineOrigin.InvariantOrigin(drawn, side, end.at().inclusive()),
                     end.at(), took);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1591,7 +1591,7 @@ public final class Partitions {
     private static List<FixtureTemplate> whereTheRulesLeaveTheValue(TypeView view,
                                                                     RuleReadingSource ruleSource,
                                                                     NumericDomain.Bounds within) {
-        DeclaredBounds.Bounds own = DeclaredBounds.of(view, ruleSource);
+        DeclaredBounds.Range own = DeclaredBounds.of(view, ruleSource);
         if (own == null) {
             return List.of();   // nothing here reads a number of this position at all
         }
@@ -2156,7 +2156,7 @@ public final class Partitions {
         if (!view.isWrapped()) {
             return List.of();
         }
-        DeclaredBounds.Bounds own = DeclaredBounds.of(view, ruleSource);
+        DeclaredBounds.Range own = DeclaredBounds.of(view, ruleSource);
         NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         // The far end has to be a value the position holds. Where the range stops short of it there
         // is nothing there to hold back, and a dense order has no value beside it to hold back

--- a/souther-compiler/src/main/java/souther/compiler/partition/WhichLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WhichLine.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.DeclaredLine;
 import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 
@@ -28,25 +29,33 @@ public sealed interface WhichLine {
      * A part of a declaration's clause, named by what issued it.
      *
      * <p>One part may draw more than one line — a rule an author named states as many rules as its
-     * body joins — so this says which part drew it and not which line of that part it is. Two lines
-     * of one part are told apart by what each says about its own value ({@link LineFacts}).
+     * body joins, and a denial carried to the leaves makes a conjunct state one comparison per leaf
+     * — so what says which line this is is the statement that drew it and not the conjunct alone.
+     * Read as the conjunct, the two ends of
+     * {@code Bool.not(String.length(name) < 1 || String.length(code) < 1)} are one line: they are on
+     * two numbers, and {@link LineFacts} says the same of both.
      *
      * <p>A part of a {@code data}'s clause, which is where this parts from {@link OfAComparisonOfAPart}.
      * The lines a declaration draws are looked up by the words that declaration wrote
      * ({@link souther.compiler.check.DeclaredBorders}), and a behavior's clause has no such reading —
      * so which kind of clause the part is of is in the type rather than asked of one that arrives.
      */
-    record OfAPart(PartId<RuleRef.Invariant> part) implements WhichLine {
+    record OfAPart(DeclaredLine drawnBy) implements WhichLine {
 
         public OfAPart {
-            if (part == null) {
+            if (drawnBy == null) {
                 throw new IllegalArgumentException("a line of a declaration is some part's");
             }
         }
 
+        /** Which conjunct of the clause drew it. */
+        public PartId<RuleRef.Invariant> part() {
+            return drawnBy.part();
+        }
+
         @Override
         public RuleRef rule() {
-            return part.rule();
+            return part().rule();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/WhichLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WhichLine.java
@@ -35,14 +35,15 @@ public sealed interface WhichLine {
      * {@code Bool.not(String.length(name) < 1 || String.length(code) < 1)} are one line: they are on
      * two numbers, and {@link LineFacts} says the same of both.
      *
-     * <p>A part of a {@code data}'s clause, which is where this parts from {@link OfAComparisonOfAPart}.
+     * <p>A line of a {@code data}'s clause, which is where this parts from
+     * {@link OfAComparisonOfAPart}.
      * The lines a declaration draws are looked up by the words that declaration wrote
      * ({@link souther.compiler.check.DeclaredBorders}), and a behavior's clause has no such reading —
      * so which kind of clause the part is of is in the type rather than asked of one that arrives.
      */
-    record OfAPart(DeclaredLine drawnBy) implements WhichLine {
+    record OfADeclarationsLine(DeclaredLine drawnBy) implements WhichLine {
 
-        public OfAPart {
+        public OfADeclarationsLine {
             if (drawnBy == null) {
                 throw new IllegalArgumentException("a line of a declaration is some part's");
             }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -3009,7 +3009,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                        AuthoredLine line) {
         ObjectNode which = into.putObject("which");
         switch (line.which()) {
-            case souther.compiler.partition.WhichLine.OfAPart it -> {
+            case souther.compiler.partition.WhichLine.OfADeclarationsLine it -> {
                 which.put("kind", "part");
                 ruleId(which.putObject("rule"), it.rule());
                 which.put("part", it.part().ordinal());

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -187,7 +187,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         };
     }
 
-    public static final int SCHEMA_VERSION = 17;
+    public static final int SCHEMA_VERSION = 18;
 
     /**
      * Where the schema this writes documents ships.
@@ -3015,6 +3015,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 which.put("kind", "part");
                 ruleId(which.putObject("rule"), it.rule());
                 which.put("part", it.part().ordinal());
+                // And which of that part's lines, which the part does not say. A conjunct states as
+                // many comparisons as a reading arrives at inside it, so a document naming the
+                // conjunct alone says the same of the two ends of
+                // `Bool.not(String.length(name) < 1 || String.length(code) < 1)` — one line where
+                // the author drew two. Written from what the line already is rather than counted
+                // here: a number this assigned would be a second answer to which line a line is.
+                declaredLine(which.putObject("line"), it.drawnBy());
             }
             case souther.compiler.partition.WhichLine.OfAComparisonOfAPart it -> {
                 which.put("kind", "statement_of_part");
@@ -3044,6 +3051,37 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         facts.put("singles", line.facts().singles());
         ArrayNode within = into.putArray("narrowedWithin");
         line.narrowedWithin().forEach(each -> typeId(within.addObject(), each));
+    }
+
+    /**
+     * Which line of a declaration's conjunct this is, as the reading that drew it named it.
+     *
+     * <p>Two shapes because a conjunct draws lines two ways, and a document that had one word for
+     * both would be saying which of them a reader is holding by leaving it out. A comparison inside
+     * the conjunct places its own end and the statement that read it names that line; what taking
+     * the conjunct away moves is the conjunct's line, paired with whichever of its statements are
+     * about the number so that the lines it draws on two numbers are two.
+     *
+     * <p>Translated and not counted. The statements are numbered where a conjunct is read for what
+     * it states, and a number assigned here would be a second answer to which line a line is —
+     * which is the mistake the conjunct alone already was.
+     */
+    private static void declaredLine(ObjectNode into,
+                                     souther.compiler.check.DeclaredLine line) {
+        switch (line) {
+            case souther.compiler.check.DeclaredLine.OfAStatement it -> {
+                into.put("kind", "statement");
+                into.put("statement", it.statement().ordinal());
+            }
+            case souther.compiler.check.DeclaredLine.OfAConjunct it -> {
+                into.put("kind", "conjunct");
+                ArrayNode paired = into.putArray("pairedWith");
+                it.pairedWith().stream()
+                        .map(souther.compiler.check.InvariantStatementId::ordinal)
+                        .sorted()
+                        .forEach(paired::add);
+            }
+        }
     }
 
     /** A level, as the thing it is a level of writes it: a place on a carrier, or a number. */

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-18.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-18.json
@@ -1,0 +1,3637 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://souther-lang.org/schema/adequacy-18.json",
+  "title": "Souther adequacy report",
+  "description": "How well a model's `example`s cover it. Emitted by `souther examples --format json`. A reader keys on `schemaVersion`: a change that removes or renames anything here raises it, and something added since does not — a key added since is optional, and a word added to an enumerated field is one no earlier document carried, so a document written before either existed is still a document of this version. That is one direction: every object here is closed, so an older copy of this schema refuses a document carrying a key added since. A reader that has to accept newer documents wants the newer schema, not a higher number.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "compilerVersion",
+    "status",
+    "adequacy",
+    "keptOpenBy",
+    "modules"
+  ],
+  "allOf": [
+    {
+      "description": "An open verdict names what it is open on, and a settled one is open on nothing. Written as a shape and not only as a sentence: the conformance corpus produced `undetermined` beside an empty array the day the field existed, and a description saying that cannot happen is a description a renderer can go on contradicting.",
+      "if": {
+        "properties": {
+          "adequacy": {
+            "const": "undetermined"
+          }
+        },
+        "required": [
+          "adequacy"
+        ]
+      },
+      "then": {
+        "properties": {
+          "keptOpenBy": {
+            "minItems": 1
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "keptOpenBy": {
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 18
+    },
+    "compilerVersion": {
+      "type": "string",
+      "description": "The compiler that produced the report, or `unreleased` when it ran from class files."
+    },
+    "weakening": {
+      "$ref": "#/$defs/weakening"
+    },
+    "status": {
+      "$ref": "#/$defs/status",
+      "description": "The weakest status among the modules. `partial` means something could not be read, so an absent number is not evidence of a gap."
+    },
+    "adequacy": {
+      "enum": [
+        "satisfied",
+        "not_satisfied",
+        "undetermined"
+      ],
+      "description": "Whether the rows meet what the asked measures require, which is not what `status` says. `undetermined` is a measure that was not asked for or could not be made; a build that gates on this refuses `not_satisfied` and nothing else."
+    },
+    "keptOpenBy": {
+      "type": "array",
+      "description": "The facts keeping `adequacy` undetermined, one entry each. Empty for a settled verdict, `satisfied` or `not_satisfied` alike: a build refused over a gap has an answer whatever else went unmeasured, so what is here is what holds the word open and never a list of everything that fell short. Not `weakening`, which is a different question at a different unit — that one is about one measure or one module, its unit is the published kind, and it says each kind once. This one is about the verdict and its unit is a fact, so two things this document calls by the same word are two entries, and the entries are not folded on what they are printed as. The one fold there is happens before: two measures that went without the same fact went without one fact.",
+      "items": {
+        "$ref": "#/$defs/adequacyOpening"
+      }
+    },
+    "modules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/module"
+      }
+    },
+    "sources": {
+      "type": "object",
+      "description": "What each source identity written elsewhere in this document is called, keyed on the identity. Every identity the document carries has an entry — a `source` subject, and the `sourceId` of every `at`. Not a list of what the compile was handed: a source this report says nothing about has no entry, so this says which files the report is about rather than which files were read. The names are the ones the same run's diagnostics use, which are chosen from the set of files in front of a reader and are neither stable across runs nor a key — which is why they are here and not in place of the identities. Not in `required`: a document written before this field existed is still a document of this version.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "ruleHandle": {
+      "type": "string",
+      "description": "How a reader finds a rule, written once here for every field that carries one. A rule the author named is found by that name: a clause of an invariant they called something is `invariant Amount (cap)`, one they named nothing is counted from the top of the declaration as `invariant Amount #2`, a clause of an `ensures` is `ensures charge (refunded)`, and a clause stating one rule over every answer is `ensures charge`. A rule they wrote rather than named has no name to look up and is found by where it is: `comparison@billing.sou:14:22` in a source this document's `sources` table names, and `comparison@7:3` where the file is the reader's to know. Code this compile reads from somewhere it holds no file for is said by what reaches it — `comparison in `Money`, reached at billing.sou:14:22`, or `comparison in `Money`, reached at 7:3`, or `comparison in `Money`` where there was no position to give. The word in front of a place says what kind of rule it is, and is one of the words `ruleId.kind` uses for a rule with no name: `predicate@billing.sou:14:22`, `predicate@7:3`, `predicate in `Money`, reached at billing.sou:14:22`, `predicate in `Money`, reached at 7:3`, `predicate in `Money``, and `fork@billing.sou:14:22`, `fork@7:3`, `fork in `Money`, reached at billing.sou:14:22`, `fork in `Money`, reached at 7:3`, `fork in `Money``. These words are how an author acts on a rule and never what tells one rule from another — two arms of one `ensures` clause may name the same case — which is `ruleId`.",
+      "examples": [
+        "invariant Amount (cap)",
+        "invariant Amount #2",
+        "ensures charge (refunded)",
+        "ensures charge",
+        "comparison@billing.sou:14:22",
+        "comparison@7:3",
+        "comparison in `Money`, reached at billing.sou:14:22",
+        "comparison in `Money`, reached at 7:3",
+        "comparison in `Money`",
+        "predicate@billing.sou:14:22",
+        "predicate@7:3",
+        "predicate in `Money`, reached at billing.sou:14:22",
+        "predicate in `Money`, reached at 7:3",
+        "predicate in `Money`",
+        "fork@billing.sou:14:22",
+        "fork@7:3",
+        "fork in `Money`, reached at billing.sou:14:22",
+        "fork in `Money`, reached at 7:3",
+        "fork in `Money`"
+      ]
+    },
+    "runSensitivity": {
+      "enum": [
+        "may_change",
+        "unaffected"
+      ],
+      "description": "Whether a wider run of this compiler could come to a different answer about one thing it fell short of. A wider run is the same sources, the same compiler build, the same dependencies and the same host, with one or more of the allowances this compiler stops under widened and none of them narrowed — an allowance being a figure it compared something against and stopped on: the steps a row is evaluated for, the depth a recursion may reach, the clock it is held to, the nodes an observation keeps, the combinations a measure walks, the states a pattern is built into. Whether a caller can set the figure today is not the question; several of them are constants, and which knobs exist is a fact about this month rather than about the stop. `may_change` does not promise that a wider run finishes the measure — a reading past one figure may be stopped by the next — it says the stop that produced this need not happen again. `unaffected` is the stronger of the two and the one to act on: no allowance widens it, so measuring the same model again with more allowed finds the same thing. Neither says anything about what a later version of this compiler could read, or about writing the model another way; both are outside what a run is. The host is not an allowance either: a stack that ran out and classes that would not link are met again by a wider run on the same machine, and a run on another machine is a different host rather than a wider run of this one."
+    },
+    "adequacyOpening": {
+      "type": "object",
+      "description": "One thing keeping the adequacy verdict undetermined, projected to what a document may say of it: the kind it is, and whether a wider run could answer it. Only one of the ways a verdict stays open is a measure going without something. A measure that could have found a gap and was never made weakens nothing, and neither does a point the rows are read out at where nothing could show a row can be written — whether one can be is a second question, settled from what showed it rather than from what the rows covered. So a list of what fell short says nothing at all about a model nobody has written rows for, or about a point nothing promised, while the verdict over each stays open. Every entry says what it is about: a document naming only the kind told a reader how many things held the verdict open and none of what they were.",
+      "required": [
+        "kind",
+        "about",
+        "runSensitivity"
+      ],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "not_measured"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "reason"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "reason"
+              ]
+            }
+          }
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/weakening/items"
+            },
+            {
+              "const": "not_measured",
+              "description": "A measure the verdict rests on was never made, so a gap it could have found is one nobody looked for. Nothing fell short here, which is why it is not one of the words above: those say what a measurement went without, and this says there was no measurement."
+            },
+            {
+              "const": "showing_stopped",
+              "description": "The rows are read out, no row is at a point the model owes one at, and what was read to show a row can be written there did not come back. The obligation stays: what did not arrive is a showing, not the model taking the point back."
+            },
+            {
+              "const": "nothing_was_composed",
+              "description": "The same point, where this compiler declined to compose a candidate for it at all — a figure of its own decided that, which is why this is its own word beside `showing_stopped` and why a wider run may get past it."
+            },
+            {
+              "const": "nothing_showed_it",
+              "description": "The same point again, where nothing was stopped and nothing arrived: no showing was made, so there is no limit to raise and nothing to name. Told apart from the two above because a reader sent after what stopped it would be looking for something nobody met."
+            }
+          ],
+          "description": "What kind of thing this is, in two vocabularies. A measure that went without something writes the word `weakening` already has for it, where one word covers more than one thing this compiler can meet — a pattern too large to build and a rule about a value made from another are both `rule_unread` — so this says which kind it was and not which of them. The four beside them are the ways a verdict stays open that no weakening covers. Two entries alike are two things rather than one said twice, whichever vocabulary they are in."
+        },
+        "reason": {
+          "$ref": "#/$defs/notMeasuredReason"
+        },
+        "runSensitivity": {
+          "$ref": "#/$defs/runSensitivity"
+        },
+        "about": {
+          "$ref": "#/$defs/subject"
+        }
+      }
+    },
+    "notMeasuredReason": {
+      "enum": [
+        "no_rows",
+        "not_asked",
+        "arms_not_asked"
+      ],
+      "description": "What a measure nobody made was waiting for, in the words this document already writes wherever a measure has no number. Written only beside `not_measured`, and one entry per measure rather than one per reason: two measures both waiting on rows are two measures nobody made, and a model with one behavior unmeasured is not the same news as a model with forty."
+    },
+    "weakening": {
+      "type": "array",
+      "minItems": 1,
+      "description": "What left this measurement weaker than its numbers look, one word per fact. Present exactly where something did, and absent where nothing did. This is what makes four status words carry five states: `unavailable` with a `reason` of `not measured` and no `weakening` is a measurement nobody asked for, and the same with a `weakening` is one that was asked for, started, and could not be finished. Beside a `partial` it says which reading fell short, which a reader used to have to find somewhere else on the page or not at all.",
+      "items": {
+        "enum": [
+          "value_unreadable",
+          "value_truncated",
+          "row_undecided",
+          "row_evaluation_limit_reached",
+          "answerer_not_established",
+          "linkage_failed",
+          "observation_absent",
+          "instrumentation_absent",
+          "probe_mapping_lost",
+          "output_cases_unreadable",
+          "input_cases_unreadable",
+          "row_did_not_finish",
+          "border_value_unreadable",
+          "border_value_absent",
+          "border_observation_unavailable",
+          "rule_unread",
+          "position_not_read",
+          "question_unanswered",
+          "rules_not_reached",
+          "bodies_not_elaborated",
+          "behavior_boundary_not_derived",
+          "behavior_input_not_read",
+          "pair_space_truncated",
+          "proof_contradicted",
+          "arms_unsettled"
+        ]
+      }
+    },
+    "ruleStoppedReadingReason": {
+      "description": "A rule this compiler read and could not use, which is what both surfaces below share. Such a rule is at a position — so a position's reading is short of it — and it is a shortfall about the rule, so a question the rule raised stands on it. Written once because the two surfaces really do share it, and not because their vocabularies happen to look alike. `exact_values_too_costly` is what a reader is told where working the values out was more than this compiler does. It is one published word over two facts this compiler tells apart: one rule names a set of strings whose machine it will not make, which is about that rule; or every rule was made into the set it names and what those come to between them was not, which is about the answer and names no rule. Sharing a word is not sharing a capability — what a document may say about the second is not what it may say about the first — so a reader is told what stopped and never which rule to go and change, and which of the two it was stays this compiler's question. `pattern_too_deeply_nested` is a rule written more deeply nested than the reading goes, which reached no values at all — its own word because every construct in such a rule is one this reads, so an author sent after a form or after the size of an answer would be looking for neither. `unread_alternative_of_a_choice` is a rule offering an alternative this compiler does not read, where what the rule leaves at the position is what its alternatives leave together — its own word beside `unsupported_syntax` because the rule written at the position was read and places what it places, so an author told that one would rewrite a clause that is not the difficulty and the branch beside it would stand as unread as it was.",
+      "enum": [
+        "unsupported_syntax",
+        "unsupported_domain",
+        "unsupported_partition_shape",
+        "unresolved_case_pairing",
+        "rule_about_a_derived_value",
+        "rule_about_an_element_of_several_sequences",
+        "unread_alternative_of_a_choice",
+        "exact_values_too_costly",
+        "pattern_too_deeply_nested"
+      ]
+    },
+    "answerRealizationStoppedReason": {
+      "description": "What the answer at a position was short of, which is a fact about what the rules of that position come to between them and about none of them: the same rules met in another order would have been built. Its own vocabulary because it names no rule, so nothing written in one of these sends a reader to a clause. It is one word with something a document could name a rule for — `exact_values_too_costly` is written here and in `ruleStoppedReadingReason`, where it is a rule naming a set of strings whose machine this will not make — and the two stay apart because the fields do: a question carries one of each where it is short in both ways, and which field a word is in says which of the two facts it is about. `behavior_distinctions_too_costly` is the other half of the same kind and stays apart from `exact_values_too_costly` because the two bound different questions: that one is what the position admits coming out wider than its declarations leave it, and this one is what a behavior's own rules about the position tell apart, so a position answered to the letter by its declaration still carries it. Schema 12 had `questionStoppedReason`, one vocabulary over both facts, and with it `rule_not_interpreted_here`; a document of that version may carry that word, nothing writes it now, and the state it was written for is an answer that was not built.",
+      "enum": [
+        "exact_values_too_costly",
+        "behavior_distinctions_too_costly"
+      ]
+    },
+    "notReadReason": {
+      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a position whose rules the reading never arrived at — no rule is named because none was seen — with which limit stopped the walk neither recorded nor promised;  `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping after a count of steps, which nothing writes any more; `returns_to_a_declaration_already_read` is the input returning at this position to a declaration the path had already opened, so what is under it is what is under that one and was not read again; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into; `rule_about_a_derived_value` is a rule read and placed, written about a value an operation made from what stands at the position — where the values came from is known and what the rule says about the values here is not; `rule_about_an_element_of_several_sequences` is a rule read and placed, written inside a block handed to more than one walk, so the name it reads an element under holds an element of a different sequence on each run and which of them the rule is about is not worked out — every position it may be about is told this one, including where some of those runs walk something the input has no part in, and unlike `rule_about_a_derived_value` nothing was made out of the element and there is no operation to read the rule back through; `rule_cuts_nothing` is a rule read from end to end whose quantity the position does not appear in, so there was no line in it to draw; `rule_cuts_outside_what_the_quantity_holds` is a rule read from end to end whose line falls where the quantity it cuts never runs — a length compared against a negative — so there is no value either side of it and no class the position is divided into; `nothing_arrives_at_the_rules_line` is a rule read from end to end whose line the declarations do leave values at, while no row that arrives at the comparison holds one of them — the conditions on the way there rule them out, a guard shadowed by a stricter guard above it — so the classes the line would make hold nothing that gets there; `rule_about_a_run` is a rule read from end to end whose line is drawn on a number taken over the values at this position rather than on any one of them — two of them either side of a total are on the line as surely as one is — so it divides the position into no classes while its border stands. `unresolved_case_pairing` is a rule read from end to end that draws a line, where each of the names it is between stands at more than one position — a field every case of a sum spreads is written once and a row writes it under one case — and which of those positions the line runs between is not worked out. `position_restricted_to_what_a_rule_admits` is a rule read from end to end that holds the position to the values it admits and places no end on them — a format states which strings stand there — where everything outside them is refused at construction, so there is no class away from them for a row to be owed at; what a reader acts on is that the value written here is one the rule admits, and whether the position is also divided is said by the classes rather than here. `rule_tells_nothing_apart` is a rule read from end to end, written about this position, that puts every value the position holds on one side of itself — a predicate over the strings here that no value satisfies, or that every value satisfies — so the model draws no line between any two of them and there is no second class for a row to be owed at; unlike `rule_cuts_nothing` the rule is about this position, and unlike `position_restricted_to_what_a_rule_admits` it leaves the values where it found them. `classes_not_composed` is every rule about this position having been read, with what they say not all sayable as one list of classes: a rule puts a line on the order the values are counted on or tells a set of them from the rest, and a class written in one of those cannot be written in the other, so a position both kinds reach has no single denominator here — unlike the two costly words nothing fell short, and a run allowed more meets it again; what the rules cut and where they part the position are unaffected and are reported as before. `behavior_distinctions_too_costly` is a behavior's rules about this position having been read, with working out what they tell apart costing more than this compiler does — its own word beside `exact_values_too_costly`, which is what the position admits coming out wider than its declarations leave it, because a position answered to the letter by its declaration still carries this one and an author told the other would go and simplify a declaration that was never the matter; the rules of a position are worked out as one group so that which of them a reader hears about does not follow the order they were walked in, and no rule of the group is named as the expensive one. `rule_cuts_nothing`, `rule_cuts_outside_what_the_quantity_holds`, `nothing_arrives_at_the_rules_line`, `position_restricted_to_what_a_rule_admits`, `rule_tells_nothing_apart` and `unsupported_partition_shape` are facts about the model or about what this measure represents, and nothing is owed on their account; the rest are facts about the compiler.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ruleStoppedReadingReason"
+        },
+        {
+          "enum": [
+            "rules_not_read_at_all",
+            "depth_limit",
+            "type_unresolved",
+            "unsupported_traversal",
+            "rule_cuts_nothing",
+            "rule_cuts_outside_what_the_quantity_holds",
+            "nothing_arrives_at_the_rules_line",
+            "rule_about_a_run",
+            "position_restricted_to_what_a_rule_admits",
+            "rule_tells_nothing_apart",
+            "classes_not_composed",
+            "behavior_distinctions_too_costly",
+            "returns_to_a_declaration_already_read"
+          ]
+        }
+      ]
+    },
+    "location": {
+      "type": "object",
+      "description": "Where on the quantity's order a point of a border is, which is what identifies it within its line. `at_the_line` is the value the rule wrote, which every line has one of. `beside_the_line` is the nearest value on one side of it, where the values there fall in another class than that value does — one side for a rule that orders the values, and both sides for one that names a value. `in_the_region` is a row away from the line, in the run on one side of it. Which of the four points each of these is follows from the place and from whether the rule holds there, and is published beside this rather than in it: a border can have two points in one role, and the role tells those two apart nowhere.",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "at_the_line",
+            "beside_the_line",
+            "in_the_region"
+          ]
+        },
+        "side": {
+          "enum": [
+            "below",
+            "above"
+          ],
+          "description": "Which way from the line, on the order the quantity's own values sit on and never on the way the rule was written. Present for every place but the value the rule wrote, which is on the line and so on neither side of it."
+        }
+      },
+      "allOf": [
+        {
+          "description": "Every place but the line's own value is on a side of it.",
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "at_the_line"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "side"
+              ]
+            }
+          },
+          "else": {
+            "required": [
+              "side"
+            ]
+          }
+        }
+      ]
+    },
+    "level": {
+      "type": "object",
+      "description": "A level of whatever a line was drawn on, in the words of what it is a level of and never of where it was read. `on_a_carrier` is a place of the carrier a coordinate is ordered by, written the way that carrier writes one. `a_count` is a number the quantity itself counts to — how far two positions stand apart, or what an arithmetic form comes to — which is on no carrier. A quantity writes a level in the terms of where it was met, and a value owed once wherever it is read cannot take its words from one of them.",
+      "required": [
+        "kind",
+        "at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "on_a_carrier",
+            "a_count"
+          ]
+        },
+        "carrier": {
+          "$ref": "#/$defs/carrier",
+          "description": "Present exactly where `kind` is `on_a_carrier`."
+        },
+        "at": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "description": "A level of a coordinate is on the order that coordinate is counted on; a number the quantity itself counts to is on none.",
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "on_a_carrier"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "carrier"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "carrier"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "typeId": {
+      "type": "object",
+      "description": "Which declaration a type is. The module and the name, because that pair is what a type's identity is: two modules may each declare a `Status` and they are two types. Not one word — a module name has dots in it, so a joined spelling cannot be taken apart again. A type the language declares has no module: it is one of a closed set the language fixes, and its name is its identity.",
+      "required": [
+        "kind",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "declared",
+            "primitive",
+            "language_case"
+          ]
+        },
+        "module": {
+          "type": "string",
+          "description": "Present exactly where `kind` is `declared`."
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "description": "Only a declaration of a module has one to name.",
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "declared"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "module"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "module"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "carrier": {
+      "type": "object",
+      "description": "Which order a level is counted on, said in this document's own words rather than in whatever a compiler calls one to itself. `ordinal` carries the enumeration and the cases it declares, because two enumerations are two orders however alike their cases count and where a case comes in the declaration is what the order is.",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "whole",
+            "dense",
+            "days",
+            "seconds",
+            "seconds_of_day",
+            "nanos",
+            "text",
+            "ordinal"
+          ]
+        },
+        "enumeration": {
+          "$ref": "#/$defs/typeId"
+        },
+        "cases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/typeId"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "description": "The enumeration and its cases are written exactly for an order a `data` of cases gives.",
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "ordinal"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "enumeration",
+              "cases"
+            ]
+          },
+          "else": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "enumeration"
+                  ]
+                },
+                {
+                  "required": [
+                    "cases"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "authoredLineId": {
+      "type": "object",
+      "description": "One line of the model: which rule drew it, and which of that rule's lines it is. Which line is `which`, and it carries the rule together with whatever names a line of that kind of rule, because the kinds are not decomposed alike. Two lines of one rule at one place are told apart by what each says about its own value — `value >= 5 && value <= 5` puts a minimum and a maximum at five and they are two lines — which is `facts`. `narrowedWithin` is the declarations that took an end in: a bound another type narrowed is not the bound it narrows.",
+      "required": [
+        "which",
+        "facts",
+        "narrowedWithin"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "which": {
+          "$ref": "#/$defs/whichLine"
+        },
+        "facts": {
+          "type": "object",
+          "description": "What the rule placed on the values either side of what it wrote. A rule that orders them says which side its own value belongs to; one that names a value orders nothing either side of it and says no side at all, which is why `valueBelongsBelow` is written exactly where `singles` is false.",
+          "required": [
+            "holdsAtTheValue",
+            "singles"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "valueBelongsBelow": {
+              "type": "boolean"
+            },
+            "holdsAtTheValue": {
+              "type": "boolean"
+            },
+            "singles": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": [
+                  "singles"
+                ],
+                "properties": {
+                  "singles": {
+                    "const": false
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "valueBelongsBelow"
+                ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "valueBelongsBelow"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "narrowedWithin": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/$defs/typeId"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "declared"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            ]
+          },
+          "description": "The declarations that took an end in, each by its identity and in their own order — a set, so which reading was met first does not move them. Always a declaration of a module: a type the language fixes narrows nothing."
+        }
+      }
+    },
+    "obligationId": {
+      "type": "object",
+      "description": "What tells one thing a row is owed for from every other, which is not what a reader is shown. A key within this document: a `partition.obligations` entry carries it and so does every finding about one, and a consumer joins them on it. Which of the four points it is is not in here — a rule that names a value owes a row outside it on each side, so two of these can be the same `role` and the role tells them apart nowhere. What does is where the point is (`location`) and, for a run, where it stops (`stops`): a guard on a name two cases spread, whose cases stop the run in different places, owes two runs of one rule at one level on one side.",
+      "required": [
+        "line",
+        "level",
+        "location"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "$ref": "#/$defs/authoredLineId"
+        },
+        "level": {
+          "$ref": "#/$defs/level"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "stops": {
+          "type": "object",
+          "description": "What settled where the run stops. `at_a_line` is a rule that put a line there, named by the line and the place it parts the values. `at_the_domain` is what every rule about the position leaves together, which is a place and no one rule. `at_the_order_end` is nothing stopping it, so the run goes as far as the order does.",
+          "required": [
+            "kind"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "enum": [
+                "at_a_line",
+                "at_the_domain",
+                "at_the_order_end"
+              ]
+            },
+            "line": {
+              "$ref": "#/$defs/authoredLineId"
+            },
+            "where": {
+              "type": "string"
+            },
+            "at": {
+              "$ref": "#/$defs/level"
+            },
+            "per": {
+              "type": "string"
+            },
+            "inclusive": {
+              "type": "boolean"
+            },
+            "towards": {
+              "enum": [
+                "above",
+                "below"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "description": "A line that stopped the run is named by the line and the place it parts the values.",
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "at_a_line"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": {
+                "required": [
+                  "line",
+                  "where"
+                ]
+              },
+              "else": {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "line"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "where"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "description": "An end the rules leave together is a place and how much of the quantity it is a place of.",
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "at_the_domain"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": {
+                "required": [
+                  "at",
+                  "per",
+                  "inclusive"
+                ]
+              },
+              "else": {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "at"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "per"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "inclusive"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "description": "An end nothing stopped is which way the run goes.",
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "at_the_order_end"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": {
+                "required": [
+                  "towards"
+                ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "towards"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "description": "A point away from the line asks for a row in the run beside it, and where that run stops is part of what the point is. A point at a value of the quantity has no run.",
+          "if": {
+            "properties": {
+              "location": {
+                "properties": {
+                  "kind": {
+                    "const": "in_the_region"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "location"
+            ]
+          },
+          "then": {
+            "required": [
+              "stops"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "stops"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "obligations": {
+      "type": "array",
+      "description": "What a set of obligations comes to: one entry per thing a row is owed for, once each however many positions read the line, with every reading of it. A behavior's account and the declarations' are two projections of one relation and are written in this one shape, so a consumer joins a finding to either by `obligationId`.",
+      "items": {
+        "type": "object",
+        "required": [
+          "obligationId",
+          "point",
+          "rule",
+          "ruleId",
+          "relation",
+          "knownWritable",
+          "status",
+          "readings"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "obligationId": {
+            "$ref": "#/$defs/obligationId"
+          },
+          "point": {
+            "enum": [
+              "on",
+              "off",
+              "in",
+              "out"
+            ]
+          },
+          "rule": {
+            "$ref": "#/$defs/ruleHandle",
+            "description": "The rule that drew the line this point is owed for. The handle and nothing else, where the `boundaries` entry for the same line writes the declarations that took its ends in beside it."
+          },
+          "ruleId": {
+            "$ref": "#/$defs/ruleId"
+          },
+          "relation": {
+            "type": "string",
+            "description": "How a row's value relates to what it is against, the word `boundaries[].items[].relation` uses."
+          },
+          "knownWritable": {
+            "type": "boolean"
+          },
+          "writableBecause": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "the_rules_prove_it",
+                "a_row_is_at_it",
+                "a_value_was_built"
+              ]
+            }
+          },
+          "disposition": {
+            "description": "What became of this obligation, which the evidence beside it is why. All three are in the count: whether a row is owed at a point is the model's answer, and nothing this compiler failed to read, compose or represent changes it. `unmet` says the absence is established, so it is a finding; whether the bar the build asked for refuses over that finding is a separate question and is answered under `findings[].disposition`. `undecided` says nobody could decide it and names the open questions under `undecidedAbout`. Every document this compiler writes carries this. Not in `required`: a document written before this field existed is still a document of this version.",
+            "enum": [
+              "met",
+              "unmet",
+              "undecided"
+            ]
+          },
+          "undecidedAbout": {
+            "description": "Every question about this obligation that nothing answered, written where `disposition` is `undecided` and never elsewhere. Both can hold of one obligation, and they are lifted by different work: the first by rows being read, the second by this compiler being able to compose, keep or represent more than it does.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "whether_a_row_is_at_it",
+                "whether_a_row_can_be_written"
+              ]
+            }
+          },
+          "status": {
+            "$ref": "#/$defs/status"
+          },
+          "reason": {
+            "enum": [
+              "not_asked",
+              "arms_not_asked",
+              "arms_unreadable",
+              "no_rows",
+              "no_arm_witnesses_it"
+            ]
+          },
+          "weakening": {
+            "$ref": "#/$defs/weakening"
+          },
+          "hit": {
+            "type": "boolean",
+            "description": "Whether some row stands at the point, under any reading of it. Present exactly where `status` is not `unavailable`."
+          },
+          "readings": {
+            "type": "array",
+            "description": "Every position that read the line, as an unordered bag. Two entries that print alike are two readings.",
+            "items": {
+              "type": "object",
+              "required": [
+                "behavior",
+                "axis",
+                "relation",
+                "against",
+                "status"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "behavior": {
+                  "type": "string"
+                },
+                "axis": {
+                  "type": "string",
+                  "description": "The position this reading met the line at, as `boundaries[].axis` names it."
+                },
+                "relation": {
+                  "type": "string"
+                },
+                "against": {
+                  "type": "string",
+                  "description": "What a row at this reading has to do, in this position's terms — `boundaries[].items[].against` for the same border and point."
+                },
+                "status": {
+                  "$ref": "#/$defs/status"
+                },
+                "reason": {
+                  "enum": [
+                    "not_asked",
+                    "arms_not_asked",
+                    "arms_unreadable",
+                    "no_rows",
+                    "no_arm_witnesses_it"
+                  ]
+                },
+                "weakening": {
+                  "$ref": "#/$defs/weakening"
+                },
+                "hit": {
+                  "type": "boolean",
+                  "description": "Whether some row stands at the point as read here."
+                }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "status": {
+                            "const": "complete"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "status": {
+                            "const": "partial"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ]
+                      }
+                    ]
+                  },
+                  "then": {
+                    "required": [
+                      "hit"
+                    ]
+                  },
+                  "else": {
+                    "not": {
+                      "required": [
+                        "hit"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "status": {
+                        "const": "unavailable"
+                      }
+                    },
+                    "required": [
+                      "status"
+                    ]
+                  },
+                  "then": {
+                    "required": [
+                      "reason"
+                    ]
+                  },
+                  "else": {
+                    "not": {
+                      "required": [
+                        "reason"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "One position that read the line, and what a row there has to do in that position's terms. A bag and not a set: two readings that print alike are two readings — what tells them apart is where the line was met, which this document does not carry — so a consumer may count these but may not deduplicate them. The order is not a contract."
+            },
+            "minItems": 1
+          },
+          "axis": {
+            "type": "string",
+            "description": "What the line is on, in the words the declaration wrote — `String.length(value)`. Present exactly where the obligation is one a declaration owns: a line a body's rule drew has no such word, since each reading names the position it met the line at and none can stand for the rest."
+          },
+          "against": {
+            "type": "string",
+            "description": "What a row here has to do, on `axis`. Present exactly with it."
+          }
+        },
+        "allOf": [
+          {
+            "description": "What the line is on and what a row has to do on it are the author's words, and only a line a declaration drew has them.",
+            "if": {
+              "required": [
+                "axis"
+              ]
+            },
+            "then": {
+              "required": [
+                "against"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "against"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Whether some row stands at the point is written exactly where the measurement has a value.",
+            "if": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "status": {
+                      "const": "complete"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                },
+                {
+                  "properties": {
+                    "status": {
+                      "const": "partial"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              ]
+            },
+            "then": {
+              "required": [
+                "hit"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "hit"
+                ]
+              }
+            }
+          },
+          {
+            "description": "Why there is no answer is written exactly where there is none.",
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "unavailable"
+                }
+              },
+              "required": [
+                "status"
+              ]
+            },
+            "then": {
+              "required": [
+                "reason"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          },
+          {
+            "description": "A ground is named exactly where one was established.",
+            "if": {
+              "required": [
+                "knownWritable",
+                "writableBecause"
+              ],
+              "properties": {
+                "knownWritable": {
+                  "const": true
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "writableBecause": {
+                  "minItems": 1
+                }
+              }
+            }
+          },
+          {
+            "description": "And none where none was.",
+            "if": {
+              "required": [
+                "knownWritable",
+                "writableBecause"
+              ],
+              "properties": {
+                "knownWritable": {
+                  "const": false
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "writableBecause": {
+                  "maxItems": 0
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "declaredLine": {
+      "type": "object",
+      "description": "Which line of one conjunct of a declaration's clause a line is. Two shapes, because a conjunct draws lines two ways and neither is the other: a comparison inside it places an end of its own, and the conjunct can leave the values somewhere none of its comparisons places — which is found by asking what the rules leave without that conjunct, and is the conjunct's line rather than any statement's. The numbers here count the statements of the one conjunct named beside this, so they mean nothing away from it.",
+      "required": [
+        "kind"
+      ],
+      "oneOf": [
+        {
+          "description": "The line one statement of the conjunct placed. `statement` is which of that conjunct's statements it is, counted from zero over everything the conjunct states rather than over the comparisons among them — a choice states neither of its sides and holds its place.",
+          "properties": {
+            "kind": {
+              "const": "statement"
+            },
+            "statement": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "statement"
+          ]
+        },
+        {
+          "description": "The line the conjunct draws, which no statement of it places. `pairedWith` is which of the conjunct's statements are about the number this line is on, and it is what tells this line from the line the same conjunct draws on another number. None of them drew it: what was taken away is the conjunct, and it takes away everything the conjunct states — so a document naming one of them would be saying that statement placed an end which another statement of the same conjunct is why.",
+          "properties": {
+            "kind": {
+              "const": "conjunct"
+            },
+            "pairedWith": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "pairedWith"
+          ]
+        }
+      ]
+    },
+    "whichLine": {
+      "type": "object",
+      "description": "Which of a rule's lines a line is, said by what named it. The three kinds of rule are not decomposed alike, and no two of their numbers mean the same thing: a declaration's clause is written in the parts its author joined and each of those draws lines of its own, so a line of one is named by the part and by which of that part's lines it is; a part of a behavior's clause states as many things as a reading of it finds, so a line of one is named by the part and by which of that part's statements it is; a comparison written in a body is a rule apiece with nothing under it, so a line of one is named by the rule alone. Written as one number, a consumer was handed a count without being told which of the three made it. The rule stands inside this rather than beside it so that only the pairs this compiler can build are documents: there is no shape here that gives a body's comparison a part, or a declaration's clause a statement of a behavior's.",
+      "required": [
+        "kind",
+        "rule"
+      ],
+      "oneOf": [
+        {
+          "description": "A line of a declaration's clause. `part` is where the conjunct it came out of stands among the parts of that clause, counted from zero, and it means something only beside the rule — two clauses each have a part numbered nought. One part draws more than one line, so `line` says which of them this is: a denial is carried to the leaves as a clause is read, so a conjunct written as a denied choice states one comparison per branch and places an end on each of the numbers they are about. Named by the part alone, those are one line — and the facts beside them do not tell them apart, since two lower bounds admitting their own value say the same thing about two numbers.",
+          "properties": {
+            "kind": {
+              "const": "part"
+            },
+            "rule": {
+              "$ref": "#/$defs/ruleId",
+              "properties": {
+                "kind": {
+                  "const": "invariant"
+                }
+              }
+            },
+            "part": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "line": {
+              "$ref": "#/$defs/declaredLine"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "part",
+            "line"
+          ]
+        },
+        {
+          "description": "One statement of one part of a behavior's clause. Both are written because they are counted in different things: the parts are counted over the clause and the statements over one part, so the second statement of the second part is the fourth of nothing. `statement` counts everything the part states and not the comparisons among them — a choice states neither of its sides and holds its place — so a consumer that counted the comparisons it could see would land elsewhere.",
+          "properties": {
+            "kind": {
+              "const": "statement_of_part"
+            },
+            "rule": {
+              "$ref": "#/$defs/ruleId",
+              "properties": {
+                "kind": {
+                  "const": "ensures"
+                }
+              }
+            },
+            "part": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "statement": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "part",
+            "statement"
+          ]
+        },
+        {
+          "description": "A comparison written in a body, which is a rule apiece: a condition holding three of them is three rules, each with a line of its own, so there is no second line of this one to be told from and no number under the rule to say which. Two lines of it at one value are told apart by `facts`, the way two lines of one part are.",
+          "properties": {
+            "kind": {
+              "const": "comparison"
+            },
+            "rule": {
+              "$ref": "#/$defs/ruleId",
+              "properties": {
+                "kind": {
+                  "const": "comparison"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ruleId": {
+      "type": "object",
+      "description": "What tells one rule of the model from every other, which is not what a reader is shown. The coordinates differ by kind because rules are told apart by different things, and every part of an identity is written: a declaration is its module and its name — two modules may each declare an `Amount`, and they are two types — and a comparison is the construct a definition wrote, numbered from zero within that definition, so which definition is part of which construct. A document written before the numbering was counted within a definition carries no `definition` and numbers over the whole source instead, which is what its absence says. A predicate carries one where a definition's body wrote it and says so in `writtenIn`, since a behavior writes such a rule in its body and in its own clauses alike; the remaining kinds never carry one. Each kind names the coordinates it carries and takes no others, which is why none of them lists what it may not have: a coordinate a later version adds for one kind is refused by the rest for not having been named there, rather than by somebody remembering to forbid it in each. A key within this document rather than a name; a consumer groups by it and shows `rule`. It names the rule and not the question — one rule raises more than one, and `question` and `subject` beside it are what tell those apart.",
+      "required": [
+        "kind",
+        "declaredIn"
+      ],
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "invariant"
+            },
+            "declaredIn": true,
+            "declaredOn": true,
+            "clause": true
+          },
+          "additionalProperties": false,
+          "required": [
+            "declaredOn",
+            "clause"
+          ]
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "ensures"
+            },
+            "declaredIn": true,
+            "behavior": true,
+            "clause": true,
+            "arm": true
+          },
+          "additionalProperties": false,
+          "required": [
+            "behavior",
+            "clause",
+            "arm"
+          ]
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "comparison"
+            },
+            "declaredIn": true,
+            "definition": true,
+            "behavior": true,
+            "ordinal": true,
+            "lowered": true
+          },
+          "additionalProperties": false,
+          "required": [
+            "behavior",
+            "ordinal",
+            "lowered"
+          ]
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "fork"
+            },
+            "declaredIn": true,
+            "definition": true,
+            "behavior": true,
+            "ordinal": true,
+            "lowered": true
+          },
+          "additionalProperties": false,
+          "required": [
+            "behavior",
+            "ordinal",
+            "lowered"
+          ]
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "predicate"
+            },
+            "declaredIn": true,
+            "definition": true,
+            "writtenIn": true,
+            "behavior": true,
+            "ordinal": true,
+            "lowered": true
+          },
+          "additionalProperties": false,
+          "required": [
+            "behavior",
+            "writtenIn",
+            "ordinal",
+            "lowered"
+          ],
+          "if": {
+            "properties": {
+              "writtenIn": {
+                "const": "body"
+              }
+            },
+            "required": [
+              "writtenIn"
+            ]
+          },
+          "then": {
+            "required": [
+              "definition"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "definition"
+              ]
+            }
+          }
+        }
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "invariant",
+            "ensures",
+            "comparison",
+            "fork",
+            "predicate"
+          ],
+          "description": "Which kind of rule of the model this is, and so which coordinates below are written. A `predicate` is a rule a body writes as one of the language's own operations over the values at a position — `String.startsWith(\"JP\", code)` — which tells a set of them from the rest and draws no line; a behavior states one in its body and in its own `ensures` alike, and it is identified by the application the author wrote together with what wrote it, which `writtenIn` says. A rule of a body is a comparison and not the construct it is written in: it may stand in the condition of an `if` or a `guard`, be given a name above the fork that tests it, or be what the behavior answers with, and it is one rule in all of those. Documents of version 3 wrote `guard` here, from the days when a rule was found by finding a fork. A `fork` is the other way round and is not that word come back: it is a fork whose condition states none of the kinds above, so what the model divides on there is something this compiler did not read, and the fork itself is what a question about it is filed under."
+        },
+        "declaredIn": {
+          "type": "string",
+          "description": "The module the rule is written in. Part of every identity here: names are unique within a module and not across them, and a construct's number starts again in each definition."
+        },
+        "declaredOn": {
+          "type": "string",
+          "description": "The declaration an invariant's clause is written on."
+        },
+        "behavior": {
+          "type": "string",
+          "description": "The behavior an `ensures` clause reads, or the one whose answer a body's comparison or predicate is read for. For a comparison this is not where it is written: a helper's comparison is read by every behavior that calls it, and `definition` says which definition wrote it. The same holds for a predicate `writtenIn` says a body wrote; for one its own clauses wrote, this is the behavior that wrote it as well, which is why the name is written once."
+        },
+        "definition": {
+          "type": "string",
+          "description": "The definition whose source wrote the construct, present in a document whose `ordinal` is counted within one. For a comparison, a document written before construct numbering became a count within a definition has none, and its `ordinal` is a count over the whole source instead — so which of the two a number means is read from whether this is here. For a predicate, what counted the ordinal is said by `writtenIn`, and this is written exactly where that is `body`."
+        },
+        "writtenIn": {
+          "enum": [
+            "body",
+            "stated"
+          ],
+          "description": "What wrote the application a predicate is, which is what its `ordinal` was counted within. A behavior states such a rule in a definition's body and in its own `ensures`, the constructs of the two are numbered apart, and both start at zero — so without this the first of each is one identity. `body` writes `definition` beside it; `stated` is the behavior's own statement of itself, which `behavior` already names."
+        },
+        "clause": {
+          "type": "integer",
+          "description": "Where the clause sits among the ones written beside it, counted from zero."
+        },
+        "arm": {
+          "type": "integer",
+          "description": "Where the rule sits among the arms of its `ensures` clause, counted from zero. Two arms may name one case and are two rules."
+        },
+        "ordinal": {
+          "type": "integer",
+          "description": "The construct the rule was written as, counted from zero among the constructs written by whatever counted it. For a comparison that is `definition`, and where `definition` is absent the document is an earlier one and this counts the constructs of the whole source. For a predicate it is what `writtenIn` names: the definition `definition` names, or the behavior's own statement of itself, whose name is `behavior`."
+        },
+        "lowered": {
+          "type": "integer",
+          "description": "Which of the comparisons one written construct lowered to this is, for a construct that lowers to more than one."
+        }
+      }
+    },
+    "coverageQuestion": {
+      "description": "What a rule of the model leaves that something has to answer. `admitted_values` is which values may stand at a position, and `boundary` is a border rows are owed at. The other two are rules this compiler did not read far enough to classify, and they are not one word because they are not one state: `boundaryNotDetermined` is a rule read far enough to say it restricts the values where it was filed and not far enough to say whether it also puts an end there — the classes are settled and only the border measure waits on it — while `notDetermined` is a rule nothing worked out at all, which holds both measures. Neither names a subject, since working one out is part of what did not happen, and the `stopped` beside either says what would have to be read further. Those four are what this compiler issues, and a word arrives here in the same change that starts raising it. `singleton` and `partition` are retired: a comparison this compiler reads owes the row at the value it singles out and the rows in the classes its line makes, and it owes them by having been read — so they are carried as the partition's own geometry rather than as questions standing against an answer. They are kept because reports of this version carried them, and a reader of an older document still meets them.",
+      "enum": [
+        "admitted_values",
+        "boundary",
+        "boundaryNotDetermined",
+        "notDetermined",
+        "singleton",
+        "partition"
+      ]
+    },
+    "status": {
+      "description": "Whether a measure has a number. `unavailable` says only that it has none; the `reason` beside it says why, and the two are not read off one another.",
+      "enum": [
+        "complete",
+        "partial",
+        "unavailable"
+      ]
+    },
+    "module": {
+      "type": "object",
+      "required": [
+        "module",
+        "status",
+        "incompleteness",
+        "behaviors"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "module": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "weakening": {
+          "$ref": "#/$defs/weakening"
+        },
+        "incompleteness": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/incompleteness"
+          }
+        },
+        "behaviors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/behavior"
+          }
+        },
+        "declarations": {
+          "type": "array",
+          "description": "What each of the module's own declarations is owed and is short of. A line an `invariant` drew is a fact about the type wherever the type is carried, so it is owed once and is not any behavior's: published under one of them it would be published under whichever a walk reached first. Grouped by who owes it, since a line two declarations took an end in together is owed to both. Not in `required`: a document written before this array existed is still a document of this version.",
+          "items": {
+            "type": "object",
+            "required": [
+              "owners",
+              "name",
+              "obligations",
+              "findings"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "What a report calls the owners above. A rendering and never a key: two sets of declarations a report writes alike are two sets."
+              },
+              "obligations": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/obligations"
+                  },
+                  {
+                    "items": {
+                      "required": [
+                        "axis",
+                        "against"
+                      ]
+                    }
+                  }
+                ],
+                "description": "What these declarations' lines are owed, once each however many positions carry the type — the declarations' side of the same relation a behavior's `partition.obligations` is the body's side of, and where a finding of kind `boundary_unmet` or `domain_point_uncovered` about one of them joins. Every one of them and not only what the module is short of: a line a row already stands at raises no finding, so a section written from the findings alone could not tell a module whose declarations owe nothing from one whose every line is answered. Each carries `axis`, the words the declaration wrote for what its line is on."
+              },
+              "findings": {
+                "$ref": "#/$defs/findings"
+              },
+              "owners": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/typeId"
+                    },
+                    {
+                      "properties": {
+                        "kind": {
+                          "const": "declared"
+                        }
+                      },
+                      "required": [
+                        "kind"
+                      ]
+                    }
+                  ]
+                },
+                "description": "Which of the module's declarations owe the lines below, in their own order. A list, because a line two declarations took an end in together is owed to both and is one entry here — `name` beside it is how a report says such a pair and is not the name of a declaration. Ordered by the declarations themselves and not by which reading of the line was met first, so the entry a reader finds them under does not turn on a walk."
+              }
+            }
+          }
+        }
+      }
+    },
+    "behavior": {
+      "type": "object",
+      "required": [
+        "name",
+        "implementation",
+        "status"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "implementation": {
+          "enum": [
+            "implemented",
+            "unimplemented",
+            "injected"
+          ],
+          "description": "Where the body comes from. `injected` is Java's to supply; `unimplemented` is Souther's to write and not written. Neither has a body here, so the rows of either are recorded rather than evaluated."
+        },
+        "rows": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "How many example rows name this behavior, across every source that writes one. Present exactly where this behavior's rows were read, and absent where they were not: a source nobody could evaluate leaves no row to count, and a build that reads no rows counted none of them. So `0` is a behavior whose rows were read and numbered none, which is what an author acts on differently from rows nobody looked at — the two were one number until this version, and a model being migrated onto read as one with no rows written. Which of the ways it was is `status` and `weakening` beside it."
+        },
+        "pending": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "How many of those rows are recorded rather than evaluated. Present and absent exactly where `rows` is, and for the same reason."
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "weakening": {
+          "$ref": "#/$defs/weakening"
+        },
+        "signature": {
+          "$ref": "#/$defs/signature"
+        },
+        "partition": {
+          "$ref": "#/$defs/partition"
+        },
+        "branch": {
+          "$ref": "#/$defs/branch"
+        },
+        "findings": {
+          "$ref": "#/$defs/findings"
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "description": "Everything the measures found about one subject and nothing filled, and what a build does about each. The measures above each say what they measured; this says which findings came out of them and which of those a build refuses over, which no measure's own object can say. Not in `required`: a document written before this array existed is still a document of this version.",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "disposition",
+          "subject"
+        ],
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "partition_not_read"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "required": [
+                "reason"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "rule_unaccounted"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "required": [
+                "ruleId"
+              ]
+            },
+            "else": {
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "partition_not_read"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": true,
+              "else": {
+                "not": {
+                  "required": [
+                    "ruleId"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "description": "Which thing a row is owed for is written exactly for the kinds that are about one, and its shape is the shape that account keeps.",
+            "if": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "kind": {
+                      "const": "boundary_unmet"
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                {
+                  "properties": {
+                    "kind": {
+                      "const": "domain_point_uncovered"
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                }
+              ]
+            },
+            "then": {
+              "required": [
+                "obligationId"
+              ],
+              "properties": {
+                "obligationId": {
+                  "$ref": "#/$defs/obligationId"
+                }
+              }
+            },
+            "else": {
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "arm_unreached"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "then": {
+                "required": [
+                  "obligationId"
+                ],
+                "properties": {
+                  "obligationId": {
+                    "$ref": "#/$defs/armObligationId"
+                  }
+                }
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "obligationId"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "properties": {
+          "kind": {
+            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `unanswered_row` is a row written with its answer still owed, and an arm whose only rows are those — told apart from `arm_unreached` because a row does go through such an arm, and read off the source rather than measured, so nothing about how much of the model could be read takes it away. `partition_not_derivable`, `partition_not_read` and `partition_rules_not_reached` are positions the model divides no way, what a reading did not read, and positions the axes did measure whose rules the walk never reached. `partition_values_not_separated` is none of those: every rule about the position arrived and every one was read, and what the reading holds is one set per position standing for a relation two of them cannot state — so the values it reports may be wider than the rules leave the position, and a class made out of them may be one no value can be in. It carries no `reason` and no `ruleId`, because no rule is answerable for it and what would lift it is a reading that keeps the alternatives apart. A `partition_not_read` is one of two things and `ruleId` says which: with it, a rule this read and could not turn into a line, named because the reader that stopped knows which rule; without it, a position whose rules the reading never arrived at, where no rule is named because none was seen. `reason` is on both, and says which limit is in the way. `rule_unaccounted` is one question a rule raised that nothing answered — said whether or not an axis came back for the position it is about, since a rule this compiler could not read is exactly the one no axis is derived from, and named for the question rather than for a measure because which section a reader meets it under follows from what it asks.",
+            "enum": [
+              "output_case_unspecified",
+              "input_case_unspecified",
+              "boundary_unmet",
+              "arm_unreached",
+              "unanswered_row",
+              "output_case_unverified",
+              "axis_class_uncovered",
+              "domain_point_uncovered",
+              "partition_not_derivable",
+              "partition_not_read",
+              "rule_unaccounted",
+              "partition_rules_not_reached",
+              "partition_values_not_separated"
+            ]
+          },
+          "disposition": {
+            "description": "What a build does about this one. `refused` is a gap `--strict` and a warned build refuse over; `reported` is a kind neither refuses over, whatever its measurement managed; `undecided` is a kind they would refuse over, from a measurement that came to no answer — telling an author to write a row they may already have written is worse than saying nothing, so it is named and not refused.",
+            "enum": [
+              "refused",
+              "undecided",
+              "reported"
+            ]
+          },
+          "obligationId": {
+            "description": "Which thing a row is owed for the finding is about, written for every kind that is about one and for no other. What a consumer joins the finding to its obligation by — in `partition.obligations` where a body's rule drew the line, in `declarations[].obligations` where one of the module's declarations owns it, and in `branch.obligations` where it is an arm of the body. Its shape is the shape that account keeps, and which one follows from `kind`: a point of a line for `boundary_unmet` and `domain_point_uncovered`, an arm for `arm_unreached`. `subject` beside it is what a reader is shown, and two obligations are shown the same words where what differs is not in the words: one rule at one level in one role owes two `in` points when two cases stop the run in different places, and a fork whose caller supplies the rule owes one arm per rule handed in, at one place and under one label.",
+            "oneOf": [
+              {
+                "$ref": "#/$defs/obligationId"
+              },
+              {
+                "$ref": "#/$defs/armObligationId"
+              }
+            ]
+          },
+          "ruleId": {
+            "$ref": "#/$defs/ruleId",
+            "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted`, and for `partition_not_read` where that entry is about a rule rather than about a position the reading never arrived at — which is why it is required for the first and only allowed for the second. The other kinds are not about a rule and never carry it."
+          },
+          "reason": {
+            "$ref": "#/$defs/notReadReason",
+            "description": "Which limit stopped the reading, present exactly on `partition_not_read`. The same word the `partition.notRead` entry this came from carries, and what a consumer joins the two by. Written because a rule can be stopped at one position by two limits at once — one conjunct of a clause relating two positions and the conjunct beside it in a form nothing reads — and the findings are then two, differing here and nowhere else."
+          },
+          "subject": {
+            "type": "string",
+            "x-souther-contains": "#/$defs/ruleHandle",
+            "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.obligations`, `axis = value` names the point of a declaration's line the way the declaration wrote it, and `ON point of comparison@billing.sou:14:22` says which of the four points a boundary finding is about and which rule drew the line — the rule as a `ruleHandle`, and a line a body drew is owed once wherever it is read and has no one quantity to be named by, so what a row there has to do is under the obligation's `readings`. A finding about a question nothing answered leads with the same handle and says what was asked after it. These words are a presentation and never a key: which obligation such a finding is about is `obligationId`. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
+          },
+          "code": {
+            "type": "string",
+            "description": "The code a build is told this under, present exactly where the kind has one. A kind a build is never told about carries no code rather than an empty one.",
+            "pattern": "^E[0-9]{4}$"
+          },
+          "at": {
+            "description": "Where the finding is, present exactly where its place is its own rather than the declaration it sits under — `arm_unreached` and nothing else. A behavior with two `guard`s has two arms labelled `else`, so the place is what tells two of these apart, and it is the same place under the same key as the matching `branch.obligations` entry, whose `disposition` is `unmet`. The other kinds are cited at the behavior's own declaration, which the entry above already names.",
+            "$ref": "#/$defs/at"
+          }
+        }
+      }
+    },
+    "armObligationId": {
+      "type": "object",
+      "description": "What tells one arm of a behavior from every other, which is not what a reader is shown. A key within this document: a consumer joins one run's arms against another run's on it. Neither `label` nor `at` is one — a body spliced in from out of sight has its copies at as many places as there are call sites, and two arms of two forks are both spelled `else`. Not a name anything outside one compilation can be matched by: `construct` is the reader's own count over what `definition` names, and what identity needs is that the numbering be a function of that definition's syntax and that no two constructs of it share a number — the definition and the number together are what tell one construct from every other, and two definitions' first constructs are two constructs. A document written before that count was kept within a definition carries no `definition` and counts the whole source instead.",
+      "required": [
+        "module",
+        "construct",
+        "lowered",
+        "part",
+        "decidedBy"
+      ],
+      "additionalProperties": false,
+      "if": {
+        "required": [
+          "decidedBy"
+        ],
+        "properties": {
+          "decidedBy": {
+            "const": "the_caller"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "rules"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "rules"
+          ]
+        }
+      },
+      "properties": {
+        "module": {
+          "type": "string",
+          "description": "The module whose source wrote the construct, which is what keeps a prelude helper's forks apart from those of the module expanding it."
+        },
+        "definition": {
+          "type": "string",
+          "description": "The definition whose source wrote the construct, present in a document whose `construct` is counted within one. A document written before construct numbering became a count within a definition has none, and its `construct` counts the whole source instead."
+        },
+        "construct": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Which construct of whatever `definition` names, by the reader's own count over it. Where `definition` is absent the document is an earlier one and this counts the constructs of the whole source."
+        },
+        "lowered": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Which fork of that construct, where a lowering makes more than one out of it — a comprehension's guards by their place in the list. Zero is the construct's own fork, which is every fork an author writes as one."
+        },
+        "part": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Which arm of the fork, by its place among the fork's arms."
+        },
+        "decidedBy": {
+          "description": "What settles which rule this fork decides by, which is part of what one arm is. `the_declaration` is a fork that decides for itself, and every copy of it spliced into a body is one arm. `the_caller` is a fork whose declaration says the caller decides, and then it is one arm per rule a caller handed in — two of those are the same construct at the same place and are two things to cover. `not_said` is the same declaration where which rule reached here could not be worked out, and such an arm is `not_counted`.",
+          "enum": [
+            "the_declaration",
+            "the_caller",
+            "not_said"
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "description": "The rules the caller handed in, in the order the declaration names the parameters, present exactly where `decidedBy` is `the_caller`. A rule named at the call site is written as the declaration it names; a rule the source wrote out is written as the block of that source it is. Naming one declaration twice hands in one rule; writing the same expression twice is two.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "declaration": {
+                "type": "string",
+                "description": "The declaration a call site named. A declaration and never a binding: there are as many bindings as there are copies of the body that put the rule there."
+              },
+              "module": {
+                "type": "string",
+                "description": "The module whose source wrote the rule out, for a rule that has no name of its own."
+              },
+              "writtenBy": {
+                "$ref": "#/$defs/writtenBy"
+              },
+              "block": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Which block of whatever `writtenBy` names the rule is, by the reader's own count over that. Where `writtenBy` is absent the document is an earlier one and this counts the blocks of the whole source."
+              }
+            }
+          }
+        }
+      }
+    },
+    "branch": {
+      "type": "object",
+      "description": "Which arms of the behavior's body the rows go through. Branch-arm coverage, not path coverage: going through both arms of two nested conditions says nothing about their combinations.",
+      "required": [
+        "status"
+      ],
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "status": {
+            "enum": [
+              "complete",
+              "partial"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "obligations",
+          "denominatorSettled"
+        ]
+      },
+      "else": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "obligations"
+              ]
+            },
+            {
+              "required": [
+                "denominatorSettled"
+              ]
+            }
+          ]
+        }
+      },
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "weakening": {
+          "$ref": "#/$defs/weakening"
+        },
+        "reason": {
+          "description": "Why there is no number, present exactly where `status` is `unavailable`. The first two are a behavior with no arm to measure at all rather than arms nothing measured, and no row would give it one: `no_body` is a `>->` composition or a behavior with no `let`, and `no_arm_obligations` is a body that owes no arm — one that forks nowhere a row can be in or out of, or whose every fork the model's own rules prove nothing arrives at. Both are claims about what the model says. The rest are a behavior that does owe arms: `not_asked` is a build that did not ask for them; `unreadable` is a run whose instrumentation could not be tied back to the body; `no_rows` is a behavior no row names; `bodies_not_elaborated` is the model saying a body is written here and nothing having made it, so what the behavior owes was not read — named for the absence rather than for any of the things that stop a module being elaborated, which nothing here can tell apart. It is what `no_body` used to be answered with, and the two are a claim about the model and a claim about this compile.",
+          "enum": [
+            "no_body",
+            "no_arm_obligations",
+            "not_asked",
+            "unreadable",
+            "no_rows",
+            "bodies_not_elaborated"
+          ]
+        },
+        "denominatorSettled": {
+          "type": "boolean",
+          "description": "Whether the arms below are all the arms this behavior owes a row for. Which arms it owes is worked out from the model's own proofs about what can reach what: an arm nothing arrives at is instrumented — a probe is what would show such a proof wrong — and is not owed, because no row can light it. False where a row went through one of those anyway: nothing about the model is wrong there and the proof is, so the arms stand where they stand and what is in doubt is the set they are counted out of. Present exactly where `obligations` is, since it qualifies that array. Which proof it was is `weakening`, as `proof_contradicted`."
+        },
+        "obligations": {
+          "type": "array",
+          "description": "Every arm this behavior is owed a row for, one entry per arm the author wrote rather than per occurrence of it: a helper spliced under three call sites has its arms counted once, and an arm the model's own rules prove nothing reaches is not owed and is not here. The canonical form of this measure and the only place an arm's state is written: how many arms there are and how many a row goes through are folds of this array, and `disposition` is what each arm came to. Present exactly where the measurement has a value, which is where `status` is `complete` or `partial`. A behavior with no arms to measure has no array here rather than an empty one — read as one, a measure that does not apply would divide into a covered count of zero and answer a question nobody put.",
+          "items": {
+            "type": "object",
+            "required": [
+              "obligationId",
+              "label",
+              "kind",
+              "construct",
+              "at",
+              "disposition"
+            ],
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "description": "An arm says where it stands once, and beside it whatever left it open. `undecided` is the reading that stopped, so it carries `weakening`; `not_counted` is the fork nothing tells apart, so it carries `notCountedBecause`; the two settled states are settled by the rows and carry neither. Nothing here re-encodes the disposition: a status and a hit beside it would be the same answer twice, free to disagree with the first.",
+                "if": {
+                  "required": [
+                    "disposition"
+                  ],
+                  "properties": {
+                    "disposition": {
+                      "const": "not_counted"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [
+                    "notCountedBecause"
+                  ],
+                  "not": {
+                    "required": [
+                      "weakening"
+                    ]
+                  }
+                },
+                "else": {
+                  "not": {
+                    "required": [
+                      "notCountedBecause"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": [
+                    "disposition"
+                  ],
+                  "properties": {
+                    "disposition": {
+                      "const": "undecided"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [
+                    "weakening"
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "required": [
+                      "weakening"
+                    ]
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "obligationId": {
+                "$ref": "#/$defs/armObligationId"
+              },
+              "disposition": {
+                "description": "Where this arm stands in the account. `met` is a row goes through it; `unmet` is no row does and every row was read, which is the one state a build refuses over and the one a finding of kind `arm_unreached` is made of; `undecided` is no row was seen to and a reading that could have been holding one did not run to the end, which is counted and is never a finding; `not_counted` is an arm outside the two numbers, with `notCountedBecause` saying why. The first three make a partition of what the count holds, so a consumer that folds them has said what the difference between the numbers is.",
+                "enum": [
+                  "met",
+                  "unmet",
+                  "undecided",
+                  "not_counted"
+                ]
+              },
+              "notCountedBecause": {
+                "description": "Why this arm is outside the count, present exactly where `disposition` is `not_counted`. `occurrences_not_told_apart` is a fork whose declaration says the caller decides where which rule that was could not be worked out: one place can stand for as many arms as there are rules reaching it, so a row through it may or may not be a row through this one. Both arms of such a fork are out together, and `weakening` says `arms_unsettled`.",
+                "enum": [
+                  "occurrences_not_told_apart"
+                ]
+              },
+              "weakening": {
+                "$ref": "#/$defs/weakening",
+                "description": "What the reading of this behavior's rows went without, present exactly where `disposition` is `undecided`. It is why nobody can say whether a row goes through this arm — a row that could have gone through it did not come back — and not a second way of saying that nobody can: what the arm came to is `disposition`, and it is said once."
+              },
+              "label": {
+                "type": "string"
+              },
+              "kind": {
+                "description": "What this way through the construct is. `then` and `else` are the arms of an `if`; `continued` is the body past a `guard` whose condition held, which the author writes no word for; `kept` and `dropped` are the element a comprehension yields and the empty list it yields instead; `case` is an arm of a `match`; `constructed` and `departure` are the two ways out of an attempted construction. Read beside `construct`: the same outcome under two constructs is two things, and an `else` written under a `guard` is not the `else` of an `if`.",
+                "enum": [
+                  "then",
+                  "else",
+                  "case",
+                  "constructed",
+                  "departure",
+                  "continued",
+                  "kept",
+                  "dropped"
+                ]
+              },
+              "construct": {
+                "description": "What the author wrote this an outcome of. The meaning of an arm is the pair: an `else` written under an `if` and one written under a `guard` are the same outcome of two constructs, and a consumer told only the outcome cannot tell them apart.",
+                "enum": [
+                  "if",
+                  "guard",
+                  "comprehension",
+                  "match"
+                ]
+              },
+              "at": {
+                "$ref": "#/$defs/at"
+              }
+            }
+          }
+        }
+      }
+    },
+    "partition": {
+      "type": "object",
+      "description": "How much of what the model distinguishes about this behavior's inputs the rows reach. Absent where there were no positions to write: the positions here are the ones the model divides, worked out from the behavior's boundary and the rules written about it, and no declaration gives them — so a boundary that did not work out leaves nothing to divide and an empty `axes` would say the model divides none of them. Said as `behavior_boundary_not_derived` in the behavior's `weakening`. A `>->` composition is not this — it is measured at its stages and carries a section saying so.",
+      "required": [
+        "axes",
+        "boundaries",
+        "obligations",
+        "pairs",
+        "notDerivable"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "axesMeasure": {
+          "type": "object",
+          "description": "Whether the positions were measured at all, which the `axes` array cannot say: an empty one is what a behavior with no position to divide has and what a behavior whose positions could not be read has. Not in `required`: a document written before this field existed is still a document of this version.",
+          "required": [
+            "status"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/$defs/status"
+            },
+            "weakening": {
+              "$ref": "#/$defs/weakening"
+            },
+            "reason": {
+              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `the_reading_did_not_run_out` is a reading that produced no position and was short of something it answers for, so the model is not thereby known to divide none; `nothing_is_divided` is a reading that answered everything it answers for and found no position the model divides, which no row would change; `no_feasible_input` is the declarations leaving the behavior no value to be measured at all, so this measure has no subject rather than having found none — a class is a set of values a row can be written at, and there are none; `no_subject` is a behavior with no positions of its own, a `>->` composition, which is measured at its stages. `no_axis_derived` is what the first was called while it also stood for the second, and is retired rather than gone.",
+              "enum": [
+                "the_reading_did_not_run_out",
+                "nothing_is_divided",
+                "no_feasible_input",
+                "no_subject",
+                "no_axis_derived"
+              ]
+            }
+          }
+        },
+        "boundariesMeasure": {
+          "type": "object",
+          "description": "The same for the lines. An empty `boundaries` array is what a model with no bound has and what a model whose bounds the reading could not reach has.",
+          "required": [
+            "status"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/$defs/status"
+            },
+            "weakening": {
+              "$ref": "#/$defs/weakening"
+            },
+            "reason": {
+              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `the_reading_did_not_run_out` is a reading that produced no line and was short of something it answers for, so the model is not thereby known to draw none; `no_rule_draws_a_line` is a reading that answered everything it answers for and found no rule drawing a line, which no row would change since a row cannot make a line; `no_feasible_input` is the declarations leaving the behavior no value to be measured at all, so this measure has no subject rather than having found no rule — a line is a place rows part, and there are no rows to part; `no_subject` is a behavior with no positions of its own. `no_lines_derived` is what the first was called while it also stood for the second, and is retired rather than gone.",
+              "enum": [
+                "the_reading_did_not_run_out",
+                "no_rule_draws_a_line",
+                "no_feasible_input",
+                "no_subject",
+                "no_lines_derived"
+              ]
+            }
+          }
+        },
+        "axes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "axis",
+              "path",
+              "classes",
+              "status"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "axis": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string",
+                "description": "The input position, as a parameter and the fields read off it. A newtype's `value` is never a step."
+              },
+              "read": {
+                "type": "object",
+                "description": "How far this measure got with the rules about this position. It qualifies `classes` and nothing else says it: a rule nothing took in may yet refuse a value one of the classes holds, so `classes` is the denominator the model states and not one every member of which is known to stand. The questions themselves are in `unanswered` beside the measures — the model raises them and every measure here is one reader of them, so a position no axis came back for still has whatever was written about it. This says only whether the questions *this* measure answers were answered: which values may stand somewhere is what classes are made of, and where a line falls is the border measure's, counted there.",
+                "required": [
+                  "extent"
+                ],
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "properties": {
+                      "extent": {
+                        "const": "complete"
+                      }
+                    },
+                    "not": {
+                      "required": [
+                        "rulesNotReached"
+                      ]
+                    }
+                  },
+                  {
+                    "properties": {
+                      "extent": {
+                        "const": "partial"
+                      }
+                    }
+                  }
+                ],
+                "properties": {
+                  "extent": {
+                    "enum": [
+                      "complete",
+                      "partial"
+                    ],
+                    "description": "Whether anything this measure reads about this position is left standing: a rule out of sight, or a question about which values may stand here that nothing answered. `partial` where either holds. A question about where the values stop does not make this `partial` — it is not this measure's to answer, and counting it here would put back a number `partition` and `border` were separated into."
+                  },
+                  "rulesNotReached": {
+                    "const": true,
+                    "description": "The walk never reached some of the rules written about this position, so what is written there is not known. Written only where that is so. Its own axis beside the questions and not exclusive with them: a rule can have arrived and gone unaccounted for while a subtree beside it was never entered, and both are said."
+                  }
+                }
+              },
+              "classes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The classes a row can be written at: what the model divides this position into, less what its own rules refuse."
+              },
+              "covered": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "excluded": {
+                "type": "array",
+                "description": "Classes the position's own rules refuse, that the body also answers `unreachable` for. Out of `classes` because no value of one can be constructed, and named here because the type still has them.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "class",
+                    "reasons"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "class": {
+                      "type": "string"
+                    },
+                    "reasons": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "The reasons written at the `unreachable`s this class leads to — one, unless several paths abort for different reasons."
+                    }
+                  }
+                }
+              },
+              "unprovenClaims": {
+                "type": "array",
+                "description": "Classes the body answers `unreachable` for that nothing settled. Still in `classes` and still owed a row: what removes an obligation is a proof, and a row written at one may reach the `unreachable` and be refused.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "class",
+                    "reasons",
+                    "why"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "class": {
+                      "type": "string"
+                    },
+                    "reasons": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "The reasons written at the `unreachable`s this class leads to."
+                    },
+                    "why": {
+                      "description": "What stopped the answer.",
+                      "enum": [
+                        "a_rule_went_unread",
+                        "the_rules_leave_the_position_nothing",
+                        "nothing_was_read_about_the_case",
+                        "the_fork_is_not_known_to_be_reached",
+                        "the_alternatives_were_not_kept_apart"
+                      ]
+                    }
+                  }
+                }
+              },
+              "unclassifiedRows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "status": {
+                "$ref": "#/$defs/status"
+              },
+              "weakening": {
+                "$ref": "#/$defs/weakening"
+              },
+              "reason": {
+                "description": "Why there is no number, present exactly where `status` is `unavailable`. A behavior no row names was not measured here, so the classes nothing sits in are not classes nothing reaches. `not_asked` is a build that asked for no measurement at all, which reads no row anywhere.",
+                "enum": [
+                  "no_rows",
+                  "not_asked"
+                ]
+              }
+            }
+          }
+        },
+        "boundaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "axis",
+              "origin",
+              "value",
+              "items"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "axis": {
+                "type": "string"
+              },
+              "origin": {
+                "type": "string",
+                "x-souther-contains": "#/$defs/ruleHandle",
+                "description": "The rule that drew this line, as a `ruleHandle`, and after it the declarations that took an end of the line in where any did. The handle alone where none did, which is what the `obligations` entry for a point of this line carries. Not itself a handle, because those words are about the line rather than about the rule; what a consumer keys on is the `ruleId` under that entry."
+              },
+              "kind": {
+                "enum": [
+                  "at_value",
+                  "between_positions",
+                  "over_a_form"
+                ],
+                "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. `over_a_form` is a rule over an arithmetic form across several positions: the line is where the form comes to `value`, `axis` names the form as an author would write it and `value` is a number the form takes rather than a value any position holds. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
+              },
+              "value": {
+                "type": "string",
+                "description": "Where the line is, as an author would write it: a value where `kind` is `at_value` or absent; the other position, and how far from it where the rule holds them apart, where it is `between_positions`; and a number the form comes to where it is `over_a_form`. Not what any one of the border's points asks for — three of the four ask for something else, and each says so itself."
+              },
+              "items": {
+                "type": "array",
+                "description": "The coverage items this border owes, keyed on the border the way the technique keys them (ISTQB CTAL-TA v4.0 §3.1.1). One per point the line has and each exactly once, told apart by `location`: a rule that orders the values has four, and a rule that names a value has five — the value it names, the nearest value on each side of it, and the run either way. How many of them a border owes a row at is the rule's answer and not a constant, so a point it owes none at carries `notOwed` rather than being left out; a document short of one would read as this compiler being short of an item the technique asks for.\n\nEvery border has a value against the line inside it and one outside it, so an `on` and an `off` are always here. The other two roles are not: a rule that names a value puts both its runs in one class, so `x == 10` has two `out` items and no `in`, and `x /= 10` the other way about.",
+                "minItems": 4,
+                "uniqueItems": true,
+                "allOf": [
+                  {
+                    "contains": {
+                      "required": [
+                        "point"
+                      ],
+                      "properties": {
+                        "point": {
+                          "const": "on"
+                        }
+                      }
+                    },
+                    "minContains": 1
+                  },
+                  {
+                    "contains": {
+                      "required": [
+                        "point"
+                      ],
+                      "properties": {
+                        "point": {
+                          "const": "off"
+                        }
+                      }
+                    },
+                    "minContains": 1
+                  }
+                ],
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "point",
+                    "location"
+                  ],
+                  "additionalProperties": false,
+                  "oneOf": [
+                    {
+                      "description": "A point no row is owed at carries which point it is and why, and nothing else. Closed rather than listing what it may not have: the list was the keys of the owed side written a second time, and a field added to that side was a field somebody had to remember to forbid here. Two went unforbidden that way — `weakening`, which no measurement of a point owing no row can produce, and `writableBecause`, which is evidence about a row nobody is owed.",
+                      "required": [
+                        "notOwed"
+                      ],
+                      "properties": {
+                        "point": {},
+                        "location": {},
+                        "notOwed": {}
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "required": [
+                        "relation",
+                        "against",
+                        "knownWritable",
+                        "status"
+                      ],
+                      "not": {
+                        "required": [
+                          "notOwed"
+                        ]
+                      }
+                    }
+                  ],
+                  "if": {
+                    "required": [
+                      "status"
+                    ],
+                    "properties": {
+                      "status": {
+                        "enum": [
+                          "complete",
+                          "partial"
+                        ]
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "hit"
+                    ]
+                  },
+                  "else": {
+                    "not": {
+                      "required": [
+                        "hit"
+                      ]
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "description": "The verdict and the grounds are one answer written twice, so this says they cannot differ. Where the array is there and `knownWritable` is `true`, some ground is in it.",
+                      "if": {
+                        "required": [
+                          "knownWritable",
+                          "writableBecause"
+                        ],
+                        "properties": {
+                          "knownWritable": {
+                            "const": true
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "writableBecause": {
+                            "minItems": 1
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "description": "And where it is there and `knownWritable` is `false`, none is. Both are conditional on the array being present, because an absent one is a producer that predates it rather than a point with no grounds.",
+                      "if": {
+                        "required": [
+                          "knownWritable",
+                          "writableBecause"
+                        ],
+                        "properties": {
+                          "knownWritable": {
+                            "const": false
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "writableBecause": {
+                            "maxItems": 0
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "properties": {
+                    "point": {
+                      "enum": [
+                        "on",
+                        "off",
+                        "in",
+                        "out"
+                      ],
+                      "description": "Which of the four coverage items of this border this entry is, in the words domain testing gives them. `on` is inside the equivalence partition the border bounds and closest to it, `off` is outside it and closest to it, `in` is inside it and away from it, and `out` is outside it and away from it. Which one the line's own value serves as turns on whether the border is closed or open, so the same place is the `on` point of `x <= 100` and the `off` point of `x < 100`. Not what tells one item of a border from another: two of them can carry one of these words, and `location` is what they differ by."
+                    },
+                    "location": {
+                      "$ref": "#/$defs/location"
+                    },
+                    "notOwed": {
+                      "enum": [
+                        "the_rules_refuse_it",
+                        "the_carrier_names_no_neighbour"
+                      ],
+                      "description": "Why no row is owed here, present exactly when one is not. `the_rules_refuse_it` is the model's own answer — nothing outside an invariant's bound can be constructed, so the points out there are excluded and counted out, and a side the rules leave one value wide has no `in` point for the same reason. `the_carrier_names_no_neighbour` is this language having no name for the value one step from the line, which a `Decimal`, a `DateTime` and a `String` do not — at a place, and at the difference two terms of a line between them stand at. The two ask different things of a reader — one is the model having settled the point and the other is a limit of this language — which is why the key is a word and not a flag."
+                    },
+                    "relation": {
+                      "type": "string",
+                      "description": "How a row here has to stand to what `against` names: `=` for a place, `in` for a run of the quantity's values, `/=` for every value but one. Present exactly where a row is owed. Two of the four items ask for a place and two ask for a run of values, so `against` is read together with this: under `=` and `/=` it is a value, and under `in` it is the run written whole. A document carrying a value for all four would name a witness of a run as though it were the run. `<` and `>` were written here by compilers that read a point away from the line as everything past it rather than as the partition the border bounds; a run is written under `in` now."
+                    },
+                    "against": {
+                      "type": "string",
+                      "description": "What that relation is against, as an author would write it. Under `=` and `/=` it is one value: a value of the position where the border's `kind` is `at_value`; the other position, stepped where the point is not where the two meet, where it is `between_positions`; and a number the form comes to where it is `over_a_form`. Under `in` it is a run of the quantity's values written whole — `10 < n <= 20` — because a run has two ends and one of them alone would name a value inside it as though it were the run."
+                    },
+                    "hit": {
+                      "type": "boolean",
+                      "description": "Whether a row this coverage measurement read stands at the point. Present exactly where the measurement has a value, which is where `status` is `complete` or `partial`. `false` is what the measurement found — no row that could be read is at the point — and never stands for a measurement that was not made or could not be finished: those have no answer here and the key is absent. Under `partial` the `false` is over what was observed, and `weakening` beside it says why that is not a complete absence."
+                    },
+                    "knownWritable": {
+                      "type": "boolean",
+                      "description": "Whether anything has shown that a row can be written at this point: `true` where at least one ground established it, `false` where none did. `false` never says the point cannot be written at — what says that is the border refusing to owe a row at the point at all, which is `notOwed`. Which grounds hold is `writableBecause`, and the causes of there being none are not listed here: each belongs to the evidence its ground comes from, and a list of them written into this sentence is one that goes stale whenever any of them moves. This is its own body of evidence and not this measurement's answer, so it is written whether or not the coverage measurement has a value: a point nobody measured whose rules prove it inhabited carries `true` beside a `status` of `unavailable`, and the two are consistent."
+                    },
+                    "writableBecause": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "enum": [
+                          "the_rules_prove_it",
+                          "a_row_is_at_it",
+                          "a_value_was_built"
+                        ]
+                      },
+                      "description": "Which grounds established that a row can be written at this point, empty where none did. A set: more than one holds at once wherever more than one was found, and no word here stands above another. `the_rules_prove_it` is the one ground about the model rather than about this run — every rule reaching the value this position sits in was read in full and leaves the point inside what they admit — so it stands whatever any search afterwards makes of the point, where the other two are what this run came to. `a_row_is_at_it` is a row this compilation read standing at the point, and holds exactly where `hit` is `true`. `a_value_was_built` is a value at the point built through the module's own decoders, and it is in no other field of this document: what the search itself came to is what the human-readable report and `--generate` carry. The order is fixed to the order the words are listed here so that two runs finding the same grounds write the same document; it carries no meaning, and a reader comparing these compares them as sets. Not in `required`: a document written before this field existed is still a document of this version, and an absent array is such a document — not a point with no grounds, which is written as an empty array. Where the field is present it is present at every point a row is owed at, and `knownWritable` is `true` exactly where it is non-empty."
+                    },
+                    "status": {
+                      "$ref": "#/$defs/status"
+                    },
+                    "weakening": {
+                      "$ref": "#/$defs/weakening"
+                    },
+                    "reason": {
+                      "description": "Why there is no answer, present exactly where `status` is `unavailable`. `not_asked` is a build that asked for no measurement, which every line of every kind says. `arms_not_asked` and `arms_unreadable` belong to a line a fork of a body drew, which is met by getting the comparison to produce a value rather than by writing the value — and that holds of all four of its points. An invariant's line is met by writing the value and is never waiting on the instrumentation. `no_arm_witnesses_it` was a guard's line whose comparison sat inside a condition whose arms did not separate the rows that reached it from the rows that did not — the second operand of an `&&` on the side where it is false. No compiler writes it any more: the comparison carries a site of its own and is observed where it runs. It is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
+                      "enum": [
+                        "not_asked",
+                        "arms_not_asked",
+                        "arms_unreadable",
+                        "no_rows",
+                        "no_arm_witnesses_it"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "obligations": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/obligations"
+            },
+            {
+              "items": {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "axis"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "against"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "What this behavior is owed a row for at the lines its own rules drew, once per point however many of its positions read the line — a guard on a name every case of a sum spreads is one entry here and one `boundaries` entry per case. The account, beside the geometry: `boundaries` is the lines at coordinates and this is the work, and the two are not one multiplied. No `axis`: a body's rule has no authored word for what its line is on, and each reading names the position it met it at. A line one of the module's declarations owns is in no behavior's account and is under `declarations` instead."
+        },
+        "pairs": {
+          "type": "object",
+          "description": "Two-class combinations, kept as the relations they are between. Counts rather than a ratio: a combination no row reaches has not been shown unreachable, only unknown, so the denominator is not known.",
+          "required": [
+            "total",
+            "status",
+            "between"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "covered": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Combinations a row sits in. Proven reachable, each by the row that sits in it."
+            },
+            "unknown": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Combinations no row sits in. Not shown unreachable and not owed: nothing tried to build one, and no bar asks for a row at a combination."
+            },
+            "weakening": {
+              "$ref": "#/$defs/weakening"
+            },
+            "status": {
+              "$ref": "#/$defs/status",
+              "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
+            },
+            "reason": {
+              "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names, nor about a build that asked for no measurement (`not_asked`).",
+              "enum": [
+                "no_rows",
+                "not_asked"
+              ]
+            },
+            "between": {
+              "type": "array",
+              "description": "The relations the combinations are between, one entry per pair of positions. A sum over them says how many there are and nothing about which two positions each is between, so a reader told some are unknown could not tell one relation from several.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "one",
+                  "other",
+                  "total"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "one": {
+                    "type": "string",
+                    "description": "One of the two positions, as `axes` names it."
+                  },
+                  "other": {
+                    "type": "string",
+                    "description": "The other."
+                  },
+                  "total": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "How many combinations the model has between them."
+                  },
+                  "covered": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "How many of them the rows reach, where a measurement was made."
+                  },
+                  "unknown": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "And how many are left."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "unanswered": {
+          "type": "array",
+          "description": "The questions this behavior's rules raise about its input positions that nothing answered, each naming the rule. Beside the measures rather than inside one: the model raises them and every measure in this object is one reader of them, so a position no axis could be derived at still has whatever was written about it. Written only where there is one. Under the earlier version these sat inside each axis, which meant a rule whose line this compiler could not read left a question standing and was reported as a model with nothing to answer for, because no axis survived to carry it. Which section of a human report a reader meets one in follows from `question`.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "at",
+              "rule",
+              "ruleId",
+              "question",
+              "subject"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "stopped"
+                ]
+              },
+              {
+                "required": [
+                  "answerStopped"
+                ]
+              }
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "at": {
+                "type": "string",
+                "description": "The position the rule is written about, as a report names it."
+              },
+              "stopped": {
+                "type": "array",
+                "description": "What the parts of the rule that raised this question left, in the order they were written: one or more distinct entries. Not what is wrong with the model — every word here is a limit of this compiler or a statement of what a rule places, and lifting one is what would let the question be answered. A question stands until every part that asked it has been read, so a part standing behind another is a second thing to lift and is a second entry here; two parts one limit stopped are one thing to lift and are one entry. What tells two entries apart is `reason` together with `sentTo`: a clause whose ends two choices left open leaves two things to lift under one word, and they are told apart by where in the rule each of them is. Where every one of them was written in one source text, the order is part of what this says: it is the order the places they stand on were written in, and a consumer sorting it would answer by a precedence nothing in the model decides. Where they were written across texts there is no such order — nothing an author did says which file comes before another — and the entries are in an order that is steady from run to run and means nothing else. Absent where nothing about the rule itself was short and `answerStopped` says what was. The same words the human report writes for this question, from the same projection — a document that carried fewer of them than the report says would be the report and the document disagreeing about one question. Under schema 16 an entry was the word alone, which said a clause with two choices in it left a reader one thing to do. Under schema 12 this also held `answerStopped`'s word, at a place in the order that came from which of this compiler's stores a reason was recorded in rather than from anything the model says.",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "reason"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "reason": {
+                      "$ref": "#/$defs/ruleStoppedReadingReason"
+                    },
+                    "sentTo": {
+                      "$ref": "#/$defs/at",
+                      "description": "Where inside the rule a reader goes about this one, for an entry about a part of it rather than about the whole. `rule` beside the entry sends them to the rule, which is the whole answer wherever what they lift is the rule; a choice whose other alternative went unread is lifted at the `||`, and the clause `rule` names reads perfectly well. Absent where the rule is the whole of it, and absent where the part is in a text this document cannot point at. The same place the `notRead` entry for the same choice carries, so a consumer holding what the values were short of and what the ends were short of knows the two are one thing to fix."
+                    }
+                  }
+                }
+              },
+              "answerStopped": {
+                "description": "What the answer at this question's position was short of, where it was short of anything. Its own field and not an entry in `stopped`: this is about what the rules of the position come to between them and about none of them, so there is no part of the rule for it to stand before or after, and a place among them would be a precedence read off which store a reason came out of. A reader has no rule to go and look at here — the same rules met in another order would have been built — and what would lift it is an allowance. Both fields where a rule is short in both ways: rewriting the form `stopped` names leaves this one where it was. One word rather than an array, because there is one such limit; a second would be two with no order between them either, and what a document should then write is a decision to take when there is one to take.",
+                "$ref": "#/$defs/answerRealizationStoppedReason"
+              },
+              "rule": {
+                "$ref": "#/$defs/ruleHandle",
+                "description": "How a reader finds the rule this question is about. The same handle the `boundaries` entry for a line the same rule drew carries, and the same one a `notRead` entry carries for a rule it could not read. What the forms are is `ruleHandle`; what tells one rule from another is `ruleId` beside this, because two arms of one `ensures` clause may name the same case and a handle is what an author acts on rather than what a consumer groups by."
+              },
+              "ruleId": {
+                "$ref": "#/$defs/ruleId"
+              },
+              "question": {
+                "$ref": "#/$defs/coverageQuestion"
+              },
+              "subject": {
+                "type": "object",
+                "description": "What the question is about, or where a reader is sent to look where nothing worked that out. The two answered questions do not share a subject: which values may stand somewhere is about the position, and a border on one position is about a number of it — the position's own values, or what an operation answers of them. A `filedAt` subject is neither: the rule's reading did not finish, so what the rule is about is the part that was not read, and the path is where the walk was looking when it stopped. A border between two things that both move with the row is on neither of them, and is not here: a comparison this compiler reads owes the rows either side of its line by having been read, so no such question is ever outstanding, and what it owes is carried as the partition's own geometry.",
+                "required": [
+                  "kind"
+                ],
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "properties": {
+                      "kind": {
+                        "const": "position"
+                      }
+                    },
+                    "not": {
+                      "required": [
+                        "at"
+                      ]
+                    },
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "kind": {
+                        "const": "filedAt"
+                      }
+                    },
+                    "not": {
+                      "required": [
+                        "at"
+                      ]
+                    },
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "kind": {
+                        "const": "comparison"
+                      }
+                    },
+                    "not": {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "path"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "measure"
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "position",
+                      "filedAt",
+                      "comparison"
+                    ],
+                    "description": "`position` is a position of an input or a number taken of one. `filedAt` is where a reader is sent to look at a rule this compiler did not read far enough to classify — a place and not a subject, since what such a rule states there is what nothing worked out. It is one word for both of those questions, because where to look is one thing however much of the rule was classified; which of them it is, is what the entry's `question` says. `comparison` is retired: it was to have been the place a comparison of two moving things draws, and no compiler ever wrote it — such a line owes its rows by having been read, so it never stands as a question. It is kept because this version promised it, and a reader holding the schema still meets the word."
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "The position, spelled as the entry's `at` is. Written for a `position` subject, and for a `filedAt` one, where it is the place the reading stopped rather than what the rule is about."
+                  },
+                  "measure": {
+                    "type": "string",
+                    "description": "The number the line falls on, where it falls on a count rather than on the position's own values — `String.length(code)` beside a `path` of `code`. Written where the question is about a count, and for a `filedAt` subject where the walk had named a number before it stopped, which is what tells two of those apart at one path."
+                  },
+                  "at": {
+                    "$ref": "#/$defs/at",
+                    "description": "Where the comparison is written, for a `comparison` subject this document can point at. Retired with the word it belongs to."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "claimsOffAxis": {
+          "type": "array",
+          "description": "Claims about positions this report has no axis for — a position deeper than the walk goes, or one whose rules the reading never arrived at. Named by position, and carrying `why` exactly where nothing settled the claim.",
+          "items": {
+            "type": "object",
+            "required": [
+              "at",
+              "class",
+              "reasons"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "at": {
+                "type": "string"
+              },
+              "class": {
+                "type": "string"
+              },
+              "reasons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "why": {
+                "description": "What stopped the answer, present exactly where nothing settled the claim.",
+                "enum": [
+                  "a_rule_went_unread",
+                  "the_rules_leave_the_position_nothing",
+                  "nothing_was_read_about_the_case",
+                  "the_fork_is_not_known_to_be_reached",
+                  "the_alternatives_were_not_kept_apart"
+                ]
+              }
+            }
+          }
+        },
+        "notDerivable": {
+          "type": "array",
+          "description": "Positions the reading ran to the end at and divided no way. Not a finding: no boundary obligation was established here, so nothing is reported against the rows. Not a statement that nothing is owed either — a bound one type away from the position a behavior takes lands in this list, and the reading cannot tell that from a position nothing bounds. A position something is written about that the reading could not take apart is in `notRead` instead, and used to be in this one. Read `boundariesMeasure` for whether the measure was made.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notRead": {
+          "type": "array",
+          "description": "What this reading could not read, each entry with the position it is at and what stopped it. What separates them from `notDerivable` is that the model does state something here — which limit stopped each one is what says whose work it is to lift. Not a statement that the position was not measured: a position with an axis and classes can carry a rule nothing read, and whether the reading of a position ran to the end is what that axis's `read` says. Two shapes, told apart by whether `rule` is there: an entry with one is a rule this read and could not turn into a line, and an entry without one is a position whose rules the reading never arrived at, where there is no rule to name because none was observed. Not in `required`: a document written before this field existed is still a document of this version.",
+          "items": {
+            "type": "object",
+            "required": [
+              "position",
+              "reason"
+            ],
+            "additionalProperties": false,
+            "dependentRequired": {
+              "rule": [
+                "ruleId"
+              ],
+              "ruleId": [
+                "rule"
+              ]
+            },
+            "properties": {
+              "position": {
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/$defs/notReadReason"
+              },
+              "rule": {
+                "$ref": "#/$defs/ruleHandle",
+                "description": "How a reader finds the rule this could not turn into a line. The same handle an `unanswered` entry and a `boundaries` entry carry for the same rule, and its forms are `ruleHandle`. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is."
+              },
+              "ruleId": {
+                "$ref": "#/$defs/ruleId",
+                "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one."
+              },
+              "sentTo": {
+                "$ref": "#/$defs/at",
+                "description": "Where inside the rule a reader goes, for an entry about a part of it rather than about the whole. `rule` beside this sends them to the rule, which is the whole answer wherever what they lift is the rule; an end a choice left open is lifted at the `||`, and the clause `rule` names reads perfectly well. Absent where the rule is the whole of it, and absent where the part is in a text this document cannot point at. Part of what tells two entries apart: two choices of one clause agree about the position, the rule and the reason, so without this the second was a repeat of the first."
+              }
+            }
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read, which includes a declaration resting on a name that resolved to nothing. There is no section in that case whether or not the positions themselves are known: a declared behavior's are its parameters and are known from the declaration, but without a boundary nothing was read of the cases at any of them, and a `>->` composition takes what its first stage takes and so has no known layout either. What that left unmeasured is the behavior's `weakening`, as `behavior_boundary_not_derived`; which name went unresolved is a compile error reported where it was written.",
+      "required": [
+        "status",
+        "output",
+        "inputs"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "weakening": {
+          "$ref": "#/$defs/weakening"
+        },
+        "reason": {
+          "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_rows` is a behavior no row names; `not_a_sum` is a signature with no sum anywhere in it, which no row could give a case to cover; `not_asked` is a build that asked for no measurement, which every measure that reads the rows says and which the sets under it say too.",
+          "enum": [
+            "no_rows",
+            "not_a_sum",
+            "not_asked"
+          ]
+        },
+        "output": {
+          "type": "object",
+          "required": [
+            "declared",
+            "status"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "declared": {
+              "$ref": "#/$defs/caseNames"
+            },
+            "specified": {
+              "$ref": "#/$defs/caseNames",
+              "description": "Cases a row expects. Somebody wrote down that the model owes this answer."
+            },
+            "observed": {
+              "$ref": "#/$defs/caseNames",
+              "description": "Cases the behavior was seen to answer with, including from a row that expected something else."
+            },
+            "verified": {
+              "$ref": "#/$defs/caseNames",
+              "description": "Cases a row expected and the behavior produced."
+            },
+            "unclassifiedRows": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Rows whose case could not be read. Above zero, a missing case is undecided rather than missing."
+            },
+            "status": {
+              "$ref": "#/$defs/status",
+              "description": "Whether the rows were counted here at all. `unavailable` where the position is not a sum, and where no row names the behavior — in both, the sets below are absent rather than empty, since a set nobody filled and a set nothing reached read alike."
+            },
+            "reason": {
+              "enum": [
+                "not_a_sum",
+                "no_rows",
+                "not_asked"
+              ]
+            },
+            "weakening": {
+              "$ref": "#/$defs/weakening"
+            }
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "description": "One entry per parameter, in order. A parameter that is not a sum has nothing to cover and reports empty sets.",
+          "items": {
+            "type": "object",
+            "required": [
+              "declared",
+              "status"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "declared": {
+                "$ref": "#/$defs/caseNames"
+              },
+              "specified": {
+                "$ref": "#/$defs/caseNames"
+              },
+              "executed": {
+                "$ref": "#/$defs/caseNames",
+                "description": "Cases the behavior was applied to. Not `observed`: nothing is claimed about what came back."
+              },
+              "verified": {
+                "$ref": "#/$defs/caseNames"
+              },
+              "excluded": {
+                "$ref": "#/$defs/caseNames",
+                "description": "Cases the position's own rules refuse. Declared and not coverable: no value of one can be constructed, so they are counted out of what the rows are held to."
+              },
+              "unclassifiedRows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "status": {
+                "$ref": "#/$defs/status",
+                "description": "Whether the rows were counted here at all. `unavailable` where the position is not a sum, and where no row names the behavior — in both, the sets below are absent rather than empty, since a set nobody filled and a set nothing reached read alike."
+              },
+              "reason": {
+                "enum": [
+                  "not_a_sum",
+                  "no_rows",
+                  "not_asked"
+                ]
+              },
+              "weakening": {
+                "$ref": "#/$defs/weakening"
+              }
+            }
+          }
+        }
+      }
+    },
+    "caseNames": {
+      "type": "array",
+      "description": "Case names, sorted, so that two runs of the same model compare.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "incompleteness": {
+      "type": "object",
+      "required": [
+        "code",
+        "scope",
+        "subject"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "enum": [
+            "behavior",
+            "source",
+            "module",
+            "position",
+            "row"
+          ],
+          "description": "What `subject` names, and so what the reason counts against. A `behavior`, a `position` and a `row` count against the behavior they are in, and each is in one. A `row` says which row of it, as the behavior, the source it is written in and the row's own name: a row written with no name is numbered within its source, so the source is part of saying which row, and two rows of one behavior that did not come back are two things to go and look at. A `module` counts against every behavior in it, because that is what a module holds. A `source` counts against every behavior too, and not for that reason: one is written only where the source was not evaluated, so which behaviors had rows in it is exactly what could not be read."
+        },
+        "code": {
+          "description": "`observation_absent` is a source none of whose rows were observed, whatever stopped them — the diagnostics say what. `linkage_failed` is the generated classes not linking: the case it exists for is the runtime being off the host's classpath, and the JVM raises the same error for a class it will not verify or accept the format of, which is why the word is the error and not one of its causes. One place writes it, an example whose evaluation raised one and observed nothing, so the rows behind it did not run and that is part of what it says. It had three, and the other two were a value being built after the rows had been read — those are the generator's to report and are not written here. `instrumentation_absent` is the classes an arm-measuring evaluation needs not having been made, named for the absence rather than for a backend that failed or inputs that were not there, which nothing here can tell apart. `answerer_not_established` is a row that was not handed to what answers its behavior, because nothing could establish that what answers it was built against this model — either the two builds say different things about something a value crossing between them depends on, or what the answer carries could not be read at all. The rows behind it were read: they were built and held to their invariants, and what is missing is only what the running would have decided. `row_undecided` is a row that did not come back, because the evaluation had no answer for it. `row_evaluation_limit_reached` is the same loss from the other cause: a figure this compiler evaluates rows under — the counted steps, the recursion depth, the clock — stopped the row before it decided anything. Two words because what a reader may do about them differs: a run that allows more keeps the second and meets the first again. One word covers the three figures, since what the measure lost is the same for all of them and the row's own diagnostic says which; a stack the host ran out of is not among them, because nothing here compared anything against it, and it is written as `row_undecided`. `probe_mapping_lost` is what it was called, and no compiler writes it any more: it is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
+          "enum": [
+            "value_unreadable",
+            "value_truncated",
+            "row_undecided",
+            "row_evaluation_limit_reached",
+            "answerer_not_established",
+            "observation_absent",
+            "linkage_failed",
+            "instrumentation_absent",
+            "probe_mapping_lost"
+          ]
+        },
+        "subject": {
+          "type": "string",
+          "description": "What the reason is about, as an identity. A `behavior`, a `module` and a `position` are named as the author wrote them. A `source` is named as the compile was handed it, which is the caller's own identity for the file and not a name to show a reader: a build passing a list of files gets that file's position in the list, and an editor keyed on document URIs gets the URI. What to call a source in front of a person is decided where a report is rendered, since it depends on which other files are being read beside it — and `sources` says what this run decided, so the identity can be looked up without holding what was handed over."
+        },
+        "at": {
+          "$ref": "#/$defs/at"
+        }
+      }
+    },
+    "at": {
+      "type": "object",
+      "description": "Where in which source. A position alone cannot say which file, since a module's rows are written across its own source and any attached ones. It says where this compile met the code, which `writtenAt` says whether to read as where the code is written.",
+      "required": [
+        "sourceId",
+        "line",
+        "column"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sourceId": {
+          "type": "string",
+          "description": "The source, as an identity, read the way a `source` subject is. `sources` says what it is called."
+        },
+        "line": {
+          "type": "integer"
+        },
+        "column": {
+          "type": "integer"
+        },
+        "writtenAt": {
+          "$ref": "#/$defs/writtenAt"
+        }
+      }
+    },
+    "writtenAt": {
+      "type": "object",
+      "description": "Whether the position beside this is where the code it names is written. A body is copied into everything that calls it, and a copy from a module this compile has no source for is given the call site, since the positions it was written at name a file nobody holds. Absent in a document written before this key existed, which is not the same as `here`: such a document does not answer the question.",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "here",
+            "outOfSight"
+          ]
+        },
+        "declaration": {
+          "type": "string",
+          "description": "The name a reader of the file the position is in reaches that code by — `List.filter`. Written where `kind` is `outOfSight` and never otherwise. How it is reached and not which module declares it: a name reached from out of sight is qualified, so it is already enough to look the code up by."
+        }
+      },
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "outOfSight"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "declaration"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "declaration"
+          ]
+        }
+      }
+    },
+    "writtenBy": {
+      "type": "object",
+      "description": "Which of the module's writings wrote the rule out. A caller handing a rule in is whatever wrote the expression there, and that is not only a definition's body: a clause of a `data`, a behavior's statement of itself and a value written in an `example` row each write one as readily. Present in a document whose `block` is counted within one of them; a document written before the count was kept that way carries none, and its `block` counts the blocks of the whole source instead.",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "declaration"
+            }
+          },
+          "required": [
+            "declaredOn"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "behavior"
+                ]
+              },
+              {
+                "required": [
+                  "definition"
+                ]
+              },
+              {
+                "required": [
+                  "sourceId"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "stated"
+            }
+          },
+          "required": [
+            "behavior"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "declaredOn"
+                ]
+              },
+              {
+                "required": [
+                  "definition"
+                ]
+              },
+              {
+                "required": [
+                  "sourceId"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "body"
+            }
+          },
+          "required": [
+            "definition"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "declaredOn"
+                ]
+              },
+              {
+                "required": [
+                  "behavior"
+                ]
+              },
+              {
+                "required": [
+                  "sourceId"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "example_rows"
+            }
+          },
+          "required": [
+            "behavior",
+            "sourceId"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "declaredOn"
+                ]
+              },
+              {
+                "required": [
+                  "definition"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "stand_in"
+            }
+          },
+          "required": [
+            "behavior",
+            "sourceId"
+          ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "declaredOn"
+                ]
+              },
+              {
+                "required": [
+                  "definition"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "kind": {
+          "description": "What wrote it. `example_rows` and `stand_in` are the two a module may write more than one of for one behavior, and they say which source as well: an attached file's rows are counted apart from the model file's, and the two written for one behavior in one source are two writings.",
+          "enum": [
+            "declaration",
+            "stated",
+            "body",
+            "example_rows",
+            "stand_in"
+          ]
+        },
+        "declaredOn": {
+          "type": "string",
+          "description": "The declaration whose clauses wrote it."
+        },
+        "behavior": {
+          "type": "string",
+          "description": "The behavior whose statement of itself wrote it, or the one whose rows or stand-in did."
+        },
+        "definition": {
+          "type": "string",
+          "description": "The definition whose body wrote it."
+        },
+        "sourceId": {
+          "type": "string",
+          "description": "The source the rows or the stand-in are written in, read the way a `source` subject is. `sources` says what it is called."
+        }
+      }
+    },
+    "subject": {
+      "description": "What one entry is about: the thing a reader is sent back to, and never what happened to it. What happened is the entry's own word and the reason beside it, so one place met in two ways is two entries about one place. Every kind carries what names it and the others carry something else; three of them name a position — as a reason spells it for a person, as the reading of the model addresses it, and as one of a behavior's declared inputs — and those are three vocabularies rather than one said three ways. Written as the union it is: a document cannot carry a place made of one kind's fields and another's, because no such place is one this compiler can build.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "module"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "module"
+            },
+            "module": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "behavior"
+            },
+            "behavior": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "source"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "source"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source, under the name this document gives it."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior",
+            "source",
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "row"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source, under the name this document gives it."
+            },
+            "name": {
+              "type": "string",
+              "description": "The row's name, where it was written with one. A row without a name is not addressable from outside this compiler, so what is written for it is `ordinal` and a reader is not handed a number to look it up by."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior",
+            "source",
+            "ordinal"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "row"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string",
+              "description": "The source, under the name this document gives it."
+            },
+            "ordinal": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Which of its behavior's rows in that source it is, where it has no name."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior",
+            "path"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "position"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string",
+              "description": "The position as an author would recognise it. Two positions this compiler holds apart can be spelled alike here, which is what `positionId` is for."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior",
+            "path",
+            "positionId"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "read_position"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string",
+              "description": "The position as an author would recognise it. Two positions this compiler holds apart can be spelled alike here, which is what `positionId` is for."
+            },
+            "positionId": {
+              "type": "string",
+              "description": "What tells apart two positions `path` spells alike. Within this document, and not a name to show a reader."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "behavior",
+            "input"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "input"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "input": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Which of the behavior's declared inputs, counted from zero."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "at",
+            "ruleId",
+            "rule"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "rule"
+            },
+            "at": {
+              "type": "string",
+              "description": "The position the rule was read at."
+            },
+            "ruleId": {
+              "$ref": "#/$defs/ruleId"
+            },
+            "stopped": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ruleStoppedReadingReason"
+              },
+              "description": "What stopped the reading of the rule, in the words the questions themselves are written under. Absent where nothing stopped it."
+            },
+            "rule": {
+              "$ref": "#/$defs/ruleHandle",
+              "description": "The rule, as a person is shown one wherever this document names a rule."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "label",
+            "line"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "border"
+            },
+            "label": {
+              "type": "string",
+              "description": "What a person is shown for the line."
+            },
+            "line": {
+              "$ref": "#/$defs/authoredLineId",
+              "description": "Which of the rule's lines this is. One rule draws more than one."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "obligationId"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "point"
+            },
+            "obligationId": {
+              "$ref": "#/$defs/obligationId"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "module",
+            "writtenBy",
+            "construct",
+            "lowered",
+            "said"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "fork"
+            },
+            "module": {
+              "type": "string"
+            },
+            "writtenBy": {
+              "$ref": "#/$defs/writtenBy"
+            },
+            "construct": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Which of that body's constructs the fork is."
+            },
+            "lowered": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "said": {
+              "type": "string",
+              "description": "What the author wrote the fork as."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "armId"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "arm"
+            },
+            "armId": {
+              "$ref": "#/$defs/armObligationId"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "module",
+            "behavior",
+            "measure"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "measure"
+            },
+            "module": {
+              "type": "string"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "measure": {
+              "enum": [
+                "reading",
+                "signature",
+                "branch",
+                "boundary",
+                "partition"
+              ],
+              "description": "Which of the measurements a behavior has exactly one of. What the rows reach of a position is measured once per position and is named by that position instead (`axis_measure`)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "module",
+            "behavior",
+            "axis"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "axis_measure"
+            },
+            "module": {
+              "type": "string"
+            },
+            "behavior": {
+              "type": "string"
+            },
+            "axis": {
+              "type": "string",
+              "description": "The position, as `axes` names it."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -216,7 +216,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     @Test
     void andWhichOfTheTwoIsNotAskedOfWhereItWasWritten() {
         RuleShortfall form = new RuleShortfall(CONSTRAINED, UnreadReason.FORM_NOT_READ,
-                new RuleShortfall.Site.AtALeaf(new ClauseExpr.Occurrence(0), new SourcePos(1, 1)));
+                new RuleShortfall.Site.AtALeaf(new ClauseOccurrence(0), new SourcePos(1, 1)));
         ChoiceSite choice = aChoice();
 
         assertEquals(java.util.Set.of(form),

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
@@ -37,7 +37,7 @@ class ALineIsNamedInTheTermsItWasWrittenInTest {
     void aNewtypesClauseIsAboutTheValueItWraps() {
         var line = lineAt("String.length(u) = 1");
         assertEquals("String.length(value)",
-                declaredBy("UserId").nameOf(line.part()));
+                declaredBy("UserId").nameOf(line.drawnBy()));
     }
 
     /**
@@ -52,8 +52,8 @@ class ALineIsNamedInTheTermsItWasWrittenInTest {
         DeclaredBorders lines = declaredBy("Pair");
         var name = lineAt("String.length(p.name) = 1");
         var code = lineAt("String.length(p.code) = 1");
-        assertEquals("String.length(name)", lines.nameOf(name.part()));
-        assertEquals("String.length(code)", lines.nameOf(code.part()));
+        assertEquals("String.length(name)", lines.nameOf(name.drawnBy()));
+        assertEquals("String.length(code)", lines.nameOf(code.drawnBy()));
     }
 
     /** Both ends of a range are the one number, which is what tells this from the case above. */
@@ -62,8 +62,8 @@ class ALineIsNamedInTheTermsItWasWrittenInTest {
         DeclaredBorders lines = declaredBy("Range");
         var bottom = lineAt("r = 1");
         var top = lineAt("r = 10");
-        assertEquals("value", lines.nameOf(bottom.part()));
-        assertEquals("value", lines.nameOf(top.part()));
+        assertEquals("value", lines.nameOf(bottom.drawnBy()));
+        assertEquals("value", lines.nameOf(top.drawnBy()));
         org.junit.jupiter.api.Assertions.assertNotEquals(bottom.part(), top.part(),
                 "the two ends are the one number and different lines");
     }
@@ -78,9 +78,9 @@ class ALineIsNamedInTheTermsItWasWrittenInTest {
     @Test
     void aDeclarationAnswersForTheClausesItWrote() {
         var line = lineAt("s.d = 0");
-        assertNotNull(declaredBy("Day").at(line.part()),
+        assertNotNull(declaredBy("Day").at(line.drawnBy()),
                 "Day wrote the clause, so Day names the line");
-        assertNull(declaredBy("Span").at(line.part()),
+        assertNull(declaredBy("Span").at(line.drawnBy()),
                 "and Span holds a value that is held to it, which is not the same thing");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest.java
@@ -61,8 +61,8 @@ class AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest {
     void oneClauseBuiltTwiceHandsOutOneSetOfCoordinates() {
         ClauseExpr one = ClauseExpr.of(clause(), true);
         ClauseExpr other = ClauseExpr.of(clause(), true);
-        Map<ClauseExpr.Occurrence, Core> here = nodesBy(one);
-        Map<ClauseExpr.Occurrence, Core> there = nodesBy(other);
+        Map<ClauseOccurrence, Core> here = nodesBy(one);
+        Map<ClauseOccurrence, Core> there = nodesBy(other);
         assertEquals(here.keySet(), there.keySet(),
                 "the occurrences are the structure's, and the two trees are one structure");
         here.forEach((at, node) -> {
@@ -115,13 +115,13 @@ class AnAccountIsFoundThroughAnyTreeOfTheSameClauseTest {
     }
 
     /** Every node of the shape, under the coordinate the shape gives it. */
-    private static Map<ClauseExpr.Occurrence, Core> nodesBy(ClauseExpr shape) {
-        Map<ClauseExpr.Occurrence, Core> out = new LinkedHashMap<>();
+    private static Map<ClauseOccurrence, Core> nodesBy(ClauseExpr shape) {
+        Map<ClauseOccurrence, Core> out = new LinkedHashMap<>();
         gather(shape, out);
         return out;
     }
 
-    private static void gather(ClauseExpr shape, Map<ClauseExpr.Occurrence, Core> out) {
+    private static void gather(ClauseExpr shape, Map<ClauseOccurrence, Core> out) {
         out.put(shape.at(), shape.written());
         switch (shape) {
             case ClauseExpr.Leaf _ -> {

--- a/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
@@ -53,14 +53,20 @@ class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
 
     /** An end above one number of `names`, placed by the clause at {@code by}. */
     private static FieldDomains.Placed upTo(NumberAt<RuleKey> on, int by, int at) {
-        return new FieldDomains.Placed(on, new PartId<>(rule(by), 0), false,
+        return new FieldDomains.Placed(on, statementOf(by), false,
                 Endpoint.inclusive(Count.of(at)));
     }
 
     /** And one below it. */
     private static FieldDomains.Placed from(NumberAt<RuleKey> on, int by, int at) {
-        return new FieldDomains.Placed(on, new PartId<>(rule(by), 0), true,
+        return new FieldDomains.Placed(on, statementOf(by), true,
                 Endpoint.inclusive(Count.of(at)));
+    }
+
+    /** The one statement of the first conjunct of clause {@code by}. */
+    private static LineProvenance statementOf(int by) {
+        return new LineProvenance.Direct(new InvariantStatementId(
+                new PartId<>(rule(by), 0), 0));
     }
 
     private static final NumberAt<RuleKey> HOW_LONG =

--- a/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
@@ -48,7 +48,7 @@ class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
     /** The clauses an end names, which is what these assertions are about: which conjunct of each
      *  drew it is beside that and is not what a reader is sent to look at. */
     private static List<RuleRef.Invariant> rulesOf(DeclaredBounds.End end) {
-        return end.from().stream().map(each -> each.part().rule()).toList();
+        return end.found().stream().map(each -> each.part().rule()).toList();
     }
 
     /** An end above one number of `names`, placed by the clause at {@code by}. */

--- a/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
@@ -252,36 +252,48 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
                 | "a" : (Pair { name = "x", code = "y" }, Pair { name = "x", code = "y" }) -> Ok
             """;
 
-    /** Every line the model draws, by what a report calls it. */
-    private static Map<String, LineOrigin> linesOf(String model) {
-        Compilation compilation = compiled(model);
+    /**
+     * Each model read once, and every question below put to that reading.
+     *
+     * <p>One compilation per source rather than one per question. What is asked here is what the
+     * readings of one model came to, so a second compilation of the same source is the same answer
+     * worked out again — and these ask several questions apiece of the two models.
+     */
+    private static final Map<String, Compilation> READ = new LinkedHashMap<>();
+
+    private static synchronized Compilation compiled(String model) {
+        return READ.computeIfAbsent(model, each -> {
+            Compilation compilation = Compilation.ofSource(each, "Main");
+            compilation.measure(Adequacy.Asked.fullReport());
+            compilation.answerEverything();
+            return compilation;
+        });
+    }
+
+    /** Every boundary the model states, as a report meets them. */
+    private static List<BorderAssessment> bordersOf(String model) {
         Map<String, List<BorderAssessment>> boundaries =
-                Adequacy.boundariesOf(compilation.db(), "example.forms");
+                Adequacy.boundariesOf(compiled(model).db(), "example.forms");
         assertNotNull(boundaries, "the model under test compiles");
-        Map<String, LineOrigin> out = new LinkedHashMap<>();
-        boundaries.values().forEach(each ->
-                each.forEach(line -> out.put(line.label(), line.border().origin())));
+        List<BorderAssessment> out = new java.util.ArrayList<>();
+        boundaries.values().forEach(out::addAll);
         return out;
     }
 
-    private static Compilation compiled(String model) {
-        Compilation compilation = Compilation.ofSource(model, "Main");
-        compilation.measure(Adequacy.Asked.fullReport());
-        compilation.answerEverything();
-        return compilation;
+    /** Every line the model draws, by what a report calls it. */
+    private static Map<String, LineOrigin> linesOf(String model) {
+        Map<String, LineOrigin> out = new LinkedHashMap<>();
+        bordersOf(model).forEach(line -> out.put(line.label(), line.border().origin()));
+        return out;
     }
 
     /** Every line drawn at {@code label}, which is more than one where two rules stop the values in
      *  the same place. */
     private static List<DeclaredLine> drawnAt(String model, String label) {
-        Compilation compilation = compiled(model);
-        Map<String, List<BorderAssessment>> boundaries =
-                Adequacy.boundariesOf(compilation.db(), "example.forms");
-        assertNotNull(boundaries, "the model under test compiles");
-        List<DeclaredLine> out = new java.util.ArrayList<>();
-        boundaries.values().forEach(each -> each.stream()
+        List<DeclaredLine> out = bordersOf(model).stream()
                 .filter(line -> line.label().equals(label))
-                .forEach(line -> out.add(drawnBy(line.border().origin()))));
+                .map(line -> drawnBy(line.border().origin()))
+                .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
         org.junit.jupiter.api.Assertions.assertFalse(out.isEmpty(),
                 () -> label + " is not a line of the model");
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
@@ -184,6 +184,40 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
     }
 
     /**
+     * And the document says which of the conjunct's lines each of them is.
+     *
+     * <p>The end of it. What the readings tell apart is worth nothing to an author if the document
+     * that reaches them says the same of both: the two lines here come out of one conjunct, so a
+     * document naming the conjunct wrote one identity twice and a reader could not ask about either
+     * of them. Held on the document rather than on the schema, because a schema says a field is
+     * there and not that two lines get two answers in it.
+     */
+    @Test
+    void andTheDocumentTellsTheTwoLinesOfOneConjunctApart() {
+        String json = souther.compiler.report.AdequacyReport.of(compiled(DENIED))
+                .json(souther.compiler.diag.SourceNameResolver.identity())
+                .replaceAll("\\s+", "");
+        java.util.regex.Matcher found = java.util.regex.Pattern
+                .compile("\"which\":\\{.{0,240}?\\},\"facts\"").matcher(json);
+        java.util.Set<String> which = new java.util.LinkedHashSet<>();
+        while (found.find()) {
+            which.add(found.group());
+        }
+
+        assertEquals(bordersOf(DENIED).stream()
+                        .map(line -> drawnBy(line.border().origin()))
+                        .distinct().count(),
+                which.size(),
+                () -> "every line the readings tell apart is one the document can be asked about: "
+                        + which);
+        assertEquals(2, which.stream()
+                        .filter(each -> each.contains("\"Pair\",\"clause\":0},\"part\":0"))
+                        .count(),
+                () -> "two of them came out of one conjunct of one clause, and the document says"
+                        + " which line of it each is: " + which);
+    }
+
+    /**
      * A conjunct paired with one statement on a number still draws the conjunct's line there.
      *
      * <p>What the pairing counts and what the intervention removes are different things. {@code

--- a/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
@@ -134,7 +134,7 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
         PartId<RuleRef.Invariant> floor = new PartId<>(holes, 1);
 
         assertEquals(java.util.Set.of(
-                        new DeclaredLine.OfAChoice(java.util.Set.of(
+                        new DeclaredLine.OfStatementsTogether(java.util.Set.of(
                                 new InvariantStatementId(apart, 0),
                                 new InvariantStatementId(apart, 1))),
                         new DeclaredLine.OfAStatement(new InvariantStatementId(floor, 0))),
@@ -142,6 +142,65 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
                 "what `apart` accounts for is the conjunct's line, drawn between the statements"
                         + " about the number, and neither of them alone drew it");
     }
+
+    /**
+     * A conjunct that accounts for an end one of its own statements placed draws no line beside it.
+     *
+     * <p>The control for the case above, and what says the rule is not a precedence between the two
+     * readings. Taking a conjunct away takes away every statement it made, so where one of them
+     * placed this end the coarser reading was bound to move it: what it establishes is the line that
+     * is already here. Counted as a line of its own, {@code n >= 0 && n /= 100} owes two rows at the
+     * bottom of its range where the author drew one.
+     */
+    @Test
+    void andDrawsNoneWhereOneOfItsOwnStatementsPlacedTheEnd() {
+        List<DeclaredLine> drawn = drawnAt(TOGETHER, "m.v = 0");
+        RuleRef.Invariant bounded = drawn.get(0).part().rule();
+
+        assertEquals(List.of(new DeclaredLine.OfAStatement(
+                        new InvariantStatementId(new PartId<>(bounded, 0), 0))),
+                drawn,
+                "the end is the one `n >= 0` places, and taking the conjunct away shows nothing"
+                        + " beside it");
+    }
+
+    /**
+     * And where the ends are apart, both are lines.
+     *
+     * <p>What tells this from the control is where the conjunct leaves the values. {@code n >= 0}
+     * places an end at nought and {@code n /= 0} takes that value away, so the number starts at one
+     * — which is not the end either statement placed, and is a line of the conjunct's own.
+     */
+    @Test
+    void andBothWhereTheEndsAreApart() {
+        List<DeclaredLine> drawn = drawnAt(MOVED, "m.v = 1");
+        PartId<RuleRef.Invariant> part = new PartId<>(drawn.get(0).part().rule(), 0);
+
+        assertEquals(List.of(new DeclaredLine.OfStatementsTogether(java.util.Set.of(
+                        new InvariantStatementId(part, 0), new InvariantStatementId(part, 1)))),
+                drawn,
+                "where the values start is the conjunct's, which no statement of it placed");
+    }
+
+    private static final String TOGETHER = """
+            module example.forms
+
+            let mixed (n: Int) = n >= 0 && n /= 100
+
+            data Mixed = { v: Int }
+                invariant bounded = mixed(v)
+
+            data Ok
+
+            behavior m : (m: Mixed) -> Ok
+            let m (m) = Ok
+
+            example m
+                | "a" : (Mixed { v = 5 }) -> Ok
+            """;
+
+    private static final String MOVED =
+            TOGETHER.replace("n >= 0 && n /= 100", "n >= 0 && n /= 0");
 
     private static final String DENIED = """
             module example.forms

--- a/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
@@ -134,13 +134,14 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
         PartId<RuleRef.Invariant> floor = new PartId<>(holes, 1);
 
         assertEquals(java.util.Set.of(
-                        new DeclaredLine.OfStatementsTogether(java.util.Set.of(
+                        new DeclaredLine.OfAConjunct(java.util.Set.of(
                                 new InvariantStatementId(apart, 0),
                                 new InvariantStatementId(apart, 1))),
-                        new DeclaredLine.OfAStatement(new InvariantStatementId(floor, 0))),
+                        new DeclaredLine.OfAConjunct(
+                                java.util.Set.of(new InvariantStatementId(floor, 0)))),
                 java.util.Set.copyOf(drawn),
-                "what `apart` accounts for is the conjunct's line, drawn between the statements"
-                        + " about the number, and neither of them alone drew it");
+                "each is the line of the conjunct taking it away moved, and neither is a statement's"
+                        + " — including the conjunct that states one thing about this number");
     }
 
     /**
@@ -176,11 +177,51 @@ class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
         List<DeclaredLine> drawn = drawnAt(MOVED, "m.v = 1");
         PartId<RuleRef.Invariant> part = new PartId<>(drawn.get(0).part().rule(), 0);
 
-        assertEquals(List.of(new DeclaredLine.OfStatementsTogether(java.util.Set.of(
+        assertEquals(List.of(new DeclaredLine.OfAConjunct(java.util.Set.of(
                         new InvariantStatementId(part, 0), new InvariantStatementId(part, 1)))),
                 drawn,
                 "where the values start is the conjunct's, which no statement of it placed");
     }
+
+    /**
+     * A conjunct paired with one statement on a number still draws the conjunct's line there.
+     *
+     * <p>What the pairing counts and what the intervention removes are different things. {@code
+     * coupled} states {@code a /= 100} about one number and {@code b >= 1} about another, so only
+     * the first is paired with {@code a} — and where {@code a}'s floor comes from {@code b >= 1}
+     * through the rule relating the two, taking the conjunct away moves it. Read from the pairing,
+     * {@code a /= 100} is said to have placed an end that {@code b >= 1} is why, which no
+     * counterfactual here tested.
+     */
+    @Test
+    void andWherePairedWithOneStatementItIsStillTheConjunctsLine() {
+        List<DeclaredLine> drawn = drawnAt(COUPLED, "p.a = 1");
+
+        assertEquals(List.of(new DeclaredLine.OfAConjunct(java.util.Set.of(
+                        new InvariantStatementId(
+                                new PartId<>(drawn.get(0).part().rule(), 0), 0)))),
+                drawn,
+                "the conjunct moved the end, and which of its statements is on this number is what"
+                        + " pairs the line rather than what drew it");
+    }
+
+    private static final String COUPLED = """
+            module example.forms
+
+            let coupled (a: Int, b: Int) = a /= 100 && b >= 1
+
+            data Pair = { a: Int, b: Int }
+                invariant coupled = coupled(a, b)
+                invariant ordered = a >= b
+
+            data Ok
+
+            behavior p : (p: Pair) -> Ok
+            let p (p) = Ok
+
+            example p
+                | "a" : (Pair { a = 5, b = 3 }) -> Ok
+            """;
 
     private static final String TOGETHER = """
             module example.forms

--- a/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneConjunctStatesAsManyLinesAsItHasStatementsTest.java
@@ -1,0 +1,256 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.LineOrigin;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A conjunct states as many lines as the reading arrives at statements inside it, and each of them
+ * is a line of the model in its own right.
+ *
+ * <p>A denial is carried to the leaves as a clause is read, so a conjunction an author wrote as a
+ * denied choice is one conjunct stating one comparison per branch. Named by the conjunct, the second
+ * of them is the first said again: a report that looks up what to call a line finds whichever was
+ * written down last, and an accounting that counts lines counts one where the author drew two.
+ *
+ * <p><b>What tells the two apart is the statement and nothing beside it.</b> The facts of a line —
+ * which side the rule keeps and whether it admits the value it stops at — are the same for two lower
+ * bounds on two numbers, so a reader holding those is holding one line twice. Which number each is
+ * on would tell them apart and is no part of a line: a clause is read once per position carrying the
+ * type, and the coordinate is spelt differently by each of those readings.
+ */
+class OneConjunctStatesAsManyLinesAsItHasStatementsTest {
+
+    /**
+     * The denied spelling draws two lines, and a report names each of them for the number it is on.
+     *
+     * <p>The case the identity is for. Both are lower bounds admitting their own value, so
+     * {@link souther.compiler.partition.LineFacts} says the same of both; they are about two
+     * numbers, and one conjunct wrote them.
+     */
+    @Test
+    void aConjunctWrittenUnderADenialDrawsALineOnEachNumberItStops() {
+        Map<String, LineOrigin> lines = linesOf(DENIED);
+        LineOrigin name = lineAt(lines, "String.length(p.name) = 1");
+        LineOrigin code = lineAt(lines, "String.length(p.code) = 1");
+
+        assertEquals(part(name), part(code), "one conjunct wrote both");
+        assertNotEquals(name.authoredLine(), code.authoredLine(),
+                "and they are two lines of the model, which is what a row at either is owed to");
+
+        DeclaredBorders borders = declaredBy(DENIED, "Pair");
+        assertEquals("String.length(name)", borders.nameOf(drawnBy(name)));
+        assertEquals("String.length(code)", borders.nameOf(drawnBy(code)));
+    }
+
+    /**
+     * And the spelling with {@code &&} draws the same two, which is what the two spellings agreeing
+     * means.
+     *
+     * <p>Here the conjuncts differ, so this passed while the identity was the conjunct alone. Read
+     * beside the case above, it says the answer does not turn on which spelling the author chose.
+     */
+    @Test
+    void andTheSpellingWithAndDrawsTheSameTwo() {
+        Map<String, LineOrigin> lines = linesOf(PLAIN);
+        LineOrigin name = lineAt(lines, "String.length(p.name) = 1");
+        LineOrigin code = lineAt(lines, "String.length(p.code) = 1");
+
+        assertNotEquals(part(name), part(code), "the author wrote two conjuncts here");
+        assertNotEquals(name.authoredLine(), code.authoredLine(), "and they are two lines");
+
+        DeclaredBorders borders = declaredBy(PLAIN, "Pair");
+        assertEquals("String.length(name)", borders.nameOf(drawnBy(name)));
+        assertEquals("String.length(code)", borders.nameOf(drawnBy(code)));
+    }
+
+    /**
+     * Two ends of one conjunct on one number, which the facts of a line do tell apart.
+     *
+     * <p>The control for the first case. A minimum and a maximum differ in which side they keep, so
+     * a reader holding the facts alone tells these two apart and is no worse off for it — which is
+     * why the first case is the one that says the statement is needed.
+     */
+    @Test
+    void aConjunctStoppingOneNumberAtBothEndsDrawsTwoLinesThere() {
+        Map<String, LineOrigin> lines = linesOf(DENIED);
+        LineOrigin bottom = lineAt(lines, "r.v = 1");
+        LineOrigin top = lineAt(lines, "r.v = 10");
+
+        assertEquals(part(bottom), part(top), "one conjunct wrote both");
+        assertNotEquals(bottom.authoredLine(), top.authoredLine(), "and they are two lines");
+        assertNotEquals(bottom.lineFacts(), top.lineFacts(),
+                "which the facts of the line say here, unlike two ends on two numbers");
+    }
+
+    /**
+     * One statement read at two positions is one line of the model.
+     *
+     * <p>The other half of what an identity is for. A clause is read once per position carrying the
+     * type, and a row is owed for what the author wrote rather than for how far the type travelled —
+     * so the readings of one statement come back as one authored line.
+     */
+    @Test
+    void oneStatementReadAtTwoPositionsIsOneLine() {
+        Map<String, LineOrigin> lines = linesOf(DENIED);
+        LineOrigin here = lineAt(lines, "String.length(p.name) = 1");
+        LineOrigin there = lineAt(lines, "String.length(q.name) = 1");
+
+        assertEquals(here.authoredLine(), there.authoredLine(),
+                "one statement, read at two positions, is one line and one debt");
+    }
+
+    /**
+     * A conjunct whose statements move an end none of them places draws the conjunct's own line.
+     *
+     * <p>{@code apart} states two disequalities, neither of which stops the values anywhere: what
+     * leaves the number starting at two is the pair of them, and the reading that finds it took the
+     * whole conjunct away. So the line is the conjunct's, and saying it was one statement's would be
+     * a claim nothing tested.
+     */
+    @Test
+    void aConjunctThatMovesAnEndNoStatementPlacesDrawsItsOwnLine() {
+        // Both conjuncts account for where the value starts, so the end carries a line apiece: the
+        // one `v >= 0` states, and the one `apart` draws between the two disequalities under it.
+        List<DeclaredLine> drawn = drawnAt(DENIED, "h.v = 2");
+        RuleRef.Invariant holes = drawn.get(0).part().rule();
+        PartId<RuleRef.Invariant> apart = new PartId<>(holes, 0);
+        PartId<RuleRef.Invariant> floor = new PartId<>(holes, 1);
+
+        assertEquals(java.util.Set.of(
+                        new DeclaredLine.OfAChoice(java.util.Set.of(
+                                new InvariantStatementId(apart, 0),
+                                new InvariantStatementId(apart, 1))),
+                        new DeclaredLine.OfAStatement(new InvariantStatementId(floor, 0))),
+                java.util.Set.copyOf(drawn),
+                "what `apart` accounts for is the conjunct's line, drawn between the statements"
+                        + " about the number, and neither of them alone drew it");
+    }
+
+    private static final String DENIED = """
+            module example.forms
+
+            data Pair = { name: String, code: String }
+                invariant both = Bool.not(String.length(name) < 1 || String.length(code) < 1)
+
+            data Range = { v: Int }
+                invariant within = Bool.not(v < 1 || v > 10)
+
+            let apart (n: Int) = n /= 0 && n /= 1
+
+            data Holes = { v: Int }
+                invariant holes = apart(v) && v >= 0
+
+            data Ok
+
+            behavior g : (p: Pair, q: Pair) -> Ok
+            let g (p, q) = Ok
+
+            behavior h : (r: Range) -> Ok
+            let h (r) = Ok
+
+            behavior k : (h: Holes) -> Ok
+            let k (h) = Ok
+
+            example g
+                | "a" : (Pair { name = "x", code = "y" }, Pair { name = "x", code = "y" }) -> Ok
+
+            example h
+                | "a" : (Range { v = 5 }) -> Ok
+
+            example k
+                | "a" : (Holes { v = 5 }) -> Ok
+            """;
+
+    private static final String PLAIN = """
+            module example.forms
+
+            data Pair = { name: String, code: String }
+                invariant both = String.length(name) >= 1 && String.length(code) >= 1
+
+            data Ok
+
+            behavior g : (p: Pair, q: Pair) -> Ok
+            let g (p, q) = Ok
+
+            example g
+                | "a" : (Pair { name = "x", code = "y" }, Pair { name = "x", code = "y" }) -> Ok
+            """;
+
+    /** Every line the model draws, by what a report calls it. */
+    private static Map<String, LineOrigin> linesOf(String model) {
+        Compilation compilation = compiled(model);
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), "example.forms");
+        assertNotNull(boundaries, "the model under test compiles");
+        Map<String, LineOrigin> out = new LinkedHashMap<>();
+        boundaries.values().forEach(each ->
+                each.forEach(line -> out.put(line.label(), line.border().origin())));
+        return out;
+    }
+
+    private static Compilation compiled(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /** Every line drawn at {@code label}, which is more than one where two rules stop the values in
+     *  the same place. */
+    private static List<DeclaredLine> drawnAt(String model, String label) {
+        Compilation compilation = compiled(model);
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), "example.forms");
+        assertNotNull(boundaries, "the model under test compiles");
+        List<DeclaredLine> out = new java.util.ArrayList<>();
+        boundaries.values().forEach(each -> each.stream()
+                .filter(line -> line.label().equals(label))
+                .forEach(line -> out.add(drawnBy(line.border().origin()))));
+        org.junit.jupiter.api.Assertions.assertFalse(out.isEmpty(),
+                () -> label + " is not a line of the model");
+        return out;
+    }
+
+    private static LineOrigin lineAt(Map<String, LineOrigin> lines, String label) {
+        LineOrigin origin = lines.get(label);
+        assertNotNull(origin, () -> label + " is not a line of the model: " + lines.keySet());
+        return origin;
+    }
+
+    /** What the reading knows about the clause that drew the line. */
+    private static DeclaredLine drawnBy(LineOrigin origin) {
+        return ((LineOrigin.InvariantOrigin) origin).drawnBy();
+    }
+
+    private static PartId<RuleRef.Invariant> part(LineOrigin origin) {
+        return drawnBy(origin).part();
+    }
+
+    /** The lines {@code name} draws, in its own terms. */
+    private static DeclaredBorders declaredBy(String model, String name) {
+        Compilation compilation = compiled(model);
+        String module = compilation.modules().get(0);
+        ReadingPolicy policy = compilation.db().ask(new Front.Reading()).value();
+        TypeSymbol named = TypeSymbols.declared(new TypeKey("example.forms", name));
+        return DeclaredBorders.of(named, Shapes.publishedDeclarations(compilation.db()),
+                Shapes.declarationCitations(compilation.db()),
+                RuleReadings.of(compilation, module), policy);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -14,6 +14,9 @@ import souther.compiler.types.WrittenOwner;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReportAnchor;
 import souther.compiler.check.RuleReadings;
@@ -198,8 +201,7 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
     void aComparisonAndABoundAtOneValueAreTwoDebts() {
         Border guard = Border.at(aLineAt(100), readAt(1), ANYWHERE);
         Border bound = Border.at(aLineAt(100),
-                new LineOrigin.InvariantOrigin(
-                        new souther.compiler.check.PartId<>(aClause(), 0),
+                new LineOrigin.InvariantOrigin(aStatementOf(aClause()),
                         souther.compiler.numeric.EndSide.LOWER, true),
                 new souther.compiler.numeric.NumericDomain.Bounds(
                         souther.compiler.numeric.Endpoint.inclusive(
@@ -252,6 +254,13 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                         new RuleReportAnchor.ByTheModuleThatWroteIt(),
                         List.of(WHERE.comparison(occurrence))),
                 new LineFacts(new ComparisonClaim.Cut(Towards.BELOW, true)));
+    }
+
+    /** The one statement of the first conjunct of {@code clause}, which is only an identity
+     *  here. */
+    private static DeclaredLine aStatementOf(RuleRef.Invariant clause) {
+        return new DeclaredLine.OfAStatement(
+                new InvariantStatementId(new PartId<>(clause, 0), 0));
     }
 
     /** The clause the bound in these tests names, which is only an identity here. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -12,6 +12,9 @@ import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Towards;
 import souther.compiler.check.Clause;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleRef;
 import souther.compiler.diag.SourceNameResolver;
@@ -224,14 +227,14 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     void aBoundThatStopsShortOfItsLineWhereTheOrderStepsIsRefused() {
         Border kept = borderOf(
                 new LineOrigin.InvariantOrigin(
-                        new souther.compiler.check.PartId<>(invariant(), THE_ONLY_CONJUNCT),
+                        theOnlyStatement(),
                         souther.compiler.numeric.EndSide.LOWER, true));
         assertEquals("= 5", kept.demand(PointRole.ON).criterion().asked(kept.cut().of()),
                 "a bound that admits its own end is at that end's ON point");
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> borderOf(new LineOrigin.InvariantOrigin(
-                        new souther.compiler.check.PartId<>(invariant(), THE_ONLY_CONJUNCT),
+                        theOnlyStatement(),
                         souther.compiler.numeric.EndSide.LOWER, false)),
                 "a rule parting the values at 6 over a range that stops at 5 is two readings of one"
                         + " model that disagree");
@@ -284,7 +287,7 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
 
         // A bound owes nothing outside itself, and says which of the three answers settled it.
         Border bound = borderOf(new LineOrigin.InvariantOrigin(
-                        new souther.compiler.check.PartId<>(invariant(), THE_ONLY_CONJUNCT),
+                        theOnlyStatement(),
                         souther.compiler.numeric.EndSide.LOWER, true));
         assertEquals(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),
                 bound.demand(PointRole.OFF));
@@ -303,6 +306,12 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
         return BoundaryTarget.at(new BorderQuantity.OfACoordinate(axis.behavior(), term,
                         souther.compiler.inputs.TermOrdersFixtures.itself(term, carrier)),
                 new Level.OnACarrier(carrier, at));
+    }
+
+    /** The one statement of the one conjunct that clause was written in. */
+    private static DeclaredLine theOnlyStatement() {
+        return new DeclaredLine.OfAStatement(new InvariantStatementId(
+                new PartId<>(invariant(), THE_ONLY_CONJUNCT), 0));
     }
 
     /** The clause the bound tests name, which is only an identity here. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
@@ -173,9 +176,10 @@ class ABoundSaysWhichSideItKeepsTest {
                 Optional.of(new ClauseName("within"))));
     }
 
-    /** The one part that clause was written in. */
-    private static souther.compiler.check.PartId<RuleRef.Invariant> aPart() {
-        return new souther.compiler.check.PartId<>(aClause(), 0);
+    /** The one statement of the one part that clause was written in. */
+    private static DeclaredLine aPart() {
+        return new DeclaredLine.OfAStatement(
+                new InvariantStatementId(new PartId<>(aClause(), 0), 0));
     }
 
     /** A clause whose two conjuncts leave the position one value. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.AReadingOfAPosition;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleReportAnchor;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.MatchedEndAttribution;
@@ -188,10 +191,12 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
 
     private static LineOrigin.InvariantOrigin aBound() {
         return new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.weigh", "Amount")), 0),
-                        Optional.of(new ClauseName("cap")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.weigh", "Amount")), 0),
+                                Optional.of(new ClauseName("cap")))), 0),
+                        0)),
                 EndSide.LOWER, true);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
@@ -174,10 +177,12 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
 
     private static LineOrigin bound(String clause) {
         return new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                        java.util.Optional.of(new ClauseName(clause)))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.rate", "Amount")), 0),
+                                java.util.Optional.of(new ClauseName(clause)))), 0),
+                        0)),
                 souther.compiler.numeric.EndSide.LOWER, true);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineIsOfAPositionTheMeasurementMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineIsOfAPositionTheMeasurementMeasuresTest.java
@@ -6,6 +6,9 @@ import souther.compiler.DefaultStdlib;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Carrier;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleRef;
@@ -90,9 +93,12 @@ class ALineIsOfAPositionTheMeasurementMeasuresTest {
 
     private static LineOrigin aBound() {
         return new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(TypeSymbols.declared(new TypeKey("example.fee", "Amount")), 0),
-                        Optional.of(new ClauseName("cap")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.fee", "Amount")), 0),
+                                Optional.of(new ClauseName("cap")))), 0),
+                        0)),
                 EndSide.LOWER, true);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineSaysWhatCountsItAndCannotSayBothTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineSaysWhatCountsItAndCannotSayBothTest.java
@@ -60,7 +60,7 @@ class ALineSaysWhatCountsItAndCannotSayBothTest {
     @Test
     void aLineOfADeclarationIsNamedByItsPart() {
         assertEquals(aClause(),
-                new WhichLine.OfAPart(new DeclaredLine.OfAStatement(new InvariantStatementId(
+                new WhichLine.OfADeclarationsLine(new DeclaredLine.OfAStatement(new InvariantStatementId(
                         new PartId<>(aClause(), 0), 0))).rule(),
                 "the clause the part is a part of, which is what such a line is of");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineSaysWhatCountsItAndCannotSayBothTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineSaysWhatCountsItAndCannotSayBothTest.java
@@ -3,6 +3,8 @@ package souther.compiler.partition;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
 import souther.compiler.check.PartId;
 import souther.compiler.check.RuleRef;
 import souther.compiler.types.SourceConstruct;
@@ -57,7 +59,9 @@ class ALineSaysWhatCountsItAndCannotSayBothTest {
     /** A line of a declaration's clause is named by the part that drew it. */
     @Test
     void aLineOfADeclarationIsNamedByItsPart() {
-        assertEquals(aClause(), new WhichLine.OfAPart(new PartId<>(aClause(), 0)).rule(),
+        assertEquals(aClause(),
+                new WhichLine.OfAPart(new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(aClause(), 0), 0))).rule(),
                 "the clause the part is a part of, which is what such a line is of");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.AReadingOfAPosition;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.MatchedEndAttribution;
 import souther.compiler.check.NarrowedBounds;
@@ -148,10 +151,12 @@ class ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest {
     /** The clause the bound is written in, which is only an identity here. */
     private static LineOrigin.InvariantOrigin aMinimum() {
         return new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.weigh", "Amount")), 0),
-                        Optional.of(new ClauseName("floor")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.weigh", "Amount")), 0),
+                                Optional.of(new ClauseName("floor")))), 0),
+                        0)),
                 EndSide.LOWER, true);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
@@ -6,6 +6,9 @@ import souther.compiler.check.AReadingOfAPosition;
 import souther.compiler.types.WrittenOwner;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.NarrowedBounds;
@@ -211,10 +214,12 @@ class OneBorderReadTwiceIsOneReadingTest {
     /** The clause the bound is written in, which is only an identity here. */
     private static LineOrigin aBound() {
         return new LineOrigin.InvariantOrigin(
-                new souther.compiler.check.PartId<>(new RuleRef.Invariant(new Clause.Ref(
-                        new Clause.Id(
-                                TypeSymbols.declared(new TypeKey("example.weigh", "Amount")), 0),
-                        Optional.of(new ClauseName("cap")))), 0),
+                new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
+                                new Clause.Id(TypeSymbols.declared(
+                                        new TypeKey("example.weigh", "Amount")), 0),
+                                Optional.of(new ClauseName("cap")))), 0),
+                        0)),
                 EndSide.LOWER, true);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -145,7 +145,7 @@ class TwoSpellingsOfOneLevelAreOneDemandTest {
     /** One clause of one declaration, which is only an identity here. */
     private static AuthoredLine aLine() {
         return new AuthoredLine(
-                new WhichLine.OfAPart(new DeclaredLine.OfAStatement(new InvariantStatementId(
+                new WhichLine.OfADeclarationsLine(new DeclaredLine.OfAStatement(new InvariantStatementId(
                         new PartId<>(new RuleRef.Invariant(new Clause.Ref(
                                 new Clause.Id(
                                         TypeSymbols.declared(

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.Count;
@@ -142,12 +145,13 @@ class TwoSpellingsOfOneLevelAreOneDemandTest {
     /** One clause of one declaration, which is only an identity here. */
     private static AuthoredLine aLine() {
         return new AuthoredLine(
-                new WhichLine.OfAPart(new souther.compiler.check.PartId<>(
-                        new RuleRef.Invariant(new Clause.Ref(
+                new WhichLine.OfAPart(new DeclaredLine.OfAStatement(new InvariantStatementId(
+                        new PartId<>(new RuleRef.Invariant(new Clause.Ref(
                                 new Clause.Id(
                                         TypeSymbols.declared(
                                                 new TypeKey("example.probe", "Amount")), 0),
-                                Optional.of(new ClauseName("floor")))), 0)),
+                                Optional.of(new ClauseName("floor")))), 0),
+                        0))),
                 new LineFacts(new ComparisonClaim.Cut(Towards.ABOVE, true)), List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -139,7 +139,7 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
 
     /** One clause of one declaration, told from the next by which clause of it this is. */
     static AuthoredLine aLine(int clause) {
-        return new AuthoredLine(new WhichLine.OfAPart(
+        return new AuthoredLine(new WhichLine.OfADeclarationsLine(
                 new DeclaredLine.OfAStatement(new InvariantStatementId(new PartId<>(
                         new souther.compiler.check.RuleRef.Invariant(
                                 new souther.compiler.check.Clause.Ref(

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
 import souther.compiler.numeric.Towards;
@@ -136,15 +139,17 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
 
     /** One clause of one declaration, told from the next by which clause of it this is. */
     static AuthoredLine aLine(int clause) {
-        return new AuthoredLine(new WhichLine.OfAPart(new souther.compiler.check.PartId<>(
-                new souther.compiler.check.RuleRef.Invariant(
-                        new souther.compiler.check.Clause.Ref(
-                                new souther.compiler.check.Clause.Id(
-                                        souther.compiler.types.TypeSymbols.declared(
-                                                new souther.compiler.types.TypeKey(
-                                                        "example.runs", "N")),
-                                        clause),
-                                java.util.Optional.empty())), 0)),
+        return new AuthoredLine(new WhichLine.OfAPart(
+                new DeclaredLine.OfAStatement(new InvariantStatementId(new PartId<>(
+                        new souther.compiler.check.RuleRef.Invariant(
+                                new souther.compiler.check.Clause.Ref(
+                                        new souther.compiler.check.Clause.Id(
+                                                souther.compiler.types.TypeSymbols.declared(
+                                                        new souther.compiler.types.TypeKey(
+                                                                "example.runs", "N")),
+                                                clause),
+                                        java.util.Optional.empty())), 0),
+                        0))),
                 new LineFacts(new ComparisonClaim.Cut(Towards.ABOVE, true)), List.of());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichEndABoundPlacedSurvivesBeingReadBackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichEndABoundPlacedSurvivesBeingReadBackTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.DeclaredLine;
+import souther.compiler.check.InvariantStatementId;
+import souther.compiler.check.PartId;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.EndSide;
@@ -83,7 +86,8 @@ class WhichEndABoundPlacedSurvivesBeingReadBackTest {
     void aBoundBuiltFromThatEndReadsBackAsThePairItCameFrom() {
         for (Row row : THE_LAW) {
             LineOrigin.InvariantOrigin origin = new LineOrigin.InvariantOrigin(
-                    new souther.compiler.check.PartId<>(aClause(), 0),
+                    new DeclaredLine.OfAStatement(new InvariantStatementId(
+                            new PartId<>(aClause(), 0), 0)),
                     DeclaredThresholds.endKept(row.cut()), row.holdsAtTheValue());
 
             assertEquals(row.cut(), origin.lineFacts().claim(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhoMayCarryTheNumberOfAStatementIsWrittenDownTest.java
@@ -38,6 +38,9 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
 
     private static final String STATEMENT_ID = "souther/compiler/partition/ClauseStatementId";
 
+    private static final String INVARIANT_STATEMENT_ID =
+            "souther/compiler/check/InvariantStatementId";
+
     /** A field that holds such a number, or a method that makes one, and why it may. */
     private record Licence(String who, String why) { }
 
@@ -45,13 +48,26 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
             new Licence("souther.compiler.partition.ClauseStatementId.ordinal",
                     "the pair itself, made where a part is read for what it states and carried from"
                             + " there. This is the name everything downstream holds instead of a"
-                            + " number, so it is the one place the two stand together"));
+                            + " number, so it is the one place the two stand together"),
+            new Licence("souther.compiler.check.InvariantStatementId.ordinal",
+                    "the same pair for a declaration's clause, which is decomposed twice as a"
+                            + " behavior's is. Two of them and not one, because the number means"
+                            + " which statement of the part its own reading arrived at: the readings"
+                            + " are separate and a number issued by either would be a place in the"
+                            + " other's list"));
 
     private static final List<Licence> MAY_MAKE = List.of(
             new Licence("souther.compiler.partition.ClauseStatements.of",
                     "the one place a part is taken apart into the things it states, which is where"
                             + " the place each of them holds among that part's statements was"
                             + " assigned"));
+
+    private static final List<Licence> MAY_MAKE_AN_INVARIANTS = List.of(
+            new Licence("souther.compiler.check.InvariantChecker.direct",
+                    "the walk that reads a declaration's conjunct for what it states, which is where"
+                            + " a statement is recognised. Numbered where an end or a hand-over is"
+                            + " written down instead, the number would say which of the outcomes"
+                            + " this was rather than which of the statements"));
 
     /**
      * Only the reading that took a part apart names one of its statements.
@@ -65,6 +81,21 @@ class WhoMayCarryTheNumberOfAStatementIsWrittenDownTest {
                 "a statement named anywhere else is a number somebody counted for themselves put"
                         + " beside whichever part they were holding. What may make one, and why: "
                         + why(MAY_MAKE));
+    }
+
+    /**
+     * And the same of a declaration's clause, whose statements a walk of its own arrives at.
+     *
+     * <p>Asked apart from the behavior's, because the two readings are apart. What they share is
+     * that the number means a place in one reading's list of what a part states, so a second maker
+     * on either side is a second answer to which statement a statement is.
+     */
+    @Test
+    void andOnlyTheWalkThatReadsADeclarationsConjunctNamesOneOfIts() {
+        assertEquals(named(MAY_MAKE_AN_INVARIANTS), callsTo(INVARIANT_STATEMENT_ID, "<init>"),
+                "a statement named anywhere else is a number somebody counted for themselves put"
+                        + " beside whichever part they were holding. What may make one, and why: "
+                        + why(MAY_MAKE_AN_INVARIANTS));
     }
 
     /** And nothing downstream of that reading holds the number instead of the name. */

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest.java
@@ -21,9 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Which line a document may say a line is, and which rule may stand in each of those.
  *
  * <p>The three kinds of rule are not decomposed alike, so the numbers under them are not
- * interchangeable: a part goes with a clause of a {@code data}, a part and a statement with a
- * clause of a behavior, and a body's comparison takes neither. This is what the document says about
- * that pairing, read off the schema rather than off the sentence in the description beside it.
+ * interchangeable: a part and which of its lines goes with a clause of a {@code data}, a part and
+ * which of its statements with a clause of a behavior, and a body's comparison takes neither. This
+ * is what the document says about that pairing, read off the schema rather than off the sentence in
+ * the description beside it.
  *
  * <p><b>Against the seal and not against a list written here.</b> What arms there are is
  * {@link WhichLine}'s answer, so an arm added to it is an arm this stops at until the document says
@@ -46,9 +47,17 @@ class EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest {
             "statement_of_part", "ensures",
             "comparison", "comparison"));
 
-    /** And which numbers each of them carries beside the rule. */
+    /**
+     * And which numbers each of them carries beside the rule.
+     *
+     * <p>A declaration's clause carries which of its parts and which of that part's lines, because
+     * a part draws more than one: a conjunct written as a denied choice states one comparison per
+     * branch and places an end on each of the numbers they are about. Carrying the part alone, the
+     * document said the same of both — and the facts beside them do not tell them apart, since two
+     * lower bounds admitting their own value say the same thing about two numbers.
+     */
     private static final Map<String, String> CARRIES = new TreeMap<>(Map.of(
-            "part", "[kind, part, rule]",
+            "part", "[kind, line, part, rule]",
             "statement_of_part", "[kind, part, rule, statement]",
             "comparison", "[kind, rule]"));
 

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest.java
@@ -93,7 +93,7 @@ class EveryArmOfAPublishedLineIsPairedWithTheRuleThatHasThatKindTest {
             arms.put(each.getSimpleName(), "");
         }
 
-        assertEquals(new TreeMap<>(Map.of("OfAPart", "", "OfAComparisonOfAPart", "",
+        assertEquals(new TreeMap<>(Map.of("OfADeclarationsLine", "", "OfAComparisonOfAPart", "",
                         "OfAComparison", "")),
                 new TreeMap<>(arms),
                 "the arms a line of the model has, which is what the words above are the document's"

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 17,
+  "schemaVersion" : 18,
   "compilerVersion" : "<version>",
   "status" : "partial",
   "weakening" : [ "bodies_not_elaborated", "rule_unread" ],
@@ -27,7 +27,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -82,7 +86,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -150,7 +158,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -205,7 +217,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -277,7 +293,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -312,7 +332,11 @@
                 "declaredOn" : "Seat",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -352,7 +376,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -407,7 +435,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -475,7 +507,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -530,7 +566,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -602,7 +642,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -637,7 +681,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -908,7 +956,11 @@
                 "declaredOn" : "Voucher",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -964,7 +1016,11 @@
                 "declaredOn" : "Voucher",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1034,7 +1090,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1090,7 +1150,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -1622,7 +1686,11 @@
                   "declaredOn" : "Party",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,
@@ -1700,7 +1768,11 @@
                   "declaredOn" : "Party",
                   "clause" : 0
                 },
-                "part" : 1
+                "part" : 1,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : true,
@@ -2064,7 +2136,11 @@
                 "declaredOn" : "Ticket",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -2120,7 +2196,11 @@
                 "declaredOn" : "Ticket",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -2190,7 +2270,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -2246,7 +2330,11 @@
                 "declaredOn" : "Party",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -2545,7 +2633,11 @@
                   "declaredOn" : "Party",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,
@@ -2623,7 +2715,11 @@
                   "declaredOn" : "Party",
                   "clause" : 0
                 },
-                "part" : 1
+                "part" : 1,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : true,

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 17,
+  "schemaVersion" : 18,
   "compilerVersion" : "<version>",
   "status" : "partial",
   "weakening" : [ "rule_unread" ],
@@ -28,7 +28,11 @@
                 "declaredOn" : "Sku",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -90,7 +94,11 @@
                 "declaredOn" : "Sku",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -166,7 +174,11 @@
                 "declaredOn" : "Price",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -221,7 +233,11 @@
                 "declaredOn" : "Price",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -290,7 +306,11 @@
                 "declaredOn" : "Weight",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -345,7 +365,11 @@
                 "declaredOn" : "Weight",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -414,7 +438,11 @@
                 "declaredOn" : "Rate",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -482,7 +510,11 @@
                 "declaredOn" : "Rate",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1095,7 +1127,11 @@
                 "declaredOn" : "送り状番号",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1157,7 +1193,11 @@
                 "declaredOn" : "送り状番号",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1802,7 +1842,11 @@
                   "declaredOn" : "Weight",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/staffing/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/staffing/expected.report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 17,
+  "schemaVersion" : 18,
   "compilerVersion" : "<version>",
   "status" : "complete",
   "adequacy" : "undetermined",
@@ -716,7 +716,11 @@
               "declaredOn" : "Hours",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -753,7 +757,11 @@
               "declaredOn" : "Hours",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -814,7 +822,11 @@
               "declaredOn" : "Hours",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -851,7 +863,11 @@
               "declaredOn" : "Hours",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -912,7 +928,11 @@
               "declaredOn" : "Rate",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -949,7 +969,11 @@
               "declaredOn" : "Rate",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -1010,7 +1034,11 @@
               "declaredOn" : "Rate",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -1047,7 +1075,11 @@
               "declaredOn" : "Rate",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -1108,7 +1140,11 @@
               "declaredOn" : "WorkDays",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -1145,7 +1181,11 @@
               "declaredOn" : "WorkDays",
               "clause" : 0
             },
-            "part" : 0
+            "part" : 0,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : false,
@@ -1206,7 +1246,11 @@
               "declaredOn" : "WorkDays",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -1243,7 +1287,11 @@
               "declaredOn" : "WorkDays",
               "clause" : 0
             },
-            "part" : 1
+            "part" : 1,
+            "line" : {
+              "kind" : "statement",
+              "statement" : 0
+            }
           },
           "facts" : {
             "valueBelongsBelow" : true,
@@ -1353,7 +1401,11 @@
                 "declaredOn" : "WorkDays",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1409,7 +1461,11 @@
                 "declaredOn" : "WorkDays",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -1474,7 +1530,11 @@
                 "declaredOn" : "Rate",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1530,7 +1590,11 @@
                 "declaredOn" : "Rate",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -1595,7 +1659,11 @@
                 "declaredOn" : "Hours",
                 "clause" : 0
               },
-              "part" : 0
+              "part" : 0,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : false,
@@ -1651,7 +1719,11 @@
                 "declaredOn" : "Hours",
                 "clause" : 0
               },
-              "part" : 1
+              "part" : 1,
+              "line" : {
+                "kind" : "statement",
+                "statement" : 0
+              }
             },
             "facts" : {
               "valueBelongsBelow" : true,
@@ -2041,7 +2113,11 @@
                   "declaredOn" : "WorkDays",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,
@@ -2119,7 +2195,11 @@
                   "declaredOn" : "WorkDays",
                   "clause" : 0
                 },
-                "part" : 1
+                "part" : 1,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : true,
@@ -2452,7 +2532,11 @@
                   "declaredOn" : "Rate",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,
@@ -2530,7 +2614,11 @@
                   "declaredOn" : "Rate",
                   "clause" : 0
                 },
-                "part" : 1
+                "part" : 1,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : true,
@@ -3074,7 +3162,11 @@
                   "declaredOn" : "Hours",
                   "clause" : 0
                 },
-                "part" : 0
+                "part" : 0,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : false,
@@ -3152,7 +3244,11 @@
                   "declaredOn" : "Hours",
                   "clause" : 0
                 },
-                "part" : 1
+                "part" : 1,
+                "line" : {
+                  "kind" : "statement",
+                  "statement" : 0
+                }
               },
               "facts" : {
                 "valueBelongsBelow" : true,


### PR DESCRIPTION
Addresses #1583.

A declaration's clause is decomposed twice. The first is the conjuncts its author joined with `&&`, which `PartId` names. The second is the statements a reading arrives at inside one of them: a denial is carried to the leaves as a clause is read, so a conjunction written as a denied choice is one conjunct stating one comparison per branch. The line pipeline had only the first, and read the conjunct as though it named one line.

So `Bool.not(String.length(name) < 1 || String.length(code) < 1)` places an end on each of two numbers and the two came out as one line. Both are lower bounds admitting their own value, so what a line records about itself says the same of both. What a report says to call one of them was whichever was written down last, under the other's number; the debt they were counted as was one where the author drew two; and a statement whose sibling had placed an end read as already accounted for, so it never reached the reading that attributes an end nothing places.

## What is here

A statement is issued where the walk recognises one, before anything is made of it, and carried from there to the end a comparison places, to the candidate a counterfactual is asked about, and to a conjunct handed on with no end read from it. Numbered where an outcome is written down instead, the number would say which of the outcomes this was rather than which of the statements — and a reading that made more of a clause would number the rest of it differently from one that made less.

Which of the conjunct's statements, and not where the comparison stands in the expanded clause. A rule written out and the same rule reached through a helper are one line of the model, and the trees they are read from are not alike: the bindings stand between the conjunct and the comparison, so the place it holds there moves with how the author spelt it. That place is still what a reading files its own answers under, and it is named beside the clause it is a coordinate of rather than left inside the shape that issues it.

How an end was found is not what the line is. A comparison places one and a counterfactual finds that a conjunct accounts for one, and where the two are about the same statement they are one line owed one row. What each reading established stays with the reading and is spent where the line is made.

A conjunct can also draw a line no statement of it draws. Two disequalities that stop the values nowhere between them leave the number starting further up, and what the reading of that end took away was the whole conjunct — so the line is the conjunct's, told from the other lines that conjunct draws by which of its statements are about the number. Said as one of them, it would be a claim the intervention never tested.

And the reading that hands each authored conjunct to the reading of one comparison no longer names the lines the model draws. It never reaches the statements, so its ends met the other reading's at the same value under a name of a different grain. What it answers now is where the values stop, which is what its callers were asking it.

## What holds it

A property over the spellings of one rule: the denied spelling draws a line on each number it stops and a report names each of them for its own number, the spelling with `&&` draws the same two, and one statement read at two positions is one line and one debt. The control is the pair of ends on one number, which the facts of a line do tell apart — so the case that needs the statement is the one where they do not.

The line a conjunct draws between its own statements, read through to what a report is handed, since an end attributed to a conjunct could still be published as one of them.

A licence for the number beside a part, extended to the declaration's side of it: which type may hold one, and which reading may issue one, each with why.

## Found on the way

#1586 — the reading that takes each authored conjunct as one comparison leaves equivalent spellings bounded differently. It predates this change. It is no longer read for the lines the model draws, and its callers that choose values still read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
