### PR TITLE
Ask the crossing where the order's own candidates ran out

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -903,27 +903,52 @@ public sealed interface Carrier extends ValueOrder {
             case ValueSet.Finite it -> it.values().stream().map(this::placeOf)
                     .filter(at -> at != null && held.admits(at) && away(apart, at))
                     .findFirst().orElse(null);
-            case ValueSet.Cofinite it -> firstHeldIn(held, anchorIn(range), it.excluded(), apart);
+            case ValueSet.Cofinite it -> {
+                Place cheap = firstHeldIn(held, anchorIn(range), it.excluded(), apart);
+                // Where the order's own candidates answered, that is the value: they read better in
+                // a row than anything worked out of a machine, and the common case is a position
+                // whose rules say nothing about its values.
+                //
+                // And where they did not, they are not a proof. What they are is a handful, and a run
+                // away from that handful holds values none of them names — so the question goes to
+                // the crossing below, which answers it exactly. Read as an answer, a rule stating a
+                // run of the strings came back as one nothing could write a value in.
+                yield cheap != null || !(this instanceof Text) ? cheap
+                        : writableIn(it, held, apart, meter);
+            }
             // The one shape whose values are not in hand: a language names its strings and does not
             // list them, so what is left of it inside the run and away from the places held apart
             // is a machine — which is the crossing between a set of strings and a run of the order,
             // and the reading of extents is where that is made. A language is a set of strings, so
             // no order but the strings holds one.
-            case ValueSet.Matching it -> {
-                if (!(this instanceof Text)) {
-                    yield null;
-                }
-                Language strings = TextExtents.stringsIn(it, held, meter);
-                // Only the words the run leaves in, which the language answers about for nothing.
-                // A word it does not hold is one the machine built to take it out would be built
-                // to change nothing.
-                Language left = strings == null ? null
-                        : strings.without(textsAt(apart).stream().filter(strings::has).toList(),
-                                meter);
-                String some = left == null ? null : left.someWritten();
-                yield some == null ? null : souther.compiler.numeric.Text.of(some);
-            }
+            case ValueSet.Matching it ->
+                    this instanceof Text ? writableIn(it, held, apart, meter) : null;
         };
