### PR TITLE
Ask what a position admits where a row beside a line is composed

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -115,7 +115,8 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + " assignment the narrowing would have and skips none of them"),
             Map.entry("souther.compiler.partition.LevelRealizer#ofTwo("
                             + "Lsouther/compiler/partition/Standing$OfTwoOnOneCarrier;"
-                            + "Lsouther/compiler/inputs/SearchRegion;)"
+                            + "Lsouther/compiler/inputs/SearchRegion;"
+                            + "Lsouther/compiler/partition/WitnessSearch;)"
                             + "Lsouther/compiler/partition/Realization;",
                     "stops walking a line at the places it tries and says which figure"),
             Map.entry("souther.compiler.partition.LevelRealizer#ofAForm("

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -862,8 +862,17 @@ public sealed interface Carrier extends ValueOrder {
      * <p>A place this order has no written value for is left in. What the set says is which values
      * the declarations leave, and a carrier that writes none of them back has nothing to put to it
      * — refused here, every class of a date would lose the representative the order composed.
+     *
+     * <p><b>For a candidate already in hand, and never for finding one.</b> A caller choosing a value
+     * out of a run and asking this afterwards is the search stopping at the first thing it reached:
+     * where the answer is no, the run may hold another value the set admits and this says nothing
+     * about it, and a class the declarations leave inhabited comes back with no representative. What
+     * finding one is is {@link #somewhereIn}, which narrows the search by the set instead of judging
+     * what came back. This is asked where a candidate comes from a policy the set does not encode —
+     * the end of a run a boundary is named for is one — and a caller that gets no for every such
+     * candidate goes on to ask that one.
      */
-    private boolean admitted(ValueSet admits, Place at) {
+    default boolean admitted(ValueSet admits, Place at) {
         Value wrote = valueAt(at);
         return wrote == null || admits.has(wrote);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AdmittedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AdmittedValues.java
@@ -1,0 +1,84 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.TermPath;
+import souther.compiler.values.ValueSet;
+
+/**
+ * What the declarations leave each position of an input, for a search that is about to compose a
+ * value at one of them.
+ *
+ * <p>Apart from the region a search runs inside. That one is arithmetic — the runs the rules leave
+ * each number, met as positions are fixed — and this is the set of values a position holds, which
+ * the arithmetic has no word for: a rule about the length of a string says nothing about where the
+ * string sorts, so a search held to the run of one number can still arrive at a value the
+ * declarations refuse. Kept as one input beside the other, neither is asked the other's question.
+ *
+ * <p>Keyed by the position and not by the number. {@code code} and {@code String.length(code)} are
+ * two numbers of one location, and what that location admits is one answer — held per number, the
+ * same answer would be copied once per measure and two copies could disagree. Which is why the key
+ * is {@link souther.compiler.inputs.NumericTerm.FromOnePosition#position()}, the location a value
+ * answering the number is written at.
+ *
+ * <p><b>Three states and not two.</b> A position whose rules leave it everything is one this answers
+ * for, with every value there is. A position this reading stopped before reaching is a different
+ * thing: nothing worked out what it holds, and a caller told "everything" would compose out of a set
+ * nobody established — which is the defect this exists to stop, moved behind a lookup. A line can be
+ * drawn at a name deeper than the positions a reading divided ({@code o.q@B.q.limit} under a choice
+ * whose cases were never filed), so the third state is reached by models somebody writes.
+ */
+public interface AdmittedValues {
+
+    /** What the declarations leave the position at {@code position}, or that nothing worked it out. */
+    Admitted at(TermPath position);
+
+    /**
+     * What a reading came to about one position's values.
+     *
+     * <p>Two cases, because a set and the absence of one are not one thing with a value standing in
+     * for the other. What a caller may do with them differs: a set narrows the search, and nothing
+     * worked out narrows nothing and licenses nothing either — a value composed against it would be a
+     * value offered at a position whose rules this compiler never read.
+     */
+    sealed interface Admitted {
+
+        /** The values the declarations leave, which is every value where no rule narrows them. */
+        record Values(ValueSet set) implements Admitted {
+
+            public Values {
+                if (set == null) {
+                    throw new IllegalArgumentException(
+                            "a position that was read holds a set, and a position that was not is"
+                                    + " NotWorkedOut rather than one holding null");
+                }
+            }
+        }
+
+        /**
+         * Nothing here worked out what the position holds.
+         *
+         * <p>A fact about this reading and not about the model. So a search that reaches one composes
+         * nothing and says so in the word it already has for what it could not build — read as a set
+         * of every value, it would offer a row at a position nothing was established about.
+         */
+        record NotWorkedOut() implements Admitted {}
+    }
+
+    /**
+     * What a reading of an input leaves its positions, from the sets it already answered with.
+     *
+     * <p>The sets are handed in rather than read out of a reading here. What a position admits is
+     * settled once, where the declarations are read, and a second route to it is a second answer
+     * about the model — including for a position this one has no entry for, which is why that comes
+     * back as nothing worked out rather than being worked out again from the path.
+     *
+     * @param byPosition the set each position the reading divided was read to leave, a position whose
+     *                   rules leave it everything included
+     */
+    static AdmittedValues of(java.util.Map<TermPath, ValueSet> byPosition) {
+        java.util.Map<TermPath, ValueSet> sets = java.util.Map.copyOf(byPosition);
+        return position -> {
+            ValueSet held = sets.get(position);
+            return held == null ? new Admitted.NotWorkedOut() : new Admitted.Values(held);
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
@@ -99,16 +99,39 @@ public sealed interface Criterion {
                 souther.compiler.check.Carrier carrier,
                 souther.compiler.numeric.Endpoint min, souther.compiler.numeric.Endpoint max) {
             LevelSpace space = LevelSpace.onACarrier(carrier);
-            LevelInterval leaves = new LevelInterval(
-                    endOf(carrier, min), endOf(carrier, max));
-            for (LevelInterval part : region().parts()) {
-                LevelInterval look = part.intersect(leaves);
-                Level found = look == null ? null : space.witness(look, away).level();
+            for (LevelInterval look : runsInside(carrier, min, max)) {
+                Level found = space.witness(look, away).level();
                 if (found instanceof Level.OnACarrier on) {
                     return on.at();
                 }
             }
             return null;
+        }
+
+        /**
+         * The runs this item leaves inside what the rules leave the position, in the order they are
+         * to be looked in.
+         *
+         * <p>One reading of the geometry, because there is more than one thing to do with it. A
+         * caller with a set of admitted values crosses each of these with that set rather than
+         * taking a value out of one of them and putting it to the set afterwards
+         * ({@link souther.compiler.check.Carrier#somewhereIn}), and it has to be looking in the same
+         * runs and in the same order as the caller that wants a value and nothing else. Read twice,
+         * the two would be free to disagree about which end of the item is the near one.
+         */
+        public java.util.List<LevelInterval> runsInside(
+                souther.compiler.check.Carrier carrier,
+                souther.compiler.numeric.Endpoint min, souther.compiler.numeric.Endpoint max) {
+            LevelInterval leaves = new LevelInterval(
+                    endOf(carrier, min), endOf(carrier, max));
+            java.util.List<LevelInterval> out = new java.util.ArrayList<>();
+            for (LevelInterval part : region().parts()) {
+                LevelInterval look = part.intersect(leaves);
+                if (look != null) {
+                    out.add(look);
+                }
+            }
+            return java.util.List.copyOf(out);
         }
 
         /** What the rules leave the position, as an end of a run of its values. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Where each position has to stand for a row to be at one coverage item.
@@ -826,7 +827,7 @@ public final class LevelRealizer {
             case Criterion.Within within ->
                     whatTheValuesAre(term, looking.admitted())
                             instanceof AdmittedValues.Admitted.Values(ValueSet admits)
-                            ? someValueIn(within, carrier, bounds, admits, looking.meter())
+                            ? someValueIn(within, carrier, bounds, admits, looking::meter)
                             : null;
         };
         if (offered == null) {
@@ -874,9 +875,17 @@ public final class LevelRealizer {
      * bounded by a rule about one number of the position starts at the one value a rule about another
      * refuses, and nothing about the run says so. The set is crossed with the run rather than asked
      * on its own, so a value it holds inside the run is not lost to whichever value it names first.
+     *
+     * <p><b>An allowance per crossing, which is why what arrives is the way to get one.</b> An item
+     * is a region and a region is as many runs as the rules leave it, so this crosses the set with
+     * each of them in turn — and a meter spends down. Shared between the runs, what the first
+     * crossing cost would be taken off what the second may spend, and whether a run is answered
+     * would follow from where it came in the order they are looked at. Which order that is is a
+     * searching policy and no answer about the values ({@link LevelRegion}).
      */
     private static Place someValueIn(Criterion.Within within, Carrier carrier,
-                                     NumericDomain.Bounds bounds, ValueSet admits, Meter meter) {
+                                     NumericDomain.Bounds bounds, ValueSet admits,
+                                     Supplier<Meter> allowance) {
         LevelSpace space = LevelSpace.onACarrier(carrier);
         List<LevelInterval> runs = within.runsInside(carrier, bounds.min(), bounds.max());
         for (LevelInterval look : runs) {
@@ -888,7 +897,7 @@ public final class LevelRealizer {
         for (LevelInterval look : runs) {
             OrderedInterval run = runOf(look, carrier);
             Place held = run == null ? null
-                    : carrier.somewhereIn(admits, run, List.of(), meter);
+                    : carrier.somewhereIn(admits, run, List.of(), allowance.get());
             if (held != null) {
                 return held;
             }
@@ -907,8 +916,9 @@ public final class LevelRealizer {
     private static OrderedInterval runOf(LevelInterval look, Carrier carrier) {
         Endpoint low = endOf(look.low(), carrier);
         Endpoint high = endOf(look.high(), carrier);
-        return look.low() != null && low == null || look.high() != null && high == null
-                ? null : new OrderedInterval(low, high);
+        boolean lost = (look.low() != null && low == null)
+                || (look.high() != null && high == null);
+        return lost ? null : new OrderedInterval(low, high);
     }
 
     /** One end of such a run, or null where it is not a place of the position. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -7,8 +7,12 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.Place;
+import souther.compiler.regex.Meter;
+import souther.compiler.values.ValueSet;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,24 +48,36 @@ public final class LevelRealizer {
      *               leave and never narrower than what reaches the item, which is what makes an
      *               exhausted walk of it a proof
      */
-    public Realization realize(Standing standing, souther.compiler.inputs.SearchRegion within) {
+    public Realization realize(Standing standing, souther.compiler.inputs.SearchRegion within,
+                               WitnessSearch looking) {
         if (within == null) {
             throw new IllegalArgumentException(
                     "a search looks inside a region, and there is always one: an item nothing on the"
                             + " way to it narrows is searched for in what the declarations leave,"
                             + " which is an answer and not an absence");
         }
+        // The other vocabulary a position is read in, and it is not optional either. A search that
+        // may be handed none is a search that composes without asking what the position holds,
+        // which is how a boundary came to be offered a value the declarations refuse.
+        if (looking == null) {
+            throw new IllegalArgumentException(
+                    "a value is composed at a position, and what that position admits is an answer"
+                            + " the reading already has: a search that may be handed none is one"
+                            + " that composes without asking");
+        }
         return switch (standing) {
-            case Standing.OfOneCoordinate one -> ofOne(one, within);
-            case Standing.OfTwoOnOneCarrier two -> ofTwo(two, within);
+            case Standing.OfOneCoordinate one -> ofOne(one, within, looking);
+            case Standing.OfTwoOnOneCarrier two -> ofTwo(two, within, looking);
             case Standing.OfAForm over -> ofAForm(over, within);
         };
     }
 
     /** One position at a place of its own carrier that the item accepts. */
     private Realization ofOne(Standing.OfOneCoordinate one,
-                              souther.compiler.inputs.SearchRegion within) {
-        Place at = placeMeeting(one.where(), one.of(), bounds(within, one.term()));
+                              souther.compiler.inputs.SearchRegion within,
+                              WitnessSearch looking) {
+        Place at = placeMeeting(one.where(), one.term(), one.of(), bounds(within, one.term()),
+                looking);
         return at == null ? Realization.Unknown.nothingComposedOne()
                 : found(Map.of(new RealizationTarget.AtOnePosition(one.term()), at), within);
     }
@@ -78,7 +94,8 @@ public final class LevelRealizer {
      * fact about the ranges and the pair may be refused or admitted by a rule neither range holds.
      */
     private Realization ofTwo(Standing.OfTwoOnOneCarrier two,
-                              souther.compiler.inputs.SearchRegion within) {
+                              souther.compiler.inputs.SearchRegion within,
+                              WitnessSearch looking) {
         NumericDomain.Bounds on = bounds(within, two.on());
         NumericDomain.Bounds together = commonRange(on, bounds(within, two.against()), two.of(),
                 two.where().anchor().asACount());
@@ -93,7 +110,8 @@ public final class LevelRealizer {
             // the other position stands at — read on, an item with no level in it was handed to a
             // reader that asks where its level falls.
             Criterion here = relativeTo(two.where(), common, two.of());
-            Place at = here == null ? null : placeMeeting(here, two.of(), on);
+            Place at = here == null ? null
+                    : placeMeeting(here, two.on(), two.of(), on, looking);
             if (at == null) {
                 continue;
             }
@@ -467,7 +485,7 @@ public final class LevelRealizer {
                             carriers[i].spacing()),
                     left);
             return switch (may) {
-                case CandidateDomain.None ignored -> Reached.EXHAUSTED;
+                case CandidateDomain.None _ -> Reached.EXHAUSTED;
                 case CandidateDomain.One only -> trying(i, only.at().at(), owed, coef, here);
                 // One value out of a coset whose values fill. There is no next one to step to, so
                 // what this walked was never the whole of it however the value turned out.
@@ -794,17 +812,22 @@ public final class LevelRealizer {
      * a row offered for a side that is really at the point against the line is a row an author pastes
      * and re-measures to find the item still uncovered.
      */
-    private static Place placeMeeting(Criterion where, Carrier carrier,
-                                      NumericDomain.Bounds bounds) {
+    private static Place placeMeeting(Criterion where, NumericTerm.FromOnePosition term,
+                                      Carrier carrier, NumericDomain.Bounds bounds,
+                                      WitnessSearch looking) {
         Place offered = switch (where) {
+            // The level itself, and the set is not asked. A point on a line stands where the rule
+            // wrote it; held to what the declarations admit, a line drawn at a value they refuse
+            // would stop being an item rather than being reported as one nothing can stand at.
             case Criterion.AtTheLevel at -> placeOf(at.at());
-            // From the end the line is at, which is what makes the row one beside the boundary
-            // rather than one at the far side of the partition. The point carries which end that is
-            // and is not asked for it again: handed it a second time, a caller could ask for a run
-            // to be read from the end it is not named for, which is the shape of one decision given
-            // from two places.
+            // Nothing composed where nothing worked out what the position holds. Which is this
+            // compiler's own limit and is reported in the word it has for one: a run searched against
+            // a set nobody established would offer a row at a position whose rules were never read.
             case Criterion.Within within ->
-                    within.somewhereInside(carrier, bounds.min(), bounds.max());
+                    whatTheValuesAre(term, looking.admitted())
+                            instanceof AdmittedValues.Admitted.Values(ValueSet admits)
+                            ? someValueIn(within, carrier, bounds, admits, looking.meter())
+                            : null;
         };
         if (offered == null) {
             return null;
@@ -814,6 +837,87 @@ public final class LevelRealizer {
         // one of them, which is the carrier's question rather than the item's.
         Place onTheGrid = carrier.onTheGrid(offered);
         return onTheGrid != null && accepts(where, carrier, onTheGrid) ? onTheGrid : null;
+    }
+
+    /**
+     * What the position admits, where the place being composed is a value of it.
+     *
+     * <p>Asked of the location the number is read from rather than of the number, because one location
+     * is measured at as many numbers as the rules name of it and admits one set of values — a rule
+     * about one of those numbers is what leaves the others short, which is the whole reason this set
+     * is here.
+     *
+     * <p><b>And every value there is where the number is one taken of the position rather than its
+     * own.</b> {@code String.length(code)} counts a string and the place composed for it is a count;
+     * the set holds the strings. Put to it, every count would be refused for not being one of them,
+     * and a boundary on a length would stop being offered a row at all. What a value carrying that
+     * count looks like is asked where such a value is written ({@link Witnesses}) and the set reaches
+     * it there.
+     */
+    private static AdmittedValues.Admitted whatTheValuesAre(NumericTerm.FromOnePosition term,
+                                                            AdmittedValues admitted) {
+        return term instanceof NumericTerm.ValueOf ? admitted.at(term.position())
+                : new AdmittedValues.Admitted.Values(ValueSet.ANY);
+    }
+
+    /**
+     * A place inside the run this item is, that the position's values take in.
+     *
+     * <p>The end the item is named for is tried first, in each run in turn. That is what makes the
+     * row one beside the boundary rather than one at the far side of the partition, and the item
+     * carries which end it is: asked for a second time by a caller, a run could be read from the end
+     * it is not named for, which is one decision given from two places.
+     *
+     * <p>And the values themselves once every one of those ends is refused. Which is the same
+     * arrangement {@link Carrier#somethingOtherThan} is under, reached for the same reason: the ends
+     * read better in a row than anything worked out of a set, and they are not exhaustive — a run
+     * bounded by a rule about one number of the position starts at the one value a rule about another
+     * refuses, and nothing about the run says so. The set is crossed with the run rather than asked
+     * on its own, so a value it holds inside the run is not lost to whichever value it names first.
+     */
+    private static Place someValueIn(Criterion.Within within, Carrier carrier,
+                                     NumericDomain.Bounds bounds, ValueSet admits, Meter meter) {
+        LevelSpace space = LevelSpace.onACarrier(carrier);
+        List<LevelInterval> runs = within.runsInside(carrier, bounds.min(), bounds.max());
+        for (LevelInterval look : runs) {
+            if (space.witness(look, within.away()).level() instanceof Level.OnACarrier on
+                    && carrier.admitted(admits, on.at())) {
+                return on.at();
+            }
+        }
+        for (LevelInterval look : runs) {
+            OrderedInterval run = runOf(look, carrier);
+            Place held = run == null ? null
+                    : carrier.somewhereIn(admits, run, List.of(), meter);
+            if (held != null) {
+                return held;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * One run of the levels as a run of the carrier's own places, or null where its ends are not
+     * places of the position.
+     *
+     * <p>Null where an end says how much of the quantity a rule wrote rather than a value of it. Such
+     * a run is in the written form's units, and a set of the position's values has nothing to say
+     * about a number in them — put to one, the set would be answering about a value nobody holds.
+     */
+    private static OrderedInterval runOf(LevelInterval look, Carrier carrier) {
+        Endpoint low = endOf(look.low(), carrier);
+        Endpoint high = endOf(look.high(), carrier);
+        return look.low() != null && low == null || look.high() != null && high == null
+                ? null : new OrderedInterval(low, high);
+    }
+
+    /** One end of such a run, or null where it is not a place of the position. */
+    private static Endpoint endOf(Bound end, Carrier carrier) {
+        if (end == null || end.at().per().compareTo(BigDecimal.ONE) != 0) {
+            return null;
+        }
+        return end.at().written() instanceof Level.OnACarrier on && on.of().equals(carrier)
+                ? new Endpoint(on.at(), end.inclusive()) : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
@@ -196,6 +196,19 @@ public final class MeasuredInput {
         return List.copyOf(out);
     }
 
+    /**
+     * What a search composing a value at one of its positions is given beside the region: the sets
+     * the declarations leave those positions, and what looking in one may cost.
+     *
+     * <p>Off this measurement and not worked out again by whoever searches. The sets are the
+     * reading's answer about the model, and the region a search runs inside is arithmetic — a caller
+     * that had only the second would compose a value the first refuses, with nothing on the way back
+     * able to tell it so.
+     */
+    public WitnessSearch witnessSearch() {
+        return Partitions.witnessSearch(divided.measurements());
+    }
+
     /** Every measure of its positions, in the order the rules name the numbers. */
     public MeasuredAxes axes() {
         return new MeasuredAxes(this, divided.axes());

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasuredInput.java
@@ -204,6 +204,13 @@ public final class MeasuredInput {
      * reading's answer about the model, and the region a search runs inside is arithmetic — a caller
      * that had only the second would compose a value the first refuses, with nothing on the way back
      * able to tell it so.
+     *
+     * <p>Built when asked rather than held here. What it holds is a set per position and an allowance
+     * to spend, and an allowance is a capability — kept as a field it would be part of an answer that
+     * is compared, which is the arrangement {@link #machines} is under and the reason a walk that
+     * reads answers for settled equality would have one more place to explain. So a caller that asks
+     * at every point of a border walks the positions at every point, and one that wants it once holds
+     * it once.
      */
     public WitnessSearch witnessSearch() {
         return Partitions.witnessSearch(divided.measurements());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -2182,5 +2182,24 @@ public final class Partitions {
                 ? List.of() : List.of(held);
     }
 
+    /**
+     * What a search composing a value at one of this phase's positions is given: the sets the
+     * declarations leave them, and what looking for a value in one may cost.
+     *
+     * <p>Here because this is where what a position admits is already in hand and where what writing
+     * one value out may cost is already granted. A search reaching for either would be a second
+     * answer about the model beside an allowance nothing granted it.
+     */
+    static WitnessSearch witnessSearch(List<PositionMeasurements> measurements) {
+        java.util.Map<TermPath, ValueSet> sets = new LinkedHashMap<>();
+        for (PositionMeasurements at : measurements) {
+            // Every position the reading measured, including the ones whose rules leave them
+            // everything. What a position admits and whether anybody asked are different states, and
+            // a map with a hole in it cannot tell a caller which of the two it is looking at.
+            sets.put(at.position().path(), at.position().admits());
+        }
+        return new WitnessSearch(AdmittedValues.of(sets), PatternPlan.Budget.OF_A_WITNESS::meter);
+    }
+
     private Partitions() {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/WitnessSearch.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WitnessSearch.java
@@ -1,0 +1,40 @@
+package souther.compiler.partition;
+
+import souther.compiler.regex.Meter;
+
+import java.util.function.Supplier;
+
+/**
+ * What a search composing a value at a position is given besides the region it runs inside.
+ *
+ * <p>Two things, and they are two because they answer different questions. {@link AdmittedValues} is
+ * what the model leaves each position, which is a fact about the declarations; the allowance is how
+ * much work looking for a value in one of those sets may take, which is a policy about this compiler.
+ * Folded into one type, a set of values would own a budget — and then how much a search may spend
+ * would travel as part of what the model admits, which is the shape #1577 kept out of {@link
+ * souther.compiler.check.Carrier}.
+ *
+ * <p>Paired here rather than passed as two arguments so that neither arrives without the other. A
+ * search handed a set and no allowance has to reach for one, and what it reaches for is a budget
+ * nothing granted it.
+ *
+ * @param admitted what the declarations leave each position
+ * @param allowance what one crossing of a set with a run may cost, asked per crossing. An allowance
+ *                  shared between them would have the first question spend what the second needs,
+ *                  and which of them went short would depend on the order they were asked in
+ */
+public record WitnessSearch(AdmittedValues admitted, Supplier<Meter> allowance) {
+
+    public WitnessSearch {
+        if (admitted == null || allowance == null) {
+            throw new IllegalArgumentException(
+                    "a value is composed out of what a position admits and within what looking for"
+                            + " one may cost, and a search is given both or neither");
+        }
+    }
+
+    /** A fresh allowance, for one crossing of a set with a run. */
+    public Meter meter() {
+        return allowance.get();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -999,7 +999,8 @@ final class Coverages {
                 // the realizer. What it composes is a candidate and no part of the item: another row
                 // in the same side is at the point as much as this one would be, so what the row is
                 // offered for goes in beside it rather than being read back off it.
-                return switch (realizer.realize(quantity.standingAt(criterion), able.region())) {
+                return switch (realizer.realize(quantity.standingAt(criterion), able.region(),
+                        input.witnessSearch())) {
                     case Realization.Found found -> {
                         // Asking nothing of what the dependencies answer. A point of a line is a
                         // place the positions stand at, and nothing about it turns on what a

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -974,6 +974,10 @@ final class Coverages {
         // against and never what the answer keeps; the account it was built from is what travels.
         souther.compiler.partition.Reachability reaching =
                 souther.compiler.partition.Reachability.of(within, rules.region());
+        // Once for the border rather than once for each of its points. What the positions of this
+        // input admit is the same answer at every point of it, and working it out where it is spent
+        // walks every position of the input at every point a row is searched for.
+        souther.compiler.partition.WitnessSearch looking = input.witnessSearch();
         return new OneSearchOfABorder() {
 
             @Override
@@ -1000,7 +1004,7 @@ final class Coverages {
                 // in the same side is at the point as much as this one would be, so what the row is
                 // offered for goes in beside it rather than being read back off it.
                 return switch (realizer.realize(quantity.standingAt(criterion), able.region(),
-                        input.witnessSearch())) {
+                        looking)) {
                     case Realization.Found found -> {
                         // Asking nothing of what the dependencies answer. A point of a line is a
                         // place the positions stand at, and nothing about it turns on what a

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest.java
@@ -10,6 +10,7 @@ import souther.compiler.report.AdequacyReport;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A choice of bounds on one position leaves the line its alternatives leave together.
@@ -123,10 +124,18 @@ class AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest {
     /**
      * And what the choice leaves is where the lines are and not which values stand there.
      *
-     * <p>Two alternatives naming one value each leave the run between them, and no value has a
-     * number in there. The outermost ends are two and five and the model draws a line at each; what
-     * is between them is a run nothing can be written in, and it comes back saying so. Read as the
-     * values the rules admit, the run would be offered as somewhere a row could stand.
+     * <p>Two alternatives naming one value each draw a line at each of them, and what each line
+     * leaves beside it is a run reaching the other — {@code 2 < n <= 5} from the first and
+     * {@code 2 <= n < 5} from the second. So what the choice settles is where the values part, and
+     * the numbers in the label are the lines rather than a claim about which values a row may be
+     * written at: a reading that took them for the run's own values would have the same two named
+     * values coming back as ends nothing lies at.
+     *
+     * <p>Each run does hold a value, and it is one of the named ones — a run beside one line reaches
+     * the next and stops there, less the value the line it is named for stands at
+     * ({@link souther.compiler.partition.Criterion.Within}). That a row at five answers the run
+     * above two as well as the point at five is two demands one row satisfies, which is what
+     * {@code Criterion.sameAs} already says about a level and a run one value wide.
      */
     @Test
     void andWhatTheChoiceLeavesIsWhereTheLinesAreAndNotWhichValuesStandThere() {
@@ -135,9 +144,14 @@ class AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest {
         assertEquals(List.of("border      borders 2   obligations 0/0"),
                 lines.stream().filter(each -> each.startsWith("border")).toList(),
                 "the outermost ends of the two named values are the lines the rules draw");
-        assertEquals(2, lines.stream()
-                        .filter(each -> each.contains("nothing composed one")).count(),
-                "and the runs between them hold no value, which is said rather than offered");
+        assertEquals(List.of("2 < n <= 5", "2 <= n < 5"),
+                lines.stream().filter(each -> each.contains("IN point n in "))
+                        .map(each -> each.replaceAll(".*IN point n in ", "")
+                                .replaceAll(" \\(invariant.*", ""))
+                        .toList(),
+                "the run each line leaves, named by that line and reaching the other");
+        assertTrue(lines.stream().noneMatch(each -> each.contains("nothing composed one")),
+                "and a value stands in each of them, which the named values are: " + lines);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhyItOwesNoRowAtAPointTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhyItOwesNoRowAtAPointTest.java
@@ -9,6 +9,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.partition.FixtureTemplate;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -298,39 +300,66 @@ class ABorderSaysWhyItOwesNoRowAtAPointTest {
     /**
      * A row on the line is not a row at a point past it, whatever the search had to start from.
      *
-     * <p>An order with no numbers has one level — where the two are equal — and every value past it
-     * is a run with no first value. So a search for a row in that run has nowhere to start but the
-     * line, and the line is the one place in reach the run does not hold. Read as a level the item
-     * accepts, a pair standing equal came back for a point that lies strictly past them, and the
-     * report went on saying no row was at it.
+     * <p>An order with no numbers has one level — where the two are equal — and a point past it is a
+     * run the level is not in. Read as a level the item accepts, a pair standing equal came back for
+     * a point that lies strictly past them.
+     *
+     * <p><b>Of every row offered at such a point, and not of one pair.</b> Which pair a search
+     * happens to compose is its own answer and moves when it learns to reach further; that a row
+     * offered for a strict side stands on the line is wrong whichever pair it is. Written as one
+     * literal, the check went on passing the day the search composed a different equal pair.
+     *
+     * <p>And nothing here says a row has to be found. Whether the search reaches one is a question
+     * about how far it can look, and a point it reaches none at is reported as such — so what is
+     * counted below is the points examined, which is what keeps this from passing because there was
+     * nothing to look at.
      */
     @Test
     void aRowOnTheLineIsNotOfferedForAPointPastIt() {
-        String rows = souther.compiler.report.GeneratedRows.of(
-                compiled("""
-                        module example.strings
+        Compilation compiled = compiled("""
+                module example.strings
 
-                        data No = { why: Int }
-                        data Yes = { v: Int }
-                        data Result = No | Yes
+                data No = { why: Int }
+                data Yes = { v: Int }
+                data Result = No | Yes
 
-                        behavior cmp : (a: String, b: String) -> Result
-                            constructs Yes, No
+                behavior cmp : (a: String, b: String) -> Result
+                    constructs Yes, No
 
-                        let cmp (a, b) = {
-                            guard a > b else No { why = 0 }
-                            Yes { v = 1 }
-                        }
+                let cmp (a, b) = {
+                    guard a > b else No { why = 0 }
+                    Yes { v = 1 }
+                }
 
-                        example cmp
-                            | "same" : ("b", "b") -> No { why = 0 }
-                        """),
-                "example.strings", "cmp", souther.compiler.diag.SourceRendering.namedByIdentity(SourceLayouts.NONE)).text();
+                example cmp
+                    | "same" : ("b", "b") -> No { why = 0 }
+                """);
+        Map<String, List<BorderAssessment>> lines =
+                Adequacy.searchedBoundariesOf(compiled.db(), "example.strings");
+        assertNotNull(lines, "the model under test compiles");
 
-        assertFalse(rows.contains("cmp(\"\", \"\")"),
-                "a pair standing equal is the line itself and is at neither side of it:\n" + rows);
-        assertTrue(rows.contains("no row for `b < a`"),
-                "and what there is to say is that nothing could build one:\n" + rows);
+        List<String> sides = new ArrayList<>();
+        lines.values().forEach(each -> each.forEach(line -> {
+            for (BorderAssessment.Point point : line.points()) {
+                if (point.role().againstTheLine() || point.owed() == null) {
+                    continue;   // the line itself, and the points nothing is owed at
+                }
+                sides.add(point.role() + " " + point.against());
+                for (ItemAssessment.Attempt attempt : point.owed().searches().each()) {
+                    if (!(attempt instanceof ItemAssessment.Attempt.Built built)) {
+                        continue;
+                    }
+                    List<String> wrote = built.row().inputs().stream()
+                            .map(FixtureTemplate::text).toList();
+                    assertNotEquals(wrote.get(0), wrote.get(1),
+                            () -> "a pair standing equal is the line itself and is at neither side"
+                                    + " of it, and this one is offered for " + point.against()
+                                    + ": " + wrote);
+                }
+            }
+        }));
+        assertFalse(sides.isEmpty(),
+                "the sides of the line this reads, which are what the rows above are offered for");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest.java
@@ -16,6 +16,7 @@ import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -236,6 +237,51 @@ class ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest {
         assertInstanceOf(Realization.Found.class, made,
                 "a count is composed for a boundary on a length, and the strings the position holds"
                         + " are not what says whether one is");
+    }
+
+    /**
+     * Each crossing of the set with a run is given an allowance of its own.
+     *
+     * <p>An item is a region and a region is as many runs as the rules leave it: a value singled out
+     * of the middle of a band leaves the run under it and the run over it. Both are crossed with the
+     * set in turn, and a meter spends down — so one shared between them would take what the first
+     * crossing cost off what the second may spend, and whether the second is answered would follow
+     * from the order the runs are looked at. Which order that is is a searching policy and says
+     * nothing about the values.
+     *
+     * <p>Counted rather than starved. A test that made the first crossing expensive enough to starve
+     * the second would be pinning how large a machine of these strings comes out, which is not what
+     * is being promised here.
+     */
+    @Test
+    void everyCrossingOfTheSetWithARunIsGivenItsOwnAllowance() {
+        Carrier whole = new Carrier.Whole();
+        // A band with a value singled out of the middle of it, which is two runs.
+        Band band = new Band(Band.endAt(null, Bound.at(count(whole, 0), true), Towards.ABOVE),
+                Band.endAt(null, Bound.at(count(whole, 10), true), Towards.BELOW));
+        Criterion where = new Criterion.Within(band, count(whole, 5), Towards.ABOVE);
+        // Nothing the order offers at the near end of either run, and a value only the upper one
+        // holds — so the lower run is crossed, answers nothing, and the upper is crossed after it.
+        ValueSet onlyEight = new ValueSet.Finite(Set.of(new Value.Number(
+                java.math.BigDecimal.valueOf(8))));
+        java.util.concurrent.atomic.AtomicInteger taken = new java.util.concurrent.atomic.AtomicInteger();
+        WitnessSearch counting = new WitnessSearch(
+                AdmittedValues.of(Map.of(CODE, onlyEight)),
+                () -> {
+                    taken.incrementAndGet();
+                    return PatternPlan.Budget.OF_A_WITNESS.meter();
+                });
+
+        new LevelRealizer().realize(
+                new Standing.OfOneCoordinate(VALUE, whole, where),
+                NothingTheRulesSay.REGION, counting);
+
+        assertTrue(taken.get() > 1,
+                () -> "one allowance per crossing, and this item is more than one run: " + taken);
+    }
+
+    private static Level count(Carrier on, long at) {
+        return new Level.OnACarrier(on, souther.compiler.numeric.Count.of(at));
     }
 
     private static Place at(Realization made) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest.java
@@ -1,0 +1,246 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Place;
+import souther.compiler.numeric.Text;
+import souther.compiler.numeric.Towards;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+import souther.compiler.types.ValueName;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row offered beside a line stands at a value the position holds.
+ *
+ * <p>The run below a line on a string starts at the empty string, and a position whose declarations
+ * ask for a character does not hold it. Composed from the run alone, that is the value offered: it is
+ * the least the order has, it is inside the run, and nothing between choosing it and building the row
+ * is able to say the declarations refuse it — the rules a placement is held against are the
+ * arithmetic ones, and a place that is a string is handed back unheld
+ * ({@code LevelRealizer.theRulesHaveNotRefused}). So the row goes out, comes back refused where it is
+ * built, and a reader is told every value was tried at a run holding all but one of them.
+ *
+ * <p>What the run cannot say is exactly this. {@code String.length(value) >= 1} is a rule about
+ * another number of the same position, so it is nowhere in the run of the order the boundary is on —
+ * which is why what the position admits is an input of its own here and not something read back off
+ * the range (#1581, and #1577 for the same sentence one route over).
+ *
+ * <p><b>Which value is composed is not held here.</b> What is held is that one is, and that it is a
+ * value the declarations leave standing. Which string a set and a run come to between them is the
+ * crossing's answer and moves with how the set is stated, which is a defect of its own (#1612) — a
+ * test naming the string would go red when that is fixed and say nothing about this.
+ */
+class ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest {
+
+    private static final TermPath CODE = TermPath.of("code");
+
+    private static final NumericTerm.FromOnePosition VALUE = new NumericTerm.ValueOf(CODE);
+
+    private static final Carrier TEXT = new Carrier.Text();
+
+    /**
+     * What {@code String.length(value) >= 1} leaves, as the reading of the declarations states it:
+     * the strings of a character or more, said as the language of them.
+     *
+     * <p>Said the way the corpus's own rule is said, because which shape a set arrives in decides
+     * what the crossing can name in it (#1612). Written as {@link ValueSet.Cofinite} of the empty
+     * string, the same set names no value above a line, and a test using it would be measuring that
+     * defect rather than this one.
+     */
+    private static final ValueSet A_CHARACTER_AT_LEAST = matching("[\\s\\S]+");
+
+    /** The one string the rule above refuses. */
+    private static final Value REFUSED = new Value.Text("");
+
+    private static ValueSet matching(String regex) {
+        PatternRead said = PatternParser.read(regex);
+        return ValueSet.matching(PatternPlan.of(
+                        assertInstanceOf(PatternRead.Read.class, said, regex).syntax())
+                .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter()));
+    }
+
+    /**
+     * The run on one side of a line at `spring`, which is what a boundary beside that line asks for.
+     *
+     * <p>The line's own value belongs to the side the run is not on, which is what an equality leaves
+     * each side: the value against the line is the point on it, and the run beside it holds every
+     * other value of that side. So the seam is built from the far side each way round, which is the
+     * shape the report shows for `voucher < spring` and `spring < voucher`.
+     */
+    private static Criterion.Within run(Towards away) {
+        LevelSpace space = LevelSpace.onACarrier(TEXT);
+        Level line = new Level.OnACarrier(TEXT, Text.of("spring"));
+        Seam parted = Seam.of(space, line, away.opposite());
+        Band band = away == Towards.BELOW
+                ? new Band(Band.endAt(null, null, Towards.ABOVE),
+                        Band.endAt(parted, null, Towards.BELOW))
+                : new Band(Band.endAt(parted, null, Towards.ABOVE),
+                        Band.endAt(null, null, Towards.BELOW));
+        return new Criterion.Within(band, null, away);
+    }
+
+    private static Realization realize(Criterion where, WitnessSearch looking) {
+        return new LevelRealizer().realize(
+                new Standing.OfOneCoordinate(VALUE, TEXT, where),
+                NothingTheRulesSay.REGION, looking);
+    }
+
+    private static WitnessSearch admitting(ValueSet set) {
+        return new WitnessSearch(AdmittedValues.of(Map.of(CODE, set)),
+                PatternPlan.Budget.OF_A_WITNESS::meter);
+    }
+
+    /**
+     * Either side of the line is offered a value the declarations leave standing.
+     *
+     * <p>Both, because the same input was missing on both. Below the line the run named a value and
+     * it was the one string the rules refuse; above it the run named none at all and the set is what
+     * has a value to name there. Different sentences in the report, one thing absent from the search.
+     */
+    @Test
+    void theRunBelowTheLineStandsAtAValueTheDeclarationsLeave() {
+        Place at = admittedValueIn(Towards.BELOW);
+
+        assertNotEquals(Text.of(""), at,
+                "the empty string is the least of the order and is the one string this position does"
+                        + " not hold");
+    }
+
+    /**
+     * And so does the run above it, which the range alone could name no value in at all.
+     *
+     * <p>A test of its own rather than the other side of a loop: each side is a way the search went
+     * wrong and a run that stopped at the first would leave the second unmeasured.
+     */
+    @Test
+    void theRunAboveTheLineStandsAtAValueTheDeclarationsLeaveToo() {
+        assertInstanceOf(Text.class, admittedValueIn(Towards.ABOVE),
+                "the range named no value above the line, and the set has one to name there");
+    }
+
+    /** The value the search offers for the run on one side, held to the set and to the run. */
+    private static Place admittedValueIn(Towards away) {
+        Place at = at(realize(run(away), admitting(A_CHARACTER_AT_LEAST)));
+        Text wrote = assertInstanceOf(Text.class, at, () -> "a string was composed " + away);
+        assertTrue(A_CHARACTER_AT_LEAST.has(new Value.Text(wrote.at())),
+                () -> "the value offered is one the declarations admit: " + at);
+        assertTrue(away == Towards.BELOW
+                        ? wrote.at().compareTo("spring") < 0
+                        : wrote.at().compareTo("spring") > 0,
+                () -> "and it is inside the run the item is: " + at + " " + away);
+        return at;
+    }
+
+    /**
+     * A position nothing was read about is offered what the order offers, which is the value against
+     * the line.
+     *
+     * <p>The other half of the same rule, and it is what says the set narrows the search rather than
+     * replacing it. The end the item is named for reads better in a row than anything worked out of a
+     * set, so it is what a position with nothing to say about its values keeps getting.
+     */
+    @Test
+    void aPositionNothingWasReadAboutKeepsWhatTheOrderOffers() {
+        assertEquals(Text.of(""), at(realize(run(Towards.BELOW), admitting(ValueSet.ANY))),
+                "the least string of the order, which is what the run below a line starts at");
+    }
+
+    /** A search that may be handed no answer about the position is one that composes without
+     *  asking, which is the shape this issue was. */
+    @Test
+    void whatThePositionAdmitsIsNotSomethingASearchMayBeHandedNoneOf() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new LevelRealizer().realize(
+                        new Standing.OfOneCoordinate(VALUE, TEXT, run(Towards.BELOW)),
+                        NothingTheRulesSay.REGION, null));
+    }
+
+    /**
+     * A position nothing worked out is said to be one, and not read as unrestricted.
+     *
+     * <p>Three states and the middle one is what this issue was. A rule leaving the position
+     * everything is an answer and comes back as the set of every value; a position this reading
+     * stopped before reaching is not that, and answering it with every value is the defect kept
+     * behind the lookup instead of in front of it. A line can be drawn at a name deeper than the
+     * positions a reading divided, so the third state is one models reach.
+     */
+    @Test
+    void aPositionNothingWorkedOutSaysSoAndIsNotReadAsUnrestricted() {
+        AdmittedValues admitted = AdmittedValues.of(Map.of(CODE, A_CHARACTER_AT_LEAST));
+
+        assertEquals(new AdmittedValues.Admitted.Values(A_CHARACTER_AT_LEAST), admitted.at(CODE));
+        assertTrue(!A_CHARACTER_AT_LEAST.has(REFUSED),
+                "the set under test is the one that refuses the least string of the order");
+        assertEquals(new AdmittedValues.Admitted.NotWorkedOut(),
+                admitted.at(TermPath.of("somewhereElse")),
+                "nothing was read about that position, which is not its rules leaving it every"
+                        + " value");
+    }
+
+    /**
+     * And a boundary at such a position composes nothing rather than a value out of every string.
+     *
+     * <p>Which is the whole point of the middle state reaching this far. Read as unrestricted, the
+     * run below the line would be offered the least string of the order — the same value this issue
+     * is about, arrived at one step further back.
+     */
+    @Test
+    void aBoundaryAtAPositionNothingWorkedOutComposesNothing() {
+        WitnessSearch elsewhere = new WitnessSearch(
+                AdmittedValues.of(Map.of(TermPath.of("somewhereElse"), A_CHARACTER_AT_LEAST)),
+                PatternPlan.Budget.OF_A_WITNESS::meter);
+
+        assertInstanceOf(Realization.Unknown.class, realize(run(Towards.BELOW), elsewhere),
+                "nothing worked out what this position holds, so nothing here composes a value at"
+                        + " it");
+    }
+
+    /**
+     * A number taken of the position is not one of its values, so the set is not put to it.
+     *
+     * <p>{@code String.length(code)} counts a string and the place composed for a boundary on it is a
+     * count; the set holds the strings. Put to it, every count is refused for not being one of them
+     * and a boundary on a length stops being offered a row — which is what happened when this was
+     * wired by the position alone. The location the set is keyed by is where a value answering the
+     * number is written, and that is not where the number itself stands.
+     */
+    @Test
+    void aNumberTakenOfThePositionIsNotHeldToTheSetOfItsValues() {
+        NumericTerm.FromOnePosition length = NumericTerm.TakenOf.of(
+                ValueName.Stdlib.operation("String", "length"), CODE,
+                souther.compiler.types.Type.Prim.STRING,
+                souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
+
+        assertEquals(CODE, length.position(),
+                "both numbers of the location are read from the one location");
+        Realization made = new LevelRealizer().realize(
+                new Standing.OfOneCoordinate(length, new Carrier.Whole(),
+                        new Criterion.Within(new Band(Band.endAt(null, null, Towards.ABOVE),
+                                Band.endAt(null, null, Towards.BELOW)), null, Towards.ABOVE)),
+                NothingTheRulesSay.REGION, admitting(A_CHARACTER_AT_LEAST));
+
+        assertInstanceOf(Realization.Found.class, made,
+                "a count is composed for a boundary on a length, and the strings the position holds"
+                        + " are not what says whether one is");
+    }
+
+    private static Place at(Realization made) {
+        Realization.Found found = assertInstanceOf(Realization.Found.class, made,
+                "the run holds values the declarations leave, so a row stands somewhere in it");
+        return found.fixing().get(new RealizationTarget.AtOnePosition(VALUE));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
@@ -200,7 +200,8 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
                 "the standing carries the order each position's number is measured on, which is"
                         + " what the search writes a value back on");
         assertInstanceOf(Realization.Found.class,
-                new LevelRealizer().realize(standing, region()),
+                new LevelRealizer().realize(standing, region(),
+                        NothingTheDeclarationsRefuse.at()),
                 "a difference of two and a half is reached by a decimal and a whole number, and by"
                         + " no two whole numbers");
     }
@@ -228,7 +229,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
         Realization made = new LevelRealizer().realize(
                 over.standingAt(
                         new Criterion.AtTheLevel(new Level.ACount(Count.of(BigDecimal.ONE)))),
-                region());
+                region(), NothingTheDeclarationsRefuse.at());
 
         assertInstanceOf(Realization.Found.class, made,
                 "a level the rules leave a row at is not a level nothing stands at");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
@@ -126,7 +126,8 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
         Standing standing = over.standingAt(
                 new Criterion.AtTheLevel(new Level.ACount(Count.of(100000))));
 
-        Realization made = new LevelRealizer().realize(standing, NothingTheRulesSay.REGION);
+        Realization made = new LevelRealizer().realize(standing, NothingTheRulesSay.REGION,
+                NothingTheDeclarationsRefuse.at());
 
         assertEquals(new Realization.Found(
                         Map.of(new RealizationTarget.OverARun(TOTAL), Count.of(100000))),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AQuotientNoDecimalWritesIsAProofAndNotAGivingUpTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AQuotientNoDecimalWritesIsAProofAndNotAGivingUpTest.java
@@ -63,7 +63,8 @@ class AQuotientNoDecimalWritesIsAProofAndNotAGivingUpTest {
                 LevelSpace.overFiniteDecimals(new BigDecimal("3")),
                 new Criterion.AtTheLevel(new Level.ACount(Count.of(BigDecimal.ONE))));
 
-        assertInstanceOf(Realization.Impossible.class, new LevelRealizer().realize(aThird, region()));
+        assertInstanceOf(Realization.Impossible.class, new LevelRealizer().realize(aThird, region(),
+                        NothingTheDeclarationsRefuse.at()));
     }
 
     /** And one it does reach comes back as the row rather than as a proof, so the check above is not
@@ -77,7 +78,8 @@ class AQuotientNoDecimalWritesIsAProofAndNotAGivingUpTest {
                 LevelSpace.overFiniteDecimals(new BigDecimal("3")),
                 new Criterion.AtTheLevel(new Level.ACount(Count.of(new BigDecimal("6")))));
 
-        assertInstanceOf(Realization.Found.class, new LevelRealizer().realize(aWhole, region()));
+        assertInstanceOf(Realization.Found.class, new LevelRealizer().realize(aWhole, region(),
+                        NothingTheDeclarationsRefuse.at()));
     }
 
     private static NumericTerm value(String field) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunBesideALineReachesTheNextAndDropsItsOwnValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunBesideALineReachesTheNextAndDropsItsOwnValueTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Towards;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A run beside a line reaches the next line and holds the value there; what it drops is the value of
+ * the line it is named for.
+ *
+ * <p>Which is what {@link Criterion.Within} is: a band, less the one level this point is against
+ * ({@code band.region().without(except)}). So of two lines at two and at five, the point away from
+ * the first is `2 < n <= 5` and five is in it, and the point away from the second is `2 <= n < 5`
+ * and two is in it. There is no rule taking the far value out, and nothing that searches for a row
+ * may act as though there were — {@link Criterion#region} is the whole of what an item means and
+ * {@code anchor} says where to start looking and never what satisfies the item.
+ *
+ * <p><b>One row answering two items is not two readings of one item.</b> A row at five stands at the
+ * point on the line at five and inside the run above two, and both are owed: what tells two items
+ * apart is what each demands, which is why a level and a run one value wide are separate demands that
+ * the same rows happen to hold ({@link Criterion#sameAs}). Read the other way — the far value taken
+ * out so that each row answers one item — a band would mean one thing to the arrangement that builds
+ * it and another to the search that fills it, which is the pair of geometries this type exists to
+ * keep as one (issue #880).
+ *
+ * <p>Written against the criteria rather than against a report, because this is the geometry. What a
+ * search manages to compose in one of these runs moves as the search learns to look further, and this
+ * says what the runs are whichever way that goes.
+ */
+class ARunBesideALineReachesTheNextAndDropsItsOwnValueTest {
+
+    private static final Carrier WHOLE = new Carrier.Whole();
+
+    private static Level at(long number) {
+        return new Level.OnACarrier(WHOLE, Count.of(number));
+    }
+
+    /**
+     * The run one of the lines leaves, in the shape the report arrives with.
+     *
+     * <p>The band is what the rules leave the position — both ends the declaration's own, held — and
+     * the point away from a line is that band less the value the line stands at. Nothing parts the
+     * band here, which is what {@code invariant n == 2 || n == 5} comes to: the two named values are
+     * the ends of what the position holds, and each is a line a row is owed at.
+     */
+    private static Criterion.Within besideTheLineAt(long named, Towards away) {
+        Band band = new Band(Band.endAt(null, Bound.at(at(2), true), Towards.ABOVE),
+                Band.endAt(null, Bound.at(at(5), true), Towards.BELOW));
+        return new Criterion.Within(band, at(named), away);
+    }
+
+    @Test
+    void theRunAboveALineHoldsTheValueAtTheNextLine() {
+        Criterion aboveTwo = besideTheLineAt(2, Towards.ABOVE);
+
+        assertTrue(aboveTwo.holds(at(5)),
+                "five is where this run stops and it stops there holding it: the rules part the"
+                        + " values at five and nothing takes five out of the run below it");
+        assertFalse(aboveTwo.holds(at(2)),
+                "and two is the value this point is named against, which is the one it drops");
+    }
+
+    /** And the run below the other line, which is the same sentence the other way round. */
+    @Test
+    void theRunBelowALineHoldsTheValueAtTheLineBeforeIt() {
+        Criterion belowFive = besideTheLineAt(5, Towards.BELOW);
+
+        assertTrue(belowFive.holds(at(2)), "two is where this run starts and it starts there"
+                + " holding it");
+        assertFalse(belowFive.holds(at(5)), "and five is the value it drops");
+    }
+
+    /**
+     * What each run is called, which is the same reading the report writes.
+     *
+     * <p>Held beside the membership above so that the label and the set cannot come apart: a run
+     * spelled as reaching the next line while holding nothing there would tell an author to write a
+     * row at a value the item refuses.
+     */
+    @Test
+    void theLabelSaysWhichEndEachRunKeeps() {
+        assertTrue(besideTheLineAt(2, Towards.ABOVE).region()
+                        .contains(at(5)),
+                "the run named for two keeps five");
+        assertTrue(besideTheLineAt(5, Towards.BELOW).region()
+                        .contains(at(2)),
+                "and the run named for five keeps two");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/NothingTheDeclarationsRefuse.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/NothingTheDeclarationsRefuse.java
@@ -1,0 +1,32 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.TermPath;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.values.ValueSet;
+
+import java.util.Map;
+
+/**
+ * Positions that hold every value there is, for tests about what a search does on its own.
+ *
+ * <p>The companion of {@link NothingTheRulesSay}, and here for the same reason: a test handing over
+ * sets that say something is testing the sets as well as the reader, and a reader that came back
+ * empty-handed would leave which of the two answered unsaid.
+ *
+ * <p>Said per position rather than answered for any position asked about. A fixture that answered for
+ * every path would let a test pass while the thing under test looks up a position nobody wired, which
+ * is the state {@link AdmittedValues} exists to refuse.
+ */
+final class NothingTheDeclarationsRefuse {
+
+    private NothingTheDeclarationsRefuse() {}
+
+    /** A search over these positions, each of them holding every value of its order. */
+    static WitnessSearch at(TermPath... positions) {
+        Map<TermPath, ValueSet> sets = new java.util.LinkedHashMap<>();
+        for (TermPath each : positions) {
+            sets.put(each, ValueSet.ANY);
+        }
+        return new WitnessSearch(AdmittedValues.of(sets), PatternPlan.Budget.OF_A_WITNESS::meter);
+    }
+}

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.generated.txt
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.generated.txt
@@ -14,8 +14,6 @@ example redeem
     | "party=4 < x <= 8"  : (Voucher("spring"), Party(5)) -> <?>
     | (Voucher("x"), Party(2))                            -> <?>
     | (Voucher("x"), Party(8))                            -> <?>
-// no row for `voucher < spring` in `redeem`: every value tried was refused at construction, which does not make the combination impossible
-// no row for `spring < voucher` in `redeem`: nothing here could build a representative for it, which does not make one unwritable
 // no row for `party = 4` in `redeem`: no row composed for it was seen reaching it, which does not make it unreachable
 // no row for `party = 5` in `redeem`: no row composed for it was seen reaching it, which does not make it unreachable
 // no row for `1 <= party < 4` in `redeem`: no row composed for it was seen reaching it, which does not make it unreachable

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/booking/expected.report.json
@@ -1314,7 +1314,7 @@
             "relation" : "in",
             "against" : "voucher < spring",
             "knownWritable" : true,
-            "writableBecause" : [ "the_rules_prove_it" ],
+            "writableBecause" : [ "the_rules_prove_it", "a_value_was_built" ],
             "status" : "unavailable",
             "reason" : "no_rows"
           }, {
@@ -1326,7 +1326,7 @@
             "relation" : "in",
             "against" : "spring < voucher",
             "knownWritable" : true,
-            "writableBecause" : [ "the_rules_prove_it" ],
+            "writableBecause" : [ "the_rules_prove_it", "a_value_was_built" ],
             "status" : "unavailable",
             "reason" : "no_rows"
           } ]
@@ -1617,7 +1617,7 @@
           },
           "relation" : "in",
           "knownWritable" : true,
-          "writableBecause" : [ "the_rules_prove_it" ],
+          "writableBecause" : [ "the_rules_prove_it", "a_value_was_built" ],
           "status" : "unavailable",
           "reason" : "no_rows",
           "disposition" : "undecided",
@@ -1678,7 +1678,7 @@
           },
           "relation" : "in",
           "knownWritable" : true,
-          "writableBecause" : [ "the_rules_prove_it" ],
+          "writableBecause" : [ "the_rules_prove_it", "a_value_was_built" ],
           "status" : "unavailable",
           "reason" : "no_rows",
           "disposition" : "undecided",


### PR DESCRIPTION
Fixes what #1581 reports, and settles the semantics #1615 asks about.

A boundary beside a line was offered a value worked out from the run of the number it is
on and from nothing else. A rule about another number of the same position — the length of
a string whose order the line is drawn on — is in neither the run nor the region the search
is held to. So the run named the least string of the order, the declarations refused it
where the row was built, and the report said every value had been tried of a run holding
all but one of them. On the other side of the line the run named no value at all and the
admitted strings had one to name there.

## What changed

What the position admits travels beside the region as `WitnessSearch`, keyed by the
location a value answering the number is written at — so the two numbers of one location
share the one answer rather than holding a copy each.

The end the item is named for is still tried first: it reads beside the line, and a
position whose rules say nothing about its values is the common case. Where every such end
is refused, the run is crossed with the set, which answers exactly. That is the arrangement
`Carrier.somethingOtherThan` is already under.

`Criterion` keeps no set of values. The runs an item leaves are its own to say, so they are
read once in `runsInside` and shared by the caller that wants a value and the caller that
wants all of them; what the declarations leave a position is a different question and stays
outside. `SearchRegion` stays arithmetic. The semantic answer and the search allowance are
also apart, which is why `WitnessSearch` pairs them rather than folding one into the other.

A number taken of the position is not held to the set. A count of a string's length is not
one of the strings, and putting the set to it refused every count.

## Three states, not two

A position whose rules leave it everything answers with every value. A position this
reading stopped before reaching says so, and a boundary there composes nothing rather than
a value out of a set nobody established. That state is reached by models somebody writes: a
line can be drawn at a name deeper than the positions a reading divided, which
`ALineDrawnOnASharedNameFallsUnderEachCaseTest` already writes down. Read as "everything",
the defect this fixes would move one step further back.

## What is checked

`ABoundaryBesideALineStandsAtAValueThePositionAdmitsTest` holds either side of the line to
a value the declarations leave, without naming which value — what a set and a run come to
between them is the crossing's answer. It also holds the three states, and that a boundary
on a length still composes a count. Reverting the search to the run alone reddens each side
on its own.

`ARunBesideALineReachesTheNextAndDropsItsOwnValueTest` writes down the geometry #1615 asks
about, against the criteria rather than against a report: a run beside a line reaches the
next line and holds the value there, and drops the value of the line it is named for.
Taking the `except` away reddens both halves.

## Two expectations move with it

`AChoiceOfBoundsLeavesTheLineTheAlternativesLeaveTest` said the runs between two named
values hold no value. The runs are closed at the far end, so each holds one of those values
and a row at it is a row in the run — which is what `Criterion.Within` means and what
`criterion.holds` says. The stale clause is replaced by the runs the lines leave, named.
That one row answers two items is two demands one row satisfies, which `Criterion.sameAs`
already says about a level and a run one value wide.

`ABorderSaysWhyItOwesNoRowAtAPointTest` asserted that nothing could build a representative
for a side of a line between two strings. One can, and the sentence it pinned is this
compiler's own limit rather than a fact about the model. What the test is for survives and
is now read off the offered rows rather than off one spelling of one pair: no row offered at
a strict side stands on the line, whichever pair the search composes. The points it reads
are counted, so it cannot pass by having nothing to look at.

## Beside the change

`LevelRealizer` had a pattern variable Checkstyle refuses. It is unrelated to this and is
fixed here because the commit hook reads the whole staged file.

The booking corpus loses the two sentences this issue is about and gains no rows: the values
now composed are already offered by rows in the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)