### PR TITLE
Address a licensed reader by a name the source states

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
@@ -71,8 +71,8 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
 
     @Test
     void nothingAddressesAReaderByAnIdentityJavacMadeUp() {
-        Set<String> madeUp = whatJavacNamedTheLambdasHere();
-        assertFalse(madeUp.isEmpty(), "this repository compiled no lambda at all, so the rule is"
+        Set<String> forbidden = whatJavacNamedTheLambdasHere();
+        assertFalse(forbidden.isEmpty(), "this repository compiled no lambda at all, so the rule is"
                 + " asked of nothing and passes by having nothing to forbid");
 
         List<ClassModel> checks = checks();
@@ -84,7 +84,7 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
             for (Map.Entry<String, List<String>> said : WhatACheckSays.of(each).entrySet()) {
                 List<String> named = new ArrayList<>();
                 for (String one : said.getValue()) {
-                    named.addAll(named$inOneText(one, madeUp));
+                    named.addAll(named$inOneText(one, forbidden));
                 }
                 if (!named.isEmpty()) {
                     addressed.put(said.getKey(), named);
@@ -118,13 +118,13 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
                 "the method the lambdas here are written in is not spelled with a $ any more, so"
                         + " this witnesses an ordinary name and the case it exists for is unasked");
 
-        Set<String> mine = lambdasOf(itself);
+        Set<String> mine = new TreeSet<>();
+        lambdasOf(itself, mine);
         assertFalse(mine.isEmpty(), "this class compiled to no lambda of its own, so there is"
                 + " nothing here to have been carried into the population");
 
-        Set<String> madeUp = whatJavacNamedTheLambdasHere();
         Set<String> missing = new TreeSet<>(mine);
-        missing.removeAll(madeUp);
+        missing.removeAll(whatJavacNamedTheLambdasHere());
         assertEquals(Set.of(), missing,
                 "a lambda this class compiled to is not in the population the rule beside this one"
                         + " is held to, so what javac named it was dropped on the way in");
@@ -144,33 +144,44 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
         return identities.stream().filter(each -> said.contains(each)).toList();
     }
 
-    /** Every lambda this repository compiled, under the address a licence writes one down by. */
+    /**
+     * Every lambda this repository compiled, under the address a licence writes one down by.
+     *
+     * <p>Built where it is asked for. The classes behind it are read once for the fork
+     * ({@link CompiledOutputs}), so what a second ask costs is the walk over what that already
+     * holds — measured, and under what a run of this varies by.
+     */
     private static Set<String> whatJavacNamedTheLambdasHere() {
         Set<String> out = new TreeSet<>();
         for (ClassModel each : EVERYTHING.all()) {
-            out.addAll(lambdasOf(each));
+            lambdasOf(each, out);
         }
         return out;
     }
 
     /**
-     * The lambdas of one class, as addresses.
+     * The lambdas of one class, as addresses, into {@code out}.
      *
      * <p>The class it was written in and the name javac gave it, written the way a licence writes a
      * method: the owner with its nesting as the source spells it, and the method after it. A name
      * alone would be an address two classes could share, and the thing forbidden is an identity
      * rather than a spelling that happens to be in use somewhere.
+     *
+     * <p>The owner is put together where one is found, because most classes have no lambda at all
+     * and spelling a name for them is work this asks of every class of every module.
      */
-    private static Set<String> lambdasOf(ClassModel model) {
-        String owner = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
-        Set<String> out = new TreeSet<>();
+    private static void lambdasOf(ClassModel model, Set<String> out) {
+        String owner = null;
         for (MethodModel method : model.methods()) {
             String name = method.methodName().stringValue();
             if (name.startsWith(A_LAMBDA)) {
+                if (owner == null) {
+                    owner = model.thisClass().asInternalName()
+                            .replace('/', '.').replace('$', '.');
+                }
                 out.add(owner + "." + name);
             }
         }
-        return out;
     }
 
     /** Whether {@code model} still has the method the lambdas here are written in. */

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
@@ -10,10 +10,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A check names what it licenses by something the source states.
@@ -29,7 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * different lambda that comes to hold that number is licensed by an entry nobody wrote for it, and
  * the check cannot tell the two apart.
  *
- * <p><b>What is refused is the number reaching the licence, and not the lambda.</b> A rule that
+ * <p><b>What is forbidden is the identity javac made, and it is taken from javac.</b> Not a
+ * spelling: a rule that recognised such a name by its shape would be a second account of how javac
+ * names a lambda, which is the same defect this is about one level up — and one that goes wrong at
+ * exactly the places a naming scheme is allowed to surprise its readers. So the population is every
+ * lambda this repository compiled, under the address a licence writes: the class it was written in,
+ * and the name javac gave it.
+ *
+ * <p><b>What is refused is the identity reaching the licence, and not the lambda.</b> A rule that
  * reads compiled classes meets lambdas wherever it walks, and answering for one by the method it was
  * written in is a reading several rules here already have. What that reading hands back is a name
  * the source states; what is refused here is writing javac's name down as the address instead.
@@ -38,9 +47,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * licence would be taken from the property being checked — a list written tomorrow would not be in
  * it — so it is every class compiled beside a test, and the rule is the narrow one.
  *
- * <p>What it does not see, said rather than left to be found: a name put together at run time out of
- * pieces is not something the class file holds as text, so a licence assembled that way would pass.
- * {@link WhatACheckSays} is what a check has written down.
+ * <p>What it does not see, said rather than left to be found. A name put together at run time out of
+ * pieces is not something the class file holds as text, so a licence assembled that way would pass;
+ * {@link WhatACheckSays} is what a check has written down. And an address of a lambda that no longer
+ * exists is not here either, because no such lambda was compiled — an entry like that matches
+ * nothing the licence it sits in walks over, and goes red there.
  */
 class NoCheckAddressesAReaderByANameJavacMadeUpTest {
 
@@ -49,61 +60,135 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     /**
-     * How javac spells a lambda: the method it was written in, and its place among the class's
-     * lambdas.
+     * The prefix javac writes a lambda's method under.
      *
-     * <p>The number is what this is about, so it is what the pattern requires. A rule that carries
-     * the prefix alone to answer for a lambda by the method around it says {@code lambda$} and stops
-     * there, which is the reading this leaves alone.
+     * <p>The whole of what is spelled here, and what the readings elsewhere spell too. It is not how
+     * the name is recognised — the names come from the classes — but what tells the texts that could
+     * name one from the texts that cannot: an address in the population has it, so a text carrying
+     * an address has it as well, and one that does not carries none.
      */
-    private static final Pattern MADE_UP = Pattern.compile("lambda\\$[^$]*\\$\\d");
+    private static final String A_LAMBDA = "lambda$";
 
     @Test
-    void nothingAddressesAReaderByTheNumberJavacGaveItsLambda() {
-        List<ClassModel> checks = new ArrayList<>();
-        for (Path module : REPOSITORY.modules()) {
-            checks.addAll(EVERYTHING.testClassesOf(module));
-        }
+    void nothingAddressesAReaderByAnIdentityJavacMadeUp() {
+        Set<String> madeUp = whatJavacNamedTheLambdasHere();
+        assertFalse(madeUp.isEmpty(), "this repository compiled no lambda at all, so the rule is"
+                + " asked of nothing and passes by having nothing to forbid");
+
+        List<ClassModel> checks = checks();
         assertFalse(checks.isEmpty(), "no check of this repository was read at all, so this rule is"
                 + " asked of nothing and passes by having nobody to ask");
 
         Map<String, List<String>> addressed = new LinkedHashMap<>();
         for (ClassModel each : checks) {
-            WhatACheckSays.of(each).forEach((where, said) -> {
-                List<String> madeUp = said.stream().filter(one -> MADE_UP.matcher(one).find())
-                        .toList();
-                if (!madeUp.isEmpty()) {
-                    addressed.put(where, madeUp);
+            for (Map.Entry<String, List<String>> said : WhatACheckSays.of(each).entrySet()) {
+                List<String> named = new ArrayList<>();
+                for (String one : said.getValue()) {
+                    named.addAll(named$inOneText(one, madeUp));
                 }
-            });
+                if (!named.isEmpty()) {
+                    addressed.put(said.getKey(), named);
+                }
+            }
         }
 
         assertEquals(Map.of(), addressed,
-                "a check addresses a reader by the number javac gave a lambda, so the entry moves"
-                        + " when a lambda is added above it and licenses whichever lambda comes to"
-                        + " hold that number. Give the reader a name the source states, or answer"
-                        + " for it by the method it was written in");
+                "a check addresses a reader by an identity javac made up, so the entry moves when a"
+                        + " lambda is added above it and licenses whichever lambda comes to hold"
+                        + " that number. Give the reader a name the source states, or answer for it"
+                        + " by the method it was written in");
     }
 
     /**
-     * And that the pattern is what javac writes, asked of javac.
+     * And that a lambda written where the name around it already has a {@code $} arrives whole.
      *
-     * <p>The rule above passes when nothing matches, which is also what it does when the spelling it
-     * looks for is not the spelling in use. So what it is held to is a name this very class made:
-     * the check above is written with a lambda, and the method that lambda became is in this class
-     * beside it.
+     * <p>The rule above passes when nothing is found, which is also what it would do if the
+     * population were built out of names javac does not write. What holds it to what javac writes is
+     * this class: every lambda here is written inside {@link #named$inOneText}, whose name carries a
+     * {@code $} of its own, so what javac made of it is a name with the separator in the middle of
+     * the part that is not the separator. A reading that took such a name apart would lose it, and
+     * an expected spelling written out here would be that reading again — so what is asked is that
+     * the lambdas this class compiled to are in the population, whatever they are called.
      */
     @Test
-    void andThatIsHowALambdaIsNamedHere() {
+    void andALambdaOfAHolderSpelledWithADollarIsInThatPopulation() {
         ClassModel itself = EVERYTHING.read(
                 NoCheckAddressesAReaderByANameJavacMadeUpTest.class.getName().replace('.', '/'));
-        List<String> lambdas = itself.methods().stream()
-                .map(MethodModel::methodName)
-                .map(each -> each.stringValue())
-                .filter(each -> MADE_UP.matcher(each).find())
-                .toList();
-        assertFalse(lambdas.isEmpty(), "no method of this class is named the way javac names a"
-                + " lambda, so the rule beside this one is looking for a spelling nothing has and"
-                + " would pass over a licence addressed by one");
+        assertTrue(holdsAMethodSpelledWithADollar(itself),
+                "the method the lambdas here are written in is not spelled with a $ any more, so"
+                        + " this witnesses an ordinary name and the case it exists for is unasked");
+
+        Set<String> mine = lambdasOf(itself);
+        assertFalse(mine.isEmpty(), "this class compiled to no lambda of its own, so there is"
+                + " nothing here to have been carried into the population");
+
+        Set<String> madeUp = whatJavacNamedTheLambdasHere();
+        Set<String> missing = new TreeSet<>(mine);
+        missing.removeAll(madeUp);
+        assertEquals(Set.of(), missing,
+                "a lambda this class compiled to is not in the population the rule beside this one"
+                        + " is held to, so what javac named it was dropped on the way in");
+    }
+
+    /**
+     * Which of {@code identities} {@code said} names.
+     *
+     * <p>Spelled with a {@code $} in its own name on purpose, and the only method here a lambda is
+     * written in. What javac makes of a lambda written here is named after this method, separator
+     * and all, which is the name the case above reads off the artifact.
+     */
+    private static List<String> named$inOneText(String said, Set<String> identities) {
+        if (!said.contains(A_LAMBDA)) {
+            return List.of();
+        }
+        return identities.stream().filter(each -> said.contains(each)).toList();
+    }
+
+    /** Every lambda this repository compiled, under the address a licence writes one down by. */
+    private static Set<String> whatJavacNamedTheLambdasHere() {
+        Set<String> out = new TreeSet<>();
+        for (ClassModel each : EVERYTHING.all()) {
+            out.addAll(lambdasOf(each));
+        }
+        return out;
+    }
+
+    /**
+     * The lambdas of one class, as addresses.
+     *
+     * <p>The class it was written in and the name javac gave it, written the way a licence writes a
+     * method: the owner with its nesting as the source spells it, and the method after it. A name
+     * alone would be an address two classes could share, and the thing forbidden is an identity
+     * rather than a spelling that happens to be in use somewhere.
+     */
+    private static Set<String> lambdasOf(ClassModel model) {
+        String owner = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+        Set<String> out = new TreeSet<>();
+        for (MethodModel method : model.methods()) {
+            String name = method.methodName().stringValue();
+            if (name.startsWith(A_LAMBDA)) {
+                out.add(owner + "." + name);
+            }
+        }
+        return out;
+    }
+
+    /** Whether {@code model} still has the method the lambdas here are written in. */
+    private static boolean holdsAMethodSpelledWithADollar(ClassModel model) {
+        for (MethodModel method : model.methods()) {
+            String name = method.methodName().stringValue();
+            if (!name.startsWith(A_LAMBDA) && name.contains("$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<ClassModel> checks() {
+        List<ClassModel> out = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            out.addAll(EVERYTHING.testClassesOf(module));
+        }
+        return out;
     }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
@@ -5,6 +5,7 @@ import souther.test.RepositoryLayout;
 
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
+import java.lang.reflect.AccessFlag;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -69,6 +70,12 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
      */
     private static final String A_LAMBDA = "lambda$";
 
+    /** The method the lambdas here are written in, whose own name carries a {@code $}. */
+    private static final String THE_HOLDER = "named$inOneText";
+
+    /** The method here that is named the way javac names a lambda and is not one. */
+    private static final String THE_DECOY = "lambda$thisClass$0";
+
     @Test
     void nothingAddressesAReaderByAnIdentityJavacMadeUp() {
         Set<String> forbidden = whatJavacNamedTheLambdasHere();
@@ -112,11 +119,11 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
      */
     @Test
     void andALambdaOfAHolderSpelledWithADollarIsInThatPopulation() {
-        ClassModel itself = EVERYTHING.read(
-                NoCheckAddressesAReaderByANameJavacMadeUpTest.class.getName().replace('.', '/'));
-        assertTrue(holdsAMethodSpelledWithADollar(itself),
-                "the method the lambdas here are written in is not spelled with a $ any more, so"
-                        + " this witnesses an ordinary name and the case it exists for is unasked");
+        ClassModel itself = EVERYTHING.read(lambda$thisClass$0());
+        assertTrue(declares(itself, THE_HOLDER),
+                "the method the lambdas here are written in is gone or is called something else, so"
+                        + " what this reads is an ordinary name and the case it exists for is"
+                        + " unasked");
 
         Set<String> mine = new TreeSet<>();
         lambdasOf(itself, mine);
@@ -128,6 +135,42 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
         assertEquals(Set.of(), missing,
                 "a lambda this class compiled to is not in the population the rule beside this one"
                         + " is held to, so what javac named it was dropped on the way in");
+    }
+
+    /**
+     * And that a method the source named that way is not in it.
+     *
+     * <p>The other side of the same question. {@code $} is a letter, so a name javac gives a lambda
+     * is a name anybody may write, and a method somebody declared is a name the source states —
+     * exactly what a licence is entitled to address a reader by. The one below is declared here for
+     * this to ask about, and what tells it from a lambda's is the flag javac sets and not what
+     * either of them is called.
+     */
+    @Test
+    void andAMethodTheSourceDeclaredThatWayIsNotInThatPopulation() {
+        ClassModel itself = EVERYTHING.read(lambda$thisClass$0());
+        assertTrue(declares(itself, THE_DECOY),
+                "the method this reads is not declared here any more, so what it asks about is"
+                        + " nothing and the answer means nothing");
+
+        assertFalse(whatJavacNamedTheLambdasHere().contains(
+                        NoCheckAddressesAReaderByANameJavacMadeUpTest.class.getName()
+                                + "." + THE_DECOY),
+                "a method this source declares is in the population of what javac made up, so the"
+                        + " rule forbids an address the source states — which is the whole of what a"
+                        + " licence is asked to use");
+    }
+
+    /**
+     * This class, as the outputs name it.
+     *
+     * <p>Declared under a name javac would give a lambda, on purpose and as the subject of the case
+     * above: a name is something anybody may write, and what says who wrote a method is the flag
+     * beside it. It does a real piece of the work here so that it is a method this class has rather
+     * than one kept for a test to look at.
+     */
+    private static String lambda$thisClass$0() {
+        return NoCheckAddressesAReaderByANameJavacMadeUpTest.class.getName().replace('.', '/');
     }
 
     /**
@@ -167,6 +210,13 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
      * alone would be an address two classes could share, and the thing forbidden is an identity
      * rather than a spelling that happens to be in use somewhere.
      *
+     * <p><b>Written by javac, which the class file says and the name does not.</b> {@code $} is a
+     * letter to Java, so a method the source declares may be called anything a lambda's is called;
+     * what makes one a lambda's is that the compiler wrote it, and that is what the synthetic flag
+     * is. The name is asked as well, because the compiler writes other methods nobody declared — a
+     * bridge, an enum's own members — and those are not what a licence would be addressing a reader
+     * by.
+     *
      * <p>The owner is put together where one is found, because most classes have no lambda at all
      * and spelling a name for them is work this asks of every class of every module.
      */
@@ -174,7 +224,7 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
         String owner = null;
         for (MethodModel method : model.methods()) {
             String name = method.methodName().stringValue();
-            if (name.startsWith(A_LAMBDA)) {
+            if (name.startsWith(A_LAMBDA) && method.flags().has(AccessFlag.SYNTHETIC)) {
                 if (owner == null) {
                     owner = model.thisClass().asInternalName()
                             .replace('/', '.').replace('$', '.');
@@ -184,11 +234,12 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
         }
     }
 
-    /** Whether {@code model} still has the method the lambdas here are written in. */
-    private static boolean holdsAMethodSpelledWithADollar(ClassModel model) {
+    /** Whether {@code model} still declares {@code named} itself, rather than javac having written
+     *  a method of that name. */
+    private static boolean declares(ClassModel model, String named) {
         for (MethodModel method : model.methods()) {
-            String name = method.methodName().stringValue();
-            if (!name.startsWith(A_LAMBDA) && name.contains("$")) {
+            if (method.methodName().stringValue().equals(named)
+                    && !method.flags().has(AccessFlag.SYNTHETIC)) {
                 return true;
             }
         }

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
@@ -76,6 +76,9 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
     /** The method here that is named the way javac names a lambda and is not one. */
     private static final String THE_DECOY = "lambda$thisClass$0";
 
+    /** The method of {@link ReadsOne} a bridge below carries the name of. */
+    private static final String THE_BRIDGED = "lambda$readsOne$0";
+
     @Test
     void nothingAddressesAReaderByAnIdentityJavacMadeUp() {
         Set<String> forbidden = whatJavacNamedTheLambdasHere();
@@ -162,6 +165,34 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
     }
 
     /**
+     * And that a bridge carrying such a name is not in it either.
+     *
+     * <p>The case between the two above. A bridge is written by the compiler and is flagged the way
+     * a lambda's method is, and the name it carries is the name of the method it bridges to — so
+     * where somebody declares one of these names, what the compiler writes beside it carries a name
+     * the source states. Answering by the name would forbid that reader; what answers is the flag
+     * saying which methods are bridges.
+     */
+    @Test
+    void andABridgeCarryingSuchANameIsNotInThatPopulation() {
+        ReadsOne<String> reader = new ReadsWhatItIsGiven();
+        assertEquals(THE_BRIDGED, reader.lambda$readsOne$0(THE_BRIDGED),
+                "the reader the bridge below is written for does not answer with what it was"
+                        + " given, so what this class holds is not what this case reads");
+
+        ClassModel written = EVERYTHING.read(
+                ReadsWhatItIsGiven.class.getName().replace('.', '/'));
+        assertTrue(bridges(written, THE_BRIDGED),
+                "the compiler wrote no bridge of that name here, so there is nothing in this"
+                        + " artifact to have been told from a lambda and the case is unasked");
+
+        assertFalse(whatJavacNamedTheLambdasHere().contains(
+                        ReadsWhatItIsGiven.class.getName().replace('$', '.') + "." + THE_BRIDGED),
+                "a bridge is in the population of what javac made up, so the rule forbids the name"
+                        + " of the method it bridges to — which is a name the source states");
+    }
+
+    /**
      * This class, as the outputs name it.
      *
      * <p>Declared under a name javac would give a lambda, on purpose and as the subject of the case
@@ -213,9 +244,17 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
      * <p><b>Written by javac, which the class file says and the name does not.</b> {@code $} is a
      * letter to Java, so a method the source declares may be called anything a lambda's is called;
      * what makes one a lambda's is that the compiler wrote it, and that is what the synthetic flag
-     * is. The name is asked as well, because the compiler writes other methods nobody declared — a
-     * bridge, an enum's own members — and those are not what a licence would be addressing a reader
-     * by.
+     * is.
+     *
+     * <p><b>And not a bridge, which the flag beside it says.</b> A bridge is written by the
+     * compiler and takes the name of the method it bridges to, so where the source declares one of
+     * these names the bridge carries it too — a name the source states, arriving under the same
+     * flag as a lambda's. The name cannot tell the two apart, because a bridge's name is not the
+     * bridge's; what tells them apart is that the class file says which methods are bridges.
+     *
+     * <p>The name is asked as well, and for what it can answer: which family of what the compiler
+     * writes this is about. An enum's own members and an accessor are named by the compiler too and
+     * are not what a licence would address a reader by.
      *
      * <p>The owner is put together where one is found, because most classes have no lambda at all
      * and spelling a name for them is work this asks of every class of every module.
@@ -224,13 +263,46 @@ class NoCheckAddressesAReaderByANameJavacMadeUpTest {
         String owner = null;
         for (MethodModel method : model.methods()) {
             String name = method.methodName().stringValue();
-            if (name.startsWith(A_LAMBDA) && method.flags().has(AccessFlag.SYNTHETIC)) {
+            if (name.startsWith(A_LAMBDA) && method.flags().has(AccessFlag.SYNTHETIC)
+                    && !method.flags().has(AccessFlag.BRIDGE)) {
                 if (owner == null) {
                     owner = model.thisClass().asInternalName()
                             .replace('/', '.').replace('$', '.');
                 }
                 out.add(owner + "." + name);
             }
+        }
+    }
+
+    /** Whether javac wrote a bridge named {@code named} into {@code model}. */
+    private static boolean bridges(ClassModel model, String named) {
+        for (MethodModel method : model.methods()) {
+            if (method.methodName().stringValue().equals(named)
+                    && method.flags().has(AccessFlag.SYNTHETIC)
+                    && method.flags().has(AccessFlag.BRIDGE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A reader named the way javac names a lambda, declared over what it reads.
+     *
+     * <p>Declared here as the subject of the case above, and implemented for one type just below:
+     * what the compiler writes into an implementation of this is a second method of the same name,
+     * taking what the parameter erases to. Nobody wrote that one, and the name it carries is the
+     * name of the one somebody did.
+     */
+    private interface ReadsOne<T> {
+        T lambda$readsOne$0(T said);
+    }
+
+    /** The implementation the bridge is written into. */
+    private static final class ReadsWhatItIsGiven implements ReadsOne<String> {
+        @Override
+        public String lambda$readsOne$0(String said) {
+            return said;
         }
     }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NoCheckAddressesAReaderByANameJavacMadeUpTest.java
@@ -1,0 +1,109 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+import souther.test.RepositoryLayout;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A check names what it licenses by something the source states.
+ *
+ * <p>A structural rule here holds a list of who may do something, each entry addressing one reader
+ * by name. A lambda is compiled to a method of its own, named after the method it was written in and
+ * numbered by where it fell among that class's lambdas — and that number is javac's answer rather
+ * than anything a line of the code says.
+ *
+ * <p>Addressed by it, a licence fails both ways. A lambda written earlier in the same class moves
+ * the number, and the entry goes red for an edit that has nothing to do with who is licensed, which
+ * is the licence being edited to match whatever the compiler did. The other way round is quieter: a
+ * different lambda that comes to hold that number is licensed by an entry nobody wrote for it, and
+ * the check cannot tell the two apart.
+ *
+ * <p><b>What is refused is the number reaching the licence, and not the lambda.</b> A rule that
+ * reads compiled classes meets lambdas wherever it walks, and answering for one by the method it was
+ * written in is a reading several rules here already have. What that reading hands back is a name
+ * the source states; what is refused here is writing javac's name down as the address instead.
+ *
+ * <p><b>Asked of every check this repository has.</b> A population taken from the checks that hold a
+ * licence would be taken from the property being checked — a list written tomorrow would not be in
+ * it — so it is every class compiled beside a test, and the rule is the narrow one.
+ *
+ * <p>What it does not see, said rather than left to be found: a name put together at run time out of
+ * pieces is not something the class file holds as text, so a licence assembled that way would pass.
+ * {@link WhatACheckSays} is what a check has written down.
+ */
+class NoCheckAddressesAReaderByANameJavacMadeUpTest {
+
+    private static final CompiledOutputs EVERYTHING = CompiledOutputs.ofEverythingCompiledHere();
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * How javac spells a lambda: the method it was written in, and its place among the class's
+     * lambdas.
+     *
+     * <p>The number is what this is about, so it is what the pattern requires. A rule that carries
+     * the prefix alone to answer for a lambda by the method around it says {@code lambda$} and stops
+     * there, which is the reading this leaves alone.
+     */
+    private static final Pattern MADE_UP = Pattern.compile("lambda\\$[^$]*\\$\\d");
+
+    @Test
+    void nothingAddressesAReaderByTheNumberJavacGaveItsLambda() {
+        List<ClassModel> checks = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            checks.addAll(EVERYTHING.testClassesOf(module));
+        }
+        assertFalse(checks.isEmpty(), "no check of this repository was read at all, so this rule is"
+                + " asked of nothing and passes by having nobody to ask");
+
+        Map<String, List<String>> addressed = new LinkedHashMap<>();
+        for (ClassModel each : checks) {
+            WhatACheckSays.of(each).forEach((where, said) -> {
+                List<String> madeUp = said.stream().filter(one -> MADE_UP.matcher(one).find())
+                        .toList();
+                if (!madeUp.isEmpty()) {
+                    addressed.put(where, madeUp);
+                }
+            });
+        }
+
+        assertEquals(Map.of(), addressed,
+                "a check addresses a reader by the number javac gave a lambda, so the entry moves"
+                        + " when a lambda is added above it and licenses whichever lambda comes to"
+                        + " hold that number. Give the reader a name the source states, or answer"
+                        + " for it by the method it was written in");
+    }
+
+    /**
+     * And that the pattern is what javac writes, asked of javac.
+     *
+     * <p>The rule above passes when nothing matches, which is also what it does when the spelling it
+     * looks for is not the spelling in use. So what it is held to is a name this very class made:
+     * the check above is written with a lambda, and the method that lambda became is in this class
+     * beside it.
+     */
+    @Test
+    void andThatIsHowALambdaIsNamedHere() {
+        ClassModel itself = EVERYTHING.read(
+                NoCheckAddressesAReaderByANameJavacMadeUpTest.class.getName().replace('.', '/'));
+        List<String> lambdas = itself.methods().stream()
+                .map(MethodModel::methodName)
+                .map(each -> each.stringValue())
+                .filter(each -> MADE_UP.matcher(each).find())
+                .toList();
+        assertFalse(lambdas.isEmpty(), "no method of this class is named the way javac names a"
+                + " lambda, so the rule beside this one is looking for a spelling nothing has and"
+                + " would pass over a licence addressed by one");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 /**
@@ -179,23 +180,31 @@ public final class ClauseHelpers {
      * apart by something other than {@link InliningPolicy}.
      */
     private static Hir.Def withInlinedInvariants(HelperInliner inliner, Hir.Def def,
-                                                java.util.function.Consumer<Made> met) {
+                                                Consumer<Made> met) {
         if (!(def instanceof Hir.Data d) || d.invariants().isEmpty()) {
             return def;
         }
         BindingOwner declared = new BindingOwner.OfData(d.declares());
         return new Hir.Data(d.written(), d.declares(), d.newtype(), d.includes(), d.fields(),
-                Hir.mapClauses(d.invariants(), clause -> {
-                    // The shape its author wrote it in, and the parts expanded where they stand —
-                    // so the clause is what those parts compose, and a reading of it holds each of
-                    // them where the shape says to look.
-                    AuthoredShape shape = shapeOf(clause);
-                    Expansion<Hir.Expr> one = inliner.expanding(() ->
-                            expandedOver(shape, part -> inliner.inline(part, declared)));
-                    met.accept(new Made(CallsLeftStanding.of(one.standing()), shape));
-                    return one.value();
-                }),
+                Hir.mapClauses(d.invariants(),
+                        clause -> inlinedClause(inliner, declared, met, clause)),
                 d.pos());
+    }
+
+    /**
+     * One clause of a declaration with its parts expanded where they stand.
+     *
+     * <p>The shape its author wrote it in, and the parts expanded where they stand — so the clause
+     * is what those parts compose, and a reading of it holds each of them where the shape says to
+     * look.
+     */
+    private static Hir.Expr inlinedClause(HelperInliner inliner, BindingOwner declared,
+                                          Consumer<Made> met, Hir.Expr clause) {
+        AuthoredShape shape = shapeOf(clause);
+        Expansion<Hir.Expr> one = inliner.expanding(() ->
+                expandedOver(shape, part -> inliner.inline(part, declared)));
+        met.accept(new Made(CallsLeftStanding.of(one.standing()), shape));
+        return one.value();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -283,9 +283,11 @@ public final class PathReachability {
         // limit and said as one: the analysis this borrows is open about what it reads, so a
         // comparison it reached and settled nothing about leaves the obligation standing. A failure
         // of the walk itself is not this and is not caught — it is this compiler's.
-        unanswered(body, plan, out, arriving).ifPresent(why ->
-                InvariantChecker.gaveUp("reachability",
-                        WhatTheCheckCannotRead.theWalkLeftAnAnswerUnmade(why)));
+        Optional<String> unmade = unanswered(body, plan, out, arriving);
+        if (unmade.isPresent()) {
+            InvariantChecker.gaveUp("reachability",
+                    WhatTheCheckCannotRead.theWalkLeftAnAnswerUnmade(unmade.get()));
+        }
         return new Answers(Optional.of(plan.identity()), out, arriving);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -160,10 +160,12 @@ public final class Preserved {
      *  may not. */
     private static Preserved readTheLibrary(Stdlib stdlib) {
         List<CompleteSignature> operations = new ArrayList<>();
-        stdlib.entries().forEach((operation, entry) -> {
-            operations.add(CompleteSignature.ofDeclaration(
-                    operation, entry.signature().params(), entry.signature().result()));
-        });
+        for (Map.Entry<ValueName.Stdlib.Operation, Stdlib.Entry> each
+                : stdlib.entries().entrySet()) {
+            operations.add(CompleteSignature.ofDeclaration(each.getKey(),
+                    each.getValue().signature().params(),
+                    each.getValue().signature().result()));
+        }
         return keeping(operations);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2291,11 +2291,20 @@ final class Terms {
         List<Core> sides = List.of(b.left(), b.right());
         ComparisonClaim placed = Comparison.of(b).map(Comparison::claim).orElse(null);
         if (placed != null) {
-            return over(sides, at, bound, depth, leaf,
-                    ps -> interned.comparison(placed.canonical(ps.get(0), ps.get(1))));
+            return over(sides, at, bound, depth, leaf, ps -> comparisonTerm(placed, ps));
         }
-        return over(sides, at, bound, depth, leaf,
-                ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));
+        return over(sides, at, bound, depth, leaf, ps -> operatorTerm(b, ps));
+    }
+
+    /** The term a comparison is: what the claim says it states, over the terms its two sides are. */
+    private Term comparisonTerm(ComparisonClaim placed, List<Term> sides) {
+        return interned.comparison(placed.canonical(sides.get(0), sides.get(1)));
+    }
+
+    /** The term a binary that placed no comparison is: the operator it was written with, over the
+     * terms its two operands are. */
+    private Term operatorTerm(Core.Binary b, List<Term> sides) {
+        return interned.operator(b.op(), sides.get(0), sides.get(1));
     }
 
     /** {@code made} of the terms {@code parts} are, or null where any of them is named by nothing. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -20,6 +20,7 @@ import souther.compiler.core.Core;
 import souther.compiler.core.Kernel;
 import souther.compiler.core.KernelSignature;
 import souther.compiler.core.GrowingFold;
+import souther.compiler.coverage.ComparisonEmissionSite;
 
 import souther.compiler.core.EnsuresEnforcement;
 import souther.compiler.jvm.GeneratedClass;
@@ -600,12 +601,21 @@ final class BodyGen {
             if (!armsAreCounted || !ctx.measuring()) {
                 return;
             }
-            ctx.comparisonSiteOf(bin).ifPresent(site -> {
-                ctx.emitted(site.raw());
-                code.dup();
-                code.loadConstant(site.raw());
-                code.invokestatic(CD_Probe, "compared", MTD_Probe_compared);
-            });
+            ctx.comparisonSiteOf(bin).ifPresent(this::comparisonProbeAt);
+        }
+
+        /**
+         * The call itself, written for the place a run through this comparison is recorded at.
+         *
+         * <p>The number is asked of the place twice for the one act: the emitter records that it
+         * wrote this number, and writes it into the instruction. What the instruction carries is a
+         * number and nothing else — a probed class has no numbering to ask what it addresses.
+         */
+        private void comparisonProbeAt(ComparisonEmissionSite site) {
+            ctx.emitted(site.raw());
+            code.dup();
+            code.loadConstant(site.raw());
+            code.invokestatic(CD_Probe, "compared", MTD_Probe_compared);
         }
 
         /**
@@ -1786,13 +1796,19 @@ final class BodyGen {
                     // between two lists ({@code WhatAnOperatorPlacesIsOneAnswerTest}). Asked for
                     // rather than assumed all the same, so that a comparison this arm names and
                     // that law stops holding for is said rather than emitted against.
-                    Comparison comparison = Comparison.of(bin).orElseThrow(
-                            () -> new IllegalStateException(
-                                    "an operator that compares placed nothing: " + bin.op()));
+                    Comparison comparison =
+                            Comparison.of(bin).orElseThrow(() -> placedNothing(bin));
                     emitComparison(comparison);
                     yield comparison;
                 }
             };
+        }
+
+        /** That an operator this arm names as one that compares placed nothing, which is the law
+         *  above having stopped holding for it. */
+        private static IllegalStateException placedNothing(Core.Binary bin) {
+            return new IllegalStateException(
+                    "an operator that compares placed nothing: " + bin.op());
         }
 
         /** What the operator computes of two numbers, through the runtime that owns the arithmetic

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonCatalog.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonCatalog.java
@@ -141,13 +141,26 @@ public final class ComparisonCatalog {
             // one answer. Gathered as nodes and recognised again where the entry is made, this
             // would be the same question asked twice about one binary, with a case to answer for
             // the second answer being different.
-            Comparison.of(binary).ifPresent(comparison -> {
-                filed(binary, behavior, met);
-                byOccurrence.put(binary.occurrence(), new Catalogued(binary.occurrence(),
-                        comparison, Citation.of(binary.pos()), binary.origin()));
-            });
+            Comparison.of(binary).ifPresent(comparison ->
+                    catalogue(binary, comparison, behavior, byOccurrence, met));
         }
         Core.forEachChild(e, child -> walk(child, behavior, byOccurrence, met));
+    }
+
+    /**
+     * The entry one recognised comparison becomes, under the occurrence the node it was recognised
+     * from carries.
+     *
+     * <p>A name, a recognition and a place put together, which is what makes this the one place they
+     * are paired: each of the three is read off the node in hand, so none of them is a caller's to
+     * supply.
+     */
+    private static void catalogue(Core.Binary binary, Comparison comparison, String behavior,
+                                  Map<ConstructOccurrence, Catalogued> byOccurrence,
+                                  Map<ConstructOccurrence, Met> met) {
+        filed(binary, behavior, met);
+        byOccurrence.put(binary.occurrence(), new Catalogued(binary.occurrence(),
+                comparison, Citation.of(binary.pos()), binary.origin()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
@@ -103,7 +103,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
             new Licence("souther.compiler.check.Conditions.polar",
                     "keys a fact by the comparison a condition states, which is written as a node"
                             + " with what is asserted of it carried beside"),
-            new Licence("souther.compiler.check.Terms.lambda$binary$0",
+            new Licence("souther.compiler.check.Terms.comparisonTerm",
                     "names the value a comparison in a body is, which is written as a term"));
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
@@ -101,7 +101,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
      * say that a name has been read against what declares it.
      */
     private static final List<Licence> MAY_ASSEMBLE = List.of(
-            new Licence("souther.compiler.check.Preserved.lambda$readTheLibrary$0",
+            new Licence("souther.compiler.check.Preserved.readTheLibrary",
                     "reads the library's own declarations, which state both halves"),
             new Licence("souther.compiler.check.OperationFactBinder.declaredSignature",
                     "the same declarations, read where a fact about an operation is held to them"),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -206,7 +206,7 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.Terms.numericMeaningOf",
                     "asks whether it computes a number, and keys the meaning by it"),
             new Held("souther.compiler.check.Terms.namedByRule", "asks whether it computes a number"),
-            new Held("souther.compiler.check.Terms.lambda$binary$1",
+            new Held("souther.compiler.check.Terms.operatorTerm",
                     "hands it to the interner, for a binary the recognition beside it found to be"
                             + " no comparison"),
             new Held("souther.compiler.check.Terms.asOperator",
@@ -306,7 +306,7 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.codegen.BodyGen.binary",
                     "which instructions the operator is emitted as, and — for the six it emits a"
                             + " comparison for — the recognition everything below it holds"),
-            new Held("souther.compiler.codegen.BodyGen.lambda$binary$0",
+            new Held("souther.compiler.codegen.BodyGen.placedNothing",
                     "names the operator in what it says of a comparison that placed nothing"),
 
             // And whether it compares at all, asked of the one place that says so — by a reader

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
@@ -118,7 +118,11 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
                     "asks the expansion and the reading's own scope about every call it cannot"
                             + " name"),
             new Licence("souther.compiler.check.PathReachability"
-                    + ".lambda$of$0(Ljava/lang/String;)",
+                    + ".of(Lsouther/compiler/core/Core;Lsouther/compiler/check/Scope;"
+                    + "Lsouther/compiler/coverage/CoverageSites$Plan;"
+                    + "Lsouther/compiler/inputs/InputDomain;"
+                    + "Lsouther/compiler/check/RuleReadingSource;"
+                    + "Lsouther/compiler/check/ReadingPolicy;)",
                     "reads which of a plan's comparisons the walk settled nothing about"));
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest.java
@@ -37,7 +37,7 @@ class WhoMaySplitAClauseIntoItsPartsIsWrittenDownTest {
     private record Licence(String who, int calls, String why) { }
 
     private static final List<Licence> MAY_SPLIT = List.of(
-            new Licence("souther.compiler.check.ClauseHelpers.lambda$withInlinedInvariants$1", 1,
+            new Licence("souther.compiler.check.ClauseHelpers.inlinedClause", 1,
                     "the expansion of a declaration's clauses, which splits before it expands so"
                             + " that each part is expanded where it stands and the shape it leaves"
                             + " is what every reader after it asks"),

--- a/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
@@ -55,7 +55,7 @@ class OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest {
     private record Licence(String who, int calls, String why) { }
 
     private static final List<Licence> MAY_ASK = List.of(
-            new Licence("souther.compiler.codegen.BodyGen.lambda$comparisonProbe$0", 2,
+            new Licence("souther.compiler.codegen.BodyGen.comparisonProbeAt", 2,
                     "where the call is written: a probed class is handed the number because that is"
                             + " what the instruction carries, and it has no numbering to ask what"
                             + " the number addresses. Twice for the one act — the emitter records"

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
@@ -95,9 +95,9 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
                             + " leaves and is a pair of nothing with nobody"));
 
     private static final List<Licence> MAY_CATALOGUE = List.of(
-            new Licence("souther.compiler.coverage.ComparisonCatalog.lambda$walk$0", 1,
-                    "the one walk that recognises a comparison, names it and says where it is"
-                            + " written, all from the node it is standing at"));
+            new Licence("souther.compiler.coverage.ComparisonCatalog.catalogue", 1,
+                    "where the one walk that recognises a comparison puts what it recognised beside"
+                            + " the name and the place, all read off the node it is standing at"));
 
     private static final List<Licence> MAY_READ = List.of(
             new Licence("souther.compiler.partition.GuardThresholds.originOf", 1,


### PR DESCRIPTION
Closes #1519.

A structural rule that licenses a reader held entries addressing one by the name javac gave a lambda — the method it was written in, and where it fell among the class's lambdas. That is not a name any line of the source says, and it fails both ways: a lambda added above it moves the number, so the licence goes red for an edit about nothing it governs and gets renumbered to match whatever the compiler did; and a different lambda coming to hold the number is licensed by an entry nobody wrote for it.

The entry named in the issue had already gone, with the reader it addressed, so what is swept here is every entry left with the same shape rather than that one. Each licence now names something the source states: the body has a method of its own wherever there is a reader to tell apart, and the lambda is gone where there is not — a walk over a map's entries, and a question asked with `if`.

Beside that, a rule over every class compiled beside a test: what a check has written down may not carry the address of a lambda this repository compiled. The addresses come from the class files rather than from a shape — the class it was written in and the name javac gave it — and which methods those are is asked of the synthetic flag the compiler set, because `$` is a letter and a method the source declares may be named the way javac names a lambda. Answering for a lambda by the method it was written in is left alone, so the two ways of naming a reader both stay open; reconciling them is not part of this.

The rule carries its own controls. The population and the checks read both have to be non-empty. One case reads this class's own compiled lambdas, written inside a method whose name carries a `$`, and asks that they are in the population — an artifact rather than an expected spelling. Another declares a method here under a lambda's name and asks that it is not, which is the distinction the flag draws. Putting a numbered address back in a licence turns the rule red naming the check and the address; putting back one no lambda answers to leaves it green and turns the licence itself red, which is where that belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)