### PR TITLE
Make a path's rules distinct where they are read, not where they are said

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -2,7 +2,6 @@ package souther.compiler.numeric;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,20 +50,34 @@ public final class NumericDomain<A> {
      */
     private static final int DIGITS_WHEN_IT_IS_NOT_A_DECIMAL = 34;
 
-    private final List<AffineConstraint<A>> rules;
+    private final StatedRules<A> stated;
     private final Map<A, Granularity> kinds;
     private final boolean readARuleNothingSatisfies;
+    private List<AffineConstraint<A>> distinctRules;
     private ClosedState<A> closed;
 
-    private NumericDomain(List<AffineConstraint<A>> rules, Map<A, Granularity> kinds,
+    private NumericDomain(StatedRules<A> stated, Map<A, Granularity> kinds,
                           boolean readARuleNothingSatisfies) {
-        this.rules = rules;
+        this.stated = stated;
         this.kinds = kinds;
         this.readARuleNothingSatisfies = readARuleNothingSatisfies;
     }
 
     public static <A> NumericDomain<A> top() {
-        return new NumericDomain<>(List.of(), Map.of(), false);
+        return new NumericDomain<>(StatedRules.none(), Map.of(), false);
+    }
+
+    /**
+     * The rules said, each of them once, derived on the first question asked of them and kept.
+     *
+     * <p>Here rather than at each saying, for the reason {@link StatedRules} gives. Everything below
+     * reads this and not what was said, so what any of them sees is a rule said twice said once.
+     */
+    private List<AffineConstraint<A>> rules() {
+        if (distinctRules == null) {
+            distinctRules = stated.distinct();
+        }
+        return distinctRules;
     }
 
     /**
@@ -100,7 +113,7 @@ public final class NumericDomain<A> {
         return switch (read) {
             // Nothing satisfies it, so nothing satisfies it together with anything else.
             case AffineConstraint.Read.HoldsNever<A> ignored ->
-                    new NumericDomain<>(List.of(), knowing.kinds, true);
+                    new NumericDomain<>(StatedRules.none(), knowing.kinds, true);
             // Every value satisfies it, so there is nothing to keep.
             case AffineConstraint.Read.HoldsAlways<A> ignored -> knowing;
             case AffineConstraint.Read.Stated<A> stated -> knowing.keeping(stated.constraint());
@@ -112,15 +125,12 @@ public final class NumericDomain<A> {
      *
      * <p>Kept and not merged into anything. A rule said twice is the same rule and the same key, so
      * the second saying adds nothing — which is what makes the answer a function of which rules were
-     * said rather than of how often each was.
+     * said rather than of how often each was. Which is settled where the rules are read
+     * ({@link #rules}) and not here: looked for here, saying a rule would cost a walk of every rule
+     * said before it, and a path stating many of them would pay that for each.
      */
     private NumericDomain<A> keeping(AffineConstraint<A> rule) {
-        if (rules.contains(rule)) {
-            return this;
-        }
-        List<AffineConstraint<A>> next = new ArrayList<>(rules);
-        next.add(rule);
-        return new NumericDomain<>(List.copyOf(next), kinds, false);
+        return new NumericDomain<>(stated.and(StatedRules.of(rule)), kinds, false);
     }
 
     /**
@@ -173,7 +183,7 @@ public final class NumericDomain<A> {
             next.put(atom, given);
         }
         return next == null ? this
-                : new NumericDomain<>(rules, Map.copyOf(next), readARuleNothingSatisfies);
+                : new NumericDomain<>(stated, Map.copyOf(next), readARuleNothingSatisfies);
     }
 
     // --- renaming and joining ---------------------------------------------------------------------
@@ -206,15 +216,11 @@ public final class NumericDomain<A> {
         Renaming<A, B> called = Renaming.of(kinds.keySet(), naming);
         Map<B, Granularity> spacing = new LinkedHashMap<>();
         kinds.forEach((atom, spaced) -> spacing.put(called.of(atom), spaced));
-        List<AffineConstraint<B>> out = new ArrayList<>();
-        for (AffineConstraint<A> rule : rules) {
-            AffineConstraint<B> renamed = rule.over(called);
-            if (!out.contains(renamed)) {
-                out.add(renamed);
-            }
+        StatedRules<B> out = StatedRules.none();
+        for (AffineConstraint<A> rule : rules()) {
+            out = out.and(StatedRules.of(rule.over(called)));
         }
-        return new NumericDomain<>(List.copyOf(out), Map.copyOf(spacing),
-                readARuleNothingSatisfies);
+        return new NumericDomain<>(out, Map.copyOf(spacing), readARuleNothingSatisfies);
     }
 
     /**
@@ -233,7 +239,7 @@ public final class NumericDomain<A> {
      * would answer about a position neither reading was about.
      */
     public NumericDomain<A> meet(NumericDomain<A> other) {
-        if (other == null || (other.rules.isEmpty() && other.kinds.isEmpty()
+        if (other == null || (other.stated.isNothing() && other.kinds.isEmpty()
                 && !other.readARuleNothingSatisfies)) {
             return this;
         }
@@ -244,13 +250,7 @@ public final class NumericDomain<A> {
                 throw new IllegalStateException("atom `" + atom + "` is " + had + " and " + spacing);
             }
         });
-        List<AffineConstraint<A>> out = new ArrayList<>(rules);
-        for (AffineConstraint<A> rule : other.rules) {
-            if (!out.contains(rule)) {
-                out.add(rule);
-            }
-        }
-        return new NumericDomain<>(List.copyOf(out), Map.copyOf(both),
+        return new NumericDomain<>(stated.and(other.stated), Map.copyOf(both),
                 readARuleNothingSatisfies || other.readARuleNothingSatisfies);
     }
 
@@ -265,7 +265,7 @@ public final class NumericDomain<A> {
      */
     private ClosedState<A> closed() {
         if (closed == null) {
-            closed = ClosedState.of(rules, kinds::get);
+            closed = ClosedState.of(rules(), kinds::get);
         }
         return closed;
     }
@@ -319,7 +319,7 @@ public final class NumericDomain<A> {
         if (!everyRelatedPositionIsSpacedAlike()) {
             return new ProjectionCertification.PositionsSpacedDifferently();
         }
-        for (AffineConstraint<A> rule : rules) {
+        for (AffineConstraint<A> rule : rules()) {
             if (!proven(rule, false)) {
                 return new ProjectionCertification.NotEveryRuleIsProven();
             }
@@ -344,7 +344,7 @@ public final class NumericDomain<A> {
      */
     private boolean everyRelatedPositionIsSpacedAlike() {
         Map<A, A> reaches = new LinkedHashMap<>();
-        for (AffineConstraint<A> rule : rules) {
+        for (AffineConstraint<A> rule : rules()) {
             A first = null;
             for (A atom : rule.form().coefs().keySet()) {
                 if (first == null) {
@@ -569,7 +569,7 @@ public final class NumericDomain<A> {
     /** The one reading of what the rules leave a form, over the state they have been worked out to. */
     private FormReach<A> reading() {
         ClosedState<A> state = closed();
-        return FormReach.over(rules, state.box(), state.differences());
+        return FormReach.over(rules(), state.box(), state.differences());
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/StatedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/StatedRules.java
@@ -1,7 +1,9 @@
 package souther.compiler.numeric;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,6 +24,12 @@ import java.util.Set;
  * <p>Order is kept because a reader of the rules writes them out. Two compiles of one model reach
  * the same rules in the same order, and a set that did not keep it would leave what is written out
  * of a domain to how the rules happened to hash.
+ *
+ * <p><b>What a composition is is a graph and not a tree.</b> Nothing here is copied, so two paths
+ * that carried on from one are two compositions holding the one they carried on from, and saying
+ * those two together says it once and reaches it twice. A reader walking what it reaches would pay
+ * for how a composition was arrived at rather than for what it holds, and doubling is a shape a
+ * caller can write — which is the cost this exists to be rid of, moved to the other end.
  *
  * @param <A> what a position is called
  */
@@ -67,16 +75,30 @@ sealed interface StatedRules<A> {
     /**
      * The rules said, each of them once, in the order they were first said.
      *
-     * <p>Walked with a stack of what is left rather than by calling down the tree. A path states one
-     * rule at a time, so the tree a long path leaves is as deep as it is long, and a walk that went
-     * down it would be a limit on how many rules a path may state.
+     * <p>Walked with a stack of what is left rather than by calling down the composition. A path
+     * states one rule at a time, so what a long path composes is as deep as it is long, and a walk
+     * that went down it would be a limit on how many rules a path may state.
+     *
+     * <p>Each of them once, and each part of the composition once — the second is what makes this a
+     * walk of what was said rather than of how it was arrived at. A part reached again holds
+     * nothing that has not been read: it was read to its end before anything beside it was reached,
+     * so everything in it was first said there or before it, and passing it leaves the order alone.
+     *
+     * <p>What is passed is the part itself and not one equal to it. A composition compares by what
+     * it holds, all the way down, so asking a set whether it has already seen one is asking the
+     * question this walk is a stack for.
      */
     default List<AffineConstraint<A>> distinct() {
         Set<AffineConstraint<A>> out = new LinkedHashSet<>();
+        Set<StatedRules<A>> read = Collections.newSetFromMap(new IdentityHashMap<>());
         Deque<StatedRules<A>> left = new ArrayDeque<>();
         left.push(this);
         while (!left.isEmpty()) {
-            switch (left.pop()) {
+            StatedRules<A> next = left.pop();
+            if (!read.add(next)) {
+                continue;
+            }
+            switch (next) {
                 case None<A> ignored -> { }
                 case One<A> one -> out.add(one.rule());
                 case Both<A> both -> {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/StatedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/StatedRules.java
@@ -1,0 +1,90 @@
+package souther.compiler.numeric;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The rules a path has been told, as it was told them.
+ *
+ * <p>What a rule arriving costs is what this exists to settle. A domain is asked what its rules
+ * leave once, when something asks it, and everything on the way there is a rule being put beside the
+ * ones already said — so a rule said twice being one rule is a property of what is read out of this
+ * rather than of every step taken into it. Enforced at each step, saying a rule means looking for it
+ * among all of them, and a path stating many of them pays for each one as many times as there are.
+ *
+ * <p>So there is nothing here but which rules were said and in what order. Saying one more and
+ * saying two paths' rules together are the same shape and cost the same nothing, and what a reader
+ * gets is {@link #distinct}, which is the rules with the second saying of any of them left out.
+ *
+ * <p>Order is kept because a reader of the rules writes them out. Two compiles of one model reach
+ * the same rules in the same order, and a set that did not keep it would leave what is written out
+ * of a domain to how the rules happened to hash.
+ *
+ * @param <A> what a position is called
+ */
+sealed interface StatedRules<A> {
+
+    /** A path that has been told nothing. */
+    record None<A>() implements StatedRules<A> {}
+
+    /** One rule. */
+    record One<A>(AffineConstraint<A> rule) implements StatedRules<A> {}
+
+    /** Everything on the left said, and then everything on the right. */
+    record Both<A>(StatedRules<A> left, StatedRules<A> right) implements StatedRules<A> {}
+
+    /** The one of these there is to hold, since it holds nothing that is anybody's. */
+    StatedRules<?> NOTHING = new None<>();
+
+    @SuppressWarnings("unchecked")
+    static <A> StatedRules<A> none() {
+        return (StatedRules<A>) NOTHING;
+    }
+
+    static <A> StatedRules<A> of(AffineConstraint<A> rule) {
+        return new One<>(rule);
+    }
+
+    /** These and then {@code other}, which is what a path told both of them was told. */
+    default StatedRules<A> and(StatedRules<A> other) {
+        if (this instanceof None<A>) {
+            return other;
+        }
+        if (other instanceof None<A>) {
+            return this;
+        }
+        return new Both<>(this, other);
+    }
+
+    /** Whether nothing has been said, which is what a domain over every assignment holds. */
+    default boolean isNothing() {
+        return this instanceof None<A>;
+    }
+
+    /**
+     * The rules said, each of them once, in the order they were first said.
+     *
+     * <p>Walked with a stack of what is left rather than by calling down the tree. A path states one
+     * rule at a time, so the tree a long path leaves is as deep as it is long, and a walk that went
+     * down it would be a limit on how many rules a path may state.
+     */
+    default List<AffineConstraint<A>> distinct() {
+        Set<AffineConstraint<A>> out = new LinkedHashSet<>();
+        Deque<StatedRules<A>> left = new ArrayDeque<>();
+        left.push(this);
+        while (!left.isEmpty()) {
+            switch (left.pop()) {
+                case None<A> ignored -> { }
+                case One<A> one -> out.add(one.rule());
+                case Both<A> both -> {
+                    left.push(both.right());
+                    left.push(both.left());
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest.java
@@ -1,0 +1,93 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a path was told, read back as the rules it holds.
+ *
+ * <p>The rules are composed as they are said and made distinct where they are read, so what every
+ * reader below sees is decided here and nowhere else. Two things follow from that and neither is
+ * visible from a domain that was told a handful of rules: that a rule said again is read once and
+ * in the place it was first said, which is what makes an answer a function of which rules were said
+ * rather than of how often or in what order a caller happened to say them; and that reading them
+ * back is not a limit on how many there may be.
+ *
+ * <p>The second is why the depth is here. A path says one rule at a time, so the composition a long
+ * path leaves is as deep as the path is long — read by calling down it, a path stating enough rules
+ * would be one the reader could not answer about at all, and the failure is not one any of these
+ * rules is about.
+ */
+class RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest {
+
+    /** A path saying enough rules for a reader that called down what they compose to not answer. */
+    private static final int LONGER_THAN_A_STACK = 100_000;
+
+    private static AffineConstraint<String> rule(String atom, long at) {
+        return new AffineConstraint.Disequality<>(
+                new CanonicalForm<>(Map.of(atom, Rational.of(1))), Rational.of(at));
+    }
+
+    private static StatedRules<String> said(List<AffineConstraint<String>> these) {
+        StatedRules<String> out = StatedRules.none();
+        for (AffineConstraint<String> each : these) {
+            out = out.and(StatedRules.of(each));
+        }
+        return out;
+    }
+
+    /** A rule said again is the same rule, and it is read where it was first said. */
+    @Test
+    void aRuleSaidAgainIsReadOnceAndWhereItWasFirstSaid() {
+        AffineConstraint<String> a = rule("x", 1);
+        AffineConstraint<String> b = rule("y", 2);
+        AffineConstraint<String> c = rule("z", 3);
+
+        assertEquals(List.of(a, b, c), said(List.of(a, b, a, c, b)).distinct());
+    }
+
+    /**
+     * Two paths' rules said together are read as the first path's and then what the second adds.
+     *
+     * <p>Which is what a caller holding the readings of two values at once is owed: what the two of
+     * them say does not depend on which of them the caller came by first having said something the
+     * other says too.
+     */
+    @Test
+    void twoPathsRulesAreReadAsTheFirstsAndThenWhatTheSecondAdds() {
+        AffineConstraint<String> a = rule("x", 1);
+        AffineConstraint<String> b = rule("y", 2);
+        AffineConstraint<String> c = rule("z", 3);
+
+        assertEquals(List.of(a, b, c), said(List.of(a, b)).and(said(List.of(b, c))).distinct());
+    }
+
+    /** Nothing said, which is what a path told nothing holds. */
+    @Test
+    void aPathToldNothingReadsBackNothing() {
+        assertEquals(List.of(), StatedRules.<String>none().distinct());
+    }
+
+    /**
+     * A path longer than a reader could call down is read back whole.
+     *
+     * <p>The rule said last is reached, and so is the one said first — which is under everything
+     * else that was said, and is the one a reader that stopped anywhere would not have.
+     */
+    @Test
+    void aPathLongerThanAStackIsReadBackWhole() {
+        AffineConstraint<String> first = rule("x", 1);
+        AffineConstraint<String> last = rule("y", 2);
+
+        StatedRules<String> deep = StatedRules.of(first);
+        for (int said = 0; said < LONGER_THAN_A_STACK; said++) {
+            deep = deep.and(StatedRules.of(first));
+        }
+
+        assertEquals(List.of(first, last), deep.and(StatedRules.of(last)).distinct());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest.java
@@ -1,9 +1,11 @@
 package souther.compiler.numeric;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,15 +19,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * rather than of how often or in what order a caller happened to say them; and that reading them
  * back is not a limit on how many there may be.
  *
- * <p>The second is why the depth is here. A path says one rule at a time, so the composition a long
- * path leaves is as deep as the path is long — read by calling down it, a path stating enough rules
- * would be one the reader could not answer about at all, and the failure is not one any of these
- * rules is about.
+ * <p>The second is why the depth and the sharing are both here. A path says one rule at a time, so
+ * the composition a long path leaves is as deep as the path is long — read by calling down it, a
+ * path stating enough rules would be one the reader could not answer about at all. And nothing is
+ * copied when two of them are said together, so what a caller says twice is reached twice and not
+ * held twice — read by what it reaches, a caller doubling what it says doubles what reading it
+ * costs. Neither failure is one any of these rules is about.
  */
 class RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest {
 
     /** A path saying enough rules for a reader that called down what they compose to not answer. */
     private static final int LONGER_THAN_A_STACK = 100_000;
+
+    /**
+     * Doublings enough that a reader paying per reach rather than per part takes far longer than
+     * this test is given, and few enough that it still stops and says so.
+     */
+    private static final int MORE_REACHES_THAN_THERE_ARE_PARTS = 27;
 
     private static AffineConstraint<String> rule(String atom, long at) {
         return new AffineConstraint.Disequality<>(
@@ -89,5 +99,27 @@ class RulesAreReadOutOnceEachHoweverDeeplyTheyWereSaidTest {
         }
 
         assertEquals(List.of(first, last), deep.and(StatedRules.of(last)).distinct());
+    }
+
+    /**
+     * What was said once and reached many times is read once.
+     *
+     * <p>Nothing is copied when two of these are said together, so two paths carrying on from one
+     * hold the one they carried on from rather than a copy of it, and saying those two together
+     * reaches it twice. Read by what it reaches, a caller doubling what it says would be read a
+     * number of times that doubles with it — which is the cost the rest of this is about, arrived
+     * at from the other end.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void whatWasSaidOnceIsReadOnceHoweverManyTimesItIsReached() {
+        AffineConstraint<String> a = rule("x", 1);
+
+        StatedRules<String> shared = StatedRules.of(a);
+        for (int doubled = 0; doubled < MORE_REACHES_THAN_THERE_ARE_PARTS; doubled++) {
+            shared = shared.and(shared);
+        }
+
+        assertEquals(List.of(a), shared.distinct());
     }
 }


### PR DESCRIPTION
A domain held its rules as a list and looked for a rule among them before
adding it, so saying a rule walked every rule said before it. Saying two
paths' rules together, and reading a value's rules as rules about something
else, asked the same question the same way. The comparison that walk makes
allocates besides: two disequalities are one rule whichever way round each
was written, so comparing them builds the other's form with every
coefficient turned around, and asking one for its hash builds the same
thing.

What the rules leave is derived from all of them at once, when something
asks. So a rule said twice being one rule is a property of what is read out
of them rather than of every step taken into them.

The rules as they were said are now a tree — nothing, one rule, or both of
two of these — that a rule arriving and two paths' rules meeting each
compose in one step. The reader asks for them made distinct, which flattens
and drops the second saying of anything, once, and is kept the way what the
rules leave is kept. The walk over the tree carries what is left to see
rather than calling down it, since a path states one rule at a time and the
tree it leaves is as deep as the path is long.

Measured on the declaration the issue names, with every position stated to
differ: the walk that dominated the profile is off the top of it, and what
remains at the top is elsewhere. Interleaved both ways against `develop`.

Issue #1588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
