### PR TITLE
Hold a reading's denials as what it was told, not as what they come to

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayBuildARefusalFromOneOfItsHalvesTest.java
@@ -107,6 +107,11 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
      * predicate, a relation and a second chance to answer — hands the same power over without
      * naming a block anywhere. So what is pinned is the way in, and a new one is a finding whatever
      * it takes.
+     *
+     * <p>Two of them take the denials as a relation and one takes the alternative whose denials
+     * they are, which is a reading whose values are still descriptions and whose denials are still
+     * what it was told. That one is a subject and not a question: what it shows is its own to say,
+     * the way a relation's is, and a caller holding one has handed over nothing it may write.
      */
     @Test
     void andWhatMayBeAskedOfARelationIsTheseTwoQuestions() {
@@ -124,12 +129,15 @@ class WhoMayBuildARefusalFromOneOfItsHalvesTest {
         }
 
         assertEquals(List.of(
-                        "<init>(L" + WHERE + "Apartness;L" + WHERE + "AskedOfARelation;L"
+                        "<init>(L" + WHERE + "Apartness;L" + WHERE + "PlannedHeld$Alternative;L"
+                                + WHERE + "AskedOfARelation;L"
                                 + WHERE + "AdmissibleValues$Box;)V private",
                         "askedOf(L" + WHERE + "AskedOfARelation;L" + WHERE + "Apartness;L"
                                 + WHERE + "AdmissibleValues$Box;)L"
                                 + WHERE + "WhatARelationShows;",
-                        "statedApart(L" + WHERE + "Apartness;)L" + WHERE + "WhatARelationShows;"),
+                        "statedApart(L" + WHERE + "Apartness;)L" + WHERE + "WhatARelationShows;",
+                        "statedApart(L" + WHERE + "PlannedHeld$Alternative;)L"
+                                + WHERE + "WhatARelationShows;"),
                 waysIn.stream().sorted().toList(),
                 "a question about the relation that a caller writes is one they may leave unasked"
                         + " wherever the blocks answered something, so what may be asked is what a"

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -133,6 +133,12 @@ public final class Apartness<A> {
         return new Apartness<>(Set.of(new Edge<>(Sameness.Block.of(one), Sameness.Block.of(other))));
     }
 
+    /** These pairs of blocks, for a caller that worked out which blocks the denials it was told
+     *  name — see {@link StatedApartness#quotientBy}. */
+    static <A> Apartness<A> ofEdges(Set<Edge<A>> edges) {
+        return new Apartness<>(edges);
+    }
+
     /** Whether nothing is stated to differ from anything. */
     public boolean isEmpty() {
         return edges.isEmpty();

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -1,5 +1,7 @@
 package souther.compiler.values;
 
+import souther.compiler.hash.ValueHash;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -69,14 +71,69 @@ sealed interface PlannedHeld<A> {
      * or not anybody has worked out what the blocks it names admit — so what changes across that
      * line is the product and not this.
      *
-     * @param product what each block is described as holding
-     * @param apart which of those blocks are stated to hold different values
+     * <p>The denials as they were stated, and not the relation between blocks they come to
+     * ({@link StatedApartness}). Which blocks a denial names is settled by everything the
+     * alternative holds as one value, and a conjunction is where that is still being found out.
+     *
+     * <p><b>And whether what it states contradicts, which it is asked as each rule arrives.</b>
+     * Worked out where an alternative is made, since that is where what would have to be walked to
+     * answer it is at its smallest: a conjunction holds the denials of both sides, and neither
+     * side's answer changes unless the conjunction holds as one value something that side held
+     * apart. Asked of the whole of what an alternative states instead, a reading would walk every
+     * denial it holds for every denial it reads.
      */
-    record Alternative<A>(Box<A> product, Apartness<A> apart) {
+    static final class Alternative<A> {
+
+        private final Box<A> product;
+        private final StatedApartness<A> stated;
+
+        /** Whether some denial this states has both ends on one of this alternative's blocks. */
+        private final boolean contradicts;
+
+        private Alternative(Box<A> product, StatedApartness<A> stated, boolean contradicts) {
+            this.product = product;
+            this.stated = stated;
+            this.contradicts = contradicts;
+        }
 
         /** One alternative that states no denial. */
         static <A> Alternative<A> of(Box<A> product) {
-            return new Alternative<>(product, Apartness.nothing());
+            return new Alternative<>(product, StatedApartness.none(), false);
+        }
+
+        /** One alternative over the positions {@code stated} names and whatever {@code product}
+         *  describes, which is what a reading of a denial holds. */
+        static <A> Alternative<A> of(Box<A> product, StatedApartness<A> stated) {
+            return new Alternative<>(product, stated, stated.contradicts(product.sameness()));
+        }
+
+        /** What each block is described as holding. */
+        Box<A> product() {
+            return product;
+        }
+
+        /** Which positions are stated to hold different values, as they were stated. */
+        StatedApartness<A> stated() {
+            return stated;
+        }
+
+        /** Whether what this states leaves nothing, which is a value stated to differ from
+         *  itself. */
+        boolean contradicts() {
+            return contradicts;
+        }
+
+        /**
+         * The relation this alternative's denials come to, between the blocks it holds as one
+         * value.
+         *
+         * <p>Built where a relation is what is wanted — what a choice reads of two branches, and
+         * what a refusal says about them. The questions a reading asks of its denials on the way
+         * there are answered by {@link #contradicts} and by what was stated, so nothing that only
+         * needs those pays for this.
+         */
+        Apartness<A> apart() {
+            return stated.quotientBy(sameness());
         }
 
         /** One alternative over positions that are each their own block, stating no denial. */
@@ -89,12 +146,16 @@ sealed interface PlannedHeld<A> {
             return product.at();
         }
 
-        /** Which positions this alternative holds as one value, over its sides and its relation
-         *  alike — see {@link AdmissibleValues.Alternative#sameness}. */
+        /**
+         * Which positions this alternative holds as one value, which is what its product is over.
+         *
+         * <p>Its denials say nothing about it. A denial names two positions and says they differ,
+         * which holds neither of them with anything — so a position a denial is all this says about
+         * is a position of its own, which is what a relation answers for a position it never heard
+         * of ({@link Sameness#blockOf}).
+         */
         Sameness<A> sameness() {
-            Set<Sameness.Block<A>> named = new LinkedHashSet<>(product.at().keySet());
-            named.addAll(apart.blocks());
-            return Sameness.of(named);
+            return product.sameness();
         }
 
         AdmittedPlan get(Sameness.Block<A> block) {
@@ -110,23 +171,50 @@ sealed interface PlannedHeld<A> {
          *  it. */
         Set<A> positions() {
             Set<A> out = new LinkedHashSet<>(product.positions());
-            apart.blocks().forEach(block -> out.addAll(block.members()));
+            out.addAll(stated.positions());
             return out;
         }
 
-        /** Both alternatives holding at once, over what the two of them hold as one value —
-         *  see {@link AdmissibleValues.Alternative#narrowedWith}. */
+        /**
+         * Both alternatives holding at once, over what the two of them hold as one value —
+         * see {@link AdmissibleValues.Alternative#narrowedWith}.
+         *
+         * <p>The denials of the two are put together and nothing else is done to them. What a
+         * denial names is two positions, and the conjunction holds those positions wherever it
+         * holds them — so there is no step here for a denial to be carried across, which is what
+         * makes what a reading spends on its denials what it says rather than how it was bracketed.
+         */
         Alternative<A> meet(Alternative<A> other) {
-            Sameness<A> heldAsOne = sameness().meet(other.sameness());
+            Sameness<A> mine = sameness();
+            Sameness<A> theirs = other.sameness();
+            Sameness<A> heldAsOne = mine.meet(theirs);
+            // A side whose blocks the conjunction leaves alone answers this the way it already
+            // did: what its denials name is what they named. The one the conjunction coarsens is
+            // walked, and it is walked against the relation the conjunction leaves rather than the
+            // one it was read against.
+            boolean both = (heldAsOne == mine ? contradicts : stated.contradicts(heldAsOne))
+                    || (heldAsOne == theirs ? other.contradicts
+                            : other.stated.contradicts(heldAsOne));
             return new Alternative<>(product.meet(other.product, heldAsOne),
-                    apart.filedIn(Refinement.of(sameness(), heldAsOne))
-                            .and(other.apart.filedIn(
-                                    Refinement.of(other.sameness(), heldAsOne))));
+                    stated.and(other.stated), both);
+        }
+
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof Alternative<?> it
+                    && product.equals(it.product) && stated.equals(it.stated);
+        }
+
+        /** What it describes and what it states to differ, which is the whole of what it is —
+         *  {@link #contradicts} is worked out from those. */
+        @Override
+        public int hashCode() {
+            return ValueHash.ofItsParts(Alternative.class, product.hashCode(), stated.hashCode());
         }
 
         @Override
         public String toString() {
-            return apart.isEmpty() ? product.toString() : product + " with " + apart;
+            return stated.isEmpty() ? product.toString() : product + " with " + stated;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -136,6 +136,19 @@ sealed interface PlannedHeld<A> {
             return stated.quotientBy(sameness());
         }
 
+        /**
+         * Where this alternative states a block to differ from itself, which is the whole of what
+         * its denials show before anything has worked out what its positions admit.
+         *
+         * <p>Answered here because the answer to whether there is one is here: it was worked out
+         * where this was made, and what it would cost to find out again is a walk of every denial
+         * the alternative holds. {@link Apartness#apartFromThemselves} decides the same way from
+         * what it was told when it was built.
+         */
+        Lacks<A> denialsApartFromThemselves() {
+            return contradicts ? stated.apartFromThemselves(sameness()) : Lacks.none();
+        }
+
         /** One alternative over positions that are each their own block, stating no denial. */
         static <A> Alternative<A> at(Map<A, AdmittedPlan> said) {
             return of(Box.at(said));

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -349,7 +349,7 @@ public sealed interface PlannedValues<A> {
         // The block and not its positions — see {@link AdmissibleValues}.
         return Refusal.ofAnAlternative(at,
                 (block, plan) -> askedOf(block, plan, asked).isEmpty(),
-                WhatARelationShows.statedApart(box.apart()));
+                WhatARelationShows.statedApart(box));
     }
 
     /** What one block's description comes to under the question, waiting where a machine would
@@ -450,7 +450,7 @@ public sealed interface PlannedValues<A> {
             Map<Sameness.Block<A>, AdmittedPlan> at = box.at();
             Refusal<A> said = Refusal.ofAnAlternative(at,
                     (_, plan) -> plan instanceof AdmittedPlan.Nothing,
-                    WhatARelationShows.statedApart(box.apart()));
+                    WhatARelationShows.statedApart(box));
             everywhere = everywhere == null ? said : Refusal.shownByBoth(everywhere, said);
             if (everywhere.isNowhere()) {
                 return Refusal.nowhere();

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -207,8 +207,8 @@ public sealed interface PlannedValues<A> {
         promised.put(Sameness.Block.of(here), AdmittedPlan.NONE);
         promised.put(Sameness.Block.of(there), AdmittedPlan.NONE);
         return new Settled<>(new Settled.Parts<>(
-                PlannedHeld.one(new PlannedHeld.Alternative<>(
-                        new PlannedHeld.Box<>(Map.of()), Apartness.of(here, there))),
+                PlannedHeld.one(PlannedHeld.Alternative.of(
+                        new PlannedHeld.Box<>(Map.of()), StatedApartness.of(here, there))),
                 Map.of(), Standing.nothing(), promised, AdmittedPlan.ANY, true,
                 Set.of(), Set.of()));
     }
@@ -288,8 +288,8 @@ public sealed interface PlannedValues<A> {
                         //
                         // And held together with what the blocks came to, since an alternative
                         // stands where its blocks and its denials both leave it standing.
-                        if (!stands.endsAMeet() && !box.apart().isEmpty()) {
-                            stands = stands.met(box.apart().holdsABlockApartFromItself()
+                        if (!stands.endsAMeet() && !box.stated().isEmpty()) {
+                            stands = stands.met(box.contradicts()
                                     ? Emptiness.EMPTY : Emptiness.UNDECIDED);
                         }
                         any = any.joined(stands);
@@ -831,9 +831,10 @@ public sealed interface PlannedValues<A> {
         // Merging a union into the smallest product containing it widens what the blocks hold; it
         // does not licence forgetting a rule both branches wrote, and a denial dropped here is one
         // no equality read beside the choice can be refused against.
-        return PlannedHeld.one(new PlannedHeld.Alternative<>(new PlannedHeld.Box<>(out),
-                Apartness.commonTo(List.of(apartInEveryAlternative(here, heldAsOne),
-                        apartInEveryAlternative(there, heldAsOne)), heldAsOne)));
+        return PlannedHeld.one(PlannedHeld.Alternative.of(new PlannedHeld.Box<>(out),
+                StatedApartness.of(Apartness.commonTo(
+                        List.of(apartInEveryAlternative(here, heldAsOne),
+                                apartInEveryAlternative(there, heldAsOne)), heldAsOne))));
     }
 
     /** What every alternative of one reading states to differ, said at {@code finer} — see

--- a/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
@@ -1,0 +1,268 @@
+package souther.compiler.values;
+
+import souther.compiler.hash.ValueHash;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Which positions a reading was told hold different values, as it was told them.
+ *
+ * <p>{@link Apartness} says which <em>blocks</em> differ, which is what a denial comes to once
+ * everything the reading holds as one value is known. Conjoining readings is where that is found
+ * out: each one is a coarsening of the last, so a relation between blocks has to be filed into the
+ * new blocks at every step, and a reading told many denials files each of them as many times as
+ * there are steps. Told as positions, a denial is what it was written as and nothing has to be
+ * refiled — the blocks its ends are on are read off the relation the conjunction leaves, once.
+ *
+ * <p>So this is for conjunction and stops there. A choice reads what its branches both deny, which
+ * pulls each relation back onto the finer blocks its ends are made of and intersects — an algebra
+ * over blocks, and one that a union of what was stated has no answer for. What crosses that line is
+ * {@link #quotientBy}, and above it there is only {@link Apartness}.
+ *
+ * <p><b>Composed in one step and compared in one step.</b> Nothing is copied when two of these are
+ * said together, so what a caller says twice is reached twice and held once, and how many were said
+ * and what they come to as one number are carried across each composition rather than walked for.
+ * A reading is put in a set of the alternatives its conjunction leaves, so what it costs to hash one
+ * is paid at every step of that conjunction and cannot be a walk of what it holds.
+ *
+ * @param <A> what a position is called
+ */
+final class StatedApartness<A> {
+
+    private static final StatedApartness<?> NOTHING =
+            new StatedApartness<>(null, null, null, null, 0, 0);
+
+    /** The denial this is, where it is one, and null where it is none of them or both of two. */
+    private final A one;
+    private final A other;
+
+    /** Both of them, where this is two said together. Null otherwise. */
+    private final StatedApartness<A> left;
+    private final StatedApartness<A> right;
+
+    /** How many were said, counting a denial said twice twice — what is held is what was said. */
+    private final int stated;
+
+    /**
+     * The denials this holds, added up.
+     *
+     * <p>Added rather than taken in order, because what this holds is a set and two callers reaching
+     * the same denials by different compositions hold the same thing. Carried across a composition
+     * instead of walked for, so that hashing one is what it costs to say one.
+     */
+    private final int mixed;
+
+    /** The denials said, each once, worked out on the first question that needs them and kept. */
+    private Set<Denial<A>> settled;
+
+    private StatedApartness(A one, A other, StatedApartness<A> left, StatedApartness<A> right,
+                            int stated, int mixed) {
+        this.one = one;
+        this.other = other;
+        this.left = left;
+        this.right = right;
+        this.stated = stated;
+        this.mixed = mixed;
+    }
+
+    /** Nothing stated to differ, which is what a reading that read no denial holds. */
+    @SuppressWarnings("unchecked")
+    static <A> StatedApartness<A> none() {
+        return (StatedApartness<A>) NOTHING;
+    }
+
+    /** The two positions stated to hold different values. */
+    static <A> StatedApartness<A> of(A one, A other) {
+        return new StatedApartness<>(one, other, null, null, 1,
+                new Denial<>(one, other).hashCode());
+    }
+
+    /**
+     * The same relation, said of the positions the blocks it relates are made of.
+     *
+     * <p>For a reader coming back the other way: a choice reads what both its branches deny, which
+     * is an algebra over blocks and is {@link Apartness}'s, and what it leaves is a reading that
+     * conjunctions carry on from.
+     *
+     * <p>Every pair of the two ends and not one pair of representatives. A denial between two
+     * blocks says that everything one of them holds differs from everything the other does, so a
+     * reading that later holds those positions apart is owed all of it — said by one pair, what the
+     * others were told would be gone the moment nothing held them together any more.
+     */
+    static <A> StatedApartness<A> of(Apartness<A> relation) {
+        StatedApartness<A> out = none();
+        for (Apartness.Edge<A> edge : relation.edges()) {
+            for (A one : edge.one().members()) {
+                for (A other : edge.other().members()) {
+                    out = out.and(of(one, other));
+                }
+            }
+        }
+        return out;
+    }
+
+    /** Both of them said, which is what a conjunction of two readings was told. */
+    StatedApartness<A> and(StatedApartness<A> more) {
+        if (stated == 0) {
+            return more;
+        }
+        if (more.stated == 0) {
+            return this;
+        }
+        return new StatedApartness<>(null, null, this, more,
+                stated + more.stated, mixed + more.mixed);
+    }
+
+    /** Whether nothing is stated to differ. */
+    boolean isEmpty() {
+        return stated == 0;
+    }
+
+    /**
+     * The denials said, each of them once.
+     *
+     * <p>Walked with a stack of what is left rather than by calling down what was composed, and
+     * passing a part it has already read. A reading states one denial at a time, so what a long one
+     * composes is as deep as it is long; and nothing is copied when two are said together, so a
+     * caller saying one thing twice reaches it twice and holds it once.
+     */
+    Set<Denial<A>> denials() {
+        if (settled == null) {
+            Set<Denial<A>> out = new LinkedHashSet<>();
+            Set<StatedApartness<A>> read = Collections.newSetFromMap(new IdentityHashMap<>());
+            Deque<StatedApartness<A>> toRead = new ArrayDeque<>();
+            toRead.push(this);
+            while (!toRead.isEmpty()) {
+                StatedApartness<A> next = toRead.pop();
+                if (!read.add(next)) {
+                    continue;
+                }
+                if (next.left != null) {
+                    toRead.push(next.right);
+                    toRead.push(next.left);
+                } else if (next.stated != 0) {
+                    out.add(new Denial<>(next.one, next.other));
+                }
+            }
+            settled = Collections.unmodifiableSet(out);
+        }
+        return settled;
+    }
+
+    /** Every position a denial names, which is every position this says anything about. */
+    Set<A> positions() {
+        Set<A> out = new LinkedHashSet<>();
+        for (Denial<A> denial : denials()) {
+            out.add(denial.one());
+            out.add(denial.other());
+        }
+        return out;
+    }
+
+    /**
+     * Whether some denial has both its ends on one block of {@code heldAsOne}, which is a value
+     * stated to differ from itself and so a reading nothing satisfies.
+     *
+     * <p>Asked of what was stated rather than of the relation it comes to, because it is the one
+     * thing a reading is asked about its denials before anything has worked out what the positions
+     * they name admit. Built as a relation to answer it, a reading would pay for every pair it holds
+     * every time it is asked whether it still stands, and it is asked that as each rule arrives.
+     *
+     * <p>Every part walked once, for {@link #denials}' reason, and nothing built: the answer is
+     * whether there is one, so the walk stops at the first.
+     */
+    boolean contradicts(Sameness<A> heldAsOne) {
+        if (stated == 0) {
+            return false;
+        }
+        Set<StatedApartness<A>> read = Collections.newSetFromMap(new IdentityHashMap<>());
+        Deque<StatedApartness<A>> toRead = new ArrayDeque<>();
+        toRead.push(this);
+        while (!toRead.isEmpty()) {
+            StatedApartness<A> next = toRead.pop();
+            if (!read.add(next)) {
+                continue;
+            }
+            if (next.left != null) {
+                toRead.push(next.right);
+                toRead.push(next.left);
+            } else if (heldAsOne.blockOf(next.one).equals(heldAsOne.blockOf(next.other))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The relation these denials come to, between the blocks {@code heldAsOne} holds their ends on.
+     *
+     * <p>Where this stops and {@link Apartness} begins. A denial names two positions and what it
+     * says is about the values they are left, so once it is known which positions are one value the
+     * denial is a pair of those — and both ends landing on one block is kept, since what it says
+     * there is that a value differs from itself.
+     */
+    Apartness<A> quotientBy(Sameness<A> heldAsOne) {
+        if (stated == 0) {
+            return Apartness.nothing();
+        }
+        Set<Apartness.Edge<A>> edges = new LinkedHashSet<>();
+        for (Denial<A> denial : denials()) {
+            edges.add(new Apartness.Edge<>(heldAsOne.blockOf(denial.one()),
+                    heldAsOne.blockOf(denial.other())));
+        }
+        return Apartness.ofEdges(edges);
+    }
+
+    @Override
+    public boolean equals(Object said) {
+        if (this == said) {
+            return true;
+        }
+        return said instanceof StatedApartness<?> it && mixed == it.mixed
+                && denials().equals(it.denials());
+    }
+
+    /** The denials it holds — see {@link ValueHash}. */
+    @Override
+    public int hashCode() {
+        return ValueHash.ofWhatItHolds(StatedApartness.class, mixed, stated);
+    }
+
+    @Override
+    public String toString() {
+        return InOneOrder.of(denials());
+    }
+
+    /**
+     * Two positions stated to hold different values.
+     *
+     * <p>Unordered, for {@link Apartness.Edge}'s reason: a denial is a pair, and which end an author
+     * wrote first is a fact about the writing.
+     */
+    record Denial<A>(A one, A other) {
+
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof Denial<?> it
+                    && ((one.equals(it.one) && other.equals(it.other))
+                            || (one.equals(it.other) && other.equals(it.one)));
+        }
+
+        @Override
+        public int hashCode() {
+            return ValueHash.ofAnUnorderedPair(Denial.class, one.hashCode(), other.hashCode());
+        }
+
+        @Override
+        public String toString() {
+            String mine = String.valueOf(one);
+            String theirs = String.valueOf(other);
+            return mine.compareTo(theirs) <= 0 ? mine + " /= " + theirs : theirs + " /= " + mine;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
@@ -227,12 +227,20 @@ final class StatedApartness<A> {
      * denial shows nothing here either, so what is skipped is the walking and not a question.
      */
     Lacks<A> apartFromThemselves(Sameness<A> heldAsOne) {
-        List<Shown<A>> out = new ArrayList<>();
+        // The blocks and not the denials that named them. Several denials the reading came to hold
+        // between one block say one thing about it, and a lack is claimed once with every route
+        // that reached it — which the relation these come to says by being a set of pairs, and is
+        // said here because nothing builds one on the way to this.
+        Set<Sameness.Block<A>> itself = new LinkedHashSet<>();
         for (Denial<A> denial : denials()) {
             Sameness.Block<A> block = heldAsOne.blockOf(denial.one());
             if (block.equals(heldAsOne.blockOf(denial.other()))) {
-                out.add(Shown.of(new RelationalLack.ABlockApartFromItself<>(block)));
+                itself.add(block);
             }
+        }
+        List<Shown<A>> out = new ArrayList<>(itself.size());
+        for (Sameness.Block<A> block : itself) {
+            out.add(Shown.of(new RelationalLack.ABlockApartFromItself<>(block)));
         }
         return Lacks.of(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/StatedApartness.java
@@ -3,10 +3,12 @@ package souther.compiler.values;
 import souther.compiler.hash.ValueHash;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,7 +37,7 @@ import java.util.Set;
 final class StatedApartness<A> {
 
     private static final StatedApartness<?> NOTHING =
-            new StatedApartness<>(null, null, null, null, 0, 0);
+            new StatedApartness<Void>(null, null, null, null, 0L);
 
     /** The denial this is, where it is one, and null where it is none of them or both of two. */
     private final A one;
@@ -45,32 +47,40 @@ final class StatedApartness<A> {
     private final StatedApartness<A> left;
     private final StatedApartness<A> right;
 
-    /** How many were said, counting a denial said twice twice — what is held is what was said. */
-    private final int stated;
-
     /**
-     * The denials this holds, added up.
+     * A bit for each denial this holds, and the same bits for the same denials.
      *
-     * <p>Added rather than taken in order, because what this holds is a set and two callers reaching
-     * the same denials by different compositions hold the same thing. Carried across a composition
-     * instead of walked for, so that hashing one is what it costs to say one.
+     * <p>What this holds is a set, so what stands for it has to be what a set is: putting two
+     * together is a union, saying one of them again changes nothing, and which order they were said
+     * in is not part of it. Bits taken together are all three — added up or counted, what would be
+     * carried is how many times a composition reaches a denial, which is a fact about how it was
+     * arrived at and is exactly what this type exists to stop anybody paying for.
+     *
+     * <p>Carried across a composition rather than walked for, so that hashing a reading is what it
+     * costs to say a denial. Two different sets may leave the same bits, which is what a hash is
+     * allowed to do; the same set never leaves different ones, which is what it is not.
      */
-    private final int mixed;
+    private final long mixed;
 
     /** The denials said, each once, worked out on the first question that needs them and kept. */
     private Set<Denial<A>> settled;
 
     private StatedApartness(A one, A other, StatedApartness<A> left, StatedApartness<A> right,
-                            int stated, int mixed) {
+                            long mixed) {
         this.one = one;
         this.other = other;
         this.left = left;
         this.right = right;
-        this.stated = stated;
         this.mixed = mixed;
     }
 
-    /** Nothing stated to differ, which is what a reading that read no denial holds. */
+    /**
+     * Nothing stated to differ, which is what a reading that read no denial holds.
+     *
+     * <p>The one of these there is, and what makes {@link #isEmpty} the question it is: saying
+     * nothing beside something leaves the something, so nothing is ever inside a composition and
+     * holding no denial is being this.
+     */
     @SuppressWarnings("unchecked")
     static <A> StatedApartness<A> none() {
         return (StatedApartness<A>) NOTHING;
@@ -78,8 +88,13 @@ final class StatedApartness<A> {
 
     /** The two positions stated to hold different values. */
     static <A> StatedApartness<A> of(A one, A other) {
-        return new StatedApartness<>(one, other, null, null, 1,
-                new Denial<>(one, other).hashCode());
+        return new StatedApartness<>(one, other, null, null,
+                bitFor(new Denial<>(one, other).hashCode()));
+    }
+
+    /** The bits one denial leaves, which are the same bits every time it is said. */
+    private static long bitFor(int denial) {
+        return (1L << (denial & 63)) | (1L << ((denial >>> 6) & 63));
     }
 
     /**
@@ -108,19 +123,19 @@ final class StatedApartness<A> {
 
     /** Both of them said, which is what a conjunction of two readings was told. */
     StatedApartness<A> and(StatedApartness<A> more) {
-        if (stated == 0) {
+        if (isEmpty()) {
             return more;
         }
-        if (more.stated == 0) {
+        if (more.isEmpty()) {
             return this;
         }
-        return new StatedApartness<>(null, null, this, more,
-                stated + more.stated, mixed + more.mixed);
+        return new StatedApartness<>(null, null, this, more, mixed | more.mixed);
     }
 
-    /** Whether nothing is stated to differ. */
+    /** Whether nothing is stated to differ, which is holding the one of these that holds
+     *  nothing. */
     boolean isEmpty() {
-        return stated == 0;
+        return this == NOTHING;
     }
 
     /**
@@ -145,7 +160,7 @@ final class StatedApartness<A> {
                 if (next.left != null) {
                     toRead.push(next.right);
                     toRead.push(next.left);
-                } else if (next.stated != 0) {
+                } else if (!next.isEmpty()) {
                     out.add(new Denial<>(next.one, next.other));
                 }
             }
@@ -177,7 +192,7 @@ final class StatedApartness<A> {
      * whether there is one, so the walk stops at the first.
      */
     boolean contradicts(Sameness<A> heldAsOne) {
-        if (stated == 0) {
+        if (isEmpty()) {
             return false;
         }
         Set<StatedApartness<A>> read = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -199,6 +214,30 @@ final class StatedApartness<A> {
     }
 
     /**
+     * Each block {@code heldAsOne} holds both ends of some denial on, which is a value stated to
+     * differ from itself.
+     *
+     * <p>{@link Apartness#apartFromThemselves} without the relation. What a reading is refused by
+     * before anything has worked out what its positions admit is only ever this, and it is asked
+     * that as each rule arrives — built as a relation to answer it, a reading would build every
+     * pair it holds for every rule it reads and read one answer out of it.
+     *
+     * <p>Asked only where there is one to find, which {@link #contradicts} answered when the
+     * alternative was made. Nothing is decided at a call site by that: a reading holding no such
+     * denial shows nothing here either, so what is skipped is the walking and not a question.
+     */
+    Lacks<A> apartFromThemselves(Sameness<A> heldAsOne) {
+        List<Shown<A>> out = new ArrayList<>();
+        for (Denial<A> denial : denials()) {
+            Sameness.Block<A> block = heldAsOne.blockOf(denial.one());
+            if (block.equals(heldAsOne.blockOf(denial.other()))) {
+                out.add(Shown.of(new RelationalLack.ABlockApartFromItself<>(block)));
+            }
+        }
+        return Lacks.of(out);
+    }
+
+    /**
      * The relation these denials come to, between the blocks {@code heldAsOne} holds their ends on.
      *
      * <p>Where this stops and {@link Apartness} begins. A denial names two positions and what it
@@ -207,7 +246,7 @@ final class StatedApartness<A> {
      * there is that a value differs from itself.
      */
     Apartness<A> quotientBy(Sameness<A> heldAsOne) {
-        if (stated == 0) {
+        if (isEmpty()) {
             return Apartness.nothing();
         }
         Set<Apartness.Edge<A>> edges = new LinkedHashSet<>();
@@ -223,14 +262,17 @@ final class StatedApartness<A> {
         if (this == said) {
             return true;
         }
+        // The bits first because they are in hand, and they only rule out: the same denials leave
+        // the same bits, so different bits are different denials and the same bits decide nothing.
         return said instanceof StatedApartness<?> it && mixed == it.mixed
                 && denials().equals(it.denials());
     }
 
-    /** The denials it holds — see {@link ValueHash}. */
+    /** The bits its denials leave, which is one thing and is what it is equal by — see
+     *  {@link ValueHash}. */
     @Override
     public int hashCode() {
-        return ValueHash.ofWhatItHolds(StatedApartness.class, mixed, stated);
+        return ValueHash.ofOnePart(StatedApartness.class, Long.hashCode(mixed));
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/values/WhatARelationShows.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/WhatARelationShows.java
@@ -25,6 +25,20 @@ public final class WhatARelationShows<A> {
 
     private final Apartness<A> apart;
 
+    /**
+     * The alternative whose denials these are, where they are still what it was told. Nothing where
+     * a relation was handed over instead.
+     *
+     * <p>A reading whose values are still descriptions is asked this as each rule arrives, and what
+     * it can be refused by then is only a block stated to differ from itself. Held as the relation
+     * its denials come to, that is a relation built for every rule read, out of every pair the
+     * reading holds — and read once.
+     *
+     * <p>The alternative and not an answer about it. What it shows is its own to say, the same way
+     * a relation's is, so nothing here promises about what a caller happened to write.
+     */
+    private final PlannedHeld.Alternative<A> alternative;
+
     /** How a reader holding the ranges settles the relation, or nothing where what is asked needs
      *  no values. */
     private final AskedOfARelation<A> relating;
@@ -33,9 +47,10 @@ public final class WhatARelationShows<A> {
      *  relation against. Nothing where there is no such reader. */
     private final AdmissibleValues.Box<A> product;
 
-    private WhatARelationShows(Apartness<A> apart, AskedOfARelation<A> relating,
-                               AdmissibleValues.Box<A> product) {
+    private WhatARelationShows(Apartness<A> apart, PlannedHeld.Alternative<A> alternative,
+                               AskedOfARelation<A> relating, AdmissibleValues.Box<A> product) {
         this.apart = apart;
+        this.alternative = alternative;
         this.relating = relating;
         this.product = product;
     }
@@ -48,7 +63,13 @@ public final class WhatARelationShows<A> {
      * waits for the sets, and is the other question below.
      */
     public static <A> WhatARelationShows<A> statedApart(Apartness<A> apart) {
-        return new WhatARelationShows<>(apart, null, null);
+        return new WhatARelationShows<>(apart, null, null, null);
+    }
+
+    /** The same question of an alternative whose denials are still what it was told — see
+     *  {@link PlannedHeld.Alternative#denialsApartFromThemselves}. */
+    static <A> WhatARelationShows<A> statedApart(PlannedHeld.Alternative<A> alternative) {
+        return new WhatARelationShows<>(null, alternative, null, null);
     }
 
     /**
@@ -62,13 +83,14 @@ public final class WhatARelationShows<A> {
     public static <A> WhatARelationShows<A> askedOf(AskedOfARelation<A> relating,
                                                     Apartness<A> apart,
                                                     AdmissibleValues.Box<A> product) {
-        return new WhatARelationShows<>(apart, relating, product);
+        return new WhatARelationShows<>(apart, null, relating, product);
     }
 
     /** The lacks, which are none where the relation refuses nothing. */
     Lacks<A> shows() {
         if (relating == null) {
-            return apart.apartFromThemselves();
+            return apart != null ? apart.apartFromThemselves()
+                    : alternative.denialsApartFromThemselves();
         }
         return relating.of(apart, product) instanceof Apartness.Reduction.Nothing<A> it
                 ? it.lacks() : Lacks.none();

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
@@ -1,0 +1,155 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The denials a reading was told, as it was told them.
+ *
+ * <p>A denial is between two positions and comes to a pair of blocks, and which blocks those are is
+ * settled by everything the reading holds as one value. A conjunction is where that is found out, so
+ * what it costs a reading to conjoin is what this decides: told as positions, the denials of two
+ * readings are put together and nothing is carried anywhere.
+ *
+ * <p>Three things follow that a model cannot show, because what a model shows is which declarations
+ * are refused and these are all rules about what a refusal costs to reach.
+ *
+ * <p>That the denials are read out once each and in the order they were first stated. That reading
+ * them back is not a limit on how many there may be, nor on how often a caller says the same thing —
+ * a reading states one denial at a time, so what a long one composes is as deep as it is long, and
+ * nothing is copied when two are said together.
+ *
+ * <p>And that a denial whose ends the reading came to hold as one value still empties it. Which of
+ * the two readings being conjoined was the one holding them apart is not something the answer may
+ * turn on, so it is asked both ways round.
+ */
+class WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest {
+
+    /** A reading saying enough denials for one that called down what they compose to not answer. */
+    private static final int LONGER_THAN_A_STACK = 100_000;
+
+    /** Doublings enough that a reader paying per reach rather than per part takes far longer than
+     *  this test is given, and few enough that it still stops and says so. */
+    private static final int MORE_REACHES_THAN_THERE_ARE_PARTS = 27;
+
+    private static StatedApartness<String> said(List<String> pairs) {
+        StatedApartness<String> out = StatedApartness.none();
+        for (String pair : pairs) {
+            String[] ends = pair.split("/");
+            out = out.and(StatedApartness.of(ends[0], ends[1]));
+        }
+        return out;
+    }
+
+    private static StatedApartness.Denial<String> denial(String one, String other) {
+        return new StatedApartness.Denial<>(one, other);
+    }
+
+    /** A denial stated again is the same denial, and it is read where it was first stated. */
+    @Test
+    void aDenialStatedAgainIsReadOnceAndWhereItWasFirstStated() {
+        assertEquals(List.of(denial("p", "q"), denial("q", "r"), denial("p", "r")),
+                List.copyOf(said(List.of("p/q", "q/r", "q/p", "p/r", "r/q")).denials()),
+                "and a denial stated the other way round is the same denial");
+    }
+
+    /** Two readings' denials said together are the first's and then what the second adds. */
+    @Test
+    void twoReadingsDenialsAreReadAsTheFirstsAndThenWhatTheSecondAdds() {
+        assertEquals(List.of(denial("p", "q"), denial("q", "r"), denial("r", "s")),
+                List.copyOf(said(List.of("p/q", "q/r")).and(said(List.of("q/r", "r/s"))).denials()));
+    }
+
+    /** Nothing stated, which is what a reading that read no denial holds. */
+    @Test
+    void aReadingToldNothingStatesNothing() {
+        assertTrue(StatedApartness.<String>none().isEmpty());
+        assertEquals(Set.of(), StatedApartness.<String>none().denials());
+    }
+
+    /**
+     * A reading longer than a reader could call down is read back whole.
+     *
+     * <p>The denial stated last is reached, and so is the one stated first — which is under
+     * everything else that was stated, and is the one a reader that stopped anywhere would not have.
+     */
+    @Test
+    void aReadingLongerThanAStackIsReadBackWhole() {
+        StatedApartness<String> deep = StatedApartness.of("p", "q");
+        for (int stated = 0; stated < LONGER_THAN_A_STACK; stated++) {
+            deep = deep.and(StatedApartness.of("p", "q"));
+        }
+        assertEquals(List.of(denial("p", "q"), denial("r", "s")),
+                List.copyOf(deep.and(StatedApartness.of("r", "s")).denials()));
+    }
+
+    /**
+     * What was stated once and reached many times is read once.
+     *
+     * <p>Nothing is copied when two of these are said together, so a caller doubling what it says
+     * holds one more part and reaches twice as much. Read by what it reaches, what a reading costs
+     * would double with it — which is the cost this whole arrangement is about, arrived at from the
+     * other end.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void whatWasStatedOnceIsReadOnceHoweverManyTimesItIsReached() {
+        StatedApartness<String> shared = StatedApartness.of("p", "q");
+        for (int doubled = 0; doubled < MORE_REACHES_THAN_THERE_ARE_PARTS; doubled++) {
+            shared = shared.and(shared);
+        }
+        assertEquals(List.of(denial("p", "q")), List.copyOf(shared.denials()));
+    }
+
+    /**
+     * The pair a denial comes to, between the blocks the reading holds its ends on.
+     *
+     * <p>Both ends landing on one block is kept: what it says there is that a value differs from
+     * itself, which nothing satisfies, and a reader that dropped it would leave the reading standing
+     * on rules that emptied it.
+     */
+    @Test
+    void aDenialComesToAPairOfTheBlocksItsEndsAreOn() {
+        StatedApartness<String> stated = StatedApartness.of("p", "r");
+
+        assertEquals(Set.of(new Apartness.Edge<>(Sameness.Block.of("p"), Sameness.Block.of("r"))),
+                stated.quotientBy(Sameness.discrete()).edges());
+
+        Apartness<String> asOne = stated.quotientBy(Sameness.of("p", "r"));
+        assertTrue(asOne.holdsABlockApartFromItself(),
+                () -> "a block stated to differ from itself, and not a pair to drop: " + asOne);
+    }
+
+    /**
+     * A reading emptied by holding as one value what it holds apart says so, whichever side of the
+     * conjunction stated which.
+     */
+    @Test
+    void holdingApartWhatIsHeldAsOneValueEmptiesTheReadingEitherWayRound() {
+        assertEquals(Emptiness.EMPTY, PlannedValues.<String>heldApart("p", "r")
+                        .meet(PlannedValues.holdingAsOne("p", "r"))
+                        .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY),
+                "the equality read after the denial");
+        assertEquals(Emptiness.EMPTY, PlannedValues.<String>holdingAsOne("p", "r")
+                        .meet(PlannedValues.heldApart("p", "r"))
+                        .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY),
+                "and read before it");
+    }
+
+    /** And a reading holding apart two positions nothing holds together is not emptied by them. */
+    @Test
+    void holdingApartTwoPositionsNothingHoldsTogetherLeavesTheReadingStanding() {
+        assertFalse(PlannedValues.<String>heldApart("p", "r")
+                        .meet(PlannedValues.holdingAsOne("p", "q"))
+                        .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
+                "holding p with q says nothing about whether p differs from r");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
@@ -152,6 +152,26 @@ class WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest {
     }
 
     /**
+     * Several denials the reading came to hold between one block are one lack.
+     *
+     * <p>What they say is that the values of that block differ from themselves, which is one thing
+     * said once however many denials were read to reach it. A lack is claimed once, with every route
+     * that reached it, so this is not a tidying: what each denial holds is the same lack, and a
+     * reading that put them in one beside the other would be holding a route as a lack of its own.
+     */
+    @Test
+    void severalDenialsCollapsingOntoOneBlockShowOneLack() {
+        StatedApartness<String> stated =
+                StatedApartness.of("p", "q").and(StatedApartness.of("p", "r"));
+        Sameness<String> asOne = Sameness.<String>discrete().joining("p", "q").joining("p", "r");
+
+        assertEquals(Apartness.of("p", "q").and(Apartness.of("p", "r"))
+                        .filedIn(Refinement.of(Sameness.discrete(), asOne)).apartFromThemselves(),
+                stated.apartFromThemselves(asOne),
+                "which is what the relation they come to shows, and is what it showed before");
+    }
+
+    /**
      * The pair a denial comes to, between the blocks the reading holds its ends on.
      *
      * <p>Both ends landing on one block is kept: what it says there is that a value differs from

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest.java
@@ -3,6 +3,7 @@ package souther.compiler.values;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,9 @@ class WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest {
     /** Doublings enough that a reader paying per reach rather than per part takes far longer than
      *  this test is given, and few enough that it still stops and says so. */
     private static final int MORE_REACHES_THAN_THERE_ARE_PARTS = 27;
+
+    /** Doublings enough that how many reaches there are is past what a count of them holds. */
+    private static final int PAST_WHAT_A_COUNT_HOLDS = 64;
 
     private static StatedApartness<String> said(List<String> pairs) {
         StatedApartness<String> out = StatedApartness.none();
@@ -107,6 +111,44 @@ class WhatAnAlternativeStatesIsReadOnceHoweverItWasComposedTest {
             shared = shared.and(shared);
         }
         assertEquals(List.of(denial("p", "q")), List.copyOf(shared.denials()));
+    }
+
+    /**
+     * A denial stated twice is the denial, and a reading is what it states.
+     *
+     * <p>Which is what every reader of these is told they hold, and is not a property of how one was
+     * arrived at. Two readings holding one denial are one alternative, so a conjunction of a reading
+     * with itself leaves the alternatives it had rather than as many again.
+     */
+    @Test
+    void aReadingStatingOneDenialTwiceIsTheReadingStatingIt() {
+        StatedApartness<String> once = StatedApartness.of("p", "q");
+        StatedApartness<String> twice = once.and(once);
+
+        assertEquals(once, twice);
+        assertEquals(once.hashCode(), twice.hashCode());
+        assertEquals(1, new LinkedHashSet<>(List.of(once, twice)).size(),
+                "so a set of alternatives holds one of them and not two");
+    }
+
+    /**
+     * And a reading that reaches its denials however many times still holds them.
+     *
+     * <p>Nothing is copied when two of these are said together, so what a caller says twice it
+     * reaches twice — carried as how many reaches there are, what a reading holds would come to
+     * nothing the moment there were as many of them as a number can count.
+     */
+    @Test
+    void aReadingReachingOneDenialPastCountingStillStatesIt() {
+        StatedApartness<String> shared = StatedApartness.of("p", "q");
+        for (int doubled = 0; doubled < PAST_WHAT_A_COUNT_HOLDS; doubled++) {
+            shared = shared.and(shared);
+        }
+
+        assertFalse(shared.isEmpty(), "a reading that states a denial states it");
+        assertEquals(List.of(denial("p", "q")), List.copyOf(shared.denials()));
+        assertTrue(shared.contradicts(Sameness.of("p", "q")),
+                "and holding its ends as one value empties the reading");
     }
 
     /**


### PR DESCRIPTION
A denial names two positions and comes to a pair of blocks, and which blocks those are is settled by everything the reading holds as one value. Conjoining readings is where that is found out: each conjunction leaves coarser blocks than either side had, so a relation between blocks had to be filed into the new ones at every step, and a reading stating many denials filed each of them about as many times as it had. What an alternative holds as one value was read off its denials as well as its product, so every step walked all of them for that too — which was the larger half of it, and is not what the issue names.

Told as positions, there is nothing for a step to carry. The denials of two readings conjoined are the denials of both, said together in one step; what an alternative holds as one value is what its product is over, since a denial holds neither of its ends with anything.

What a reading is asked about its denials before anything has worked out what their positions admit is whether some denial has both ends on one block, which empties it. It is asked that as each rule arrives, so it is answered where an alternative is made: a conjunction holds the denials of both sides, and neither side's answer changes unless the conjunction holds as one value something that side held apart. Asked of the whole of what was stated instead, a reading would walk every denial it holds for every denial it reads.

The relation itself is what a choice reads of two branches and what a refusal says about them. Those are unchanged — what a choice states is still the pull-back and intersection it was, and it is what hands a conjunction back something to carry on from. The relation is built where one of them asks for it.

What is composed is a graph and not a tree: nothing is copied when two readings' denials are said together, so two conjunctions carrying on from one reach it twice and hold it once. Reading it back walks each part once and carries what is left to see rather than calling down it, for the reason the last two changes of this shape give.

Measured on the declaration the issue names, with every position stated to differ. The conjunction is off the profile: what an alternative holds as one value, the filing, and the putting together are all gone from it, and so is the question asked as each rule arrives. What remains of that reproduction is a refusal account built as each rule is read whether or not anything is refused, which is not about denials and is not this.

Issue #1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
