### PR TITLE
Ask for the account of a refusal where a refusal was found

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -356,7 +356,8 @@ sealed interface Confinement<A> {
                                       PositionEnvelope.Restrictions<A> outside,
                                       Admitting<A> admitting,
                                       Refusing<A> refused,
-                                      Refusal<A> alreadyShown, StringMachineAnswers machines) {
+                                      AskedOfTheReadingAlone<A> alreadyShown,
+                                      StringMachineAnswers machines) {
         // The ends holding a position nothing, which is that reading's own answer whatever else
         // places the position: a reading left with no range at all names none, and where it names
         // one, that is where the lack is.
@@ -465,12 +466,18 @@ sealed interface Confinement<A> {
             // Each of those places holds something on its own, so "the values admit nothing" is
             // true of the declaration and says less than what was shown — and which of the two
             // nearer sentences it is is the refusal's to say and not a second reading of it.
+            //
+            // The one place the reading is asked what refused it, and asked once: this is the only
+            // answer here that is about the alternatives rather than about them met with what
+            // places their positions, and every other way out of this question is settled without
+            // it.
+            Refusal<A> already = alreadyShown.of();
             return new Admission<>(souther.compiler.values.Emptiness.EMPTY,
-                    switch (alreadyShown.nearest()) {
+                    switch (already.nearest()) {
                         case NOWHERE -> EmptyBy.VALUES;
                         case AT_EACH_OF -> EmptyBy.POSITIONS_HELD_AS_ONE;
                         case OF_THEM_TOGETHER -> EmptyBy.POSITIONS_HELD_APART;
-                    }, alreadyShown, Shown.BY_THE_READINGS);
+                    }, already, Shown.BY_THE_READINGS);
         }
         return new Admission<>(souther.compiler.values.Emptiness.EMPTY, EmptyBy.SET_AND_RANGE, where, how);
     }
