### PR TITLE
Take the dependency, action and plugin bumps onto develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '25'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '25'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '25'

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>25</maven.compiler.release>
         <raoh.version>0.7.2</raoh.version>
-        <jspecify.version>1.0.0</jspecify.version>
+        <jspecify.version>1.0.1</jspecify.version>
         <!-- Where compiled classes go, named so the `m2e` profile below can send the editor's
              somewhere else. A build outside the editor uses the Maven defaults. -->
         <build.classes>${project.basedir}/target/classes</build.classes>
@@ -65,8 +65,8 @@
              into. A build that is not the hook leaves it at the root module's sources, which do
              not exist, so the goal has nothing to read. -->
         <checkstyle.staged.dir>${project.basedir}/src/main/java</checkstyle.staged.dir>
-        <checkstyle.version>10.26.1</checkstyle.version>
-        <nullaway.version>0.13.8</nullaway.version>
+        <checkstyle.version>14.0.0</checkstyle.version>
+        <nullaway.version>0.14.0</nullaway.version>
         <!-- What NullAway is asked for, written once. The gate below and the `lint` profile both
              ask, and a gate configured differently in each is a gate whose answer depends on which
              build asked. -->
@@ -91,8 +91,8 @@
              tracked to it: it moves when the interface between a build plugin and a driver moves,
              which is why it is released from souther-lang/souther-build-api and named here like any
              other outside dependency. -->
-        <souther.build.api.version>1.0.0</souther.build.api.version>
-        <junit.version>6.1.2</junit.version>
+        <souther.build.api.version>1.1.0</souther.build.api.version>
+        <junit.version>6.1.3</junit.version>
         <!-- Named rather than written where it is used: `souther init` writes a project that runs
              its tests, and what it hands that project is this number. -->
         <surefire.version>3.5.6</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <junit.version>6.1.3</junit.version>
         <!-- Named rather than written where it is used: `souther init` writes a project that runs
              its tests, and what it hands that project is this number. -->
-        <surefire.version>3.5.6</surefire.version>
+        <surefire.version>3.6.0</surefire.version>
         <!-- The coverage agent a run under `-Pcoverage-by-class` carries. Named once because two
              places need the same number: the profile that starts the agent and the test-support
              module that compiles against its runtime. -->
@@ -315,7 +315,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.16.0</version>
                 <configuration>
                     <compilerArgs>
                         <!-- Every warning javac can give, and none of them is a thing to walk past.
@@ -346,7 +346,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.6</version>
+                <version>3.6.0</version>
                 <configuration>
                     <systemPropertyVariables>
                         <souther.jar>${project.build.directory}/souther.jar</souther.jar>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -75,14 +75,14 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <!-- jOOQ (provided by raoh-jooq) is needed at runtime to load/verify a generated
              recordDecoder()'s $DecRecord bytecode in tests. -->
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.21.6</version>
+            <version>3.21.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Dependabot cuts its branches from `main`, so the bumps it opened there never reach the branch the work happens on. These are its three open ones, cherry-picked onto `develop`: the maven dependency group, the GitHub Actions group, and the maven plugin group.

The plugin bump conflicted — it carries `main`'s fork count and surefire version in the same hunk, and `develop` has since rewritten what stands there. Resolved by taking `develop`'s block and the new surefire version alone.

Checkstyle's major bump is the one nothing in CI would have caught: the plugin is bound to no phase, so only `.githooks/pre-commit` runs it. Checked here that the new Checkstyle reads `config/checkstyle.xml` and still refuses a file with an unused import.

Supersedes #1175, #1256 and #1490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)