### PR TITLE
Take a settling onto one reading rather than read the declaration again

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -432,7 +432,7 @@ public final class FieldDomains {
 
     /** Settlings written as names, read as what stands at each. What a caller naming a place means
      *  is the value there; a count taken of one is a coordinate it has to name. */
-    private static Map<NumberAt<RuleKey>, Count> atValues(Map<RuleKey, Count> settled) {
+    public static Map<NumberAt<RuleKey>, Count> atValues(Map<RuleKey, Count> settled) {
         Map<NumberAt<RuleKey>, Count> out = new LinkedHashMap<>();
         settled.forEach((path, at) -> out.put(NumberAt.valueOf(path), at));
         return out;
@@ -945,6 +945,25 @@ public final class FieldDomains {
      * worked out before the settling.
      */
     public Settled given(Map<NumberAt<RuleKey>, Count> fixed) {
+        return new Settled(settling(fixed), namedBy, atomAt, countAt);
+    }
+
+    /**
+     * The same rules with these coordinates settled, for a caller building a value at a position
+     * under them.
+     *
+     * <p>Beside {@link #given} and not part of it. What a caller settling on behalf of an input
+     * wants is the constraints themselves, to be said together with another parameter's; what a
+     * caller composing a value wants is where one position stops and how many it holds. The second
+     * is a question one value's rules answer alone, and the first is a question they must not — so
+     * the two are handed over as two, and neither of them can be asked for the other.
+     */
+    public Composing composing(Map<NumberAt<RuleKey>, Count> fixed) {
+        return new Composing(settling(fixed), atomAt, countAt);
+    }
+
+    /** These constraints with an equality on each settled coordinate taken onto them. */
+    private ConstraintState<FactSubject> settling(Map<NumberAt<RuleKey>, Count> fixed) {
         ConstraintState<FactSubject> taken = constraints;
         for (Map.Entry<NumberAt<RuleKey>, Count> each : fixed.entrySet()) {
             NumberAt<RuleKey> where = each.getKey();
@@ -957,7 +976,55 @@ public final class FieldDomains {
                 taken = ConstraintState.settling(taken, atom, each.getValue(), spaced);
             }
         }
-        return new Settled(taken, namedBy, atomAt, countAt);
+        return taken;
+    }
+
+    /**
+     * One value's rules with some of its coordinates settled, read for building a value under them.
+     *
+     * <p>Not a {@link FieldDomains} and not a {@link Settled}. What it answers is read off the
+     * constraints as they now stand, so a position is told where it stops under everything chosen
+     * before it — which is the reading a search choosing one position at a time is entitled to, and
+     * the one it would otherwise get by reading the declaration over at every position.
+     */
+    public static final class Composing {
+
+        private final ConstraintState<FactSubject> constraints;
+        private final Map<RuleKey, FactSubject> atomAt;
+        private final Map<RuleKey, Counted> countAt;
+
+        private Composing(ConstraintState<FactSubject> constraints,
+                          Map<RuleKey, FactSubject> atomAt, Map<RuleKey, Counted> countAt) {
+            this.constraints = constraints;
+            this.atomAt = atomAt;
+            this.countAt = countAt;
+        }
+
+        /**
+         * The two numeric projections a caller building a value at {@code path} chooses against.
+         *
+         * <p>The value's own range and what it holds are handed over together and stay apart
+         * ({@link Held}). A caller filling a position needs both — which values may stand there,
+         * and how many a collection there must hold — and the two are numbers of different things.
+         */
+        public ConstructionLimits at(RuleKey path) {
+            if (path == null || path.isTheValueItself()) {
+                return ConstructionLimits.NONE;
+            }
+            NumericDomain.Bounds values = boundsOn(atomAt.get(path));
+            Counted counted = countAt.get(path);
+            NumericDomain.Bounds held = counted == null ? null : boundsOn(counted.atom());
+            return new ConstructionLimits(values, held == null ? null : new Held(held));
+        }
+
+        /** Where these constraints stop one subject, or null where they stop it nowhere. */
+        private NumericDomain.Bounds boundsOn(FactSubject atom) {
+            if (atom == null) {
+                return null;
+            }
+            NumericDomain.Bounds bounds = constraints.numbers().boundsOf(atom);
+            return bounds.saysNothing() ? null : bounds;
+        }
     }
 
     /**
@@ -1063,6 +1130,24 @@ public final class FieldDomains {
                         + claim.position() + "`, so neither name is the whole of it");
             }
         }
+    }
+
+    /**
+     * What a caller composing a value at one position chooses against.
+     *
+     * <p>A projection of constraints and not a reading. Every other answer of a
+     * {@link FieldDomains} is worked out while the declaration is being read; these two are read
+     * off the state the clauses came to, so they can be asked again of that state with a coordinate
+     * settled into it — which is the whole reason a search choosing one position at a time does not
+     * have to read the declaration once per position it chooses.
+     *
+     * @param values where the value standing at the position stops, or null where nothing stops it
+     * @param held   how many a collection there holds, or null where no rule counts it
+     */
+    public record ConstructionLimits(NumericDomain.Bounds values, Held held) {
+
+        /** A position the rules reach in neither way. */
+        public static final ConstructionLimits NONE = new ConstructionLimits(null, null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionedCandidates.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionedCandidates.java
@@ -1,0 +1,80 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.FieldDomains;
+import souther.compiler.check.RuleKey;
+import souther.compiler.check.RuleReadingContext;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What one position can take, for a search choosing them one at a time.
+ *
+ * <p>The rules of the value being composed are read once and handed each settling as it arrives
+ * ({@link FieldDomains#given}), which is what a settling is: an equality taken onto everything the
+ * clauses came to. A search that read the declaration at each position would be arriving at the
+ * same state by reading every clause over again.
+ *
+ * <p><b>What a position can take is kept, and this is where keeping it belongs.</b> A depth-first
+ * search reaches one settling by many routes and asks the same position about it at each of them,
+ * which is a fact about how the search walks and not about what the rules mean. Kept in the reading,
+ * it would be the rules holding a note about a caller that repeats itself; kept here, it is one
+ * search's own working.
+ *
+ * <p>One of these per search. What it holds is true under the value being composed and the caller's
+ * fixed positions, and both are settled when it is made.
+ */
+final class ConditionedCandidates {
+
+    private final RuleReadingContext reading;
+    private final FieldDomains rules;
+    private final Map<Map<RuleKey, Count>, FieldDomains.Composing> states = new HashMap<>();
+    private final Map<Asked, List<FixtureTemplate>> found = new HashMap<>();
+
+    /**
+     * @param rules the value's rules with nothing settled, read once for the whole search
+     */
+    ConditionedCandidates(RuleReadingContext reading, FieldDomains rules) {
+        this.reading = reading;
+        this.rules = rules;
+    }
+
+    /**
+     * What can stand at {@code position} once {@code settled} is taken on.
+     *
+     * @param settled the numbers the positions before this one took, named as the rules of the value
+     *                being composed name them. Never held on to: what is kept is a copy taken here
+     */
+    List<FixtureTemplate> at(ConstructionPlan.Slot position, Map<RuleKey, Count> settled) {
+        Asked asked = new Asked(position.at(), settled);
+        List<FixtureTemplate> known = found.get(asked);
+        if (known != null) {
+            return known;
+        }
+        RuleKey field = position.at().ruleKey();
+        FieldDomains.ConstructionLimits limits = field == null
+                ? FieldDomains.ConstructionLimits.NONE
+                : state(asked.settled()).at(field);
+        List<FixtureTemplate> stands = Partitions.displacedRepresentativesOf(position.type(),
+                reading, limits.values(), limits.held());
+        found.put(asked, stands);
+        return stands;
+    }
+
+    /** The rules with these coordinates settled, worked out once however many positions ask under
+     *  it. */
+    private FieldDomains.Composing state(Map<RuleKey, Count> settled) {
+        return states.computeIfAbsent(settled, at -> rules.composing(FieldDomains.atValues(at)));
+    }
+
+    /** One position under one settling, which is what the same answer is the answer to. */
+    private record Asked(TermPath at, Map<RuleKey, Count> settled) {
+
+        private Asked {
+            settled = Map.copyOf(settled);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConditionedCandidates.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConditionedCandidates.java
@@ -14,8 +14,8 @@ import java.util.Map;
  * What one position can take, for a search choosing them one at a time.
  *
  * <p>The rules of the value being composed are read once and handed each settling as it arrives
- * ({@link FieldDomains#given}), which is what a settling is: an equality taken onto everything the
- * clauses came to. A search that read the declaration at each position would be arriving at the
+ * ({@link FieldDomains#composing}), which is what a settling is: an equality taken onto everything
+ * the clauses came to. A search that read the declaration at each position would be arriving at the
  * same state by reading every clause over again.
  *
  * <p><b>What a position can take is kept, and this is where keeping it belongs.</b> A depth-first

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -4263,8 +4263,14 @@ public final class Generator {
         positions.addAll(
                 found.stream().filter(each -> !decided.containsKey(each.at())).toList());
         Budget budget = new Budget();
+        // The rules of the value being composed, read once for the whole search. Every position's
+        // turn is answered by taking what the positions before it took onto this, which is the
+        // reading a settling states and not a second one of the declaration.
+        ConditionedCandidates candidates = new ConditionedCandidates(subject.ruleReading(),
+                rulesOf(subject.types().get(p), subject.rules(), subject.inputs().policy(),
+                        Map.of(), subject.machines()));
         FixtureTemplate built = descend(subject, p, plan, positions, 0, new LinkedHashMap<>(),
-                new LinkedHashMap<>(settled), decided, check, budget);
+                new LinkedHashMap<>(settled), decided, check, budget, candidates);
         if (built != null) {
             return new Outcome.Built(built);
         }
@@ -4311,13 +4317,15 @@ public final class Generator {
      * @param chosen  what the positions before this one took
      * @param settled the numbers among them, which is what a projection can be asked about
      * @param budget  assignments left to compose, shared down the whole search
+     * @param candidates what a position can take under a settling, shared down the whole search
      */
     private static FixtureTemplate descend(MeasuredInput subject, int p, ConstructionPlan plan,
                                            List<ConstructionPlan.Slot> positions, int index,
                                            Map<TermPath, FixtureTemplate> chosen,
                                            Map<TermPath, Place> settled,
                                            Map<TermPath, List<FixtureTemplate>> decided,
-                                           CandidateCheck check, Budget budget) {
+                                           CandidateCheck check, Budget budget,
+                                           ConditionedCandidates candidates) {
         if (index == positions.size()) {
             if (!budget.spend()) {
                 return null;
@@ -4327,14 +4335,15 @@ public final class Generator {
         }
         ConstructionPlan.Slot position = positions.get(index);
         TermPath where = position.at();
-        for (FixtureTemplate candidate : candidatesAt(subject, p, position, settled, decided)) {
+        for (FixtureTemplate candidate
+                : candidatesAt(subject, p, position, settled, decided, candidates)) {
             chosen.put(where, candidate);
             Place number = Counts.writtenIn(candidate.value());
             if (number != null) {
                 settled.put(where, number);
             }
             FixtureTemplate found = descend(subject, p, plan, positions, index + 1, chosen, settled,
-                    decided, check, budget);
+                    decided, check, budget, candidates);
             if (found != null) {
                 return found;
             }
@@ -4351,18 +4360,14 @@ public final class Generator {
     private static List<FixtureTemplate> candidatesAt(MeasuredInput subject, int p,
                                                       ConstructionPlan.Slot position,
                                                       Map<TermPath, Place> settled,
-                                                      Map<TermPath, List<FixtureTemplate>> decided) {
+                                                      Map<TermPath, List<FixtureTemplate>> decided,
+                                                      ConditionedCandidates candidates) {
         List<FixtureTemplate> fixed = decided.get(position.at());
         if (fixed != null) {
             return fixed;
         }
         TermPath at = TermPath.of(subject.parameters().get(p));
-        FieldDomains left = rulesOf(subject.types().get(p), subject.rules(),
-                subject.inputs().policy(), under(at, settled), subject.machines());
-        RuleKey field = fieldUnder(position.at());
-        return Partitions.displacedRepresentativesOf(position.type(), subject.ruleReading(),
-                field == null ? null : left.at(field).bounds(),
-                field == null ? null : left.heldAt(field));
+        return candidates.at(position, under(at, settled));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1823,8 +1823,12 @@ public final class Partitions {
         java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
         Map<RuleKey, Count> settled = new LinkedHashMap<>();
-        FieldDomains left = FieldDomains.of(record, ruleSource, reading.policy(), settled,
+        // The record's rules, read once. Each field is then chosen against this with the fields
+        // before it settled into it, which is what a settling states — a reading per settled field
+        // would be paying for every clause again to arrive where the first one already is.
+        FieldDomains rules = FieldDomains.of(record, ruleSource, reading.policy(),
                 reading.readings());
+        FieldDomains.Composing left = rules.composing(Map.of());
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {
             return null;
@@ -1832,10 +1836,9 @@ public final class Partitions {
         for (Map.Entry<String, Type> field : fields.entrySet()) {
             FixtureTemplate at = given.get(field.getKey());
             if (at == null) {
-                RuleKey named =
-                        RuleKey.of(field.getKey());
+                FieldDomains.ConstructionLimits limits = left.at(RuleKey.of(field.getKey()));
                 List<FixtureTemplate> stands = representativesHolding(field.getValue(), reading,
-                        left.at(named).bounds(), left.heldAt(named), inside);
+                        limits.values(), limits.held(), inside);
                 if (stands.isEmpty()) {
                     return null;
                 }
@@ -1847,8 +1850,7 @@ public final class Partitions {
             // which leaves `b` its whole range and takes the bottom of it.
             if (Counts.writtenIn(at.value()) instanceof Count count) {
                 settled.put(RuleKey.of(field.getKey()), count);
-                left = FieldDomains.of(record, ruleSource, reading.policy(), settled,
-                        reading.readings());
+                left = rules.composing(FieldDomains.atValues(settled));
             }
         }
         return chosen;

--- a/souther-compiler/src/test/java/souther/compiler/check/ASettlingBelowAFieldIsTakenOnLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASettlingBelowAFieldIsTakenOnLikeAnyOtherTest.java
@@ -1,0 +1,133 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A coordinate a clause reaches below a field is settled the same way one at a field is.
+ *
+ * <p>The rules of a record name positions at whatever depth they can reach, so
+ * {@code interval.startsAt} is one name and not two. Reading the declaration with such a name
+ * settled and taking that settling onto a reading already made have to leave the same thing, or a
+ * search that reads once is answering about a position it never fixed.
+ *
+ * <p><b>Written here rather than left to the models.</b> What the corpora happen to write is what
+ * the population this is a case of asks about, and the statement is about the language and not
+ * about them: a model rewritten to relate two fields directly would take the whole depth out of
+ * that population with nothing to see.
+ */
+class ASettlingBelowAFieldIsTakenOnLikeAnyOtherTest {
+
+    private static final String NAMES_BELOW_A_FIELD = """
+            module booking.deep
+
+            data Span = { startsAt: Int, endsAt: Int }
+            data Window = { interval: Span, cap: Int }
+                invariant within = interval.startsAt < cap
+                invariant ordered = interval.startsAt < interval.endsAt
+
+            data Ok
+
+            behavior take : (w: Window) -> Ok
+            """;
+
+    @Test
+    void aNameReachingBelowAFieldLeavesWhatAReadingUnderItLeaves() {
+        Read read = read();
+        FieldDomains base = FieldDomains.of(read.declared(), read.source(), read.policy(),
+                DeclarationReadings.NONE);
+
+        RuleKey below = RuleKey.of("interval").then("startsAt");
+        // That the reading files a coordinate under the whole name, said as what a settling beside
+        // it does: with nothing settled the clause stops nothing, since what it holds the name
+        // against is open. Asked first, because every comparison below would hold of a name the
+        // rules say nothing about — two derivations agreeing that nothing is known is not this.
+        assertTrue(FieldDomains.of(read.declared(), read.source(), read.policy(),
+                        Map.of(RuleKey.of("cap"), new Count(BigDecimal.valueOf(5))),
+                        DeclarationReadings.NONE)
+                        .at(below).bounds() != null,
+                "`" + below + "` is a name this record's rules reach, and settling `cap` beside it "
+                        + "stops it nowhere");
+
+        for (RuleKey settledAt : List.of(below, RuleKey.of("cap"),
+                RuleKey.of("interval").then("endsAt"))) {
+            for (long at : new long[] {0, 1, 5}) {
+                Map<RuleKey, Count> settling = Map.of(settledAt, new Count(BigDecimal.valueOf(at)));
+                FieldDomains readUnder = FieldDomains.of(read.declared(), read.source(),
+                        read.policy(), settling, DeclarationReadings.NONE);
+                FieldDomains.Composing takenOn = base.composing(FieldDomains.atValues(settling));
+                for (RuleKey asked : List.of(below, RuleKey.of("interval").then("endsAt"),
+                        RuleKey.of("cap"), RuleKey.of("interval"))) {
+                    NumericDomain.Bounds values = readUnder.at(asked).bounds();
+                    assertEquals(values, takenOn.at(asked).values(),
+                            () -> "with `" + settledAt + "` settled at " + at + ", `" + asked
+                                    + "` stops where the same settling taken onto one reading "
+                                    + "says it stops");
+                    assertEquals(readUnder.heldAt(asked), takenOn.at(asked).held(),
+                            () -> "with `" + settledAt + "` settled at " + at + ", `" + asked
+                                    + "` holds what the same settling taken onto one reading "
+                                    + "says it holds");
+                }
+            }
+        }
+    }
+
+    /**
+     * That settling the name below a field moves what is left beside it.
+     *
+     * <p>What makes the comparison above about a settling rather than about two readings of the
+     * same rules. A record whose clause the settling does not reach would answer alike either way,
+     * and the agreement would say nothing about whether the settling arrived at all.
+     */
+    @Test
+    void settlingTheNameBelowAFieldMovesWhatIsLeftBesideIt() {
+        Read read = read();
+        FieldDomains base = FieldDomains.of(read.declared(), read.source(), read.policy(),
+                DeclarationReadings.NONE);
+        RuleKey below = RuleKey.of("interval").then("startsAt");
+        Map<RuleKey, Count> settling = Map.of(below, new Count(BigDecimal.valueOf(5)));
+
+        NumericDomain.Bounds before = base.composing(Map.of()).at(RuleKey.of("cap")).values();
+        NumericDomain.Bounds after =
+                base.composing(FieldDomains.atValues(settling)).at(RuleKey.of("cap")).values();
+
+        assertNotEquals(before, after,
+                "settling `" + below + "` leaves `cap` where it was, so the clause relating them "
+                        + "was not taken on and nothing else here would notice");
+    }
+
+    /** The declaration the rules above are written on, with everything it needs to be read. */
+    private record Read(TypeSymbol.AtModule declared, RuleReadingSource source,
+                        ReadingPolicy policy) {}
+
+    private static Read read() {
+        Compilation compilation = Compilation.ofSource(NAMES_BELOW_A_FIELD, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        RuleReadingSource source = RuleReadings.of(compilation, module);
+        Map<String, DeclaredSig> sigs =
+                compilation.db().ask(new Bodies.DeclaredSignatures(module)).value();
+        Type window = sigs.get("take").inputs().get(0).type();
+        if (!(TypeView.of(window, source.symbols()).shape()
+                instanceof Shape.Product(TypeSymbol.AtModule declared, Map<String, Type> _))) {
+            throw new IllegalStateException("the behavior above takes a record");
+        }
+        return new Read(declared, source,
+                compilation.db().ask(new Front.Reading()).value());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest.java
@@ -1,0 +1,195 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.conformance.RepositoryModels;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Reading a declaration with a coordinate settled and taking the settling onto a reading already
+ * made answer the same thing about building a value.
+ *
+ * <p>What a search choosing one position at a time asks for at each of them is where the value
+ * there stops and how many it holds, both under whatever the positions before it took. Those two
+ * are the whole of what the rules give it. Read a declaration per position and they are answered by
+ * a reading made under the settling; taken onto a reading made once, they are answered by a
+ * projection of the constraints that reading came to — and this is the statement that the two are
+ * the same question.
+ *
+ * <p>The statement is what lets one reading serve a whole search. Without it a search that read the
+ * declaration once would be answering about the rules as they stood before it chose anything, which
+ * is the reading that leaves {@code b} its whole range while {@code a < b} is still open.
+ */
+@Tag("population")
+class ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest {
+
+    /**
+     * Every record the models reach, every settling of one or two of its coordinates.
+     *
+     * <p>The settlings are taken from what each coordinate's own reading leaves it, plus the two
+     * numbers any counted position can take. A pair as well as a single, because a rule relating two
+     * positions says nothing until one of them is fixed and the whole point of settling one at a
+     * time is what it leaves the other.
+     */
+    @Test
+    void everySettlingLeavesWhatAReadingUnderItLeaves() {
+        int compared = 0;
+        int stopped = 0;
+        int counted = 0;
+        for (Record record : recordsRead()) {
+            FieldDomains base = FieldDomains.of(record.declared(), record.source(), record.policy(),
+                    DeclarationReadings.NONE);
+            for (Map<RuleKey, Count> settling : settlings(base, record.fields())) {
+                FieldDomains readUnder = FieldDomains.of(record.declared(), record.source(),
+                        record.policy(), settling, DeclarationReadings.NONE);
+                FieldDomains.Composing takenOn = base.composing(named(settling));
+                for (RuleKey field : record.fields()) {
+                    NumericDomain.Bounds values = readUnder.at(field).bounds();
+                    FieldDomains.Held held = readUnder.heldAt(field);
+                    FieldDomains.ConstructionLimits limits = takenOn.at(field);
+                    assertEquals(values, limits.values(),
+                            () -> "where " + record.declared() + " is read with " + settling
+                                    + " settled, `" + field + "` stops where the same settling "
+                                    + "taken onto one reading says it stops");
+                    assertEquals(held, limits.held(),
+                            () -> "where " + record.declared() + " is read with " + settling
+                                    + " settled, `" + field + "` holds what the same settling "
+                                    + "taken onto one reading says it holds");
+                    compared++;
+                    stopped += values == null ? 0 : 1;
+                    counted += held == null ? 0 : 1;
+                }
+            }
+        }
+        assertFalse(compared == 0,
+                "no record of any model this repository carries was compared, so this holds by "
+                        + "asking nothing");
+        // And that what was compared says something. Two readings agreeing that nothing is known
+        // about every coordinate is an agreement either of them could reach by answering nothing,
+        // and it is the answer a projection that read the wrong state would give.
+        assertFalse(stopped == 0, "no coordinate was stopped anywhere, so every comparison above "
+                + "was of one absent range against another");
+        assertFalse(counted == 0, "no coordinate was counted, so nothing above compared what a "
+                + "position holds");
+        System.out.println("construction limits compared: " + compared + ", of them " + stopped
+                + " stopped and " + counted + " counted");
+    }
+
+    /** One record declaration, read where its rules are. */
+    private record Record(TypeSymbol.AtModule declared, RuleReadingSource source,
+                          ReadingPolicy policy, List<RuleKey> fields) {}
+
+    /**
+     * The settlings asked about: each coordinate at each value it could take, and each pair of them
+     * at the first value each could.
+     */
+    private static List<Map<RuleKey, Count>> settlings(FieldDomains base, List<RuleKey> fields) {
+        Map<RuleKey, List<Count>> take = new LinkedHashMap<>();
+        for (RuleKey field : fields) {
+            take.put(field, values(base.at(field).bounds()));
+        }
+        List<Map<RuleKey, Count>> out = new ArrayList<>();
+        for (RuleKey field : fields) {
+            for (Count at : take.get(field)) {
+                out.add(Map.of(field, at));
+            }
+        }
+        for (int i = 0; i < fields.size(); i++) {
+            for (int j = i + 1; j < fields.size(); j++) {
+                List<Count> one = take.get(fields.get(i));
+                List<Count> other = take.get(fields.get(j));
+                if (one.isEmpty() || other.isEmpty()) {
+                    continue;
+                }
+                Map<RuleKey, Count> both = new LinkedHashMap<>();
+                both.put(fields.get(i), one.get(0));
+                both.put(fields.get(j), other.get(0));
+                out.add(both);
+            }
+        }
+        return out;
+    }
+
+    /** What one coordinate is settled at: where its own rules stop it, and the two numbers a
+     *  coordinate with no end still takes. */
+    private static List<Count> values(NumericDomain.Bounds bounds) {
+        Set<Count> out = new LinkedHashSet<>();
+        out.add(new Count(BigDecimal.ZERO));
+        out.add(new Count(BigDecimal.ONE));
+        if (bounds != null) {
+            end(bounds.min(), out);
+            end(bounds.max(), out);
+        }
+        return List.copyOf(out);
+    }
+
+    private static void end(Endpoint endpoint, Set<Count> out) {
+        if (endpoint != null && endpoint.at() instanceof Count at) {
+            out.add(at);
+        }
+    }
+
+    /** The same settling as the names a reading of the value writes it under. */
+    private static Map<NumberAt<RuleKey>, Count> named(Map<RuleKey, Count> settling) {
+        Map<NumberAt<RuleKey>, Count> out = new LinkedHashMap<>();
+        settling.forEach((field, at) -> out.put(NumberAt.valueOf(field), at));
+        return out;
+    }
+
+    /** Every record every behavior of every model this repository carries reads, and the ones
+     *  under them. */
+    private static List<Record> recordsRead() {
+        List<Record> out = new ArrayList<>();
+        for (Compilation compilation : RepositoryModels.all()) {
+            ReadingPolicy policy = compilation.db().ask(new Front.Reading()).value();
+            for (String module : compilation.modules()) {
+                RuleReadingSource source = RuleReadings.of(compilation, module);
+                Set<TypeSymbol> seen = new LinkedHashSet<>();
+                for (DeclaredSig declared
+                        : compilation.db().ask(new Bodies.DeclaredSignatures(module)).value()
+                                .values()) {
+                    for (DeclaredSig.Input input : declared.inputs()) {
+                        under(input.type(), source, policy, seen, out);
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static void under(Type type, RuleReadingSource source, ReadingPolicy policy,
+                              Set<TypeSymbol> seen, List<Record> out) {
+        if (!(TypeView.of(type, source.symbols()).shape()
+                instanceof Shape.Product(TypeSymbol.AtModule declared, Map<String, Type> fields))) {
+            return;
+        }
+        if (!seen.add(declared)) {
+            return;
+        }
+        List<RuleKey> keys = new ArrayList<>();
+        fields.keySet().forEach(field -> keys.add(RuleKey.of(field)));
+        if (!keys.isEmpty()) {
+            out.add(new Record(declared, source, policy, keys));
+        }
+        fields.values().forEach(field -> under(field, source, policy, seen, out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest.java
@@ -55,14 +55,16 @@ class ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest {
         int compared = 0;
         int stopped = 0;
         int counted = 0;
+        int deep = 0;
         for (Record record : recordsRead()) {
             FieldDomains base = FieldDomains.of(record.declared(), record.source(), record.policy(),
                     DeclarationReadings.NONE);
-            for (Map<RuleKey, Count> settling : settlings(base, record.fields())) {
+            List<RuleKey> coordinates = coordinatesOf(base, record.fields());
+            for (Map<RuleKey, Count> settling : settlings(base, coordinates)) {
                 FieldDomains readUnder = FieldDomains.of(record.declared(), record.source(),
                         record.policy(), settling, DeclarationReadings.NONE);
                 FieldDomains.Composing takenOn = base.composing(named(settling));
-                for (RuleKey field : record.fields()) {
+                for (RuleKey field : coordinates) {
                     NumericDomain.Bounds values = readUnder.at(field).bounds();
                     FieldDomains.Held held = readUnder.heldAt(field);
                     FieldDomains.ConstructionLimits limits = takenOn.at(field);
@@ -77,6 +79,7 @@ class ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest {
                     compared++;
                     stopped += values == null ? 0 : 1;
                     counted += held == null ? 0 : 1;
+                    deep += field.steps().size() > 1 ? 1 : 0;
                 }
             }
         }
@@ -90,13 +93,40 @@ class ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest {
                 + "was of one absent range against another");
         assertFalse(counted == 0, "no coordinate was counted, so nothing above compared what a "
                 + "position holds");
+        // And that a name reaching below a field was among them. A clause names a position at
+        // whatever depth it can reach, and a population that had come to hold only the shallowest
+        // of them would go on passing while saying it compared every coordinate.
+        assertFalse(deep == 0, "no coordinate below a field was compared, so nothing above says "
+                + "the two derivations agree about the names a clause reaches through");
         System.out.println("construction limits compared: " + compared + ", of them " + stopped
-                + " stopped and " + counted + " counted");
+                + " stopped, " + counted + " counted and " + deep + " named below a field");
     }
 
     /** One record declaration, read where its rules are. */
     private record Record(TypeSymbol.AtModule declared, RuleReadingSource source,
-                          ReadingPolicy policy, List<RuleKey> fields) {}
+                          ReadingPolicy policy, Map<String, Type> fields) {}
+
+    /**
+     * The coordinates of one record that are asked about.
+     *
+     * <p>Taken from the reading and not from the fields the type declares. A clause of a record
+     * names positions at whatever depth it can reach — {@code interval.startsAt} is one name and
+     * not two — so the names a search settles and asks under are the reading's own, and a
+     * population built by walking the fields one step at a time would compare only the shallowest
+     * of them while saying it compared every one.
+     *
+     * <p>The declared fields as well, which the reading has no entry for where no rule reaches
+     * them. A position nothing is written about is one both derivations must still answer alike
+     * about, and it is the answer a projection reading the wrong state gives most easily.
+     */
+    private static List<RuleKey> coordinatesOf(FieldDomains rules, Map<String, Type> fields) {
+        Set<RuleKey> out = new LinkedHashSet<>();
+        fields.keySet().forEach(field -> out.add(RuleKey.of(field)));
+        rules.placed().forEach(placed -> out.add(placed.path()));
+        rules.stated().forEach(placed -> out.add(placed.path()));
+        out.remove(RuleKey.THE_VALUE);
+        return List.copyOf(out);
+    }
 
     /**
      * The settlings asked about: each coordinate at each value it could take, and each pair of them
@@ -176,20 +206,39 @@ class ASettlingReadAgainAndASettlingTakenOnLeaveTheSameConstructionLimitsTest {
         return out;
     }
 
+    /**
+     * Every record a value of {@code type} can hold, however it is reached.
+     *
+     * <p>Through the cases of a sum, through what a collection holds and through what stands under
+     * an optional as well as through a record's fields. A search composing a value reaches a
+     * declaration by every one of these, so a walk that followed fields alone would leave out the
+     * records only a case or an element leads to and would say it had walked them.
+     */
     private static void under(Type type, RuleReadingSource source, ReadingPolicy policy,
                               Set<TypeSymbol> seen, List<Record> out) {
-        if (!(TypeView.of(type, source.symbols()).shape()
-                instanceof Shape.Product(TypeSymbol.AtModule declared, Map<String, Type> fields))) {
-            return;
+        Shape shape = TypeView.of(type, source.symbols()).shape();
+        switch (shape) {
+            case Shape.Product(TypeSymbol name, Map<String, Type> fields) -> {
+                if (!(name instanceof TypeSymbol.AtModule declared) || !seen.add(declared)) {
+                    return;
+                }
+                if (!fields.isEmpty()) {
+                    out.add(new Record(declared, source, policy, fields));
+                }
+                fields.values().forEach(field -> under(field, source, policy, seen, out));
+            }
+            case Shape.Cases(Set<TypeSymbol> members) ->
+                    members.forEach(each -> under(Type.ref(each), source, policy, seen, out));
+            case Shape.Sequence(var _, Type element) ->
+                    under(element, source, policy, seen, out);
+            case Shape.Optional(Type element) -> under(element, source, policy, seen, out);
+            case Shape.Mapping(Type key, Type value) -> {
+                under(key, source, policy, seen, out);
+                under(value, source, policy, seen, out);
+            }
+            case Shape.Tuple(List<Type> elements) ->
+                    elements.forEach(each -> under(each, source, policy, seen, out));
+            default -> { }
         }
-        if (!seen.add(declared)) {
-            return;
-        }
-        List<RuleKey> keys = new ArrayList<>();
-        fields.keySet().forEach(field -> keys.add(RuleKey.of(field)));
-        if (!keys.isEmpty()) {
-            out.add(new Record(declared, source, policy, keys));
-        }
-        fields.values().forEach(field -> under(field, source, policy, seen, out));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest.java
@@ -46,6 +46,12 @@ class WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest {
             // declaration and not an input — no behavior, no parameter, no path rooted at one — so
             // the declaration's own words are the right ones and there is nothing to translate.
             "souther.compiler.partition.Partitions",
+            // What one position of a row's value can take, which is the same subject as the reader
+            // below and the settling it does at each step. Its own name because the answers are
+            // kept: a search reaches one settling by many routes and asks the same position about
+            // it at each of them, and that is a fact about how the search walks rather than about
+            // what the rules mean.
+            "souther.compiler.partition.ConditionedCandidates",
             // A row's value for one parameter, composed a position at a time. Its positions are
             // where a value has to be built and not what the behavior declares it takes: a class
             // naming a constructor for a sum puts positions under it that no reading of the
@@ -89,13 +95,18 @@ class WhoConditionsAValuesRulesWithoutTheInputsReadingIsNamedTest {
      * settlings — so a check on the name alone would report every reader of a declaration as one
      * that settles a position of it.
      *
+     * <p>Every member that hands back settled rules and not the one a caller happened to reach for.
+     * Which of them a settling comes back as says what the caller may then ask, and says nothing
+     * about whether the settling happened — a register that read one of them would go quiet for
+     * every caller that used the other.
+     *
      * <p>Whether the settlings are taken, and not where in the list they are. A reader may be
      * handed something else beside them — where it borrows what has already been made of the
      * declaration is one such thing — and a check that looked at the last argument would go quiet
      * the day one was added, which is a check that reads nothing while reporting nothing.
      */
     private static boolean conditions(String member, java.lang.constant.MethodTypeDesc taken) {
-        if (member.equals("given")) {
+        if (member.equals("given") || member.equals("composing")) {
             return true;
         }
         return (member.equals("of") || member.equals("unshared"))


### PR DESCRIPTION
Most of what analysing a large model costs is the second pass of the search that
composes a parameter's value — the one that chooses positions one at a time, and
that a corpus whose rules never send the search into it never pays for at all.
Nearly all of that pass's time was going on reading the declaration over at every
position of every branch, and on deriving each position's candidates again from
what that reading came to.

A settling is an equality taken onto everything the clauses came to, which is
what `FieldDomains.given` already states. So the rules are read once and handed
each settling as it arrives. What a caller composing a value needs back is where
the position stops and how many it holds; those come off the constraints as they
now stand, as their own value from their own kind of settled reading. The two
kinds stay apart: a caller settling on behalf of an input gets the constraints to
be said together with another parameter's, and cannot ask one value's rules where
a position stops.

What a position can take is kept beside the search. Reaching one settling by many
routes and asking the same position at each of them is how the walk moves, not
what the rules mean, so the answers are kept where the walk is.

`Partitions`, the other reader that composes a value, reads once the same way. It
settles a record's fields in order rather than over a tree of them, so it keeps
nothing.

The search walks the same tree it walked before — the same nodes, the same leaves,
the same assignments refused and accepted — and the report for the largest model
this repository carries comes out identical.

That reading a declaration under a settling and taking that settling onto a
reading already made answer alike about building a value is checked over every
record every model here reaches, under each settling of one and of two of its
coordinates, with the two ends of the comparison counted so an agreement about
nothing cannot pass for one.

Refs #1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)