### PR TITLE
Settle a predicate without paying for the ones a path settled already

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -16,6 +16,11 @@ import java.util.function.Function;
  * discharged by a guard stating the same predicate of the same term, and reported when there is
  * none. Immutable, threaded functionally alongside the numeric domain.
  *
+ * <p>What the guards settled is held as they settled it ({@link SettledPredicates}) and read out
+ * once, where a reader asks. Every way a predicate arrives — a guard settling one, two readings said
+ * together, a change of vocabulary — is a composition and costs nothing that grows with what the
+ * path had already.
+ *
  * <p>Kept in the order the predicates were settled. Nothing here answers with one of them, and a
  * renaming that has to refuse two subjects under one name names whichever it reaches first — read
  * off a set whose iteration order is salted once per run, which of two collisions is reported would
@@ -26,28 +31,53 @@ import java.util.function.Function;
  */
 public final class PredicateFacts<A> {
 
-    private final boolean bottom;    // contradictory guards — this path is not taken
-    private final Set<A> holds;
-    private final Set<A> fails;
+    /**
+     * A contradiction settled under names this state does not have.
+     *
+     * <p>What a change of vocabulary leaves of guards that cannot all hold. Nothing there is asked
+     * of the naming: a path nothing reaches says the same thing under any names, and handing its
+     * subjects over would have a renaming refusing two of them over a disagreement on a path the
+     * program never takes.
+     */
+    private final boolean contradictedUnderOtherNames;
 
-    private PredicateFacts(boolean bottom, Set<A> holds, Set<A> fails) {
-        this.bottom = bottom;
-        this.holds = held(holds);
-        this.fails = held(fails);
+    private final SettledPredicates<A> settled;
+
+    /** What {@link #settled} comes to, computed where it is asked for and kept. */
+    private Settlings<A> settlings;
+
+    /** The predicates settled each way, and whether one of them was settled both ways. */
+    private record Settlings<A>(boolean contradictory, Set<A> holds, Set<A> fails) {}
+
+    private PredicateFacts(boolean contradictedUnderOtherNames, SettledPredicates<A> settled) {
+        this.contradictedUnderOtherNames = contradictedUnderOtherNames;
+        this.settled = settled;
     }
 
-    private static <A> Set<A> held(Set<A> of) {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(of));
+    private Settlings<A> settlings() {
+        if (settlings == null) {
+            Set<A> holds = new LinkedHashSet<>();
+            Set<A> fails = new LinkedHashSet<>();
+            boolean contradictory = false;
+            for (SettledPredicates.One<A> one : settled.distinct()) {
+                Set<A> theOtherWay = one.positive() ? fails : holds;
+                contradictory = contradictory || theOtherWay.contains(one.key());
+                (one.positive() ? holds : fails).add(one.key());
+            }
+            settlings = new Settlings<>(contradictory, Collections.unmodifiableSet(holds),
+                    Collections.unmodifiableSet(fails));
+        }
+        return settlings;
     }
 
     /** Contradictory guards, which is one key settled both ways however it was reached. */
     private static <A> PredicateFacts<A> bottom() {
-        return new PredicateFacts<>(true, Set.of(), Set.of());
+        return new PredicateFacts<>(true, SettledPredicates.none());
     }
 
     /** Nothing settled either way. */
     public static <A> PredicateFacts<A> none() {
-        return new PredicateFacts<>(false, Set.of(), Set.of());
+        return new PredicateFacts<>(false, SettledPredicates.none());
     }
 
     /**
@@ -60,32 +90,23 @@ public final class PredicateFacts<A> {
      * needs the numbers.
      */
     public boolean isBottom() {
-        return bottom;
+        return contradictedUnderOtherNames || settlings().contradictory();
     }
 
     /** The facts with {@code key} settled. Settling it both ways makes the path infeasible. */
     PredicateFacts<A> assume(A key, boolean positive) {
-        if (bottom) {
-            return this;
-        }
-        if ((positive ? fails : holds).contains(key)) {
-            return bottom();
-        }
-        Set<A> next = new LinkedHashSet<>(positive ? holds : fails);
-        next.add(key);
-        return positive
-                ? new PredicateFacts<>(false, next, fails)
-                : new PredicateFacts<>(false, holds, next);
+        return new PredicateFacts<>(contradictedUnderOtherNames,
+                settled.and(SettledPredicates.of(key, positive)));
     }
 
     /** Whether the guards prove {@code key} (or its negation, when {@code positive} is false). */
     boolean entails(A key, boolean positive) {
-        return bottom || (positive ? holds : fails).contains(key);
+        return isBottom() || (positive ? settlings().holds() : settlings().fails()).contains(key);
     }
 
     /** Whether the guards prove the opposite of what {@code positive} asks of {@code key}. */
     boolean refutes(A key, boolean positive) {
-        return !bottom && (positive ? fails : holds).contains(key);
+        return !isBottom() && (positive ? settlings().fails() : settlings().holds()).contains(key);
     }
 
     /**
@@ -93,18 +114,12 @@ public final class PredicateFacts<A> {
      *
      * <p>A predicate one of them holds and the other denies is one key settled both ways, which is
      * the same contradiction reaching this the same way it reaches it from a single reading.
-     * Nothing else here relates two predicates, so the rest is the two sets put together.
+     * Nothing else here relates two predicates, so the rest is what each of them settled, settled.
      */
     public PredicateFacts<A> meet(PredicateFacts<A> other) {
-        if (bottom || other.bottom) {
-            return bottom();
-        }
-        Set<A> bothHold = new LinkedHashSet<>(holds);
-        bothHold.addAll(other.holds);
-        Set<A> bothFail = new LinkedHashSet<>(fails);
-        bothFail.addAll(other.fails);
-        return bothHold.stream().anyMatch(bothFail::contains)
-                ? bottom() : new PredicateFacts<>(false, bothHold, bothFail);
+        return new PredicateFacts<>(
+                contradictedUnderOtherNames || other.contradictedUnderOtherNames,
+                settled.and(other.settled));
     }
 
     /**
@@ -119,13 +134,16 @@ public final class PredicateFacts<A> {
      * caller holding one of those sees all of them.
      */
     public <B> PredicateFacts<B> renamed(Function<A, B> naming) {
-        if (bottom) {
+        if (isBottom()) {
             return bottom();
         }
-        Set<B> outHolds = new LinkedHashSet<>();
-        holds.forEach(key -> outHolds.add(naming.apply(key)));
-        Set<B> outFails = new LinkedHashSet<>();
-        fails.forEach(key -> outFails.add(naming.apply(key)));
-        return new PredicateFacts<>(false, outHolds, outFails);
+        SettledPredicates<B> out = SettledPredicates.none();
+        for (A key : settlings().holds()) {
+            out = out.and(SettledPredicates.of(naming.apply(key), true));
+        }
+        for (A key : settlings().fails()) {
+            out = out.and(SettledPredicates.of(naming.apply(key), false));
+        }
+        return new PredicateFacts<>(false, out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/SettledPredicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SettledPredicates.java
@@ -1,0 +1,112 @@
+package souther.compiler.check;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The predicates a path's guards have settled, as they settled them.
+ *
+ * <p>What a predicate arriving costs is what this exists to settle. The predicates are asked about
+ * once, where something asks them, and everything on the way there is one more of them being put
+ * beside the ones already settled — so a predicate settled twice being settled once is a property of
+ * what is read out of this rather than of every step taken into it. Held as the two sets a reader
+ * wants, each step remakes them, and a path settling many predicates pays for each one as many times
+ * as there are.
+ *
+ * <p>So there is nothing here but which predicates were settled, which way round, and in what order.
+ * Settling one more and saying two paths' predicates together are the same shape and cost the same
+ * nothing, and what a reader gets is {@link #distinct}, which is the settlings with the second
+ * arrival of any of them left out.
+ *
+ * <p>Order is kept because a reader of these hands every subject to a renaming, and a renaming that
+ * has to refuse two subjects under one name names whichever it reaches first. Read off a set whose
+ * iteration order is salted once per run, which of two collisions is reported would move between
+ * runs of the same compiler.
+ *
+ * <p><b>What a composition is is a graph and not a tree.</b> Nothing here is copied, so two paths
+ * that carried on from one are two compositions holding the one they carried on from, and saying
+ * those two together says it once and reaches it twice. A reader walking what it reaches would pay
+ * for how a composition was arrived at rather than for what it holds, and doubling is a shape a
+ * caller can write — which is the cost this exists to be rid of, moved to the other end.
+ *
+ * @param <A> what a fact is filed under
+ */
+sealed interface SettledPredicates<A> {
+
+    /** A path whose guards have settled nothing. */
+    record None<A>() implements SettledPredicates<A> {}
+
+    /** One predicate, settled as holding where {@code positive}, and as failing where it is not. */
+    record One<A>(A key, boolean positive) implements SettledPredicates<A> {}
+
+    /** Everything on the left settled, and then everything on the right. */
+    record Both<A>(SettledPredicates<A> left, SettledPredicates<A> right)
+            implements SettledPredicates<A> {}
+
+    /** The one of these there is to hold, since it holds nothing that is anybody's. */
+    SettledPredicates<?> NOTHING = new None<>();
+
+    @SuppressWarnings("unchecked")
+    static <A> SettledPredicates<A> none() {
+        return (SettledPredicates<A>) NOTHING;
+    }
+
+    static <A> SettledPredicates<A> of(A key, boolean positive) {
+        return new One<>(key, positive);
+    }
+
+    /** These and then {@code other}, which is what a path that settled both of them settled. */
+    default SettledPredicates<A> and(SettledPredicates<A> other) {
+        if (this instanceof None<A>) {
+            return other;
+        }
+        if (other instanceof None<A>) {
+            return this;
+        }
+        return new Both<>(this, other);
+    }
+
+    /**
+     * The settlings, each of them once, in the order they were first settled.
+     *
+     * <p>Walked with a stack of what is left rather than by calling down the composition. A path
+     * settles one predicate at a time, so what a long path composes is as deep as it is long, and a
+     * walk that went down it would be a limit on how many predicates a path may settle.
+     *
+     * <p>Each of them once, and each part of the composition once — the second is what makes this a
+     * walk of what was settled rather than of how it was arrived at. A part reached again holds
+     * nothing that has not been read: it was read to its end before anything beside it was reached,
+     * so everything in it was first settled there or before it, and passing it leaves the order
+     * alone.
+     *
+     * <p>What is passed is the part itself and not one equal to it. A composition compares by what
+     * it holds, all the way down, so asking a set whether it has already seen one is asking the
+     * question this walk is a stack for.
+     */
+    default List<One<A>> distinct() {
+        Set<One<A>> out = new LinkedHashSet<>();
+        Set<SettledPredicates<A>> read = Collections.newSetFromMap(new IdentityHashMap<>());
+        Deque<SettledPredicates<A>> left = new ArrayDeque<>();
+        left.push(this);
+        while (!left.isEmpty()) {
+            SettledPredicates<A> next = left.pop();
+            if (!read.add(next)) {
+                continue;
+            }
+            switch (next) {
+                case None<A> ignored -> { }
+                case One<A> one -> out.add(one);
+                case Both<A> both -> {
+                    left.push(both.right());
+                    left.push(both.left());
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/PredicatesAreReadOutOnceEachHoweverDeeplyTheyWereSettledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/PredicatesAreReadOutOnceEachHoweverDeeplyTheyWereSettledTest.java
@@ -1,0 +1,200 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the guards settled, read back as the predicates a path holds.
+ *
+ * <p>The settlings are composed as they are made and read out where a reader asks, so what every
+ * reader of a state sees is decided here and nowhere else. Two things follow from that and neither
+ * is visible from a path that settled a handful of predicates: that a predicate settled again is
+ * read once and in the place it was first settled, which is what makes an answer a function of which
+ * predicates were settled rather than of how often or in what order a caller happened to settle
+ * them; and that reading them back is not a limit on how many there may be.
+ *
+ * <p>The second is why the depth and the sharing are both here. A guard settles one predicate at a
+ * time, so the composition a long path leaves is as deep as the path is long — read by calling down
+ * it, a path settling enough predicates would be one the reader could not answer about at all. And
+ * nothing is copied when two paths' predicates are said together, so what a caller says twice is
+ * reached twice and not held twice — read by what it reaches, a caller doubling what it says doubles
+ * what reading it costs. Neither failure is one any of these rules is about.
+ */
+class PredicatesAreReadOutOnceEachHoweverDeeplyTheyWereSettledTest {
+
+    /** A path settling enough predicates for a reader that called down what they compose to not
+     *  answer. */
+    private static final int LONGER_THAN_A_STACK = 100_000;
+
+    /**
+     * Doublings enough that a reader paying per reach rather than per part takes far longer than
+     * this test is given, and few enough that it still stops and says so.
+     */
+    private static final int MORE_REACHES_THAN_THERE_ARE_PARTS = 27;
+
+    private static SettledPredicates<String> holding(String key) {
+        return SettledPredicates.of(key, true);
+    }
+
+    private static SettledPredicates<String> failing(String key) {
+        return SettledPredicates.of(key, false);
+    }
+
+    private static SettledPredicates<String> settled(List<SettledPredicates<String>> these) {
+        SettledPredicates<String> out = SettledPredicates.none();
+        for (SettledPredicates<String> each : these) {
+            out = out.and(each);
+        }
+        return out;
+    }
+
+    /** A predicate settled again is the same settling, and it is read where it was first made. */
+    @Test
+    void aPredicateSettledAgainIsReadOnceAndWhereItWasFirstSettled() {
+        assertEquals(List.of(holding("a"), failing("b"), holding("c")),
+                settled(List.of(holding("a"), failing("b"), holding("a"), holding("c"),
+                        failing("b"))).distinct());
+    }
+
+    /** The same predicate settled the other way round is another settling, and both are read. */
+    @Test
+    void aPredicateSettledBothWaysIsTwoSettlings() {
+        assertEquals(List.of(holding("a"), failing("a")),
+                settled(List.of(holding("a"), failing("a"))).distinct());
+    }
+
+    /**
+     * Two paths' predicates said together are read as the first path's and then what the second
+     * adds.
+     *
+     * <p>Which is what a caller holding the readings of two values at once is owed: what the two of
+     * them settled does not depend on which of them the caller came by first having settled
+     * something the other settled too.
+     */
+    @Test
+    void twoPathsPredicatesAreReadAsTheFirstsAndThenWhatTheSecondAdds() {
+        assertEquals(List.of(holding("a"), failing("b"), holding("c")),
+                settled(List.of(holding("a"), failing("b")))
+                        .and(settled(List.of(failing("b"), holding("c")))).distinct());
+    }
+
+    /** Nothing settled, which is what a path whose guards said nothing holds. */
+    @Test
+    void aPathThatSettledNothingReadsBackNothing() {
+        assertEquals(List.of(), SettledPredicates.<String>none().distinct());
+    }
+
+    /**
+     * A path longer than a reader could call down is read back whole.
+     *
+     * <p>The predicate settled last is reached, and so is the one settled first — which is under
+     * everything else that was settled, and is the one a reader that stopped anywhere would not
+     * have.
+     */
+    @Test
+    void aPathLongerThanAStackIsReadBackWhole() {
+        SettledPredicates<String> deep = holding("first");
+        for (int settled = 0; settled < LONGER_THAN_A_STACK; settled++) {
+            deep = deep.and(holding("first"));
+        }
+
+        assertEquals(List.of(holding("first"), failing("last")),
+                deep.and(failing("last")).distinct());
+    }
+
+    /**
+     * What was settled once and reached many times is read once.
+     *
+     * <p>Nothing is copied when two of these are said together, so two paths carrying on from one
+     * hold the one they carried on from rather than a copy of it, and saying those two together
+     * reaches it twice. Read by what it reaches, a caller doubling what it says would be read a
+     * number of times that doubles with it — which is the cost the rest of this is about, arrived
+     * at from the other end.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void whatWasSettledOnceIsReadOnceHoweverManyTimesItIsReached() {
+        SettledPredicates<String> shared = holding("a");
+        for (int doubled = 0; doubled < MORE_REACHES_THAN_THERE_ARE_PARTS; doubled++) {
+            shared = shared.and(shared);
+        }
+
+        assertEquals(List.of(holding("a")), shared.distinct());
+    }
+
+    /** A path deeper than a reader could call down answers what it settled. */
+    @Test
+    void aStateDeeperThanAStackAnswersWhatItSettled() {
+        PredicateFacts<String> facts = PredicateFacts.none();
+        for (int settled = 0; settled < LONGER_THAN_A_STACK; settled++) {
+            facts = facts.assume("p" + (settled % 3), true);
+        }
+
+        assertFalse(facts.isBottom());
+        assertTrue(facts.entails("p0", true));
+        assertTrue(facts.refutes("p1", false));
+        assertFalse(facts.entails("p3", true));
+    }
+
+    /** One key settled both ways is a contradiction however far apart the two were settled. */
+    @Test
+    void aKeySettledBothWaysIsAContradictionHoweverFarApartTheyWereSettled() {
+        PredicateFacts<String> facts = PredicateFacts.<String>none().assume("p", true);
+        for (int settled = 0; settled < LONGER_THAN_A_STACK; settled++) {
+            facts = facts.assume("q" + settled, true);
+        }
+
+        assertTrue(facts.assume("p", false).isBottom());
+    }
+
+    /** And when the two settlings are one reading's and another's. */
+    @Test
+    void aKeyTwoReadingsSettleTwoWaysIsAContradictionWhereTheyAreMet() {
+        assertTrue(PredicateFacts.<String>none().assume("p", true)
+                .meet(PredicateFacts.<String>none().assume("p", false))
+                .isBottom());
+    }
+
+    /**
+     * Guards that cannot all hold are still guards that cannot all hold in another vocabulary, and
+     * no subject of theirs is handed to the naming.
+     *
+     * <p>A path nothing reaches says the same thing under any names. Handing its subjects over would
+     * have a renaming refusing two of them over a disagreement on a path the program never takes.
+     */
+    @Test
+    void aContradictionCrossesIntoAnotherVocabularyWithoutNamingItsSubjects() {
+        AtomicInteger named = new AtomicInteger();
+        PredicateFacts<String> nothing =
+                PredicateFacts.<String>none().assume("p", true).assume("p", false);
+
+        PredicateFacts<String> said = nothing.renamed(key -> {
+            named.incrementAndGet();
+            return "elsewhere." + key;
+        });
+
+        assertTrue(said.isBottom());
+        assertEquals(0, named.get(), "a path nothing reaches has no subject to name");
+    }
+
+    /** And a path that is reached takes every subject it settled through the naming. */
+    @Test
+    void whatIsSettledCrossesIntoAnotherVocabularyEachWayRound() {
+        PredicateFacts<String> said = PredicateFacts.<String>none()
+                .assume("p", true).assume("q", false)
+                .renamed(key -> "elsewhere." + key);
+
+        assertFalse(said.isBottom());
+        assertTrue(said.entails("elsewhere.p", true));
+        assertTrue(said.refutes("elsewhere.q", true));
+        assertFalse(said.entails("p", true), "the old names are not this vocabulary's");
+    }
+}


### PR DESCRIPTION
Closes #1590.

## What was happening

The predicates a path's guards had settled were held as the two sets a reader wants — the ones they prove and the ones they deny. Settling one more made a set holding what was there and the one that arrived, and the set that did not change was made again beside it. Saying two readings' predicates together and reading a value's predicates as predicates about something else built both sets anew in the same way. So none of the ways a path came by a predicate cost what the predicate was; each of them cost what the path had already, and what a path spent on its guards grew with the square of how many of them it settled.

Measured on the declaration whose positions are all stated to differ — the reproduction #1588 was measured on. With the cost that issue was about gone, this was the largest single thing left in that profile. Counted rather than guessed at: an instrumented run of the reproduction copied tens of millions of elements while reading them back a handful of times, off a single state.

## What is in

`SettledPredicates` (sealed `None | One | Both`) holds what the guards settled, as they settled it. Composing is O(1) and copies nothing; `distinct()` is the only thing that walks, and it leaves out the second arrival of any settling. `PredicateFacts` holds one of these and the reading it comes to — the predicates settled each way and whether one of them was settled both ways — computed where a reader asks and kept.

Order is kept because a reader hands every subject to a renaming, and a renaming that has to refuse two subjects under one name names whichever it reaches first. What a composition leaves is a graph and not a tree, so the walk passes a part it has already read rather than a part it reaches again, and it walks with a stack: a path settles one predicate at a time, so what a long path composes is as deep as it is long.

Guards that cannot all hold still cross into another vocabulary without any subject of theirs being handed to the naming. A path nothing reaches says the same thing under any names, and naming its subjects would have a renaming refusing two of them over a disagreement on a path the program never takes.

## Measured

Interleaved both ways in one session, the compiler classes of each variant complete in their own directory and the classpath differing in that one entry. The reproduction's diagnostics are the same either way. On the profile, what settling a predicate takes falls from about half of it to a fraction of a percent, and the reproduction's wall time falls by roughly a third to a half at both sizes tried.

## Checked

`PredicatesAreReadOutOnceEachHoweverDeeplyTheyWereSettledTest`. Each rule was shown to go red by mutation: swapping the walk's two pushes reddens the order cases; calling down the composition instead of walking it with a stack overflows the stack on the deep cases; dropping the set of parts already read leaves the shared case running past its timeout; dropping the short circuit in `renamed` has a contradiction's subjects handed to the naming; inverting the contradiction test reddens the cases here and `WhetherAPathIsReachedIsAskedOfEveryDomainTest` with them.

Full run from the reactor root: every module green, none skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