+    }
+
+    /**
+     * A string of {@code set} that lies inside {@code held}, stands at none of {@code apart}, and a
+     * source can carry, or null where the crossing names none or ran out.
+     *
+     * <p>Asked of the reading of extents whatever shape the set is in. Which strings a set holds
+     * inside a run of the order is one question, and a set that lists the values it leaves out
+     * answers it the same way a set that names a language does — that one is every string less a
+     * handful, which is a language as much as any other. So the shapes differ in what they cost and
+     * not in what they come to: asked one way for one of them, a rule stating a run of the strings
+     * was answered as a rule nothing could write a value for.
+     *
+     * <p>What comes back is a value a source can carry, which is narrower than what the set holds: a
+     * set whose strings are all control characters has a value to offer and none to write, and a row
+     * nobody can paste is not a row.
+     */
+    private Place writableIn(ValueSet set, OrderedInterval held, List<Place> apart, Meter meter) {
+        Language strings = TextExtents.stringsIn(set, held, meter);
+        // Only the words the run leaves in, which the language answers about for nothing. A word it
+        // does not hold is one the machine built to take it out would be built to change nothing.
+        Language left = strings == null ? null
+                : strings.without(textsAt(apart).stream().filter(strings::has).toList(), meter);
+        String some = left == null ? null : left.someWritten();
+        return some == null ? null : souther.compiler.numeric.Text.of(some);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest.java
@@ -1,0 +1,144 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.Place;
+import souther.compiler.numeric.Text;
+import souther.compiler.regex.Meter;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two restrictions coming to the same values are one question, whichever of them was written down.
+ *
+ * <p>What a search for a value is given is a set the declarations leave and a run of the order, and
+ * what it is asked about is the values in both. So the same values reached by putting the restriction
+ * in the set and by putting it in the run are the same question, and a value written out for one is a
+ * value written out for the other.
+ *
+ * <p>Which they are not. A set that names a language is crossed with the run as a machine and a
+ * string is read out of it wherever the run leaves one; a set that names every value but a few has no
+ * machine built for it here, and the walk that stands in offers the least string and then longer ones
+ * built from a letter — none of which is inside a run away from that handful. So a rule written as a
+ * comparison comes back with no value where the same rule written as a prefix comes back with one,
+ * and a report says nothing could build a representative for a run holding as many strings as there
+ * are.
+ *
+ * <p>The shapes are right to differ; a set naming its values and a set naming a language are not
+ * searched the same way. What is wrong is that the difference reaches the answer, which is a step a
+ * reader of the model cannot see.
+ *
+ * <p><b>About a witness that can be written, and not about which one.</b> What this order hands back
+ * is a value a source can carry ({@link souther.compiler.regex.Language#someWritten}), so what has to
+ * agree is whether one exists — two searches may write out different strings. And where an allowance
+ * ran out there is no answer to agree about: that is an explicit limit and not evidence that the run
+ * holds nothing, which is why it is told apart here rather than read off a null.
+ */
+class OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest {
+
+    private static final Carrier TEXT = new Carrier.Text();
+
+    /** The strings strictly between `JP` and `JQ`, said as a run of the order. */
+    private static final OrderedInterval BETWEEN = new OrderedInterval(
+            Endpoint.exclusive(Text.of("JP")), Endpoint.exclusive(Text.of("JQ")));
+
+    /** The whole of the order, said as a run. */
+    private static final OrderedInterval EVERYTHING = new OrderedInterval(null, null);
+
+    /** The strings `JP` starts, said as a set. */
+    private static final ValueSet STARTING_WITH_JP = matching("JP[\\s\\S]*");
+
+    /** What a search came back with, told apart from having had no room to answer. */
+    private sealed interface Answer {
+        record Wrote(String string) implements Answer {}
+        record NoneWritable() implements Answer {}
+        record RanOut(Meter.Stopped limit) implements Answer {}
+    }
+
+    private static ValueSet matching(String regex) {
+        PatternRead said = PatternParser.read(regex);
+        return ValueSet.matching(PatternPlan.of(
+                        assertInstanceOf(PatternRead.Read.class, said, regex).syntax())
+                .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter()));
+    }
+
+    /**
+     * What the order says about the values of {@code set} inside {@code run}.
+     *
+     * <p>The meter is read beside the answer, because a null is both "nothing here writes one" and
+     * "there was no room to find out" and only one of those is a fact about the values.
+     */
+    private static Answer asked(ValueSet set, OrderedInterval run) {
+        Meter meter = PatternPlan.Budget.OF_A_WITNESS.meter();
+        Place at = TEXT.somewhereIn(set, run, List.of(), meter);
+        if (at != null) {
+            return new Answer.Wrote(((Text) at).at());
+        }
+        return meter.stoppedBy() == null ? new Answer.NoneWritable()
+                : new Answer.RanOut(meter.stoppedBy());
+    }
+
+    /** Which of the three it was, for a comparison that is not about which string was written. */
+    private static Class<?> answerClass(Answer answer) {
+        return answer.getClass();
+    }
+
+    /**
+     * The two ways of saying it reach the same strings, which is what makes them one question.
+     *
+     * <p>Measured rather than argued. A test whose two cases turned out to be about two sets of
+     * values would be asking for the same answer to two questions.
+     */
+    @Test
+    void theTwoRestrictionsReachTheSameStrings() {
+        for (String each : List.of("JPa", "JP0", "JPzzz")) {
+            assertTrue(BETWEEN.admits(Text.of(each)) && STARTING_WITH_JP.has(new Value.Text(each)),
+                    () -> each + " is in both");
+        }
+        for (String each : List.of("JP", "JQ", "JR", "J", "")) {
+            assertTrue(!(BETWEEN.admits(Text.of(each))
+                            && STARTING_WITH_JP.has(new Value.Text(each))),
+                    () -> each + " is in neither, once each side is met with the other");
+        }
+    }
+
+    /** A set naming a language, met with the whole order: a string is written out. */
+    @Test
+    void aSetThatNamesTheStringsIsAskedAndAnswers() {
+        assertInstanceOf(Answer.Wrote.class, asked(STARTING_WITH_JP, EVERYTHING),
+                "the language holds strings a source can carry, and one of them is written out");
+    }
+
+    /** The same strings reached through the run instead, which comes to the same answer. */
+    @Test
+    void andSoIsTheRunThatLeavesTheSameStrings() {
+        assertInstanceOf(Answer.Wrote.class, asked(ValueSet.ANY, BETWEEN),
+                "the run holds every string `JP` starts but itself, and a search told so by the run"
+                        + " rather than by the set has the same values to choose from");
+    }
+
+    /**
+     * And the two together are that question again.
+     *
+     * <p>Compared as which of the three answers came back and not as which string. Two searches over
+     * one domain may write out different values of it; what they may not do is disagree about whether
+     * the domain has one to write.
+     */
+    @Test
+    void andTheTwoTogetherAreTheSameQuestionAgain() {
+        assertEquals(answerClass(asked(STARTING_WITH_JP, BETWEEN)),
+                answerClass(asked(ValueSet.ANY, BETWEEN)),
+                "one domain, one answer about whether a witness can be written");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Two restrictions coming to the same values are one question, whichever of them was written down.
@@ -52,9 +51,6 @@ class OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest {
     /** The strings strictly between `JP` and `JQ`, said as a run of the order. */
     private static final OrderedInterval BETWEEN = new OrderedInterval(
             Endpoint.exclusive(Text.of("JP")), Endpoint.exclusive(Text.of("JQ")));
-
-    /** The whole of the order, said as a run. */
-    private static final OrderedInterval EVERYTHING = new OrderedInterval(null, null);
 
     /** The strings `JP` starts, said as a set. */
     private static final ValueSet STARTING_WITH_JP = matching("JP[\\s\\S]*");
@@ -95,28 +91,34 @@ class OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest {
     }
 
     /**
-     * The two ways of saying it reach the same strings, which is what makes them one question.
+     * The two ways of saying it hold the same strings, which is what makes them one question.
      *
-     * <p>Measured rather than argued. A test whose two cases turned out to be about two sets of
-     * values would be asking for the same answer to two questions.
+     * <p>Membership compared against membership, and not the two sides put together and refused. The
+     * run stops short of `JP` and the language holds it, so a test asking only that no string is in
+     * both would pass on the strength of `JP` being in one — which is what a domain differing looks
+     * like, said as though it were the domains agreeing.
+     *
+     * <p>The comparison is between the run alone and the run met with the language, which is how the
+     * two arrive: a rule written as an ordering comparison leaves the position every string and stops
+     * them on the ordered side, and one written as a prefix leaves the strings and is stopped there
+     * too. The run lies inside the language, so the two come to one set.
      */
     @Test
-    void theTwoRestrictionsReachTheSameStrings() {
-        for (String each : List.of("JPa", "JP0", "JPzzz")) {
-            assertTrue(BETWEEN.admits(Text.of(each)) && STARTING_WITH_JP.has(new Value.Text(each)),
-                    () -> each + " is in both");
-        }
-        for (String each : List.of("JP", "JQ", "JR", "J", "")) {
-            assertTrue(!(BETWEEN.admits(Text.of(each))
-                            && STARTING_WITH_JP.has(new Value.Text(each))),
-                    () -> each + " is in neither, once each side is met with the other");
+    void theTwoRestrictionsHoldTheSameStrings() {
+        for (String each : List.of("JPa", "JP0", "JPzzz", "JP", "JQ", "JR", "J", "", "A")) {
+            boolean fromTheRun = BETWEEN.admits(Text.of(each));
+            boolean fromTheLanguage = BETWEEN.admits(Text.of(each))
+                    && STARTING_WITH_JP.has(new Value.Text(each));
+
+            assertEquals(fromTheRun, fromTheLanguage,
+                    () -> "`" + each + "` is in one domain exactly when it is in the other");
         }
     }
 
-    /** A set naming a language, met with the whole order: a string is written out. */
+    /** A set naming a language, met with that run: a string is written out. */
     @Test
     void aSetThatNamesTheStringsIsAskedAndAnswers() {
-        assertInstanceOf(Answer.Wrote.class, asked(STARTING_WITH_JP, EVERYTHING),
+        assertInstanceOf(Answer.Wrote.class, asked(STARTING_WITH_JP, BETWEEN),
                 "the language holds strings a source can carry, and one of them is written out");
     }
 


### PR DESCRIPTION
Fixes what #1612 reports: two rules stating the same strings are answered differently
when a search is asked for a value in them, because the shape the restriction arrived in
decides which crossing runs.

`Carrier.somewhereIn` sends a `ValueSet.Matching` to `TextExtents.stringsIn`, which builds
the crossing with the run exactly. A `ValueSet.Cofinite` — every string but a handful, the
whole order included — went to `firstHeldIn` instead, which offers the least string and
then longer ones built from a letter, as many as the values named between the exclusions
and the places held apart. A run away from that handful holds strings none of them names,
and the walk coming back empty was read as an answer about the values.

The reading of extents already takes any `ValueSet`. So the cheap candidates stay first —
they read better in a row, and a position whose rules say nothing about its values is the
common case — and where they are exhausted the question goes to the crossing. Both shapes
reach it through one method now.

`Carrier.someStringInside` is untouched. That one answers a run of the order with no set
beside it, and declining to name a string past an end it stops short of is right there:
which character to put after a bound is a choice the model never stated. Asking a set for
one of its own values is not that choice.

## What is checked

`OneEffectiveDomainIsOneAnswerHoweverItWasRestrictedTest` puts the same strings to the
order twice — once restricted through the set, once through the run — having first measured
that the two reach the same strings, so the test is not comparing two domains. It compares
which of three answers came back and not which string: a witness, no writable witness, or
the allowance ran out, told apart by reading the meter beside the answer rather than off a
null.

Reverting the fallback reddens the two cases that are about the divergence and leaves the
other two green.

The corpora do not move. Nothing asked this question with a set of that shape and a run
away from its candidates until a boundary search was given the admitted values, which is
#1581 and comes after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)