### PR TITLE
Give a class's debug table only lines of the file the class names

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -253,7 +253,8 @@ public final class Backend {
             }
         }
         CodegenContext ctx = new CodegenContext(module.name(), symbols, kernels, caseToSums, typePackage,
-                module.exposing().isEmpty(), exposed, standingCalls, layouts);
+                module.exposing().isEmpty(), exposed, standingCalls, layouts,
+                module.pos().quotedFrom());
         ctx.setDischargeInvariants(dischargeInvariants);
         ctx.setInvariantStatements(invariantStatements);
         ctx.setValueShapes(shapes);
@@ -1326,7 +1327,7 @@ public final class Backend {
             // implements its public interface (which itself extends Behavior for a single-input one)
             cb.withInterfaceSymbols(cdBehavior(spec.name()));
             emitInjection(cb, cdB, injected);
-            if (where instanceof EnsuresEnforcement.AtTheCallee(Contract contract)) {
+            if (where instanceof EnsuresEnforcement.AtTheCallee(Contract _)) {
                 emitCheckingApply(cb, cdB, spec, mtdApply, n);
             }
             cb.withMethodBody(bodyMethod, mtdApply, bodyFlags, code -> {
@@ -1553,7 +1554,7 @@ public final class Backend {
                             code.goto_(end);
                             code.labelBinding(doApply);
                         }
-                        case Composition.Routing.Always ignored -> { }
+                        case Composition.Routing.Always _ -> { }
                     }
                     applyStage(code, cdP, stage.behavior(), requiredNames, reqStages, behaviorDeps,
                             stage.answers(), arity + 1);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -627,11 +627,26 @@ final class BodyGen {
             code.invokestatic(CD_Probe, "hit", MTD_Probe_hit);
         }
 
-        /** Binds the bytecode that follows to {@code e}'s source line, for the {@code LineNumberTable}
-         * (spec §target-jdk). Every {@code Core} node keeps its {@code SourcePos}, so a runtime stack trace
-         * — an invariant abort above all — points back to the {@code .sou} line. Consecutive nodes on
-         * the same line (a subexpression tree, or a tail node re-lined by {@code genExpr}) collapse to
-         * one entry. */
+        /**
+         * Binds the bytecode that follows to {@code e}'s source line, for the {@code LineNumberTable}
+         * (spec §target-jdk). Every {@code Core} node keeps its {@code SourcePos}, so a runtime stack
+         * trace — an invariant abort above all — points back to the {@code .sou} line. Consecutive
+         * nodes on the same line (a subexpression tree, or a tail node re-lined by {@code genExpr})
+         * collapse to one entry.
+         *
+         * <p>A node written in another text writes nothing. The class carries one
+         * {@code SourceFile}, which is this module's, and a helper declared in another file of the
+         * same compile keeps the positions it was written at — so its line is a line of a file this
+         * class does not name, and the file it does name may be shorter than it. Leaving the entry
+         * out is what the table has for saying so: the pc then falls under the entry before it,
+         * which is a line of this class's own file because that is the only kind of line written
+         * here.
+         *
+         * <p>What stands there is the call. A helper takes at least one parameter — the language
+         * refuses a {@code let} with an empty parameter list, and a helper that takes nothing is a
+         * value, whose construction is settled where it is written — so the copy is always wrapped
+         * in the bindings the expansion made, and those carry the call's own position.
+         */
         private void emitLine(Core e) {
             souther.compiler.diag.PhysicalPos sits = ctx.sits(e.pos());
             int line = sits == null ? 0 : sits.line();
@@ -824,9 +839,13 @@ final class BodyGen {
          *
          * <p>No file name. This compiler is not given one — a generated class's {@code SourceFile}
          * is derived from its module name rather than threaded down from a path — and deriving one
-         * here would name a file that need not exist, and would name the reading module's when the
-         * {@code unreachable} came in with an inlined helper of another. A reader at run time has
-         * the frame's own file and line; a reader of E1911 has the row's place beside this one.
+         * here would name a file that need not exist. A reader at run time has the frame's own file
+         * and line; a reader of E1911 has the row's place beside this one.
+         *
+         * <p>Which is why an {@code unreachable} that came in with an inlined helper of another file
+         * says its reason and no numbers. A place with no file beside it is read against the frame's,
+         * and the frame's file is this class's — so a line of the helper's file put here would be
+         * read as a line of this one. The reason is what the model wrote and stands on its own.
          */
         private String abortMessage(Core.Unreachable u) {
             souther.compiler.diag.PhysicalPos sits = ctx.sits(u.pos());
@@ -929,7 +948,7 @@ final class BodyGen {
                     unbox(code, bound, bslot);
                     bind(c.binder(), bslot, bound);
                 }
-                case Refinement.OptionAbsent ignored -> { }
+                case Refinement.OptionAbsent _ -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -409,6 +409,7 @@ final class BodyGen {
                         store(code, slot, vt);
                         bind(li.binder(), slot, vt);
                     }
+                    emitLine(li);   // re-pin: a bound value may have moved the line off the call
                     emitTail(li.body(), cdB, requiredNames, requiredSuccess, expected);
                 }
                 case Core.If iff -> {
@@ -642,10 +643,12 @@ final class BodyGen {
          * which is a line of this class's own file because that is the only kind of line written
          * here.
          *
-         * <p>What stands there is the call. A helper takes at least one parameter — the language
-         * refuses a {@code let} with an empty parameter list, and a helper that takes nothing is a
-         * value, whose construction is settled where it is written — so the copy is always wrapped
-         * in the bindings the expansion made, and those carry the call's own position.
+         * <p>Which entry stands there is the {@code let} the copy is the body of. The bindings an
+         * expansion makes carry the call's own position, and between them and the copy the bound
+         * value is emitted — an argument written on its own line binds that line, and the copy binds
+         * nothing to move it back. So the call is bound again before the body, which is the same
+         * re-pin a construction does once its fields are on the stack. Binding it where the body
+         * binds a line of its own costs nothing: two lines at one offset are one entry, the last.
          */
         private void emitLine(Core e) {
             souther.compiler.diag.PhysicalPos sits = ctx.sits(e.pos());
@@ -792,6 +795,7 @@ final class BodyGen {
                     int s = slot(vt);
                     store(code, s, vt);
                     bind(li.binder(), s, vt);
+                    emitLine(li);   // re-pin: a bound value may have moved the line off the call
                     genExpr(li.body(), expected);
                 }
                 // a block has no value of its own; it is inlined by the call it is passed to

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -11,7 +11,10 @@ import souther.compiler.core.KernelSignatures;
 import souther.compiler.core.ValueShape;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.ast.Hir;
+import souther.compiler.diag.PhysicalPos;
+import souther.compiler.diag.QuotedFrom;
 import souther.compiler.diag.SourceLayouts;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.check.TypeOps;
@@ -27,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static souther.compiler.codegen.Descriptors.*;
@@ -85,8 +89,22 @@ final class CodegenContext {
      */
     private final SourceLayouts layouts;
 
-    /** Where a place sits in the text it is in, or null where this compilation holds no such text. */
-    souther.compiler.diag.PhysicalPos sits(souther.compiler.diag.SourcePos place) {
+    /**
+     * Which text the classes generated here are of.
+     *
+     * <p>A class carries one {@code SourceFile}, and it is this module's. So this is the one text
+     * whose line numbers a class generated here can be read against: a place in any other text has
+     * no line to contribute, because whatever line that place is at is a line of a file the class
+     * does not name, and the file it does name may be shorter than it.
+     */
+    private final QuotedFrom home;
+
+    /** Where a place sits in the text this module's classes name, or null where it sits in another
+     *  text or this compilation holds none. */
+    PhysicalPos sits(SourcePos place) {
+        if (place == null || !home.equals(place.quotedFrom())) {
+            return null;
+        }
         return layouts.resolve(place);
     }
 
@@ -420,8 +438,9 @@ final class CodegenContext {
     CodegenContext(String pkg, DerivedSymbols symbols, KernelSignatures kernels,
                    Map<String, List<GeneratedClass>> caseToSums,
                    Map<String, String> typePackage, boolean exposeAll, Set<String> exposed,
-                   Map<String, Type> standingCalls, SourceLayouts layouts) {
+                   Map<String, Type> standingCalls, SourceLayouts layouts, QuotedFrom home) {
         this.layouts = layouts;
+        this.home = Objects.requireNonNull(home, "the classes of a module are of the text it was read from");
         this.pkg = pkg;
         this.symbols = symbols;
         this.kernels = kernels;

--- a/souther-compiler/src/test/java/souther/compiler/CompileSourceMapTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSourceMapTest.java
@@ -116,6 +116,95 @@ class CompileSourceMapTest {
     }
 
     @Test
+    void aSplicedHelpersAbortPointsAtTheCallAndNotAtTheArgumentBelowIt() throws Exception {
+        // The call opens on line 6 and its argument sits on line 7. Between the call's own line and
+        // the body it stands for, the argument is emitted and writes a line of its own, so the last
+        // line written before the copy is not the call unless the call is written again after it.
+        String uses = """
+                module app.spread
+                import lib.rule ( 金額, shrink )
+
+                behavior make : (x: Int) -> 金額
+                    constructs 金額
+                let make (x) = shrink(
+                    x + 1
+                )
+                """;
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compileModules(List.of(RULE, uses)), getClass().getClassLoader());
+        Object impl = Emitted.behavior(loader, "app.spread", "make").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("app.spread."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals("spread.sou", frame.getFileName(), "the frame names the class's own source file");
+        assertEquals(6, frame.getLineNumber(), "the frame points at the call, not at the argument below it");
+    }
+
+    @Test
+    void theSameHoldsForACallTheBodyDoesNotAnswerWith() throws Exception {
+        // The same copy, reached where a value is wanted rather than in tail position: bound to a
+        // name the block goes on to answer with. It is emitted by the other of the two emitters,
+        // which binds the call and its argument in the same order.
+        String uses = """
+                module app.inner
+                import lib.rule ( 金額, shrink )
+
+                behavior make : (x: Int) -> 金額
+                    constructs 金額
+                let make (x) = {
+                    let z = shrink(
+                        x + 1
+                    )
+                    z
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compileModules(List.of(RULE, uses)), getClass().getClassLoader());
+        Object impl = Emitted.behavior(loader, "app.inner", "make").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("app.inner."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals("inner.sou", frame.getFileName(), "the frame names the class's own source file");
+        assertEquals(7, frame.getLineNumber(), "the frame points at the call, not at the argument below it");
+    }
+
+    @Test
+    void aLetTheAuthorWroteLeavesItsBodysOwnLineInFront() throws Exception {
+        // The other side of the re-pin. This `let` binds a value written below it too, so the call
+        // is bound again before its body — and the body is written in the file the class names, so
+        // it binds a line of its own at that offset and that is the one the offset keeps.
+        String src = """
+                module demo
+                data 金額 = Int
+                    invariant value >= 0
+                behavior make : (x: Int) -> 金額 constructs 金額
+                let make (x) = {
+                    let y =
+                        x + 1
+                    金額(y - 100)
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object impl = Emitted.behavior(loader, "demo", "make").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("demo."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals(8, frame.getLineNumber(), "the abort points at the construction, not at the `let` above it");
+    }
+
+    @Test
     void aHelperSplicedWithinOneFileKeepsItsOwnLine() throws Exception {
         // The same splice with nothing crossed: the helper's body is written in the file the class
         // names, so its own line is a line that file has, and it is the more useful of the two.

--- a/souther-compiler/src/test/java/souther/compiler/CompileSourceMapTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSourceMapTest.java
@@ -5,6 +5,7 @@ import souther.runtime.ConstraintViolation;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,6 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * runtime stack trace — most importantly an invariant abort ({@code ConstraintViolation}) — points
  * back to the {@code .sou} source line rather than "Unknown Source". The source file name is the
  * module's simple name plus {@code .sou}.
+ *
+ * <p>One file and one line, and they are a pair: the line is a line of the file the class names.
+ * A helper written in another file of the same compile and expanded here keeps the positions it was
+ * written at, and those are positions in a file this class does not name — so what the table is
+ * given for them is the call, which is the line of this file the author can act on.
  */
 class CompileSourceMapTest {
 
@@ -66,5 +72,71 @@ class CompileSourceMapTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
         assertEquals(6, frame.getLineNumber(), "the abort points at the construction, not the field-init line");
+    }
+
+    /** What {@code app.uses} calls, whose body constructs the value that aborts. The construction is
+     *  on line 9 of this text, and {@code uses.sou} is shorter than that. */
+    private static final String RULE = """
+            module lib.rule exposing ( 金額, shrink )
+
+            data 金額 = Int
+                invariant value >= 0
+
+
+
+
+            let shrink (x: Int): 金額 = 金額(x - 100)
+            """;
+
+    @Test
+    void aSplicedHelpersAbortPointsAtTheCallInTheFileTheClassNames() throws Exception {
+        // The class is app.uses's, so its SourceFile is uses.sou; the construction that aborts is
+        // written in rule.sou. A line of the declaring file in this class's table would be a line
+        // of a file this class does not name, and uses.sou has no line to be read as it.
+        String uses = """
+                module app.uses
+                import lib.rule ( 金額, shrink )
+
+                behavior make : (x: Int) -> 金額
+                    constructs 金額
+                let make (x) = shrink(x)
+                """;
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compileModules(List.of(RULE, uses)), getClass().getClassLoader());
+        Object impl = Emitted.behavior(loader, "app.uses", "make").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("app.uses."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals("uses.sou", frame.getFileName(), "the frame names the class's own source file");
+        assertEquals(6, frame.getLineNumber(), "the frame points at the call, which is what uses.sou has");
+    }
+
+    @Test
+    void aHelperSplicedWithinOneFileKeepsItsOwnLine() throws Exception {
+        // The same splice with nothing crossed: the helper's body is written in the file the class
+        // names, so its own line is a line that file has, and it is the more useful of the two.
+        String src = """
+                module demo
+                data 金額 = Int
+                    invariant value >= 0
+                let shrink (x: Int): 金額 = 金額(x - 100)
+                behavior make : (x: Int) -> 金額 constructs 金額
+                let make (x) = shrink(x)
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object impl = Emitted.behavior(loader, "demo", "make").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("demo."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals("demo.sou", frame.getFileName(), "the frame names the .sou source file");
+        assertEquals(4, frame.getLineNumber(), "the frame points at the helper's construction");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/APlannedArmNothingEmittedIsNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/APlannedArmNothingEmittedIsNamedTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.diag.QuotedFrom;
 import souther.compiler.diag.SourceLayouts;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +69,7 @@ class APlannedArmNothingEmittedIsNamedTest {
         DerivedSymbols symbols = Scopes.derived(compilation.db(), MODULE).value();
         CodegenContext ctx = new CodegenContext(MODULE, symbols,
                 symbols.library().kernelSignatures(), Map.of(), Map.of(), true, Set.of(), Map.of(),
-                SourceLayouts.NONE);
+                SourceLayouts.NONE, new QuotedFrom.TextItCannotName());
         ctx.setCoveragePlan(plan);
         return ctx;
     }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/AnEmitterWritesWhatItWasHandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/AnEmitterWritesWhatItWasHandedTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.diag.QuotedFrom;
 import souther.compiler.diag.SourceLayouts;
 import org.junit.jupiter.api.Test;
 
@@ -146,7 +147,8 @@ class AnEmitterWritesWhatItWasHandedTest {
             }
         }
         return new CodecGen(new CodegenContext("m", symbols, symbols.library().kernelSignatures(),
-                caseToSums, Map.of(), true, Set.of(), Map.of(), SourceLayouts.NONE));
+                caseToSums, Map.of(), true, Set.of(), Map.of(), SourceLayouts.NONE,
+                new QuotedFrom.TextItCannotName()));
     }
 
 }


### PR DESCRIPTION
A stack trace through a helper written in another file of the same compile named
the caller's file and the declaring file's line (#1603). A class carries one
`SourceFile`, which is the module's; a spliced helper keeps the positions it was
written at, so the line put in the table was a line of a file the class does not
name, and the file it does name may be shorter than it.

Which text a class's debug table may be read against is now settled where the
context for a module's generation is built, and asked for there. A place in
another text has no line to contribute, and leaving the entry out is what the
table has for saying so: the offset then falls under the entry before it.

What stands there is the call, and it takes a second piece to make that true.
The bindings an expansion makes carry the call's own position, but between them
and the copy the bound value is emitted — an argument written on its own line
binds that line, and the copy binds nothing to move it back. So the call is
bound again before the body, which is the re-pin a construction already does
once its fields are on the stack. Where the body binds a line of its own it
costs nothing: two lines at one offset are one entry, the last.

The same holds for an `unreachable` that arrived with such a helper: it says the
reason the model wrote and no numbers, because a place with no file beside it is
read against the frame's, and the frame's file is the class's.

Where a report points is unchanged. A diagnostic about the helper's body still
quotes the declaring file, which is a file the reader holds. What has no room for
two files is the class, so the fix is in what is written into the class and not
in how a splice records its provenance.

`SourceDebugExtension` (JSR-45) is deliberately not here. It is what the JVM has
for attributing lines of one class to several sources, but a `Throwable`'s stack
trace reads `SourceFile` and `LineNumberTable`, so it would not have settled this
on its own — and doing it properly is its own piece of work: a stratum to define,
a file table per source, an output line-number space to allocate, and tools to
read it. That is cross-source stepping, and it belongs in its own issue.

## Checks

A two-module regression pins the frame at the call in the file the class names,
and a second writes the argument on a line of its own — which is the case the
re-pin is for, and it goes red without it. A third reaches the same copy where a
value is wanted rather than in tail position, so each of the two emitters has a
witness of its own; each goes red alone.

Their controls are the same splice within one file, which keeps the helper's own
line, and a `let` the author wrote whose body binds a line of its own — the
offset keeps that one, not the re-pin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)