@@ -509,6 +516,25 @@ sealed interface Confinement<A> {
     @FunctionalInterface
     interface Refusing<A> {
         Refusal<A> of(AskedOfEachBlock<A> blocks, AskedOfARelation<A> relation);
+    }
+
+    /**
+     * What a reading's own descriptions show it refused by, asked of the reading and nothing else.
+     *
+     * <p>Beside {@link Admitting} and {@link Refusing} and not one of them. Those two are asked
+     * against a placing of the positions, which is why each of them takes the walk's two questions;
+     * this one is answered out of the alternatives alone and there is no placing for it to consult.
+     * The difference is which reading the answer is about and not how many questions it takes.
+     *
+     * <p><b>A question, because the walk mostly does not refuse.</b> The answer is worked out over
+     * every position each alternative describes and every denial each of them states, and it is
+     * read in one place: where a reading has been found to hold nothing and what emptied it is the
+     * values rather than the ends. Handed over as an answer instead, what it costs to ask whether a
+     * reading stands would follow how much the reading says rather than what was asked of it.
+     */
+    @FunctionalInterface
+    interface AskedOfTheReadingAlone<A> {
+        Refusal<A> of();
     }
 
     /**
@@ -725,7 +751,7 @@ sealed interface Confinement<A> {
                             // one.
                             (asked, _) -> values.anyAlternativeAdmits(asked),
                             (asked, _) -> values.refusedInEveryAlternativeAt(asked),
-                            values.refusedBy(), machines),
+                            values::refusedBy, machines),
                     LeftUnbuilt.NOTHING);
         }
 
@@ -910,7 +936,7 @@ sealed interface Confinement<A> {
                     shown != null ? shown : Confinement.admission(ordered, carriers, outside,
                             made.values()::anyAlternativeAdmits,
                             made.values()::refusedInEveryAlternativeAt,
-                            made.values().refusedBy(), machines),
+                            made.values()::refusedBy, machines),
                     made.leftUnbuilt());
         }
 
@@ -985,7 +1011,7 @@ sealed interface Confinement<A> {
             return new ReadAdmission<>(
                     shown != null ? shown : Confinement.admission(ordered, carriers, outside,
                             values::anyAlternativeAdmits, values::refusedInEveryAlternativeAt,
-                            values.refusedBy(), machines),
+                            values::refusedBy, machines),
                     leftUnbuilt);
         }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.numeric.Text;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.PlannedValues;
+import souther.compiler.values.StringMachineAnswers;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reading was refused by is asked for where a refusal has been found, and nowhere else.
+ *
+ * <p>{@link Confinement#admission} is asked three things. Two of them are questions about the
+ * reading met with what places its positions, and the walk asks each where it wants an answer. The
+ * third is about the alternatives alone — what every one of them describes itself as refused by —
+ * and exactly one way out of the question reads it: the reading holds nothing, and what emptied it
+ * is the values rather than the ends.
+ *
+ * <p>So it is a question too, and this is what says so. A reading that stands, one the ends leave
+ * nothing, and one whose values and ranges share no value are three answers that owe an author
+ * nothing about the alternatives, and the third question is not asked on any of them. Handed an
+ * answer instead, what it costs to ask whether a reading stands would follow how many rules the
+ * reading holds, on every one of these paths.
+ *
+ * <p>Asked of {@link Confinement#admission} directly, because what is under test is which arm
+ * reaches for the question. The two questions beside it are the reading's own, so what walks here
+ * is what walks in production and only the answer being counted is this test's.
+ *
+ * <p>The name of the verdict is written out because this package declares one of its own.
+ */
+class TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest {
+
+    /** A reading with something in it, which is the answer most askings reach. */
+    @Test
+    void aReadingThatStandsIsNeverAskedWhatRefusedIt() {
+        Confinement.Admission<FactSubject> said = askedNever(
+                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
+                OrderedIntervals.top());
+
+        assertFalse(said.emptiness().isEmpty(), "the reading holds a value");
+    }
+
+    /** And a reading the ends leave nothing, which the ends answer for on their own. */
+    @Test
+    void aReadingTheEndsEmptyIsNeverAskedWhatRefusedIt() {
+        Confinement.Admission<FactSubject> said = askedNever(
+                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
+                atLeast("B").meet(atMost("A")));
+
+        assertEquals(Confinement.EmptyBy.ORDER, said.by());
+    }
+
+    /**
+     * And a reading whose values and whose ends each hold something and share nothing.
+     *
+     * <p>The one that would be paid for on every declaration an author gets wrong this way. What
+     * refused it is where the set and the range were asked together, which the walk has in hand,
+     * and what the alternatives say about themselves is a sentence nobody here is owed.
+     */
+    @Test
+    void aReadingEmptiedByItsValuesAndItsEndsTogetherIsNeverAskedWhatRefusedIt() {
+        Confinement.Admission<FactSubject> said = askedNever(
+                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
+                atLeast("B"));
+
+        assertEquals(Confinement.EmptyBy.SET_AND_RANGE, said.by());
+        assertTrue(said.emptiness().isEmpty());
+    }
+
+    /**
+     * And the one arm that is owed it, which asks once and reports what it was told.
+     *
+     * <p>Once, because the answer is worked out over every position every alternative describes:
+     * asked a second time it would be worked out a second time, and the arm has no more to learn
+     * from it than which of the two nearer sentences this is.
+     */
+    @Test
+    void aReadingItsValuesEmptyIsAskedWhatRefusedItExactlyOnce() {
+        PlannedValues<FactSubject> values =
+                PlannedValues.<FactSubject>at(X, AdmittedPlan.of(ValueSet.just(Value.text("A"))))
+                        .meet(PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("B")))));
+        int[] asked = {0};
+
+        Confinement.Admission<FactSubject> said = admission(values, OrderedIntervals.top(), () -> {
+            asked[0]++;
+            return values.refusedBy();
+        });
+
+        assertEquals(1, asked[0], "the arm that is owed the account asks for it once");
+        assertEquals(values.refusedBy(), said.site(), "and reports what it was told");
+        assertEquals(Confinement.EmptyBy.VALUES, said.by());
+    }
+
+    private static final Term.Interner NAMES = new Term.Interner();
+    private static final FactSubject X = FactSubject.of(NAMES.written("x"));
+
+    /** The strings from {@code least} up. */
+    private static OrderedIntervals<FactSubject> atLeast(String least) {
+        return OrderedIntervals.at(X,
+                new OrderedInterval(Endpoint.inclusive(Text.of(least)), null));
+    }
+
+    /** And the strings up to {@code most}, so that the two of them together name none. */
+    private static OrderedIntervals<FactSubject> atMost(String most) {
+        return OrderedIntervals.at(X,
+                new OrderedInterval(null, Endpoint.inclusive(Text.of(most))));
+    }
+
+    /** The same question, asked where being asked what refused the reading is the failure. */
+    private static Confinement.Admission<FactSubject> askedNever(PlannedValues<FactSubject> values,
+                                                                 OrderedIntervals<FactSubject> ends) {
+        return admission(values, ends, () -> {
+            throw new AssertionError("this answer was reached without a refusal to write down");
+        });
+    }
+
+    private static Confinement.Admission<FactSubject> admission(PlannedValues<FactSubject> values,
+                                                                OrderedIntervals<FactSubject> ends,
+                                                                Confinement.AskedOfTheReadingAlone<FactSubject> refusedBy) {
+        return Confinement.admission(ends, Map.of(X, Carrier.TEXT),
+                PositionEnvelope.Restrictions.nothingSpokenOf(),
+                (asked, _) -> values.anyAlternativeAdmits(asked),
+                (asked, _) -> values.refusedInEveryAlternativeAt(asked),
+                refusedBy, StringMachineAnswers.NONE);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest.java
@@ -12,11 +12,12 @@ import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a reading was refused by is asked for where a refusal has been found, and nowhere else.
@@ -24,58 +25,62 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>{@link Confinement#admission} is asked three things. Two of them are questions about the
  * reading met with what places its positions, and the walk asks each where it wants an answer. The
  * third is about the alternatives alone — what every one of them describes itself as refused by —
- * and exactly one way out of the question reads it: the reading holds nothing, and what emptied it
- * is the values rather than the ends.
+ * and one way out of the question reads it: the reading holds nothing, and what emptied it is the
+ * values rather than the ends.
  *
- * <p>So it is a question too, and this is what says so. A reading that stands, one the ends leave
- * nothing, and one whose values and ranges share no value are three answers that owe an author
- * nothing about the alternatives, and the third question is not asked on any of them. Handed an
- * answer instead, what it costs to ask whether a reading stands would follow how many rules the
- * reading holds, on every one of these paths.
+ * <p><b>The population is the ways out and not the ones that came to mind.</b> A question asked
+ * before any of them is a question asked on all of them, so what holds the asking to the one arm
+ * that is owed an answer is every other arm refusing to be asked. Each way out below is pinned to
+ * the verdict and the proof it carries, so that a case reaching some other way out is a case that
+ * stopped testing what it names.
  *
  * <p>Asked of {@link Confinement#admission} directly, because what is under test is which arm
  * reaches for the question. The two questions beside it are the reading's own, so what walks here
  * is what walks in production and only the answer being counted is this test's.
  *
+ * <p>A way out is a walk and not a pair of readings held side by side: where the positions stop is
+ * made where it is asked for, since a value holding that beside what the positions admit is one its
+ * reader could ask either of alone.
+ *
  * <p>The name of the verdict is written out because this package declares one of its own.
  */
 class TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest {
 
-    /** A reading with something in it, which is the answer most askings reach. */
-    @Test
-    void aReadingThatStandsIsNeverAskedWhatRefusedIt() {
-        Confinement.Admission<FactSubject> said = askedNever(
-                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
-                OrderedIntervals.top());
-
-        assertFalse(said.emptiness().isEmpty(), "the reading holds a value");
-    }
-
-    /** And a reading the ends leave nothing, which the ends answer for on their own. */
-    @Test
-    void aReadingTheEndsEmptyIsNeverAskedWhatRefusedIt() {
-        Confinement.Admission<FactSubject> said = askedNever(
-                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
-                atLeast("B").meet(atMost("A")));
-
-        assertEquals(Confinement.EmptyBy.ORDER, said.by());
-    }
-
     /**
-     * And a reading whose values and whose ends each hold something and share nothing.
+     * Every way out of the question but the one that is owed an account.
      *
-     * <p>The one that would be paid for on every declaration an author gets wrong this way. What
-     * refused it is where the set and the range were asked together, which the walk has in hand,
-     * and what the alternatives say about themselves is a sentence nobody here is owed.
+     * <p>What each of them must be is the verdict written beside it, so that a way out reached by
+     * some other road is not read as the one it is named for.
      */
     @Test
-    void aReadingEmptiedByItsValuesAndItsEndsTogetherIsNeverAskedWhatRefusedIt() {
-        Confinement.Admission<FactSubject> said = askedNever(
-                PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("A")))),
-                atLeast("B"));
+    void noWayOutButOneAsksTheReadingWhatRefusedIt() {
+        // Every one of them, and not the first that breaks. A question moved out of the arm that
+        // is owed it is asked on several of these at once, and which ones is what says how far it
+        // moved — so the asking is written down and read at the end rather than thrown.
+        List<String> asked = new ArrayList<>();
+        List<String> reached = new ArrayList<>();
+        List<String> owed = new ArrayList<>();
+        for (Exit exit : everyWayOutButOne()) {
+            Confinement.Admission<FactSubject> said =
+                    exit.way().asked(() -> asked.add(exit.name()));
 
-        assertEquals(Confinement.EmptyBy.SET_AND_RANGE, said.by());
-        assertTrue(said.emptiness().isEmpty());
+            reached.add(exit.name() + ": " + said.by() + " " + said.how());
+            owed.add(exit.name() + ": " + exit.by() + " " + exit.how());
+        }
+
+        assertEquals(List.of(), asked,
+                "no way out but one is owed what the alternatives say refused them");
+        assertEquals(owed, reached, "and each of them is the way out it is written down as");
+    }
+
+    /** And that a reading holding something is one of them, which the verdicts above do not say. */
+    @Test
+    void aReadingThatStandsIsOneOfThoseWaysOut() {
+        Confinement.Admission<FactSubject> said = stands(() -> {
+            throw new AssertionError("asked what refused a reading that stands");
+        });
+
+        assertFalse(said.emptiness().isEmpty(), "the reading holds a value");
     }
 
     /**
@@ -87,51 +92,104 @@ class TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest {
      */
     @Test
     void aReadingItsValuesEmptyIsAskedWhatRefusedItExactlyOnce() {
-        PlannedValues<FactSubject> values =
-                PlannedValues.<FactSubject>at(X, AdmittedPlan.of(ValueSet.just(Value.text("A"))))
-                        .meet(PlannedValues.at(X, AdmittedPlan.of(ValueSet.just(Value.text("B")))));
+        PlannedValues<FactSubject> values = holding(X, "A").meet(holding(X, "B"));
         int[] asked = {0};
 
-        Confinement.Admission<FactSubject> said = admission(values, OrderedIntervals.top(), () -> {
-            asked[0]++;
-            return values.refusedBy();
-        });
+        Confinement.Admission<FactSubject> said = admission(values, OrderedIntervals.top(),
+                PositionEnvelope.Restrictions.nothingSpokenOf(), () -> asked[0]++);
 
         assertEquals(1, asked[0], "the arm that is owed the account asks for it once");
         assertEquals(values.refusedBy(), said.site(), "and reports what it was told");
         assertEquals(Confinement.EmptyBy.VALUES, said.by());
     }
 
+    /** One asking of the question, told what to do where the reading is asked what refused it. */
+    @FunctionalInterface
+    private interface Way {
+        Confinement.Admission<FactSubject> asked(Runnable whenAsked);
+    }
+
+    /** One way out, and what it must answer to be that way out. */
+    private record Exit(String name, Way way, Confinement.EmptyBy by, Confinement.Shown how) {}
+
+    private static List<Exit> everyWayOutButOne() {
+        return List.of(
+                new Exit("a reading that stands",
+                        TheAccountOfARefusalIsAskedForWhereThereIsOneToHoldTest::stands,
+                        Confinement.EmptyBy.NOTHING_SHOWN, Confinement.Shown.BY_THE_READINGS),
+                new Exit("ends naming no value at all", whenAsked -> admission(holding(X, "A"),
+                        atLeast(X, "B").meet(atMost(X, "A")),
+                        PositionEnvelope.Restrictions.nothingSpokenOf(), whenAsked),
+                        Confinement.EmptyBy.ORDER, Confinement.Shown.BY_THE_READINGS),
+                // A position the alternatives never name, left nowhere once what is required of it
+                // outside is met with its own ends. The reading stands, so this is reached past the
+                // walk and not before it.
+                new Exit("a position placed nowhere by what is outside",
+                        whenAsked -> admission(holding(X, "A"), atMost(Y, "A"),
+                                placing(Y, atLeastInterval("B")), whenAsked),
+                        Confinement.EmptyBy.ORDER,
+                        Confinement.Shown.ONCE_THE_POSITIONS_ARE_PLACED),
+                // A block stated to differ from itself, which is a lack about several blocks
+                // together and is nearer than what the alternatives say about themselves.
+                new Exit("blocks refused together",
+                        whenAsked -> admission(PlannedValues.<FactSubject>holdingAsOne(X, Y)
+                                .meet(PlannedValues.heldApart(X, Y)), OrderedIntervals.top(),
+                                PositionEnvelope.Restrictions.nothingSpokenOf(), whenAsked),
+                        Confinement.EmptyBy.POSITIONS_HELD_APART,
+                        Confinement.Shown.BY_THE_READINGS),
+                new Exit("values and ends sharing no value",
+                        whenAsked -> admission(holding(X, "A"), atLeast(X, "B"),
+                                PositionEnvelope.Restrictions.nothingSpokenOf(), whenAsked),
+                        Confinement.EmptyBy.SET_AND_RANGE, Confinement.Shown.BY_THE_READINGS));
+    }
+
     private static final Term.Interner NAMES = new Term.Interner();
     private static final FactSubject X = FactSubject.of(NAMES.written("x"));
+    private static final FactSubject Y = FactSubject.of(NAMES.written("y"));
+
+    /** A reading with something in it, wherever its positions are put. */
+    private static Confinement.Admission<FactSubject> stands(Runnable whenAsked) {
+        return admission(holding(X, "A"), OrderedIntervals.top(),
+                PositionEnvelope.Restrictions.nothingSpokenOf(), whenAsked);
+    }
+
+    /** A reading leaving {@code position} the one value {@code only}. */
+    private static PlannedValues<FactSubject> holding(FactSubject position, String only) {
+        return PlannedValues.at(position, AdmittedPlan.of(ValueSet.just(Value.text(only))));
+    }
 
     /** The strings from {@code least} up. */
-    private static OrderedIntervals<FactSubject> atLeast(String least) {
-        return OrderedIntervals.at(X,
-                new OrderedInterval(Endpoint.inclusive(Text.of(least)), null));
+    private static OrderedInterval atLeastInterval(String least) {
+        return new OrderedInterval(Endpoint.inclusive(Text.of(least)), null);
+    }
+
+    private static OrderedIntervals<FactSubject> atLeast(FactSubject position, String least) {
+        return OrderedIntervals.at(position, atLeastInterval(least));
     }
 
     /** And the strings up to {@code most}, so that the two of them together name none. */
-    private static OrderedIntervals<FactSubject> atMost(String most) {
-        return OrderedIntervals.at(X,
+    private static OrderedIntervals<FactSubject> atMost(FactSubject position, String most) {
+        return OrderedIntervals.at(position,
                 new OrderedInterval(null, Endpoint.inclusive(Text.of(most))));
     }
 
-    /** The same question, asked where being asked what refused the reading is the failure. */
-    private static Confinement.Admission<FactSubject> askedNever(PlannedValues<FactSubject> values,
-                                                                 OrderedIntervals<FactSubject> ends) {
-        return admission(values, ends, () -> {
-            throw new AssertionError("this answer was reached without a refusal to write down");
-        });
+    /** What the readings outside this one prove about {@code position}. */
+    private static PositionEnvelope.Restrictions<FactSubject> placing(FactSubject position,
+                                                                      OrderedInterval within) {
+        return new PositionEnvelope.Restrictions<>(
+                Map.of(position, new PositionRestriction.Within(within)));
     }
 
     private static Confinement.Admission<FactSubject> admission(PlannedValues<FactSubject> values,
                                                                 OrderedIntervals<FactSubject> ends,
-                                                                Confinement.AskedOfTheReadingAlone<FactSubject> refusedBy) {
-        return Confinement.admission(ends, Map.of(X, Carrier.TEXT),
-                PositionEnvelope.Restrictions.nothingSpokenOf(),
+                                                                PositionEnvelope.Restrictions<FactSubject> outside,
+                                                                Runnable whenAsked) {
+        return Confinement.admission(ends, Map.of(X, Carrier.TEXT, Y, Carrier.TEXT), outside,
                 (asked, _) -> values.anyAlternativeAdmits(asked),
                 (asked, _) -> values.refusedInEveryAlternativeAt(asked),
-                refusedBy, StringMachineAnswers.NONE);
+                () -> {
+                    whenAsked.run();
+                    return values.refusedBy();
+                }, StringMachineAnswers.NONE);
     }
 }


### PR DESCRIPTION
`admission` asks for the account of a refusal only where it has found a refusal whose account must be held.

Whether a reading admits anything is asked of three things. Two of them are questions, put to the walk where an answer is wanted. The third was an answer — what every alternative describes itself as refused by, worked out over every position each of them names and every denial each of them states — and it was handed over before the walk had begun. One arm of the question reads it, and every other way out is settled without it.

It is a question now, asked of the reading alone because there is no placing of the positions for it to consult, and read in the one arm that is owed an account.

## What this is not

Not a performance fix. The issue attributed a measurable share of what was left of #1418's reproduction to this, and that attribution does not hold: on current `develop` the account does not appear in a profile of that reproduction at all, and interleaving the two builds both ways shows no wall-clock difference. What the issue describes structurally is real and is what this closes. The same correction has been added to the issue, and a note recorded while working on #1418, saying this was the largest thing left in that reproduction, is wrong for the same reason.

## Verification

```
12012 tests, 0 failures

The new test takes its cases from the ways out of the question,
and names every one a moved question reaches:
- asking before any of them: 5 named, 2 failures
- asking above the lack about several blocks together: 2 named, 1 failure
- asking twice in the arm that is owed it: 1 failure

On the measured reproductions the account was needed 0 times,
although admission was asked up to 19,464 times.
No measurable wall-clock improvement was found on current develop.
```

Completes #1593, which is closed by hand once this is merged — the base here is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
