### PR TITLE
Say a fork as the choice it is, and not as a composition

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest.java
+++ b/souther-bench/src/test/java/souther/bench/AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest.java
@@ -61,7 +61,15 @@ class AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest {
             "souther.compiler.check.Conditions#settledBy", "what choosing the arm states, as"
                     + " relations",
             "souther.compiler.check.InvariantChecker#opening", "what a walk over paths reads of it:"
-                    + " the node it asks, and where choosing the arm puts the reading"));
+                    + " the node it asks, and where choosing the arm puts the reading",
+            "souther.compiler.check.ValueOrigin#decidedBy", "which expressions a reading of the"
+                    + " choice depends on. Not what choosing an arm binds or settles, and not read"
+                    + " off the fork: the node a value is one of several at says which several, and"
+                    + " what each of them turns on is said per arm",
+            "souther.compiler.inputs.InputReads#choosing", "the same question Terms#chose answers,"
+                    + " in the vocabulary a reading of the inputs speaks. Two readings of one body"
+                    + " name a position in two ways and each owns what a name means to it, as they"
+                    + " do for a let's binding"));
 
     @Test
     void everyReaderOfHowAnArmWasDecidedNamesEveryWayThereIs() throws IOException {

--- a/souther-compiler/src/main/java/souther/compiler/check/Choice.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Choice.java
@@ -56,12 +56,12 @@ import java.util.List;
  * {@link Decides} by the reader that opens splits, which has an arm per way of deciding and stops at
  * the ways it does not open.
  */
-record Choice(Kind kind, List<Arm> arms) {
+public record Choice(Kind kind, List<Arm> arms) {
 
     /** What is being chosen between, for a reader whose answer differs by which it is. Named after
      * what decides the choice rather than after the syntax, since that is what a reader wanting more
      * than the values is asking about. */
-    enum Kind {
+    public enum Kind {
 
         /** A condition decides, and the values are its two branches. */
         A_CONDITION,
@@ -79,13 +79,13 @@ record Choice(Kind kind, List<Arm> arms) {
     }
 
     /** One value a choice may answer, and the node that decides it is the one. */
-    record Arm(Core answers, Decides decidedBy) {}
+    public record Arm(Core answers, Decides decidedBy) {}
 
     /** Two values standing in a relation, as the values themselves. What a case of a library
      * definition is reached under, lowered out of the table's own way of naming an argument: a
      * reader below this asks what the relation says of two values, and not which position of which
      * call they arrived at. */
-    record ArgumentRelation(Core left, Rel rel, Core right) {}
+    public record ArgumentRelation(Core left, Rel rel, Core right) {}
 
     /**
      * What decides one arm, as the node that decides it.
@@ -94,7 +94,7 @@ record Choice(Kind kind, List<Arm> arms) {
      * that held and an attempt that departed are decided by different things and settle different
      * things, so a reader treating them alike would have to tell them apart again.
      */
-    sealed interface Decides {
+    public sealed interface Decides {
 
         /** The condition held, or it did not. */
         record ACondition(Core cond, boolean holding) implements Decides {}
@@ -128,7 +128,7 @@ record Choice(Kind kind, List<Arm> arms) {
         }
     }
 
-    Choice {
+    public Choice {
         arms = List.copyOf(arms);
         if (arms.isEmpty()) {
             throw new IllegalArgumentException(kind + " is a value that is one of several and it was"
@@ -147,7 +147,7 @@ record Choice(Kind kind, List<Arm> arms) {
      * {@code if} has in common is being one of two; what a call answers depends on the operation,
      * and for all but a few of them it is one value.
      */
-    static Choice of(Core e) {
+    public static Choice of(Core e) {
         return switch (e) {
             case Core.If iff -> new Choice(Kind.A_CONDITION, List.of(
                     new Arm(iff.then(), new Decides.ACondition(iff.cond(), true)),

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -604,14 +604,20 @@ public final class FieldDomains {
      * @param wrote     where the author wrote it, for whoever reports about the clause. A position
      *                  and not the expression, so there is nothing here to read a meaning off a
      *                  second time
+     * @param root      the clause this conjunct was read out of. Carried because a reader below
+     *                  asks whether an expression answers a value, which is rooted: the sides of
+     *                  the comparison are what a binding above them is evaluated before, and read
+     *                  as trees of their own they have that name free. Not a meaning to read off a
+     *                  second time — nothing here reads the tree, and whoever asks the rooted
+     *                  question needs to be able to name it
      */
     public record WithoutAnEnd(InvariantStatementId statement, StatedComparison states,
-                               SourcePos wrote) {
+                               SourcePos wrote, Core root) {
 
         public WithoutAnEnd {
-            if (statement == null || states == null || wrote == null) {
-                throw new IllegalArgumentException(
-                        "a conjunct handed on is some clause's comparison, written somewhere");
+            if (statement == null || states == null || wrote == null || root == null) {
+                throw new IllegalArgumentException("a conjunct handed on is some clause's"
+                        + " comparison, written somewhere, read out of that clause");
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -16,6 +16,7 @@ import souther.compiler.numeric.NumericDomain;
 import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.core.Evaluated;
+import souther.compiler.coverage.Arrivals;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.InvariantMessage;
@@ -2790,6 +2791,10 @@ public final class InvariantChecker {
      */
     private Places placesIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName) {
         Map<RuleKey, Coordinate> met = new LinkedHashMap<>();
+        // A clause of a declaration stands in no body — it is checked whenever a value is built,
+        // and nothing is on the way to it — so what this walk is handed is a tree with nothing
+        // above it.
+        Arrivals answering = Arrivals.whereNothingStandsAbove();
         ValueOrigin<RuleKey> origin = ValueOrigin.of(e, at,
                 new ValueOrigin.Reading<RuleKey, Denotations>() {
 
@@ -2851,6 +2856,13 @@ public final class InvariantChecker {
                 Terms.Chose chose = terms.chose(decidedBy, where);
                 return chose.opened() == null ? new ValueOrigin.Opened.Entered<>(chose.at())
                         : new ValueOrigin.Opened.NotEntered<>();
+            }
+
+            /** Whether an expression answers a value, of the tree this reading was made for, as
+             *  for a body's reading next door. */
+            @Override
+            public boolean answers(Core here, Denotations where) {
+                return answering.at(here);
             }
         });
         return new Places(origin, met);

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2261,7 +2261,7 @@ public final class InvariantChecker {
         // places no end (ADR-0090). The reader already knows: the reason it records for such a
         // comparison is `ComparisonBetweenPositions`.
         if (about != null && numbered.claim() instanceof ComparisonClaim.Cut
-                && coordinatesIn(numbered.other(), at, byName).isEmpty()
+                && coordinatesIn(numbered.other(), at, byName, Arrivals.inTheTree(bin)).isEmpty()
                 && shape instanceof ClauseStates.SomethingElse named) {
             Set<RuleKey> names = new LinkedHashSet<>(named.named());
             // The name the bound sits at, which the walk over the comparison writes anyway. Added
@@ -2546,7 +2546,8 @@ public final class InvariantChecker {
             // would say — and every number the leaf writes about is one waiting on that reading,
             // the numbers an operation answers among them.
             case CanonicalForm.NotRead _ -> {
-                Coordinate against = heldAgainstAConstant(bin, at, byName);
+                Coordinate against =
+                        heldAgainstAConstant(bin, at, byName, Arrivals.inTheTree(bin));
                 yield against == null ? ELSEWHERE : statedOn(against);
             }
             // The positions cancelled, and what is left is a number against a number. Asked of the
@@ -2578,13 +2579,16 @@ public final class InvariantChecker {
      * narrower one.
      */
     private Coordinate heldAgainstAConstant(Core.Binary bin, Denotations at,
-                                            Map<FactSubject, Coordinate> byName) {
+                                            Map<FactSubject, Coordinate> byName,
+                                            Arrivals answering) {
         Coordinate left = byName.get(nameOf(bin.left(), at));
         Coordinate right = byName.get(nameOf(bin.right(), at));
-        if (left != null && right == null && coordinatesIn(bin.right(), at, byName).isEmpty()) {
+        if (left != null && right == null
+                && coordinatesIn(bin.right(), at, byName, answering).isEmpty()) {
             return left;
         }
-        if (right != null && left == null && coordinatesIn(bin.left(), at, byName).isEmpty()) {
+        if (right != null && left == null
+                && coordinatesIn(bin.left(), at, byName, answering).isEmpty()) {
             return right;
         }
         return null;
@@ -2628,8 +2632,12 @@ public final class InvariantChecker {
     private ClauseStates states(Core clause, Denotations at,
                                 Map<FactSubject, Coordinate> byName, CanonicalForm read,
                                 RunsRead runs) {
+        // Whether an expression answers a value, of this clause. A clause stands in no body, so it
+        // is the root; the nodes under it are read where they stand, a binding above one of them
+        // being evaluated before it.
+        Arrivals answering = Arrivals.inTheTree(clause);
         List<RuleKey> found = new ArrayList<>();
-        namedIn(clause, at, byName, found);
+        namedIn(clause, at, byName, answering, found);
         // What the rule cuts, ahead of what it looks like. Which values a rule restricts is settled
         // by the quantity its canonical form cuts, and that is the rule `UnreadComparison.why` is
         // written around one layer down — asked of what the rule cuts, and of the sides only where
@@ -2658,7 +2666,7 @@ public final class InvariantChecker {
             return new ClauseStates.ARelation();
         }
         SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> stopped =
-                stoppedOnTheFormOf(found, read, byName);
+                stoppedOnTheFormOf(found, read, byName, answering);
         // And where whether it states one was not worked out, the question stands with no answer.
         // Left out, a limit of this compiler would come out as a rule that raises no such question,
         // which is what a rule read to the end and stating no bound comes out as.
@@ -2695,7 +2703,8 @@ public final class InvariantChecker {
      * answer about.
      */
     private SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> stoppedOnTheFormOf(
-            List<RuleKey> found, CanonicalForm read, Map<FactSubject, Coordinate> byName) {
+            List<RuleKey> found, CanonicalForm read, Map<FactSubject, Coordinate> byName,
+            Arrivals answering) {
         SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> out = new LinkedHashMap<>();
         // Only a rule that orders the values. An equality singles one out and puts no end anywhere,
         // which is what it states and not what a reading of it managed — so however little of the
@@ -2710,7 +2719,7 @@ public final class InvariantChecker {
         // here as separate readings of separate comparisons, which is why this is asked per name
         // rather than said once of the clause.
         BlockReason.RuleReadingStopped why = UnreadComparison.notAboutOwnValues(
-                placesIn(stopped.stoppedAt(), stopped.under(), byName).origin());
+                placesIn(stopped.stoppedAt(), stopped.under(), byName, answering).origin());
         found.forEach(each -> out.put(each, List.of(why)));
         return out;
     }
@@ -2724,8 +2733,8 @@ public final class InvariantChecker {
      * it is a coordinate of its own.
      */
     private void namedIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName,
-                         List<RuleKey> out) {
-        for (Coordinate each : coordinatesIn(e, at, byName)) {
+                         Arrivals answering, List<RuleKey> out) {
+        for (Coordinate each : coordinatesIn(e, at, byName, answering)) {
             if (!out.contains(each.path())) {
                 out.add(each.path());
             }
@@ -2741,8 +2750,9 @@ public final class InvariantChecker {
      * its values are ordered on, and a count is ordered as a whole number whatever it counts.
      */
     private List<Coordinate> coordinatesIn(Core e, Denotations at,
-                                           Map<FactSubject, Coordinate> byName) {
-        Places places = placesIn(e, at, byName);
+                                           Map<FactSubject, Coordinate> byName,
+                                           Arrivals answering) {
+        Places places = placesIn(e, at, byName, answering);
         List<Coordinate> out = new ArrayList<>();
         for (RuleKey path : places.origin().positions()) {
             out.add(places.met().get(path));
@@ -2758,9 +2768,11 @@ public final class InvariantChecker {
      * walk reached through a value the readers below have no reason to hold.
      */
     private List<Coordinate> coordinatesIn(StatedComparison comparison, Denotations at,
-                                           Map<FactSubject, Coordinate> byName) {
-        List<Coordinate> out = new ArrayList<>(coordinatesIn(comparison.left(), at, byName));
-        out.addAll(coordinatesIn(comparison.right(), at, byName));
+                                           Map<FactSubject, Coordinate> byName,
+                                           Arrivals answering) {
+        List<Coordinate> out =
+                new ArrayList<>(coordinatesIn(comparison.left(), at, byName, answering));
+        out.addAll(coordinatesIn(comparison.right(), at, byName, answering));
         return out;
     }
 
@@ -2789,12 +2801,9 @@ public final class InvariantChecker {
      * shape are taken apart the same way. What is this reader's own is the lookup: a clause names a
      * coordinate of the value it is written about, where a body names a position of an input.
      */
-    private Places placesIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName) {
+    private Places placesIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName,
+                            Arrivals answering) {
         Map<RuleKey, Coordinate> met = new LinkedHashMap<>();
-        // A clause of a declaration stands in no body — it is checked whenever a value is built,
-        // and nothing is on the way to it — so what this walk is handed is a tree with nothing
-        // above it.
-        Arrivals answering = Arrivals.whereNothingStandsAbove();
         ValueOrigin<RuleKey> origin = ValueOrigin.of(e, at,
                 new ValueOrigin.Reading<RuleKey, Denotations>() {
 
@@ -2904,14 +2913,16 @@ public final class InvariantChecker {
             return;
         }
         StatedComparison comparison = read.comparison();
-        Places left = placesIn(comparison.left(), at, byName);
-        Places right = placesIn(comparison.right(), at, byName);
+        // The clause is the root, as it is where what this clause names is worked out.
+        Arrivals answering = Arrivals.inTheTree(clause);
+        Places left = placesIn(comparison.left(), at, byName, answering);
+        Places right = placesIn(comparison.right(), at, byName, answering);
         Predicate<RuleKey> ordered = place -> carrierAt(place, left, right) != null;
         Map<RuleKey, Coordinate> met = new LinkedHashMap<>();
-        for (Coordinate each : coordinatesIn(comparison, at, byName)) {
+        for (Coordinate each : coordinatesIn(comparison, at, byName, answering)) {
             met.putIfAbsent(each.path(), each);
         }
-        switch (cuts(read, byName)) {
+        switch (cuts(read, byName, answering)) {
             case UnreadComparison.Quantity.Read<RuleKey> quantity -> {
                 BlockReason.RuleWithoutLineReason why =
                         UnreadComparison.ofTheQuantity(quantity, ordered);
@@ -3468,10 +3479,11 @@ public final class InvariantChecker {
      * two accounts and the answer would be inside the thing it is an answer about.
      */
     private UnreadComparison.Quantity<RuleKey> cuts(CanonicalForm form,
-                                                    Map<FactSubject, Coordinate> byName) {
+                                                    Map<FactSubject, Coordinate> byName,
+                                                    Arrivals answering) {
         return switch (form) {
             case CanonicalForm.NotRead it -> new UnreadComparison.Quantity.NotRead<>(
-                    placesIn(it.stoppedAt(), it.under(), byName).origin());
+                    placesIn(it.stoppedAt(), it.under(), byName, answering).origin());
             case CanonicalForm.CutsNothing _ -> new UnreadComparison.Quantity.CutsNothing<>();
             case CanonicalForm.Over it -> it.positions().size() == 1
                     ? new UnreadComparison.Quantity.OverOne<>(it.positions().iterator().next())

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2169,6 +2169,11 @@ public final class InvariantChecker {
         // no line and was about no number, while the reading that turns clauses into sets read it
         // perfectly well.
         Core clause = said.of();
+        // Whether an expression answers a value, of the clause this part was read out of. The root
+        // and not the part: a binding is crossed before this, and the part under it is one the
+        // binding is evaluated before — read as a root of its own, the name that binding gave would
+        // be free and an arm depending on it would answer a value the clause never comes to.
+        Arrivals answering = Arrivals.inTheTree(of.clause());
         // What a rule about the strings at a position says about where they stop, which is a rule
         // of this conjunct as much as an ordering written here is. Beside the reading of
         // comparisons and not inside it: what such a rule states is not a comparison and has no
@@ -2198,7 +2203,8 @@ public final class InvariantChecker {
             // to be handed: what is below reads a clause for the end it places on a position and
             // for which declarations narrowed that position, and neither is a thing another shape
             // of rule states.
-            settle(clause, from, of, statement, said.at(), states(clause, at, byName, null, runs),
+            settle(clause, from, of, statement, said.at(),
+                    states(clause, at, byName, null, answering, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             return;
@@ -2225,7 +2231,8 @@ public final class InvariantChecker {
         StatedComparison.Numbered<Coordinate> numbered =
                 comparison.at(each -> byName.get(nameOf(each, at)));
         if (asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
-            settle(bin, from, of, statement, said.at(), states(bin, at, byName, read, runs),
+            settle(bin, from, of, statement, said.at(),
+                    states(bin, at, byName, read, answering, runs),
                     new InvariantBound.Read.NoEnd(),
                     byName, raised, took, raisedByPart);
             // And handed on, which is not the same as being reported. A rule that rules one value
@@ -2233,7 +2240,8 @@ public final class InvariantChecker {
             // author to lift and there is a conjunct for the reading that draws lines to make what
             // it can of.
             withoutAnEnd.putIfAbsent(new HandOver(statement),
-                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos()));
+                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos(),
+                            of.clause()));
             return;
         }
         // An end where the other side is a constant, and a relation everywhere else. Which it is
@@ -2253,7 +2261,7 @@ public final class InvariantChecker {
         // What the clause is about, asked of the comparison and not of what `end` came to. A
         // coordinate compared for order against something naming no other coordinate states where
         // the values stop, whether or not the number on the other side is one this could fold.
-        ClauseStates shape = states(bin, at, byName, read, runs);
+        ClauseStates shape = states(bin, at, byName, read, answering, runs);
         // And nothing of this value on the other side. `ARelation` is only what
         // `Relates.twoPositions` recognises, which wants each whole side to be a position — so
         // `width <= height + 1` is not one, and read as a bound it raised a question about where
@@ -2261,7 +2269,7 @@ public final class InvariantChecker {
         // places no end (ADR-0090). The reader already knows: the reason it records for such a
         // comparison is `ComparisonBetweenPositions`.
         if (about != null && numbered.claim() instanceof ComparisonClaim.Cut
-                && coordinatesIn(numbered.other(), at, byName, Arrivals.inTheTree(bin)).isEmpty()
+                && coordinatesIn(numbered.other(), at, byName, answering).isEmpty()
                 && shape instanceof ClauseStates.SomethingElse named) {
             Set<RuleKey> names = new LinkedHashSet<>(named.named());
             // The name the bound sits at, which the walk over the comparison writes anyway. Added
@@ -2307,12 +2315,13 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            noLineDrawn(read, bin, part, at, byName, noLines);
+            noLineDrawn(read, bin, part, at, byName, answering, noLines);
             // The hand-over beside the finding, and not read off it. Both come of this conjunct
             // having no end, and they answer different questions: what an author is owed a word
             // about, and what the next reading is given to read.
             withoutAnEnd.putIfAbsent(new HandOver(statement),
-                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos()));
+                    new FieldDomains.WithoutAnEnd(statement, comparison, said.written().pos(),
+                            of.clause()));
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -2395,7 +2404,10 @@ public final class InvariantChecker {
                 // The one number the rule is over, which is the same answer the attribution of an
                 // end to a conjunct is put forward on. A rule over several is a line between them
                 // and an end at none, so it puts nothing forward.
-                return switch (lineStatedIn(it.of(), it.positive(), at, byName)) {
+                // The clause this leaf was read out of does not reach here either, and what is
+                // asked is which number the rule is over rather than which arms it may come to.
+                return switch (lineStatedIn(it.of(), it.positive(), at, byName,
+                        Arrivals.everyArmIsTakenForAValue())) {
                     case StatedLines.Statement.OnWhatStandsAtAPosition found ->
                             Set.of(found.number());
                     case StatedLines.Statement.OnADerivedNumber found ->
@@ -2445,7 +2457,11 @@ public final class InvariantChecker {
 
             @Override
             public StatedLines.Statement of(Core leaf, boolean positive, Denotations at) {
-                return lineStatedIn(leaf, positive, at, byName);
+                // One reader over however many clauses reach this value, handed a leaf and not the
+                // clause it was read out of — so there is no tree here to root a reading of
+                // arrivals at, and the part is the one thing it must not be rooted at.
+                return lineStatedIn(leaf, positive, at, byName,
+                        Arrivals.everyArmIsTakenForAValue());
             }
 
             @Override
@@ -2512,7 +2528,8 @@ public final class InvariantChecker {
      * looked for a name spelled as a whole side would call it a rule about nothing.
      */
     private StatedLines.Statement lineStatedIn(Core leaf, boolean positive, Denotations at,
-                                               Map<FactSubject, Coordinate> byName) {
+                                               Map<FactSubject, Coordinate> byName,
+                                               Arrivals answering) {
         if (!(leaf instanceof Core.Binary bin)) {
             return NO_LINE;
         }
@@ -2547,7 +2564,7 @@ public final class InvariantChecker {
             // the numbers an operation answers among them.
             case CanonicalForm.NotRead _ -> {
                 Coordinate against =
-                        heldAgainstAConstant(bin, at, byName, Arrivals.inTheTree(bin));
+                        heldAgainstAConstant(bin, at, byName, answering);
                 yield against == null ? ELSEWHERE : statedOn(against);
             }
             // The positions cancelled, and what is left is a number against a number. Asked of the
@@ -2631,11 +2648,7 @@ public final class InvariantChecker {
      */
     private ClauseStates states(Core clause, Denotations at,
                                 Map<FactSubject, Coordinate> byName, CanonicalForm read,
-                                RunsRead runs) {
-        // Whether an expression answers a value, of this clause. A clause stands in no body, so it
-        // is the root; the nodes under it are read where they stand, a binding above one of them
-        // being evaluated before it.
-        Arrivals answering = Arrivals.inTheTree(clause);
+                                Arrivals answering, RunsRead runs) {
         List<RuleKey> found = new ArrayList<>();
         namedIn(clause, at, byName, answering, found);
         // What the rule cuts, ahead of what it looks like. Which values a rule restricts is settled
@@ -2908,13 +2921,12 @@ public final class InvariantChecker {
      */
     private void noLineDrawn(CanonicalForm read, Core clause, PartId<RuleRef.Invariant> part,
                             Denotations at,
-                            Map<FactSubject, Coordinate> byName, List<FieldDomains.NoLine> out) {
+                            Map<FactSubject, Coordinate> byName, Arrivals answering,
+                            List<FieldDomains.NoLine> out) {
         if (!(read.comparison().claim() instanceof ComparisonClaim.Cut)) {
             return;
         }
         StatedComparison comparison = read.comparison();
-        // The clause is the root, as it is where what this clause names is worked out.
-        Arrivals answering = Arrivals.inTheTree(clause);
         Places left = placesIn(comparison.left(), at, byName, answering);
         Places right = placesIn(comparison.right(), at, byName, answering);
         Predicate<RuleKey> ordered = place -> carrierAt(place, left, right) != null;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2829,25 +2829,28 @@ public final class InvariantChecker {
             }
 
             /**
-             * And an arm is read where the fork stands, which is this reader declining a reading
-             * it has and not one it lacks ({@link Terms#choosing} would give it).
+             * And an arm that opened a name is one this reader does not go inside, which it says
+             * rather than reading the arm where the fork stands.
              *
              * <p>What a clause is about is one of a pair. The reading of values reads the same
              * conjunct and says which coordinates it constrained, and a coordinate this names that
              * the other never reached is a question standing with nothing to account for it
              * ({@link FieldDomains.AStandingQuestionWithNoAccount}) — which is the two coming
-             * apart, not a fact about the model. That reading does not go inside an arm, so neither
-             * does this one, and a clause whose arm reads what the arm bound names one position
-             * fewer than it is about.
+             * apart, not a fact about the model. That reading does not go inside a name an arm
+             * opened, so neither does this one, and a clause whose arm reads what the arm bound
+             * names one position fewer than it is about.
              *
-             * <p>Declined and not answered wrongly. What comes back for such an arm is a value this
-             * reader can say nothing about, which is what it is here: the name is out of its reach.
-             * A body's reading is not in this position — what the reading of an input holds for an
-             * arm's name is settled for every walk that goes inside one — and it enters.
+             * <p>Which arms those are is {@link Terms}' answer and not a list kept here. It says
+             * what choosing an arm binds and what that arm opened, and an arm that opened nothing
+             * is read where the fork stands by every reader — a condition settles what it settles
+             * wherever it is read, and a departure was taken where nothing was built.
              */
             @Override
-            public Denotations choosing(Choice.Decides decidedBy, Denotations where) {
-                return where;
+            public ValueOrigin.Opened<Denotations> choosing(Choice.Decides decidedBy,
+                                                            Denotations where) {
+                Terms.Chose chose = terms.chose(decidedBy, where);
+                return chose.opened() == null ? new ValueOrigin.Opened.Entered<>(chose.at())
+                        : new ValueOrigin.Opened.NotEntered<>();
             }
         });
         return new Places(origin, met);

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2827,6 +2827,28 @@ public final class InvariantChecker {
             public Denotations inside(Core.LetIn li, Denotations where) {
                 return terms.inside(li, where);
             }
+
+            /**
+             * And an arm is read where the fork stands, which is this reader declining a reading
+             * it has and not one it lacks ({@link Terms#choosing} would give it).
+             *
+             * <p>What a clause is about is one of a pair. The reading of values reads the same
+             * conjunct and says which coordinates it constrained, and a coordinate this names that
+             * the other never reached is a question standing with nothing to account for it
+             * ({@link FieldDomains.AStandingQuestionWithNoAccount}) — which is the two coming
+             * apart, not a fact about the model. That reading does not go inside an arm, so neither
+             * does this one, and a clause whose arm reads what the arm bound names one position
+             * fewer than it is about.
+             *
+             * <p>Declined and not answered wrongly. What comes back for such an arm is a value this
+             * reader can say nothing about, which is what it is here: the name is out of its reach.
+             * A body's reading is not in this position — what the reading of an input holds for an
+             * arm's name is settled for every walk that goes inside one — and it enters.
+             */
+            @Override
+            public Denotations choosing(Choice.Decides decidedBy, Denotations where) {
+                return where;
+            }
         });
         return new Places(origin, met);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -326,6 +326,13 @@ public final class UnreadComparison {
             // position, which is the same rule about a value made from one with a layer of
             // arithmetic over it.
             case ValueOrigin.Composed<K> composed -> composed.madeFrom() != null;
+            // Every value it could be, and not any of them. The word this picks promises the
+            // position was found and only following the operation back is missing; where one arm of
+            // a choice is a position's own values or a literal, that promise is false and what an
+            // author is owed is the other word. What decided the choice is not asked: an operation
+            // over the test made none of the values the rule is about.
+            case ValueOrigin.OneOf<K> choice ->
+                    choice.alternatives().stream().allMatch(UnreadComparison::madeByAnOperation);
             case ValueOrigin.IsAPosition<K> _, ValueOrigin.Written<K> _,
                  ValueOrigin.Unnameable<K> _ -> false;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -331,11 +331,21 @@ public final class UnreadComparison {
             // a choice is a position's own values or a literal, that promise is false and what an
             // author is owed is the other word. What decided the choice is not asked: an operation
             // over the test made none of the values the rule is about.
-            case ValueOrigin.OneOf<K> choice ->
-                    choice.alternatives().stream().allMatch(UnreadComparison::madeByAnOperation);
+            case ValueOrigin.OneOf<K> choice -> everyOneMadeByAnOperation(choice.alternatives());
             case ValueOrigin.IsAPosition<K> _, ValueOrigin.Written<K> _,
                  ValueOrigin.Unnameable<K> _ -> false;
         };
+    }
+
+    /** Whether every value in {@code of} is one an operation made of a position. Stops at the
+     *  first that is not, each answer being a walk of whatever stands under it. */
+    private static <K> boolean everyOneMadeByAnOperation(List<ValueOrigin<K>> of) {
+        for (ValueOrigin<K> each : of) {
+            if (!madeByAnOperation(each)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private UnreadComparison() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -333,7 +333,7 @@ public final class UnreadComparison {
             // over the test made none of the values the rule is about.
             case ValueOrigin.OneOf<K> choice -> everyOneMadeByAnOperation(choice.alternatives());
             case ValueOrigin.IsAPosition<K> _, ValueOrigin.Written<K> _,
-                 ValueOrigin.Unnameable<K> _ -> false;
+                 ValueOrigin.Unnameable<K> _, ValueOrigin.NoValue<K> _ -> false;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -124,7 +124,9 @@ public sealed interface ValueOrigin<K> {
         @Override
         public Set<K> positions() {
             Set<K> out = new LinkedHashSet<>(decidedBy.positions());
-            out.addAll(across(alternatives));
+            for (ValueOrigin<K> each : alternatives) {
+                out.addAll(each.positions());
+            }
             return Collections.unmodifiableSet(out);
         }
     }
@@ -307,8 +309,7 @@ public sealed interface ValueOrigin<K> {
         }
         if (e instanceof Core.Match match) {
             return new OneOf<>(of(match.scrutinee(), at, reading, following),
-                    partsOf(match.cases().stream().map(Core.Case::body).toList(), at, reading,
-                            following));
+                    partsOf(armsOf(match), at, reading, following));
         }
         List<Core> children = new ArrayList<>();
         Core.forEachChild(e, children::add);
@@ -324,6 +325,15 @@ public sealed interface ValueOrigin<K> {
         out.add(attempt.then());
         for (Core.ElseArm arm : attempt.els()) {
             out.add(arm.body());
+        }
+        return out;
+    }
+
+    /** What a match may come to: what each of its arms answers. */
+    private static List<Core> armsOf(Core.Match match) {
+        List<Core> out = new ArrayList<>(match.cases().size());
+        for (Core.Case each : match.cases()) {
+            out.add(each.body());
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -108,26 +108,56 @@ public sealed interface ValueOrigin<K> {
      * {@code if flag then a else b} is one no reading of {@code flag} is outside of. Where its value
      * came from does not: none of the strings the value is are {@code flag}'s.
      */
-    record OneOf<K>(ValueOrigin<K> decidedBy, List<ValueOrigin<K>> alternatives)
+    record OneOf<K>(List<ValueOrigin<K>> decidedBy, List<ValueOrigin<K>> alternatives)
             implements ValueOrigin<K> {
 
         public OneOf {
-            Objects.requireNonNull(decidedBy, "a choice names what decided it");
+            decidedBy = List.copyOf(decidedBy);
             alternatives = List.copyOf(alternatives);
             if (alternatives.isEmpty()) {
                 // A choice between nothing is not a choice. An expression that chooses has the
                 // values it chooses between, and one of them is what it comes to.
                 throw new IllegalArgumentException("a choice states what it is between");
             }
+            for (ValueOrigin<K> each : alternatives) {
+                if (each instanceof NoValue<K>) {
+                    // A path that comes to no value is not one of the values, so it is not one of
+                    // the alternatives either. Held here, it would answer for the value alongside
+                    // the arms that have one, and every reader taking all of them together would
+                    // be answering about a path the value never came down.
+                    throw new IllegalArgumentException(
+                            "a path that comes to no value is not a value this may be");
+                }
+            }
         }
 
         @Override
         public Set<K> positions() {
-            Set<K> out = new LinkedHashSet<>(decidedBy.positions());
+            Set<K> out = new LinkedHashSet<>();
+            for (ValueOrigin<K> each : decidedBy) {
+                out.addAll(each.positions());
+            }
             for (ValueOrigin<K> each : alternatives) {
                 out.addAll(each.positions());
             }
             return Collections.unmodifiableSet(out);
+        }
+    }
+
+    /**
+     * No value stands here: the path this is on comes to none.
+     *
+     * <p>Its own arm and not {@link Unnameable}, which is a value this reader has nothing to say
+     * about. An arm departing with {@code unreachable} is not a value the expression may be, and
+     * read as one it takes every reader that asks something of all of them down with it — what the
+     * whole was made from, whether every value it may be was made by an operation. Both of those
+     * are questions about the values, and this is the absence of one.
+     */
+    record NoValue<K>() implements ValueOrigin<K> {
+
+        @Override
+        public Set<K> positions() {
+            return Set.of();
         }
     }
 
@@ -190,7 +220,7 @@ public sealed interface ValueOrigin<K> {
             // one of them and nothing here says which. What decided it is not asked: a choice made
             // on what stands at a position is not a value made from it.
             case OneOf<K> choice -> sameMadeFrom(choice.alternatives());
-            case IsAPosition<K> _, Written<K> _, Unnameable<K> _ -> null;
+            case IsAPosition<K> _, Written<K> _, Unnameable<K> _, NoValue<K> _ -> null;
         };
     }
 
@@ -247,6 +277,10 @@ public sealed interface ValueOrigin<K> {
 
         /** What {@code li}'s body is read in. */
         E inside(Core.LetIn li, E at);
+
+        /** What the arm {@code decidedBy} chooses is read in: {@code at} with whatever choosing
+         *  that arm binds entered. */
+        E choosing(Choice.Decides decidedBy, E at);
     }
 
     /** What {@code e} is made of. */
@@ -280,6 +314,11 @@ public sealed interface ValueOrigin<K> {
         // settled where the arithmetic already settles it. A two-argument call the language has an
         // operator for is not one of these: {@link Terms#asOperator} has already turned it into the
         // arithmetic it stands for, which is what {@link Composed} is.
+        // Asked before the choice below, and the call an operation defines by cases is the one
+        // place the two could both answer. A rule about what such a call answered is one to be
+        // followed back through the operation, which is what an application says and what a reader
+        // of it acts on; which of its arguments the answer is comes from the same table and is a
+        // question about the library rather than about this body.
         ValueName operation = Terms.operationOf(e);
         if (operation != null) {
             return new Applied<>(operation, partsOf(Terms.argsOf(e), at, reading, following));
@@ -296,20 +335,16 @@ public sealed interface ValueOrigin<K> {
         if (e instanceof Core.LetIn li) {
             return of(li.body(), reading.inside(li, at), reading, following);
         }
-        // A fork, said as the choice it is. Walked by its children it would come back composed of
-        // what it turned on and what it chooses between alike, and the two are not one relation.
-        if (e instanceof Core.If iff) {
-            return new OneOf<>(of(iff.cond(), at, reading, following),
-                    partsOf(List.of(iff.then(), iff.els()), at, reading, following));
+        if (e instanceof Core.Unreachable) {
+            return new NoValue<>();
         }
-        if (e instanceof Core.IfConstructed attempt) {
-            // What the attempt builds is what decides the branch: its invariant is the test.
-            return new OneOf<>(of(attempt.construct(), at, reading, following),
-                    partsOf(armsOf(attempt), at, reading, following));
-        }
-        if (e instanceof Core.Match match) {
-            return new OneOf<>(of(match.scrutinee(), at, reading, following),
-                    partsOf(armsOf(match), at, reading, following));
+        // A value that is one of several, said as the choice it is. Which several and what decides
+        // each is {@link Choice}'s answer and not read off the node here: walked by its children a
+        // fork comes back composed of what it turned on and what it chooses between alike, and the
+        // two are not one relation.
+        Choice choice = Choice.of(e);
+        if (choice != null) {
+            return oneOf(choice, at, reading, following);
         }
         List<Core> children = new ArrayList<>();
         Core.forEachChild(e, children::add);
@@ -319,23 +354,78 @@ public sealed interface ValueOrigin<K> {
         return new Composed<>(partsOf(children, at, reading, following));
     }
 
-    /** What an attempted construction may come to: the value it builds, and every departure. */
-    private static List<Core> armsOf(Core.IfConstructed attempt) {
-        List<Core> out = new ArrayList<>();
-        out.add(attempt.then());
-        for (Core.ElseArm arm : attempt.els()) {
-            out.add(arm.body());
+    /**
+     * What {@code choice} is made of: every value it may be, read where that value is written, and
+     * what decided which of them it is.
+     *
+     * <p>Each arm in the reading its own arm opens ({@link Reading#choosing}). A {@code match}
+     * arm's name stands for the value that was matched read as the case the arm selects, and an
+     * attempt's name stands for what it built — neither of them is a name outside the arm, so an
+     * arm read in the reading the fork stands in is one whose own answer cannot be looked up.
+     *
+     * <p>An arm that comes to no value is not one of the values, and a choice all of whose arms
+     * come to none comes to none itself.
+     */
+    private static <K, E> ValueOrigin<K> oneOf(Choice choice, E at, Reading<K, E> reading,
+                                               Set<souther.compiler.types.BindingId> following) {
+        List<Core> deciding = new ArrayList<>();
+        List<ValueOrigin<K>> values = new ArrayList<>(choice.arms().size());
+        for (Choice.Arm arm : choice.arms()) {
+            for (Core each : decidedBy(arm.decidedBy())) {
+                if (noneIs(deciding, each)) {
+                    deciding.add(each);
+                }
+            }
+            ValueOrigin<K> value = of(arm.answers(), reading.choosing(arm.decidedBy(), at), reading,
+                    following);
+            if (!(value instanceof NoValue<K>)) {
+                values.add(value);
+            }
         }
-        return out;
+        return values.isEmpty() ? new NoValue<>()
+                : new OneOf<>(partsOf(deciding, at, reading, following), values);
     }
 
-    /** What a match may come to: what each of its arms answers. */
-    private static List<Core> armsOf(Core.Match match) {
-        List<Core> out = new ArrayList<>(match.cases().size());
-        for (Core.Case each : match.cases()) {
-            out.add(each.body());
+    /**
+     * What one arm is chosen by, as the expressions it turns on.
+     *
+     * <p>An arm per way of deciding, so a way added to the language stops here until somebody says
+     * what it turns on. What this answers is which expressions a reading of the choice depends on;
+     * what choosing an arm binds and what it settles are the other two questions about the same
+     * node, and each is answered where its own vocabulary is.
+     */
+    private static List<Core> decidedBy(Choice.Decides decidedBy) {
+        return switch (decidedBy) {
+            case Choice.Decides.ACondition(Core cond, boolean _) -> List.of(cond);
+            case Choice.Decides.ACase(Core.Case _, Core scrutinee) -> List.of(scrutinee);
+            // What the attempt tried to build is what its invariant was tested on, whichever way
+            // the test went.
+            case Choice.Decides.ItWasBuilt(Core.IfConstructed attempt) ->
+                    List.of(attempt.construct());
+            case Choice.Decides.ItDeparted(Core.IfConstructed attempt, Core.ElseArm _) ->
+                    List.of(attempt.construct());
+            // The values the arguments stand between, which is what the library's own definition
+            // reads to say which case it answers in.
+            case Choice.Decides.ByArgumentRelations(List<Choice.ArgumentRelation> relations) -> {
+                List<Core> out = new ArrayList<>(relations.size() * 2);
+                for (Choice.ArgumentRelation each : relations) {
+                    out.add(each.left());
+                    out.add(each.right());
+                }
+                yield out;
+            }
+        };
+    }
+
+    /** Whether {@code of} holds no node that is {@code e}. The same expression decides every arm of
+     *  a fork, and read once it is walked once. */
+    private static boolean noneIs(List<Core> of, Core e) {
+        for (Core each : of) {
+            if (each == e) {
+                return false;
+            }
         }
-        return out;
+        return true;
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -282,6 +282,16 @@ public sealed interface ValueOrigin<K> {
         /** Where the arm {@code decidedBy} chooses is read, which is {@code at} with whatever
          *  choosing that arm binds entered — or nowhere this reading goes. */
         Opened<E> choosing(Choice.Decides decidedBy, E at);
+
+        /**
+         * Whether {@code e}, standing where {@code at} says it stands, can be evaluated to a value.
+         *
+         * <p>{@link NormalReturn}'s question, asked of the caller because the answer is rooted: an
+         * expression read as a body of its own has every name in it free, and a name bound to
+         * something that aborts is what makes the difference. Which body {@code e} stands in is
+         * what the caller knows and this walk does not.
+         */
+        boolean answers(Core e, E at);
     }
 
     /**
@@ -308,57 +318,13 @@ public sealed interface ValueOrigin<K> {
         record NotEntered<E>() implements Opened<E> {}
     }
 
-    /**
-     * What one walk carries as it goes: the names it is already inside, and the tree it is reading.
-     *
-     * <p>The tree is here because whether an expression answers a value is asked of that expression
-     * where it stands, and a name read through stands in a tree of its own. Held rather than
-     * rebuilt, since the question is only ever asked of a fork's arms and most expressions hold
-     * none.
-     */
-    final class Walk {
-
-        private final Set<souther.compiler.types.BindingId> following = new java.util.HashSet<>();
-        private Core reading;
-        private NormalReturn answering;
-
-        private Walk(Core reading) {
-            this.reading = reading;
-        }
-
-        /** Whether {@code e}, standing where it stands in the tree being read, answers a value.
-         *  {@link NormalReturn}'s answer: an expression that has to evaluate an {@code unreachable}
-         *  on its way answers none, and which expressions those are is not a fact about the node. */
-        private boolean answers(Core e) {
-            if (answering == null) {
-                // A tree the language's own operations stand in, which is the tree this walk is
-                // for: what counts as one is asked of {@link Terms} above, and a call kept standing
-                // is the model naming an operation rather than an expansion that failed.
-                answering = NormalReturn.ofBodyWhereTheOperationsStand(reading);
-            }
-            return answering.at(e);
-        }
-
-        /** Read {@code tree} instead until {@link #leave}, a name having been read through to it. */
-        private Core enter(Core tree) {
-            Core was = reading;
-            reading = tree;
-            answering = null;
-            return was;
-        }
-
-        private void leave(Core was) {
-            reading = was;
-            answering = null;
-        }
-    }
-
     /** What {@code e} is made of. */
     static <K, E> ValueOrigin<K> of(Core e, E at, Reading<K, E> reading) {
-        return of(e, at, reading, new Walk(e));
+        return of(e, at, reading, new java.util.HashSet<>());
     }
 
-    private static <K, E> ValueOrigin<K> of(Core raw, E at, Reading<K, E> reading, Walk walk) {
+    private static <K, E> ValueOrigin<K> of(Core raw, E at, Reading<K, E> reading,
+                                            Set<souther.compiler.types.BindingId> following) {
         Core e = Terms.asOperator(raw);
         K here = reading.positionOf(e, at);
         if (here != null) {
@@ -366,11 +332,9 @@ public sealed interface ValueOrigin<K> {
         }
         if (e instanceof Core.Read read) {
             AffineForms.ReadThrough<E> through = reading.readThrough(read, at);
-            if (through != null && walk.following.add(read.binding())) {
-                Core was = walk.enter(through.value());
-                ValueOrigin<K> inside = of(through.value(), through.at(), reading, walk);
-                walk.leave(was);
-                walk.following.remove(read.binding());
+            if (through != null && following.add(read.binding())) {
+                ValueOrigin<K> inside = of(through.value(), through.at(), reading, following);
+                following.remove(read.binding());
                 return inside;
             }
             // A name standing for several values is not one this walk reads through. What may be
@@ -392,7 +356,7 @@ public sealed interface ValueOrigin<K> {
         // question about the library rather than about this body.
         ValueName operation = Terms.operationOf(e);
         if (operation != null) {
-            return new Applied<>(operation, partsOf(Terms.argsOf(e), at, reading, walk));
+            return new Applied<>(operation, partsOf(Terms.argsOf(e), at, reading, following));
         }
         if (writtenOut(e)) {
             return new Written<>();
@@ -404,7 +368,7 @@ public sealed interface ValueOrigin<K> {
         // arithmetic next door reaches it, so the two cannot come to different values for one
         // expression.
         if (e instanceof Core.LetIn li) {
-            return of(li.body(), reading.inside(li, at), reading, walk);
+            return of(li.body(), reading.inside(li, at), reading, following);
         }
         // A value that is one of several, said as the choice it is. Which several and what decides
         // each is {@link Choice}'s answer and not read off the node here: walked by its children a
@@ -412,14 +376,14 @@ public sealed interface ValueOrigin<K> {
         // two are not one relation.
         Choice choice = Choice.of(e);
         if (choice != null) {
-            return oneOf(choice, at, reading, walk);
+            return oneOf(choice, at, reading, following);
         }
         List<Core> children = new ArrayList<>();
         Core.forEachChild(e, children::add);
         if (children.isEmpty()) {
             return leafOf(e, at, reading);
         }
-        return new Composed<>(partsOf(children, at, reading, walk));
+        return new Composed<>(partsOf(children, at, reading, following));
     }
 
     /**
@@ -433,14 +397,14 @@ public sealed interface ValueOrigin<K> {
      * arm a reading does not go inside comes to a value it can say nothing about, which is what
      * such an arm is to it.
      *
-     * <p>Which arms are values the expression may be is {@link NormalReturn}'s answer and is not
-     * read off the node: an {@code unreachable} standing where a value is built takes the whole
-     * expression around it with it, and an operator that stops as soon as its answer is settled
-     * answers a value on some runs and not others. A choice no arm of which answers one comes to
-     * none itself.
+     * <p>Which arms are values the expression may be is asked of the reading and not read off the
+     * node: an {@code unreachable} standing where a value is built takes the whole expression
+     * around it with it, and an operator that stops as soon as its answer is settled answers a
+     * value on some runs and not others. A choice no arm of which answers one comes to none
+     * itself.
      */
     private static <K, E> ValueOrigin<K> oneOf(Choice choice, E at, Reading<K, E> reading,
-                                               Walk walk) {
+                                               Set<souther.compiler.types.BindingId> following) {
         List<Core> deciding = new ArrayList<>();
         List<ValueOrigin<K>> values = new ArrayList<>(choice.arms().size());
         for (Choice.Arm arm : choice.arms()) {
@@ -449,16 +413,16 @@ public sealed interface ValueOrigin<K> {
                     deciding.add(each);
                 }
             }
-            if (!walk.answers(arm.answers())) {
+            if (!reading.answers(arm.answers(), at)) {
                 continue;
             }
             values.add(switch (reading.choosing(arm.decidedBy(), at)) {
-                case Opened.Entered<E>(E inside) -> of(arm.answers(), inside, reading, walk);
+                case Opened.Entered<E>(E inside) -> of(arm.answers(), inside, reading, following);
                 case Opened.NotEntered<E> _ -> new Unnameable<K>();
             });
         }
         return values.isEmpty() ? new NoValue<>()
-                : new OneOf<>(partsOf(deciding, at, reading, walk), values);
+                : new OneOf<>(partsOf(deciding, at, reading, following), values);
     }
 
     /**
@@ -504,10 +468,10 @@ public sealed interface ValueOrigin<K> {
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,
-                                                       Walk walk) {
+                                                       Set<souther.compiler.types.BindingId> following) {
         List<ValueOrigin<K>> out = new ArrayList<>();
         for (Core each : of) {
-            out.add(of(each, at, reading, walk));
+            out.add(of(each, at, reading, following));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -37,7 +38,7 @@ public sealed interface ValueOrigin<K> {
     record IsAPosition<K>(K at) implements ValueOrigin<K> {
 
         public IsAPosition {
-            java.util.Objects.requireNonNull(at, "this one names the position it is");
+            Objects.requireNonNull(at, "this one names the position it is");
         }
 
         @Override
@@ -58,7 +59,7 @@ public sealed interface ValueOrigin<K> {
             implements ValueOrigin<K> {
 
         public Applied {
-            java.util.Objects.requireNonNull(operation, "an application names its operation");
+            Objects.requireNonNull(operation, "an application names its operation");
             arguments = List.copyOf(arguments);
         }
 
@@ -93,6 +94,41 @@ public sealed interface ValueOrigin<K> {
         }
     }
 
+    /**
+     * A value that is one of several, and what decided which of them it is.
+     *
+     * <p>Told apart from {@link Composed} because the two are different relations. Everything under
+     * a composition contributed to the value; the alternatives of a choice are what the value may
+     * be, of which one is. A fork read as a composition puts what it turned on beside the values it
+     * chooses between, and a reader asking where the value came from is answered with the position
+     * that decided which value it is.
+     *
+     * <p><b>{@code decidedBy} contributes to dependency positions, but not to value provenance.</b>
+     * Which positions the expression depends on includes what it turned on — a comparison over
+     * {@code if flag then a else b} is one no reading of {@code flag} is outside of. Where its value
+     * came from does not: none of the strings the value is are {@code flag}'s.
+     */
+    record OneOf<K>(ValueOrigin<K> decidedBy, List<ValueOrigin<K>> alternatives)
+            implements ValueOrigin<K> {
+
+        public OneOf {
+            Objects.requireNonNull(decidedBy, "a choice names what decided it");
+            alternatives = List.copyOf(alternatives);
+            if (alternatives.isEmpty()) {
+                // A choice between nothing is not a choice. An expression that chooses has the
+                // values it chooses between, and one of them is what it comes to.
+                throw new IllegalArgumentException("a choice states what it is between");
+            }
+        }
+
+        @Override
+        public Set<K> positions() {
+            Set<K> out = new LinkedHashSet<>(decidedBy.positions());
+            out.addAll(across(alternatives));
+            return Collections.unmodifiableSet(out);
+        }
+    }
+
     /** A value written out where it stands. */
     record Written<K>() implements ValueOrigin<K> {
 
@@ -113,7 +149,7 @@ public sealed interface ValueOrigin<K> {
     record MadeFromAPosition<K>(K at) implements ValueOrigin<K> {
 
         public MadeFromAPosition {
-            java.util.Objects.requireNonNull(at, "this one names where the value came from");
+            Objects.requireNonNull(at, "this one names where the value came from");
         }
 
         @Override
@@ -148,8 +184,26 @@ public sealed interface ValueOrigin<K> {
             case MadeFromAPosition<K> from -> from.at();
             case Applied<K> applied -> firstMadeFrom(applied.arguments());
             case Composed<K> composed -> firstMadeFrom(composed.parts());
+            // Only where every value it could be came from the one position, since the value is
+            // one of them and nothing here says which. What decided it is not asked: a choice made
+            // on what stands at a position is not a value made from it.
+            case OneOf<K> choice -> sameMadeFrom(choice.alternatives());
             case IsAPosition<K> _, Written<K> _, Unnameable<K> _ -> null;
         };
+    }
+
+    /** The one position everything in {@code of} is made from, or null where they differ or any of
+     *  them is made from none. */
+    private static <K> K sameMadeFrom(List<ValueOrigin<K>> of) {
+        K agreed = null;
+        for (ValueOrigin<K> each : of) {
+            K from = each.madeFrom();
+            if (from == null || (agreed != null && !agreed.equals(from))) {
+                return null;
+            }
+            agreed = from;
+        }
+        return agreed;
     }
 
     private static <K> K firstMadeFrom(List<ValueOrigin<K>> of) {
@@ -240,12 +294,38 @@ public sealed interface ValueOrigin<K> {
         if (e instanceof Core.LetIn li) {
             return of(li.body(), reading.inside(li, at), reading, following);
         }
+        // A fork, said as the choice it is. Walked by its children it would come back composed of
+        // what it turned on and what it chooses between alike, and the two are not one relation.
+        if (e instanceof Core.If iff) {
+            return new OneOf<>(of(iff.cond(), at, reading, following),
+                    partsOf(List.of(iff.then(), iff.els()), at, reading, following));
+        }
+        if (e instanceof Core.IfConstructed attempt) {
+            // What the attempt builds is what decides the branch: its invariant is the test.
+            return new OneOf<>(of(attempt.construct(), at, reading, following),
+                    partsOf(armsOf(attempt), at, reading, following));
+        }
+        if (e instanceof Core.Match match) {
+            return new OneOf<>(of(match.scrutinee(), at, reading, following),
+                    partsOf(match.cases().stream().map(Core.Case::body).toList(), at, reading,
+                            following));
+        }
         List<Core> children = new ArrayList<>();
         Core.forEachChild(e, children::add);
         if (children.isEmpty()) {
             return leafOf(e, at, reading);
         }
         return new Composed<>(partsOf(children, at, reading, following));
+    }
+
+    /** What an attempted construction may come to: the value it builds, and every departure. */
+    private static List<Core> armsOf(Core.IfConstructed attempt) {
+        List<Core> out = new ArrayList<>();
+        out.add(attempt.then());
+        for (Core.ElseArm arm : attempt.els()) {
+            out.add(arm.body());
+        }
+        return out;
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
+import souther.compiler.coverage.NormalReturn;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -278,18 +279,86 @@ public sealed interface ValueOrigin<K> {
         /** What {@code li}'s body is read in. */
         E inside(Core.LetIn li, E at);
 
-        /** What the arm {@code decidedBy} chooses is read in: {@code at} with whatever choosing
-         *  that arm binds entered. */
-        E choosing(Choice.Decides decidedBy, E at);
+        /** Where the arm {@code decidedBy} chooses is read, which is {@code at} with whatever
+         *  choosing that arm binds entered — or nowhere this reading goes. */
+        Opened<E> choosing(Choice.Decides decidedBy, E at);
+    }
+
+    /**
+     * Where an arm's answer is read.
+     *
+     * <p>Two answers and not one reading. An arm that binds nothing is read where the fork stands,
+     * and so is an arm whose name a reading does not follow — and told apart by the reading they
+     * come back as, the second reads a name that means something else outside the arm as though the
+     * arm had opened it.
+     *
+     * @param <E> what the caller carries as it goes inside a binding
+     */
+    sealed interface Opened<E> {
+
+        /** The reading the arm is read in, with whatever it binds entered. */
+        record Entered<E>(E at) implements Opened<E> {
+
+            public Entered {
+                Objects.requireNonNull(at, "an arm that is entered is read somewhere");
+            }
+        }
+
+        /** This reading does not go inside the arm, so what the arm answers is out of its reach. */
+        record NotEntered<E>() implements Opened<E> {}
+    }
+
+    /**
+     * What one walk carries as it goes: the names it is already inside, and the tree it is reading.
+     *
+     * <p>The tree is here because whether an expression answers a value is asked of that expression
+     * where it stands, and a name read through stands in a tree of its own. Held rather than
+     * rebuilt, since the question is only ever asked of a fork's arms and most expressions hold
+     * none.
+     */
+    final class Walk {
+
+        private final Set<souther.compiler.types.BindingId> following = new java.util.HashSet<>();
+        private Core reading;
+        private NormalReturn answering;
+
+        private Walk(Core reading) {
+            this.reading = reading;
+        }
+
+        /** Whether {@code e}, standing where it stands in the tree being read, answers a value.
+         *  {@link NormalReturn}'s answer: an expression that has to evaluate an {@code unreachable}
+         *  on its way answers none, and which expressions those are is not a fact about the node. */
+        private boolean answers(Core e) {
+            if (answering == null) {
+                // A tree the language's own operations stand in, which is the tree this walk is
+                // for: what counts as one is asked of {@link Terms} above, and a call kept standing
+                // is the model naming an operation rather than an expansion that failed.
+                answering = NormalReturn.ofBodyWhereTheOperationsStand(reading);
+            }
+            return answering.at(e);
+        }
+
+        /** Read {@code tree} instead until {@link #leave}, a name having been read through to it. */
+        private Core enter(Core tree) {
+            Core was = reading;
+            reading = tree;
+            answering = null;
+            return was;
+        }
+
+        private void leave(Core was) {
+            reading = was;
+            answering = null;
+        }
     }
 
     /** What {@code e} is made of. */
     static <K, E> ValueOrigin<K> of(Core e, E at, Reading<K, E> reading) {
-        return of(e, at, reading, new java.util.HashSet<>());
+        return of(e, at, reading, new Walk(e));
     }
 
-    private static <K, E> ValueOrigin<K> of(Core raw, E at, Reading<K, E> reading,
-                                            Set<souther.compiler.types.BindingId> following) {
+    private static <K, E> ValueOrigin<K> of(Core raw, E at, Reading<K, E> reading, Walk walk) {
         Core e = Terms.asOperator(raw);
         K here = reading.positionOf(e, at);
         if (here != null) {
@@ -297,9 +366,11 @@ public sealed interface ValueOrigin<K> {
         }
         if (e instanceof Core.Read read) {
             AffineForms.ReadThrough<E> through = reading.readThrough(read, at);
-            if (through != null && following.add(read.binding())) {
-                ValueOrigin<K> inside = of(through.value(), through.at(), reading, following);
-                following.remove(read.binding());
+            if (through != null && walk.following.add(read.binding())) {
+                Core was = walk.enter(through.value());
+                ValueOrigin<K> inside = of(through.value(), through.at(), reading, walk);
+                walk.leave(was);
+                walk.following.remove(read.binding());
                 return inside;
             }
             // A name standing for several values is not one this walk reads through. What may be
@@ -321,7 +392,7 @@ public sealed interface ValueOrigin<K> {
         // question about the library rather than about this body.
         ValueName operation = Terms.operationOf(e);
         if (operation != null) {
-            return new Applied<>(operation, partsOf(Terms.argsOf(e), at, reading, following));
+            return new Applied<>(operation, partsOf(Terms.argsOf(e), at, reading, walk));
         }
         if (writtenOut(e)) {
             return new Written<>();
@@ -333,10 +404,7 @@ public sealed interface ValueOrigin<K> {
         // arithmetic next door reaches it, so the two cannot come to different values for one
         // expression.
         if (e instanceof Core.LetIn li) {
-            return of(li.body(), reading.inside(li, at), reading, following);
-        }
-        if (e instanceof Core.Unreachable) {
-            return new NoValue<>();
+            return of(li.body(), reading.inside(li, at), reading, walk);
         }
         // A value that is one of several, said as the choice it is. Which several and what decides
         // each is {@link Choice}'s answer and not read off the node here: walked by its children a
@@ -344,14 +412,14 @@ public sealed interface ValueOrigin<K> {
         // two are not one relation.
         Choice choice = Choice.of(e);
         if (choice != null) {
-            return oneOf(choice, at, reading, following);
+            return oneOf(choice, at, reading, walk);
         }
         List<Core> children = new ArrayList<>();
         Core.forEachChild(e, children::add);
         if (children.isEmpty()) {
             return leafOf(e, at, reading);
         }
-        return new Composed<>(partsOf(children, at, reading, following));
+        return new Composed<>(partsOf(children, at, reading, walk));
     }
 
     /**
@@ -361,13 +429,18 @@ public sealed interface ValueOrigin<K> {
      * <p>Each arm in the reading its own arm opens ({@link Reading#choosing}). A {@code match}
      * arm's name stands for the value that was matched read as the case the arm selects, and an
      * attempt's name stands for what it built — neither of them is a name outside the arm, so an
-     * arm read in the reading the fork stands in is one whose own answer cannot be looked up.
+     * arm read in the reading the fork stands in is one whose own answer cannot be looked up. An
+     * arm a reading does not go inside comes to a value it can say nothing about, which is what
+     * such an arm is to it.
      *
-     * <p>An arm that comes to no value is not one of the values, and a choice all of whose arms
-     * come to none comes to none itself.
+     * <p>Which arms are values the expression may be is {@link NormalReturn}'s answer and is not
+     * read off the node: an {@code unreachable} standing where a value is built takes the whole
+     * expression around it with it, and an operator that stops as soon as its answer is settled
+     * answers a value on some runs and not others. A choice no arm of which answers one comes to
+     * none itself.
      */
     private static <K, E> ValueOrigin<K> oneOf(Choice choice, E at, Reading<K, E> reading,
-                                               Set<souther.compiler.types.BindingId> following) {
+                                               Walk walk) {
         List<Core> deciding = new ArrayList<>();
         List<ValueOrigin<K>> values = new ArrayList<>(choice.arms().size());
         for (Choice.Arm arm : choice.arms()) {
@@ -376,14 +449,16 @@ public sealed interface ValueOrigin<K> {
                     deciding.add(each);
                 }
             }
-            ValueOrigin<K> value = of(arm.answers(), reading.choosing(arm.decidedBy(), at), reading,
-                    following);
-            if (!(value instanceof NoValue<K>)) {
-                values.add(value);
+            if (!walk.answers(arm.answers())) {
+                continue;
             }
+            values.add(switch (reading.choosing(arm.decidedBy(), at)) {
+                case Opened.Entered<E>(E inside) -> of(arm.answers(), inside, reading, walk);
+                case Opened.NotEntered<E> _ -> new Unnameable<K>();
+            });
         }
         return values.isEmpty() ? new NoValue<>()
-                : new OneOf<>(partsOf(deciding, at, reading, following), values);
+                : new OneOf<>(partsOf(deciding, at, reading, walk), values);
     }
 
     /**
@@ -429,10 +504,10 @@ public sealed interface ValueOrigin<K> {
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,
-                                                       Set<souther.compiler.types.BindingId> following) {
+                                                       Walk walk) {
         List<ValueOrigin<K>> out = new ArrayList<>();
         for (Core each : of) {
-            out.add(of(each, at, reading, following));
+            out.add(of(each, at, reading, walk));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
@@ -2,8 +2,8 @@ package souther.compiler.coverage;
 
 import souther.compiler.core.Core;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Whether an expression answers a value, for a reader that asks about more than one of them.
@@ -13,10 +13,10 @@ import java.util.Map;
  * name bound to something that aborts is what makes the difference. Which tree a reader's questions
  * are about is the reader's own fact, and this is where the reader says it.
  *
- * <p>Two answers to that, and a reader has one or the other. A reading of a body asks about the
- * nodes of that body, whichever of them the walk reaches. A reading of a declaration's clause has
- * no body — a clause is checked whenever a value is built and stands on the way to nothing — so
- * what it is handed is a tree with nothing above it, and each is a root of its own.
+ * <p>So the root is named where the reading is made. A body is one tree and a declaration's clause
+ * is another — a clause is checked whenever a value is built and stands on the way to nothing — and
+ * what differs between the two readers is which node each of them names, not what either does with
+ * the nodes under it.
  */
 public interface Arrivals {
 
@@ -24,26 +24,48 @@ public interface Arrivals {
     boolean at(Core e);
 
     /**
-     * The nodes of one body, read once.
+     * The nodes of the tree {@code root} is the root of, read once.
+     *
+     * <p>One way in, and the root is named. Which tree the questions are about is a fact about that
+     * tree and never about the node being asked: a node under a binding is one the binding is
+     * evaluated before, and the same node read as the root of its own tree has that name free. A
+     * reader that took each node it was asked about for a root would answer the second question
+     * everywhere, and a way of saying so is a way of getting it wrong.
      *
      * <p>Built when something first asks, most expressions holding no fork and the question being
      * asked only about the arms of one.
+     *
+     * <p>A reader that reads several trees makes one of these per tree, where it crosses into one.
+     * A body is a tree; so is a declaration's clause, which stands in no body — what differs is
+     * which node the caller names, not how the answer is worked out.
      */
-    static Arrivals inTheBody(Core body) {
-        NormalReturn answering = NormalReturn.lazilyWhereTheOperationsStand(body);
+    static Arrivals inTheTree(Core root) {
+        NormalReturn answering = NormalReturn.lazilyWhereTheOperationsStand(root);
         return answering::at;
     }
 
     /**
-     * Every tree it is asked about, each read as the root it is.
+     * The same over several trees, for a reader whose expressions have no one root.
      *
-     * <p>For a reader whose expressions stand in no body. What this cannot see is a name bound
-     * above what it is handed, there being nothing above it to bind one — and what it must not do
-     * is answer about some other tree, which is why the reading is per tree rather than one reading
-     * asked about nodes it was not rooted at.
+     * <p>A declaration's clause arrives as the two sides of a comparison and no node above them, so
+     * those are the roots there are. Named here as they are named for one, and a node standing in
+     * none of them is refused the way a node from another body is — what this does not do is take
+     * the node it was asked about for a root of its own.
      */
-    static Arrivals whereNothingStandsAbove() {
-        Map<Core, NormalReturn> read = new IdentityHashMap<>();
-        return e -> read.computeIfAbsent(e, NormalReturn::lazilyWhereTheOperationsStand).at(e);
+    static Arrivals inTheTrees(Core... roots) {
+        List<NormalReturn> readings = new ArrayList<>(roots.length);
+        for (Core each : roots) {
+            readings.add(NormalReturn.lazilyWhereTheOperationsStand(each));
+        }
+        return e -> {
+            for (NormalReturn each : readings) {
+                if (each.holds(e)) {
+                    return each.at(e);
+                }
+            }
+            throw new IllegalArgumentException(
+                    "no tree this reads holds this " + e.getClass().getSimpleName()
+                            + " at " + e.pos());
+        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
@@ -1,0 +1,49 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * Whether an expression answers a value, for a reader that asks about more than one of them.
+ *
+ * <p>{@link NormalReturn} is rooted: it answers about the nodes of one tree and refuses a node from
+ * anywhere else, because reading such a node as a body of its own has every name in it free and a
+ * name bound to something that aborts is what makes the difference. Which tree a reader's questions
+ * are about is the reader's own fact, and this is where the reader says it.
+ *
+ * <p>Two answers to that, and a reader has one or the other. A reading of a body asks about the
+ * nodes of that body, whichever of them the walk reaches. A reading of a declaration's clause has
+ * no body — a clause is checked whenever a value is built and stands on the way to nothing — so
+ * what it is handed is a tree with nothing above it, and each is a root of its own.
+ */
+public interface Arrivals {
+
+    /** Whether {@code e} answers a value. */
+    boolean at(Core e);
+
+    /**
+     * The nodes of one body, read once.
+     *
+     * <p>Built when something first asks, most expressions holding no fork and the question being
+     * asked only about the arms of one.
+     */
+    static Arrivals inTheBody(Core body) {
+        NormalReturn answering = NormalReturn.lazilyWhereTheOperationsStand(body);
+        return answering::at;
+    }
+
+    /**
+     * Every tree it is asked about, each read as the root it is.
+     *
+     * <p>For a reader whose expressions stand in no body. What this cannot see is a name bound
+     * above what it is handed, there being nothing above it to bind one — and what it must not do
+     * is answer about some other tree, which is why the reading is per tree rather than one reading
+     * asked about nodes it was not rooted at.
+     */
+    static Arrivals whereNothingStandsAbove() {
+        Map<Core, NormalReturn> read = new IdentityHashMap<>();
+        return e -> read.computeIfAbsent(e, NormalReturn::lazilyWhereTheOperationsStand).at(e);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Arrivals.java
@@ -2,9 +2,6 @@ package souther.compiler.coverage;
 
 import souther.compiler.core.Core;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Whether an expression answers a value, for a reader that asks about more than one of them.
  *
@@ -45,27 +42,20 @@ public interface Arrivals {
     }
 
     /**
-     * The same over several trees, for a reader whose expressions have no one root.
+     * Every expression taken for one that answers a value, for a reader that is not told which tree
+     * its expressions stand in.
      *
-     * <p>A declaration's clause arrives as the two sides of a comparison and no node above them, so
-     * those are the roots there are. Named here as they are named for one, and a node standing in
-     * none of them is refused the way a node from another body is — what this does not do is take
-     * the node it was asked about for a root of its own.
+     * <p>Not a root and not a guess at one. A reader handed a part of a clause and no clause has
+     * nothing to root a reading at, and rooting at the part is the one answer that is wrong — it
+     * reads the part as a tree of its own and loses whatever bound a name above it. So this says
+     * what it does not know, and what it costs is an arm that answers no value counted among the
+     * values, which is what such an arm came to before anybody asked.
+     *
+     * <p>For the reader to stop needing this, the walk that hands it a part has to hand over the
+     * clause the part was read out of.
      */
-    static Arrivals inTheTrees(Core... roots) {
-        List<NormalReturn> readings = new ArrayList<>(roots.length);
-        for (Core each : roots) {
-            readings.add(NormalReturn.lazilyWhereTheOperationsStand(each));
-        }
-        return e -> {
-            for (NormalReturn each : readings) {
-                if (each.holds(e)) {
-                    return each.at(e);
-                }
-            }
-            throw new IllegalArgumentException(
-                    "no tree this reads holds this " + e.getClass().getSimpleName()
-                            + " at " + e.pos());
-        };
+    static Arrivals everyArmIsTakenForAValue() {
+        return e -> true;
     }
+
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -90,11 +90,6 @@ public final class NormalReturn {
                 () -> ValueArrivals.ofBodyWhereTheOperationsStand(body, Anonymous.NAMING));
     }
 
-    /** Whether this is the reading of the body {@code e} stands in. */
-    public boolean holds(Core e) {
-        return reading().holds(e);
-    }
-
     /** Whether {@code e}, standing where it stands in this body, can be evaluated to a value. */
     public boolean at(Core e) {
         return reading().arrivesAt(e);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -32,10 +32,24 @@ import souther.compiler.flow.ValueArrivals;
  */
 public final class NormalReturn {
 
-    private final ValueArrivals<AnonymousPath> reading;
+    private final java.util.function.Supplier<ValueArrivals<AnonymousPath>> of;
+
+    private ValueArrivals<AnonymousPath> reading;
 
     private NormalReturn(ValueArrivals<AnonymousPath> reading) {
         this.reading = reading;
+        this.of = null;
+    }
+
+    private NormalReturn(java.util.function.Supplier<ValueArrivals<AnonymousPath>> of) {
+        this.of = of;
+    }
+
+    private ValueArrivals<AnonymousPath> reading() {
+        if (reading == null) {
+            reading = of.get();
+        }
+        return reading;
     }
 
     /**
@@ -63,9 +77,22 @@ public final class NormalReturn {
                 ValueArrivals.ofBodyWhereTheOperationsStand(body, Anonymous.NAMING));
     }
 
+    /**
+     * The same, read when something first asks.
+     *
+     * <p>For a caller that holds a body every reading of it may want this about and most do not:
+     * whether an expression answers a value is asked about the arms of a fork, and a body with no
+     * fork in it is never asked at all. The reading is one body's, so building it once when the
+     * first question comes is the same answer as building it with the body.
+     */
+    public static NormalReturn lazilyWhereTheOperationsStand(Core body) {
+        return new NormalReturn(
+                () -> ValueArrivals.ofBodyWhereTheOperationsStand(body, Anonymous.NAMING));
+    }
+
     /** Whether {@code e}, standing where it stands in this body, can be evaluated to a value. */
     public boolean at(Core e) {
-        return reading.arrivesAt(e);
+        return reading().arrivesAt(e);
     }
 
     /**
@@ -83,7 +110,7 @@ public final class NormalReturn {
      * thing was made — neither is a truth this reading has anything to say about.
      */
     public boolean mayEnter(Core fork, int part) {
-        return !(fork instanceof Core.If iff) || reading.comesAt(iff.cond()).mayCome(part == 0);
+        return !(fork instanceof Core.If iff) || reading().comesAt(iff.cond()).mayCome(part == 0);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -50,6 +50,19 @@ public final class NormalReturn {
         return new NormalReturn(ValueArrivals.ofBody(body, Anonymous.NAMING));
     }
 
+    /**
+     * The same, of a tree the language's own operations stand in.
+     *
+     * <p>Which kind of tree this is, is the caller's to say and this class's to spend. A call kept
+     * standing is a defect in a tree the operations were expanded in and the model naming an
+     * operation in one they stand in, and a reader that answered it for itself would be deciding
+     * what a tree is from the outside of the reading that walks it.
+     */
+    public static NormalReturn ofBodyWhereTheOperationsStand(Core body) {
+        return new NormalReturn(
+                ValueArrivals.ofBodyWhereTheOperationsStand(body, Anonymous.NAMING));
+    }
+
     /** Whether {@code e}, standing where it stands in this body, can be evaluated to a value. */
     public boolean at(Core e) {
         return reading.arrivesAt(e);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -90,6 +90,11 @@ public final class NormalReturn {
                 () -> ValueArrivals.ofBodyWhereTheOperationsStand(body, Anonymous.NAMING));
     }
 
+    /** Whether this is the reading of the body {@code e} stands in. */
+    public boolean holds(Core e) {
+        return reading().holds(e);
+    }
+
     /** Whether {@code e}, standing where it stands in this body, can be evaluated to a value. */
     public boolean at(Core e) {
         return reading().arrivesAt(e);

--- a/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
@@ -166,6 +166,17 @@ public final class ValueArrivals<P> {
     }
 
     /**
+     * Whether this reading was rooted at the body holding {@code e}.
+     *
+     * <p>For a caller that reads several trees and has to say which of them a node stands in. Asked
+     * rather than found out from the refusal above, since a reading answering a question it was not
+     * rooted for is the thing that refusal exists to stop.
+     */
+    public boolean holds(Core e) {
+        return e != null && settled.containsKey(e);
+    }
+
+    /**
      * The ways {@code e} is settled to {@code want}, or that this reading cannot enumerate them.
      *
      * <p>All of them or none. One arrival whose value is unread may be among the ways to either

--- a/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
@@ -166,17 +166,6 @@ public final class ValueArrivals<P> {
     }
 
     /**
-     * Whether this reading was rooted at the body holding {@code e}.
-     *
-     * <p>For a caller that reads several trees and has to say which of them a node stands in. Asked
-     * rather than found out from the refusal above, since a reading answering a question it was not
-     * rooted for is the thing that refusal exists to stop.
-     */
-    public boolean holds(Core e) {
-        return e != null && settled.containsKey(e);
-    }
-
-    /**
      * The ways {@code e} is settled to {@code want}, or that this reading cannot enumerate them.
      *
      * <p>All of them or none. One arrival whose value is unread may be among the ways to either

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ClauseWithoutAnEnd.java
@@ -40,13 +40,14 @@ import souther.compiler.types.TypeSymbol;
  *                 clause under a name names no position at all
  */
 public record ClauseWithoutAnEnd(InvariantStatementId statement, StatedComparison states,
-                                 SourcePos wrote, TermPath at, TypeSymbol.AtModule readUnder) {
+                                 SourcePos wrote, souther.compiler.core.Core readOutOf,
+                                 TermPath at, TypeSymbol.AtModule readUnder) {
 
     public ClauseWithoutAnEnd {
-        if (statement == null || states == null || wrote == null || at == null
-                || readUnder == null) {
-            throw new IllegalArgumentException(
-                    "a clause is one of a declaration's, is written, and is about a value somewhere");
+        if (statement == null || states == null || wrote == null || readOutOf == null
+                || at == null || readUnder == null) {
+            throw new IllegalArgumentException("a clause is one of a declaration's, is written, is"
+                    + " read out of a clause, and is about a value somewhere");
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.Choice;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
@@ -180,6 +181,19 @@ public final class InputReads {
      * left, which is what the set says and the arm does not.
      */
     public InputReads insideArm(Core.Match match, Core.Case arm, Symbols symbols) {
+        return insideArmOn(match.scrutinee(), arm, symbols);
+    }
+
+    /**
+     * The same, where the value the arm matched is what the caller holds rather than the node that
+     * matched it.
+     *
+     * <p>Named apart from the one above and not written as its wider signature. What an arm narrows
+     * is the scrutinee, and a walk that has the {@code match} in hand would be passing the node it
+     * is standing on into a slot that takes any expression — which every caller compiles and one of
+     * them gets wrong.
+     */
+    public InputReads insideArmOn(Core scrutinee, Core.Case arm, Symbols symbols) {
         if (arm.binder() == null || arm.binder().binding() == null) {
             return this;
         }
@@ -188,11 +202,11 @@ public final class InputReads {
         // sum narrows to several of the position's distinctions and so to no one of them.
         Refinement narrowing = arm.selectedCase().map(Refinement::of).orElse(null);
         if (narrowing == null) {
-            return admitting(match, arm, symbols);
+            return admitting(scrutinee, arm, symbols);
         }
         // What the arm narrows is a position of the input, and a scrutinee that stands at none
         // narrows nothing.
-        TermPath scrutinee = switch (pathOf(match.scrutinee(), symbols)) {
+        TermPath standing = switch (pathOf(scrutinee, symbols)) {
             case PathResolution.At(var at) -> at;
             case PathResolution.NotAPosition _ -> null;
             // A scrutinee that only may stand at a position narrows nothing here either. What an
@@ -200,10 +214,10 @@ public final class InputReads {
             // value under this arm is a case of every one of them at once.
             case PathResolution.MayStandAt _ -> null;
         };
-        if (scrutinee == null) {
-            return admitting(match, arm, symbols);
+        if (standing == null) {
+            return admitting(scrutinee, arm, symbols);
         }
-        TermPath narrowed = scrutinee.refine(narrowing);
+        TermPath narrowed = standing.refine(narrowing);
         // And nothing is asked of the reading. What this answers is which location the arm's name
         // stands for, which the arm and the scrutinee's path settle between them: the value that was
         // matched, read as the case the arm selects. Whether a row is ever written there — whether
@@ -241,8 +255,8 @@ public final class InputReads {
      * an arm no value reaches, so the name inside it stands for nothing — which is what a name with
      * no meaning here already says, and is not a set of no members.
      */
-    private InputReads admitting(Core.Match match, Core.Case arm, Symbols symbols) {
-        ReadMeaning.OneOf one = pluralityOf(match.scrutinee(), symbols);
+    private InputReads admitting(Core scrutinee, Core.Case arm, Symbols symbols) {
+        ReadMeaning.OneOf one = pluralityOf(scrutinee, symbols);
         if (one == null) {
             return this;
         }
@@ -300,6 +314,32 @@ public final class InputReads {
             case Core.Construct nd -> nd.typeName();
             case Core.UnitValue unit -> unit.data();
             default -> null;
+        };
+    }
+
+    /**
+     * The reading an arm's answer is read in: this, with what choosing that arm binds entered.
+     *
+     * <p>Asked of {@link Choice.Decides} rather than of the node an arm stands in, so that a way of
+     * deciding added to the language stops here until somebody says what choosing it binds. Written
+     * in this vocabulary and not shared with the one next door: what a name means to a reading of
+     * the inputs is this class's answer throughout, and {@link souther.compiler.check.Terms} gives
+     * the same sum the answer its own readers speak.
+     */
+    public InputReads choosing(Choice.Decides decidedBy, Symbols symbols) {
+        return switch (decidedBy) {
+            // A condition binds nothing. Which way it went is settled where the arm is read.
+            case Choice.Decides.ACondition _ -> this;
+            case Choice.Decides.ACase(Core.Case arm, Core scrutinee) ->
+                    insideArmOn(scrutinee, arm, symbols);
+            // The invariant held, so the name the attempt writes stands for what was built.
+            case Choice.Decides.ItWasBuilt(Core.IfConstructed attempt) ->
+                    and(attempt.binder(), attempt.construct());
+            // A departure is taken where nothing was built, so it has nothing to enter.
+            case Choice.Decides.ItDeparted _ -> this;
+            // An operation defined by cases answers a value the call was already given. It
+            // introduces no name.
+            case Choice.Decides.ByArgumentRelations _ -> this;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -657,6 +657,7 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
     List<ClauseWithoutAnEnd> clausesWithoutAnEnd() {
         return bounds().withoutAnEnd().stream()
                 .map(each -> new ClauseWithoutAnEnd(each.statement(), each.states(), each.wrote(),
+                        each.root(),
                         root,
                         bounds().named()))
                 .toList();

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -337,7 +337,10 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
         }
         for (souther.compiler.inputs.TermPath named
                 : GuardThresholds.mentionedIn(leftSide, reads, ruleSource.symbols(),
-                        souther.compiler.coverage.Arrivals.inTheTree(leftSide))) {
+                        // A side of a comparison and not a clause: what this is handed is the side
+                        // alone, and rooting a reading of arrivals at it would read it as a tree of
+                        // its own and lose whatever bound a name above it.
+                        souther.compiler.coverage.Arrivals.everyArmIsTakenForAValue())) {
             for (NumericTerm atom : left.coefs().keySet()) {
                 if (atom.subjectPath().equals(named)) {
                     return atom;

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -337,7 +337,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
         }
         for (souther.compiler.inputs.TermPath named
                 : GuardThresholds.mentionedIn(leftSide, reads, ruleSource.symbols(),
-                        souther.compiler.coverage.Arrivals.whereNothingStandsAbove())) {
+                        souther.compiler.coverage.Arrivals.inTheTree(leftSide))) {
             for (NumericTerm atom : left.coefs().keySet()) {
                 if (atom.subjectPath().equals(named)) {
                     return atom;

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -336,7 +336,8 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             return null;
         }
         for (souther.compiler.inputs.TermPath named
-                : GuardThresholds.mentionedIn(leftSide, reads, ruleSource.symbols())) {
+                : GuardThresholds.mentionedIn(leftSide, reads, ruleSource.symbols(),
+                        souther.compiler.coverage.Arrivals.whereNothingStandsAbove())) {
             for (NumericTerm atom : left.coefs().keySet()) {
                 if (atom.subjectPath().equals(named)) {
                     return atom;

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -382,9 +382,9 @@ public final class BehaviorSetStatements {
      *
      * <p>A subject that <em>is</em> what stands at more than one place is asked first, and of the
      * reading rather than of what the value is made of. That is the other sentence — nothing was
-     * made out of it and there is no operation to read backwards — and what an expression is made
-     * of has no way to say it: a value that is one of several places is not one built out of all
-     * of them.
+     * made out of it and there is no operation to read backwards — and it is not the choice a body
+     * writes: what may stand at several places is one name whose position differs from run to run,
+     * and the body holds no arms to read it off.
      */
     private static Outcome whereItsValueCameFrom(PredicateReadings.Reading each, Symbols symbols) {
         if (each.reads().cameFrom(each.subject(), symbols)
@@ -405,15 +405,15 @@ public final class BehaviorSetStatements {
      * from.
      *
      * <p>Read here and not asked of what an expression is made of as a whole, because that answer
-     * does not hold the question. What is made out of several things and what is one of several
-     * things arrive in one arm: the parts of a choice are the values it chooses between and what it
-     * turns on, side by side. A union over that arm files a rule at what decided which value the
-     * subject is, and a reader sent there is sent to a position the rule says nothing about.
+     * holds two questions and this is one of them. Which positions an expression names includes
+     * what a choice turned on — a reading of it is one nothing about the expression is outside of —
+     * and where the value came from does not. So a choice is read for the values it chooses
+     * between and never for what decided which of them it is.
      *
-     * <p>So the arms that do state where a value came from are read, and the one that does not is
-     * left. What that costs is a rule under a choice shown nowhere, which is what such a rule comes
-     * to already; what reading it would cost is a rule shown at the wrong position, which is worse
-     * and is the thing an author cannot tell from a rule their model states.
+     * <p>The arithmetic nothing here takes apart is left rather than read, because a form this
+     * could not read is one it cannot say the provenance of. What that costs is a rule under such a
+     * form shown nowhere; what reading it would cost is a rule shown at a position the rule says
+     * nothing about, which an author cannot tell from a rule their model states.
      *
      * <p>A switch with no default, so an arm added to what an expression is made of is one somebody
      * says the provenance of before this compiles.
@@ -426,6 +426,10 @@ public final class BehaviorSetStatements {
             // a string joined out of two positions is made out of both, and an author who wrote a
             // rule about the joined value is owed the sentence at each.
             case ValueOrigin.Applied<TermPath> it -> across(it.arguments());
+            // A value that is one of several came from wherever each of those came from, and from
+            // nowhere else: what decided which of them it is holds none of the values the rule is
+            // about, and an author sent there is sent to a position the rule says nothing of.
+            case ValueOrigin.OneOf<TermPath> it -> across(it.alternatives());
             // A value written where it stands came from no position, and one nothing here can name
             // came from none this can name.
             case ValueOrigin.Written<TermPath> _, ValueOrigin.Unnameable<TermPath> _ -> Set.of();

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -218,7 +218,7 @@ public final class BehaviorSetStatements {
         List<ClassingBlocker> blocked = new ArrayList<>();
         List<StandingQuestion.NothingClassifiesIt> nothingClassifies = new ArrayList<>();
         for (PredicateReadings.Reading each : read.predicates()) {
-            switch (ask(each, symbols)) {
+            switch (ask(each, symbols, read.arrivals())) {
                 case Outcome.OfADistinction(Asked it) -> asked.add(it);
                 case Outcome.NotGot(var at, var why) ->
                         blocked.add(new ClassingBlocker(at, each.origin(), why));
@@ -320,11 +320,12 @@ public final class BehaviorSetStatements {
      * <p>Exhaustive with no {@code default}: an outcome the table of predicates learns is one
      * somebody decides about here rather than one that quietly takes its neighbour's answer.
      */
-    private static Outcome ask(PredicateReadings.Reading each, Symbols symbols) {
+    private static Outcome ask(PredicateReadings.Reading each, Symbols symbols,
+                               souther.compiler.coverage.Arrivals answering) {
         // Where the rule's subject stands, read where the rule stands.
         PathResolution stands = each.reads().pathOf(each.subject(), symbols);
         if (!(stands instanceof PathResolution.At at)) {
-            return saidWithoutADenominator(each, stands, symbols);
+            return saidWithoutADenominator(each, stands, symbols, answering);
         }
         NumericTerm.FromOnePosition term = new NumericTerm.ValueOf(at.path());
         return switch (each.reading()) {
@@ -357,10 +358,12 @@ public final class BehaviorSetStatements {
      * which position the rule was of.
      */
     private static Outcome saidWithoutADenominator(PredicateReadings.Reading each,
-                                                   PathResolution stands, Symbols symbols) {
+                                                   PathResolution stands, Symbols symbols,
+                                                   souther.compiler.coverage.Arrivals answering) {
         return switch (stands) {
             case PathResolution.MayStandAt(var among) -> mayStandAt(among);
-            case PathResolution.NotAPosition _ -> whereItsValueCameFrom(each, symbols);
+            case PathResolution.NotAPosition _ ->
+                    whereItsValueCameFrom(each, symbols, answering);
             // The caller asks this only where the subject stands at no one place.
             case PathResolution.At at -> throw new IllegalArgumentException(
                     "a rule whose subject stands at " + at.path() + " has a denominator");
@@ -386,13 +389,14 @@ public final class BehaviorSetStatements {
      * writes: what may stand at several places is one name whose position differs from run to run,
      * and the body holds no arms to read it off.
      */
-    private static Outcome whereItsValueCameFrom(PredicateReadings.Reading each, Symbols symbols) {
+    private static Outcome whereItsValueCameFrom(PredicateReadings.Reading each, Symbols symbols,
+                                                 souther.compiler.coverage.Arrivals answering) {
         if (each.reads().cameFrom(each.subject(), symbols)
                 instanceof PathResolution.MayStandAt(var among)) {
             return mayStandAt(among);
         }
         Set<TermPath> from = positionsItCameFrom(
-                GuardThresholds.originOf(each.subject(), each.reads(), symbols));
+                GuardThresholds.originOf(each.subject(), each.reads(), symbols, answering));
         // And a rule about a value that came from no position the reading can name, which has
         // nowhere to be said.
         return from.isEmpty() ? new Outcome.Nowhere()
@@ -527,7 +531,7 @@ public final class BehaviorSetStatements {
             if (left.isEmpty()) {
                 continue;
             }
-            ForkOfItsOwn asked = asked(behavior, each.fork(), left, symbols, reaches);
+            ForkOfItsOwn asked = asked(behavior, each.fork(), left, symbols, read.arrivals(), reaches);
             if (asked != null) {
                 out.add(asked);
             }
@@ -590,7 +594,7 @@ public final class BehaviorSetStatements {
             if (unread.isEmpty()) {
                 continue;
             }
-            ForkOfItsOwn asked = asked(behavior, each, unread, symbols, reaches);
+            ForkOfItsOwn asked = asked(behavior, each, unread, symbols, read.arrivals(), reaches);
             if (asked != null) {
                 out.add(new Standing(each, unread, asked));
             }
@@ -625,6 +629,7 @@ public final class BehaviorSetStatements {
      */
     private static ForkOfItsOwn asked(String behavior, ComparisonReadings.ForkMet fork,
                                       List<Unread> unread, Symbols symbols,
+                                      souther.compiler.coverage.Arrivals answering,
                                       RuleReachNumbering reaches) {
         SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> filed =
                 new LinkedHashMap<>();
@@ -639,7 +644,7 @@ public final class BehaviorSetStatements {
             // element leaves the fork turning on the sequence it walks, and that is where a reader
             // is owed the question.
             List<Core> places = each.parts().stream()
-                    .anyMatch(one -> namesSomething(one, fork, symbols))
+                    .anyMatch(one -> namesSomething(one, fork, symbols, answering))
                     ? each.parts() : List.of(each.atom());
             for (Core part : places) {
             // Where the part stands at places this could not choose between, those are the places,
@@ -653,7 +658,7 @@ public final class BehaviorSetStatements {
                         new BlockReason.RuleAboutAnElementOfSeveralSequences()));
                 continue;
             }
-            GuardThresholds.Names names = GuardThresholds.namesIn(part, fork.reads(), symbols);
+            GuardThresholds.Names names = GuardThresholds.namesIn(part, fork.reads(), symbols, answering);
             BlockReason.RuleReadingStopped why =
                     UnreadComparison.notAboutOwnValues(names.origin());
             names.met().keySet().forEach(at -> filed.putIfAbsent(FilingCoordinate.at(at), why));
@@ -666,8 +671,9 @@ public final class BehaviorSetStatements {
 
     /** Whether {@code part} names a position of the input, however the reading gets there. */
     private static boolean namesSomething(Core part, ComparisonReadings.ForkMet fork,
-                                          Symbols symbols) {
+                                          Symbols symbols,
+                                          souther.compiler.coverage.Arrivals answering) {
         return fork.reads().pathOf(part, symbols) instanceof PathResolution.MayStandAt
-                || !GuardThresholds.namesIn(part, fork.reads(), symbols).met().isEmpty();
+                || !GuardThresholds.namesIn(part, fork.reads(), symbols, answering).met().isEmpty();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -430,9 +430,10 @@ public final class BehaviorSetStatements {
             // nowhere else: what decided which of them it is holds none of the values the rule is
             // about, and an author sent there is sent to a position the rule says nothing of.
             case ValueOrigin.OneOf<TermPath> it -> across(it.alternatives());
-            // A value written where it stands came from no position, and one nothing here can name
-            // came from none this can name.
-            case ValueOrigin.Written<TermPath> _, ValueOrigin.Unnameable<TermPath> _ -> Set.of();
+            // A value written where it stands came from no position, one nothing here can name came
+            // from none this can name, and a path that comes to no value came from nowhere at all.
+            case ValueOrigin.Written<TermPath> _, ValueOrigin.Unnameable<TermPath> _,
+                 ValueOrigin.NoValue<TermPath> _ -> Set.of();
             case ValueOrigin.Composed<TermPath> _ -> Set.of();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -244,6 +244,7 @@ sealed interface ComparisonAssessment {
     static ComparisonAssessment of(String behavior, StatedComparison comparison, Citation at,
                                    InputReading read, InputReads reads,
                                    BindingId answer,
+                                   souther.compiler.coverage.Arrivals answering,
                                    boolean drawnByAnInvariant) {
         Quantities quantities = read.quantities();
         // Asked first, and of the whole comparison. A rule that reads the answer anywhere in it is
@@ -253,7 +254,7 @@ sealed interface ComparisonAssessment {
         if (readsAnswer(comparison.left(), answer) || readsAnswer(comparison.right(), answer)) {
             return new AnswerDependent();
         }
-        return switch (Cutting.read(behavior, comparison, read, reads)) {
+        return switch (Cutting.read(behavior, comparison, read, reads, answering)) {
             case Cutting.Read.Cuts cuts ->
                     onTheQuantity(at, cuts.cutting(), quantities, drawnByAnInvariant);
             // Read to the end and cutting nothing, which is a fact about the rule and not a limit

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -164,7 +164,8 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
      * reading is one value for the whole of this walk. Put in it, the reading would be copied at
      * every step and asked of whichever copy a reader happened to hold.
      */
-    private record Body(String behavior, InputReading read) {
+    private record Body(String behavior, InputReading read,
+                        souther.compiler.coverage.Arrivals answering) {
 
         Symbols symbols() {
             return read.symbols();
@@ -198,7 +199,8 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
         // — a condition inside a helper spliced in from elsewhere is still one this reading met.
         ConditionNumbering numbering =
                 new ConditionNumbering(read.symbols().module(), behavior);
-        walk(body, new Body(behavior, read), reads,
+        walk(body, new Body(behavior, read, souther.compiler.coverage.Arrivals.inTheBody(body)),
+                reads,
                 LiveFlow.of(body), List.of(), true, readings, forks, numbering);
         return new ComparisonReadings(readings, forks, numbering.metAt());
     }
@@ -231,7 +233,7 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
                     .<BoundaryPolicy.Standing>map(BoundaryPolicy.Standing.Refused::new)
                     .orElseGet(() -> new BoundaryPolicy.Standing.Admitted(
                             ComparisonAssessment.of(in.behavior(), comparison.stated(), where,
-                                    in.read(), reads, null, false)));
+                                    in.read(), reads, null, in.answering(), false)));
             out.add(new Reading(stands, comparison, where, reads, assumed, standing));
         }
         switch (e) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -199,7 +199,7 @@ record ComparisonReadings(List<Reading> comparisons, List<ForkMet> forks,
         // — a condition inside a helper spliced in from elsewhere is still one this reading met.
         ConditionNumbering numbering =
                 new ConditionNumbering(read.symbols().module(), behavior);
-        walk(body, new Body(behavior, read, souther.compiler.coverage.Arrivals.inTheBody(body)),
+        walk(body, new Body(behavior, read, souther.compiler.coverage.Arrivals.inTheTree(body)),
                 reads,
                 LiveFlow.of(body), List.of(), true, readings, forks, numbering);
         return new ComparisonReadings(readings, forks, numbering.metAt());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -138,7 +138,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * with it.
      */
     static Read read(String behavior, StatedComparison comparison,
-                     InputReading read, InputReads reads) {
+                     InputReading read, InputReads reads,
+                     souther.compiler.coverage.Arrivals answering) {
         AffineReading.OfAComparison canonical =
                 AffineReading.read(comparison, read.domain(), reads, read.rules());
         return switch (canonical) {
@@ -158,7 +159,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             // is what a date against a written date and a case of an enumeration do: the values are
             // ones it cannot count, and the comparison still states a line.
             case AffineReading.OfAComparison.Stopped stopped ->
-                    asWritten(behavior, comparison, stopped, read, reads);
+                    asWritten(behavior, comparison, stopped, read, reads, answering);
         };
     }
 
@@ -273,7 +274,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      */
     private static Read asWritten(String behavior, StatedComparison comparison,
                                   AffineReading.OfAComparison.Stopped canonical,
-                                  InputReading read, InputReads reads) {
+                                  InputReading read, InputReads reads,
+                                  souther.compiler.coverage.Arrivals answering) {
         Quantities quantities = read.quantities();
         Cutting drawn = atAPosition(behavior,
                 ComparedLine.asWritten(comparison, read, reads), quantities);
@@ -288,7 +290,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             return new Read.Cuts(drawn);
         }
         return new Read.Stopped(GuardThresholds.whatEachPlaceIsLeftWith(
-                comparison, canonical, read, reads));
+                comparison, canonical, read, reads, answering));
     }
 
     /** One position's own values, cut where the reading found the line, or null where that reading

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -77,8 +77,7 @@ public final class DeclaredThresholds {
         ComparisonAssessment assessed = ComparisonAssessment.of(behavior, clause.states(),
                 Citation.of(clause.wrote()), read,
                 InputReads.ofADeclaredClause(roots), null,
-                souther.compiler.coverage.Arrivals.inTheTrees(
-                        clause.states().left(), clause.states().right()), true);
+                souther.compiler.coverage.Arrivals.inTheTree(clause.readOutOf()), true);
         // Only the quantity that is on no position. Why this drew no line where it drew none is not
         // said here: the reading of ends already answered for this clause at each position it names,
         // and a second sentence about one rule is two answers to one question.

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -77,7 +77,8 @@ public final class DeclaredThresholds {
         ComparisonAssessment assessed = ComparisonAssessment.of(behavior, clause.states(),
                 Citation.of(clause.wrote()), read,
                 InputReads.ofADeclaredClause(roots), null,
-                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), true);
+                souther.compiler.coverage.Arrivals.inTheTrees(
+                        clause.states().left(), clause.states().right()), true);
         // Only the quantity that is on no position. Why this drew no line where it drew none is not
         // said here: the reading of ends already answered for this clause at each position it names,
         // and a second sentence about one rule is two answers to one question.

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -76,7 +76,8 @@ public final class DeclaredThresholds {
         // to, which reads as an arrival that restricts nothing.
         ComparisonAssessment assessed = ComparisonAssessment.of(behavior, clause.states(),
                 Citation.of(clause.wrote()), read,
-                InputReads.ofADeclaredClause(roots), null, true);
+                InputReads.ofADeclaredClause(roots), null,
+                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), true);
         // Only the quantity that is on no position. Why this drew no line where it drew none is not
         // said here: the reading of ends already answered for this clause at each position it names,
         // and a second sentence about one rule is two answers to one question.

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -185,7 +185,9 @@ public final class EnsuresThresholds {
                                 InputReading read, Drawn out) {
         reportRuleWithoutLine(rule.ref(), it.stated(), rule.value(),
                 ComparisonAssessment.atEachOf(
-                        GuardThresholds.mentionedIn(it.stated(), it.reads(), read.symbols()).stream()
+                        GuardThresholds.mentionedIn(it.stated(), it.reads(), read.symbols(),
+                                        souther.compiler.coverage.Arrivals
+                                                .whereNothingStandsAbove()).stream()
                                 .map(FilingCoordinate::at).toList(),
                         new BlockReason.UnreadComparisonForm()),
                 out.noLine());
@@ -216,7 +218,8 @@ public final class EnsuresThresholds {
         // whole domain — which is what an arrival that restricts nothing reads as.
         ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison.stated(),
                 Citation.of(e.pos()), read,
-                reads, rule.value(), false);
+                reads, rule.value(),
+                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), false);
         // What the positions this names are left with, where the reading of lines drew none. Asked
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -187,7 +187,7 @@ public final class EnsuresThresholds {
                 ComparisonAssessment.atEachOf(
                         GuardThresholds.mentionedIn(it.stated(), it.reads(), read.symbols(),
                                         souther.compiler.coverage.Arrivals
-                                                .whereNothingStandsAbove()).stream()
+                                                .inTheTree(it.stated())).stream()
                                 .map(FilingCoordinate::at).toList(),
                         new BlockReason.UnreadComparisonForm()),
                 out.noLine());
@@ -219,7 +219,7 @@ public final class EnsuresThresholds {
         ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison.stated(),
                 Citation.of(e.pos()), read,
                 reads, rule.value(),
-                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), false);
+                souther.compiler.coverage.Arrivals.inTheTree(e), false);
         // What the positions this names are left with, where the reading of lines drew none. Asked
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -144,7 +144,9 @@ public final class EnsuresThresholds {
                         conjunct.part(), conjunct.stated().orNull(), reads, read.symbols())) {
                     switch (said.statement()) {
                         case ClauseStatements.Statement.Compares it ->
-                                compared(it, rule, said.id(), read, drawn);
+                                compared(it, rule, said.id(), read,
+                                        souther.compiler.coverage.Arrivals.inTheTree(
+                                                conjunct.stated().orNull()), drawn);
                         // A form no reader of clauses reads. Which positions it is about is still
                         // said, because a position left out of every answer is reported as one the
                         // model draws no line through — and the model says otherwise in the rule
@@ -152,7 +154,9 @@ public final class EnsuresThresholds {
                         // the statement is nobody's, which is one fact about it and not one per
                         // reader that turned it away.
                         case ClauseStatements.Statement.NotRead it ->
-                                notRead(it, rule, read, drawn);
+                                notRead(it, rule, read,
+                                        souther.compiler.coverage.Arrivals.inTheTree(
+                                                conjunct.stated().orNull()), drawn);
                         // Read by the reader that publishes what a rule tells apart
                         // ({@link BehaviorSetStatements}), and a finding here would be this reader
                         // saying it could not read a rule that was read.
@@ -182,12 +186,12 @@ public final class EnsuresThresholds {
      */
     private static void notRead(ClauseStatements.Statement.NotRead it,
                                 StatedContract.StatedRule rule,
-                                InputReading read, Drawn out) {
+                                InputReading read,
+                                souther.compiler.coverage.Arrivals answering, Drawn out) {
         reportRuleWithoutLine(rule.ref(), it.stated(), rule.value(),
                 ComparisonAssessment.atEachOf(
                         GuardThresholds.mentionedIn(it.stated(), it.reads(), read.symbols(),
-                                        souther.compiler.coverage.Arrivals
-                                                .inTheTree(it.stated())).stream()
+                                        answering).stream()
                                 .map(FilingCoordinate::at).toList(),
                         new BlockReason.UnreadComparisonForm()),
                 out.noLine());
@@ -206,7 +210,8 @@ public final class EnsuresThresholds {
      */
     private static void compared(ClauseStatements.Statement.Compares it,
                                  StatedContract.StatedRule rule, ClauseStatementId said,
-                                 InputReading read, Drawn out) {
+                                 InputReading read,
+                                 souther.compiler.coverage.Arrivals answering, Drawn out) {
         Core e = it.stated();
         InputReads reads = it.reads();
         Comparison comparison = it.comparison();
@@ -219,7 +224,7 @@ public final class EnsuresThresholds {
         ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison.stated(),
                 Citation.of(e.pos()), read,
                 reads, rule.value(),
-                souther.compiler.coverage.Arrivals.inTheTree(e), false);
+                answering, false);
         // What the positions this names are left with, where the reading of lines drew none. Asked
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -420,8 +420,9 @@ public final class GuardThresholds {
             /** The reading the arm opens, which is the reading's own answer: what a name an arm
              *  binds stands for is settled once, where every walk that goes inside one asks. */
             @Override
-            public InputReads choosing(Choice.Decides decidedBy, InputReads at) {
-                return at.choosing(decidedBy, symbols);
+            public ValueOrigin.Opened<InputReads> choosing(Choice.Decides decidedBy,
+                                                           InputReads at) {
+                return new ValueOrigin.Opened.Entered<>(at.choosing(decidedBy, symbols));
             }
         }), met);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.AnalysisBody;
 import souther.compiler.check.Carrier;
+import souther.compiler.check.Choice;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.StatedComparison;
 import souther.compiler.check.ComparisonClaim;
@@ -414,6 +415,13 @@ public final class GuardThresholds {
             @Override
             public InputReads inside(Core.LetIn li, InputReads at) {
                 return at.and(li.binder(), li.value());
+            }
+
+            /** The reading the arm opens, which is the reading's own answer: what a name an arm
+             *  binds stands for is settled once, where every walk that goes inside one asks. */
+            @Override
+            public InputReads choosing(Choice.Decides decidedBy, InputReads at) {
+                return at.choosing(decidedBy, symbols);
             }
         }), met);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -35,6 +35,8 @@ import souther.compiler.check.PathReachability;
 import souther.compiler.coverage.ComparisonEmissionIndex;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.EmittedComparisonState;
+import souther.compiler.coverage.Arrivals;
+import souther.compiler.flow.ValueArrivals;
 import souther.compiler.types.ModelOccurrence;
 import souther.compiler.types.Type;
 
@@ -344,13 +346,22 @@ public final class GuardThresholds {
      */
     record Names(ValueOrigin<TermPath> origin, java.util.Map<TermPath, Type> met) {}
 
-    /** What {@code e} is made of, for a caller that has no use for the types. */
-    static ValueOrigin<TermPath> originOf(Core e, InputReads reads, Symbols symbols) {
-        return namesIn(e, reads, symbols).origin();
+    /**
+     * What {@code e} is made of, for a caller that has no use for the types.
+     *
+     * @param answering whether an expression answers a value, of the tree {@code e} stands in.
+     *                  Handed over rather than made here: it is rooted, and which tree {@code e}
+     *                  stands in is what the caller knows — read as a body of its own, a subtree
+     *                  has every name in it free and a name bound to something that aborts is what
+     *                  makes the difference
+     */
+    static ValueOrigin<TermPath> originOf(Core e, InputReads reads, Symbols symbols,
+                                          Arrivals answering) {
+        return namesIn(e, reads, symbols, answering).origin();
     }
 
     /** The same, with what stood at each position the walk met. */
-    static Names namesIn(Core e, InputReads reads, Symbols symbols) {
+    static Names namesIn(Core e, InputReads reads, Symbols symbols, Arrivals answering) {
         java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>();
         return new Names(ValueOrigin.of(e, reads,
                 new ValueOrigin.Reading<TermPath, InputReads>() {
@@ -424,6 +435,20 @@ public final class GuardThresholds {
                                                            InputReads at) {
                 return new ValueOrigin.Opened.Entered<>(at.choosing(decidedBy, symbols));
             }
+
+            /**
+             * Whether an expression answers a value, of the tree this reading was made for.
+             *
+             * <p>The tree and not the body it stands in, which this reader is not handed. What that
+             * costs is a name bound above the tree to something that aborts, which is read here as
+             * a name like any other; what it does not do is answer about a tree this is no reading
+             * of — {@link ValueArrivals} refuses a node it was not rooted at rather than reading it
+             * as a body of its own.
+             */
+            @Override
+            public boolean answers(Core here, InputReads at) {
+                return answering.at(here);
+            }
         }), met);
     }
 
@@ -445,11 +470,11 @@ public final class GuardThresholds {
     static java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped>
             whatEachPlaceIsLeftWith(StatedComparison comparison,
                                     AffineReading.OfAComparison.Stopped stopped,
-                                    InputReading read, InputReads reads) {
+                                    InputReading read, InputReads reads, Arrivals answering) {
         Symbols symbols = read.symbols();
-        Names left = namesIn(comparison.left(), reads, symbols);
-        Names right = namesIn(comparison.right(), reads, symbols);
-        Names here = namesIn(stopped.node(), stopped.at(), symbols);
+        Names left = namesIn(comparison.left(), reads, symbols, answering);
+        Names right = namesIn(comparison.right(), reads, symbols, answering);
+        Names here = namesIn(stopped.node(), stopped.at(), symbols, answering);
         java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>(left.met());
         right.met().forEach(met::putIfAbsent);
         here.met().forEach(met::putIfAbsent);
@@ -459,7 +484,7 @@ public final class GuardThresholds {
                 at -> met.containsKey(at) && orderable(met.get(at), symbols);
         java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> out =
                 new java.util.LinkedHashMap<>();
-        for (FilingCoordinate at : filedAt(comparison, read, reads)) {
+        for (FilingCoordinate at : filedAt(comparison, read, reads, answering)) {
             out.putIfAbsent(at,
                     UnreadComparison.whereItStopped(ruleAt(at, left, right), notRead, ordered));
         }
@@ -493,8 +518,9 @@ public final class GuardThresholds {
      * one, a side would be carrying two answers to "which position is this about" and the
      * comparison between them would be settled by whichever the caller looked at.
      */
-    static List<TermPath> mentionedIn(Core e, InputReads reads, Symbols symbols) {
-        return new ArrayList<>(originOf(e, reads, symbols).positions());
+    static List<TermPath> mentionedIn(Core e, InputReads reads, Symbols symbols,
+                                      Arrivals answering) {
+        return new ArrayList<>(originOf(e, reads, symbols, answering).positions());
     }
 
     /**
@@ -514,7 +540,7 @@ public final class GuardThresholds {
      */
     static List<FilingCoordinate> filedAt(StatedComparison comparison,
                                                InputReading read,
-                                               InputReads reads) {
+                                               InputReads reads, Arrivals answering) {
         Symbols symbols = read.symbols();
         List<FilingCoordinate> out = new ArrayList<>();
         for (Core side : List.of(comparison.left(), comparison.right())) {
@@ -529,8 +555,8 @@ public final class GuardThresholds {
         // stands at no position of the input, so what a walk over it meets is what a walk over each
         // side meets.
         List<TermPath> named = new ArrayList<>();
-        mentioned(comparison.left(), reads, symbols, named);
-        mentioned(comparison.right(), reads, symbols, named);
+        mentioned(comparison.left(), reads, symbols, answering, named);
+        mentioned(comparison.right(), reads, symbols, answering, named);
         for (TermPath each : named) {
             if (out.stream().noneMatch(had -> had.path().equals(each))) {
                 add(FilingCoordinate.at(each), out);
@@ -546,8 +572,9 @@ public final class GuardThresholds {
     }
 
     /** The same, added to what a caller has already gathered from beside it. */
-    private static void mentioned(Core e, InputReads reads, Symbols symbols, List<TermPath> out) {
-        for (TermPath each : originOf(e, reads, symbols).positions()) {
+    private static void mentioned(Core e, InputReads reads, Symbols symbols, Arrivals answering,
+                                  List<TermPath> out) {
+        for (TermPath each : originOf(e, reads, symbols, answering).positions()) {
             if (!out.contains(each)) {
                 out.add(each);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
@@ -186,9 +186,8 @@ record PredicateReadings(List<Reading> predicates, Set<Core> statedAt,
         // Whether an expression answers a value, of this body. Rooted there and not at whatever a
         // reader happens to hand over: a subtree read as a body of its own has every name in it
         // free, and a name bound to something that aborts is what makes the difference.
-        return new PredicateReadings(predicates, statedAt, body == null
-                ? souther.compiler.coverage.Arrivals.whereNothingStandsAbove()
-                : souther.compiler.coverage.Arrivals.inTheBody(body.core()));
+        return new PredicateReadings(predicates, statedAt, souther.compiler.coverage.Arrivals
+                .inTheTree(body == null ? null : body.core()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
@@ -54,7 +54,8 @@ import java.util.Set;
  * value of the model is ever on either side of. So a reading is made only where what is computed is
  * read on the way to the answer, which is the one thing carried down this walk.
  */
-record PredicateReadings(List<Reading> predicates, Set<Core> statedAt) {
+record PredicateReadings(List<Reading> predicates, Set<Core> statedAt,
+                         souther.compiler.coverage.Arrivals arrivals) {
 
     PredicateReadings {
         predicates = List.copyOf(predicates);
@@ -182,7 +183,12 @@ record PredicateReadings(List<Reading> predicates, Set<Core> statedAt) {
                 }
             }
         }
-        return new PredicateReadings(predicates, statedAt);
+        // Whether an expression answers a value, of this body. Rooted there and not at whatever a
+        // reader happens to hand over: a subtree read as a body of its own has every name in it
+        // free, and a name bound to something that aborts is what makes the difference.
+        return new PredicateReadings(predicates, statedAt, body == null
+                ? souther.compiler.coverage.Arrivals.whereNothingStandsAbove()
+                : souther.compiler.coverage.Arrivals.inTheBody(body.core()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What decided a choice contributes to the positions it depends on, and to nothing it is made of.
+ *
+ * <p>The two questions a choice is asked. Which positions the expression names includes what it
+ * turned on — a reading of that position is one nothing about the expression is outside of — and
+ * where its value came from does not, since none of the values the expression comes to are the ones
+ * standing there.
+ *
+ * <p>Written over the algebra rather than over a model, because this is the law the arms of
+ * {@link ValueOrigin} are built to state. What a reader of a body does with it is its own, and is
+ * said where that reader is.
+ */
+class AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest {
+
+    private static ValueOrigin<String> choiceOn(ValueOrigin<String> decidedBy,
+                                                List<ValueOrigin<String>> alternatives) {
+        return new ValueOrigin.OneOf<>(decidedBy, alternatives);
+    }
+
+    /** What it turned on is a position the expression names. */
+    @Test
+    void whatDecidedTheChoiceIsAmongThePositionsItNames() {
+        assertEquals(List.of("flag", "a", "b"),
+                List.copyOf(choiceOn(new ValueOrigin.IsAPosition<>("flag"),
+                        List.of(new ValueOrigin.IsAPosition<>("a"),
+                                new ValueOrigin.IsAPosition<>("b"))).positions()));
+    }
+
+    /** And it is not where the value came from, however the value it decided between was made. */
+    @Test
+    void whatDecidedTheChoiceIsNotWhereTheValueCameFrom() {
+        assertNull(choiceOn(new ValueOrigin.MadeFromAPosition<>("xs[*]"),
+                List.of(new ValueOrigin.IsAPosition<>("a"),
+                        new ValueOrigin.IsAPosition<>("b"))).madeFrom());
+    }
+
+    /** A choice is made from the one position every value it may be came from. */
+    @Test
+    void aChoiceBetweenValuesFromOnePositionIsMadeFromThatPosition() {
+        assertEquals("xs[*]", choiceOn(new ValueOrigin.IsAPosition<>("flag"),
+                List.of(new ValueOrigin.MadeFromAPosition<>("xs[*]"),
+                        new ValueOrigin.MadeFromAPosition<>("xs[*]"))).madeFrom());
+    }
+
+    /**
+     * And from none where they came from two, the value being one of them and nothing saying which.
+     */
+    @Test
+    void aChoiceBetweenValuesFromTwoPositionsIsMadeFromNeither() {
+        assertNull(choiceOn(new ValueOrigin.IsAPosition<>("flag"),
+                List.of(new ValueOrigin.MadeFromAPosition<>("xs[*]"),
+                        new ValueOrigin.MadeFromAPosition<>("ys[*]"))).madeFrom());
+    }
+
+    /** And from none where one of them came from nowhere this can name. */
+    @Test
+    void aChoiceWithOneAlternativeFromNowhereIsMadeFromNowhere() {
+        assertNull(choiceOn(new ValueOrigin.IsAPosition<>("flag"),
+                List.of(new ValueOrigin.MadeFromAPosition<>("xs[*]"),
+                        new ValueOrigin.Written<>())).madeFrom());
+    }
+
+    /** A choice between nothing is not a choice. */
+    @Test
+    void aChoiceStatesWhatItIsBetween() {
+        assertThrows(IllegalArgumentException.class,
+                () -> choiceOn(new ValueOrigin.IsAPosition<>("flag"), List.of()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest.java
@@ -24,7 +24,7 @@ class AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest {
 
     private static ValueOrigin<String> choiceOn(ValueOrigin<String> decidedBy,
                                                 List<ValueOrigin<String>> alternatives) {
-        return new ValueOrigin.OneOf<>(decidedBy, alternatives);
+        return new ValueOrigin.OneOf<>(List.of(decidedBy), alternatives);
     }
 
     /** What it turned on is a position the expression names. */
@@ -75,5 +75,28 @@ class AChoiceDependsOnWhatDecidedItAndIsMadeOfWhatItChoosesBetweenTest {
     void aChoiceStatesWhatItIsBetween() {
         assertThrows(IllegalArgumentException.class,
                 () -> choiceOn(new ValueOrigin.IsAPosition<>("flag"), List.of()));
+    }
+
+    /**
+     * And a path that comes to no value is not one of the values it may be.
+     *
+     * <p>Refused here rather than dropped, so that a walk which gathers the arms of a fork has to
+     * say what it does with one that departs. Held as an alternative, it would answer for the value
+     * beside the arms that have one: what the whole was made from and whether every value it may be
+     * was made by an operation are both questions about the values, and a departure is the absence
+     * of one.
+     */
+    @Test
+    void aPathThatComesToNoValueIsNotOneOfTheValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> choiceOn(new ValueOrigin.IsAPosition<>("flag"),
+                        List.of(new ValueOrigin.IsAPosition<>("a"), new ValueOrigin.NoValue<>())));
+    }
+
+    /** A path with no value on it names no position and came from none. */
+    @Test
+    void aPathWithNoValueNamesNothing() {
+        assertEquals(List.of(), List.copyOf(new ValueOrigin.NoValue<String>().positions()));
+        assertNull(new ValueOrigin.NoValue<String>().madeFrom());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
@@ -71,6 +71,61 @@ class AStoppedReadingSaysWhatStoppedItAtEachPlaceTest {
                         + "nothing about what that position carries");
     }
 
+    /**
+     * A clause over a value chosen between two, where every value it may be was made by an
+     * operation over a position.
+     *
+     * <p>Whichever way the choice went, what the rule is about is a length and what stands at the
+     * position is a string: the position was found and following the operation back is the part
+     * this compiler does not have.
+     */
+    private static final String EVERY_VALUE_IT_MAY_BE_WAS_MADE_BY_AN_OPERATION = """
+            module demo
+
+            let pick (flag: Bool, a: String, b: String) : Int =
+                if flag then String.length(String.uppercase(a))
+                else String.length(String.uppercase(b))
+
+            data N = { n: Int, flag: Bool, a: String, b: String }
+                invariant said = n < pick(flag, a, b)
+            """;
+
+    /**
+     * And the same where one of them is the values at a position rather than something made of
+     * them.
+     *
+     * <p>Whichever way that choice went is what nothing here read, so what an author is owed is not
+     * the word that promises the position was found and only the operation stands in the way.
+     */
+    private static final String ONE_VALUE_IT_MAY_BE_IS_A_POSITION = """
+            module demo
+
+            let pick (flag: Bool, a: String, b: Int) : Int =
+                if flag then String.length(String.uppercase(a)) else b
+
+            data N = { n: Int, flag: Bool, a: String, b: Int }
+                invariant said = n < pick(flag, a, b)
+            """;
+
+    @Test
+    void aChoiceEveryArmOfWhichAnOperationMadeIsARuleAboutADerivedValue() {
+        FieldDomains read = read(EVERY_VALUE_IT_MAY_BE_WAS_MADE_BY_AN_OPERATION);
+
+        assertEquals(List.of(new BlockReason.RuleAboutADerivedValue()), reasonsAt(read, "a"),
+                "the strings here are what the length the rule is about was taken of");
+        assertEquals(List.of(new BlockReason.RuleAboutADerivedValue()), reasonsAt(read, "b"));
+    }
+
+    @Test
+    void aChoiceOneArmOfWhichIsAPositionIsAFormThatWentUnread() {
+        FieldDomains read = read(ONE_VALUE_IT_MAY_BE_IS_A_POSITION);
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "a"),
+                "one value it may be is the values at a position, so following an operation back "
+                        + "is not what stands between the rule and them");
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "b"));
+    }
+
     private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read,
                                                                      String field) {
         return read.noLineAt(RuleKey.of(field)).stream().map(FieldDomains.NoLine::why).toList();

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
@@ -72,14 +72,44 @@ class AnArmIsReadWhereTheArmStandsTest {
         }
 
         @Override
-        public String choosing(Choice.Decides decidedBy, String at) {
-            return switch (decidedBy) {
+        public ValueOrigin.Opened<String> choosing(Choice.Decides decidedBy, String at) {
+            return new ValueOrigin.Opened.Entered<>(switch (decidedBy) {
                 case Choice.Decides.ACondition _ -> at;
                 case Choice.Decides.ACase _ -> "arm";
                 case Choice.Decides.ItWasBuilt _ -> "built";
                 case Choice.Decides.ItDeparted _ -> at;
                 case Choice.Decides.ByArgumentRelations _ -> at;
-            };
+            });
+        }
+    };
+
+    /** A reading that goes inside no arm, as the reading of a clause of a {@code data} does not. */
+    private static final ValueOrigin.Reading<String, String> WHICH_GOES_INSIDE_NO_ARM =
+            new ValueOrigin.Reading<>() {
+
+        @Override
+        public String positionOf(Core e, String at) {
+            return WHERE_IT_WAS_READ.positionOf(e, at);
+        }
+
+        @Override
+        public String madeFrom(Core e, String at) {
+            return null;
+        }
+
+        @Override
+        public AffineForms.ReadThrough<String> readThrough(Core.Read read, String at) {
+            return null;
+        }
+
+        @Override
+        public String inside(Core.LetIn li, String at) {
+            return at;
+        }
+
+        @Override
+        public ValueOrigin.Opened<String> choosing(Choice.Decides decidedBy, String at) {
+            return new ValueOrigin.Opened.NotEntered<>();
         }
     };
 
@@ -173,6 +203,29 @@ class AnArmIsReadWhereTheArmStandsTest {
 
         assertEquals(1, choice.alternatives().size(),
                 () -> "the value it built, and not the departure: " + choice.alternatives());
+    }
+
+    /**
+     * And an arm a reading does not go inside is a value it can say nothing about, rather than one
+     * read where the fork stands.
+     *
+     * <p>Still one of the values the expression may be: the arm answers a value, and what this
+     * reading is short of is the name it answers with. Read outside the arm instead, a name that
+     * means something else out there would come back as the arm's own answer.
+     */
+    @Test
+    void anArmAReadingDoesNotGoInsideIsAValueItCannotName() {
+        ValueOrigin<String> origin = ValueOrigin.of(
+                attempt(read("a", 0), read("held", 1), List.of(read("b", 2))),
+                "outside", WHICH_GOES_INSIDE_NO_ARM);
+
+        if (!(origin instanceof ValueOrigin.OneOf<String> choice)) {
+            throw new AssertionError("a fork is a value that is one of several: " + origin);
+        }
+        assertEquals(2, choice.alternatives().size(),
+                () -> "both arms answer a value: " + choice.alternatives());
+        assertInstanceOf(ValueOrigin.Unnameable.class, choice.alternatives().getFirst());
+        assertInstanceOf(ValueOrigin.Unnameable.class, choice.alternatives().getLast());
     }
 
     /** And a fork every arm of which comes to no value comes to none itself. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
+import souther.compiler.coverage.NormalReturn;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
@@ -47,9 +48,15 @@ class AnArmIsReadWhereTheArmStandsTest {
     private static final SourceConstructOrigin ORIGIN = SourceConstructOrigin.written(
             new WrittenOwner.Body("demo", "go"), 0, SourceConstruct.IF);
 
-    /** A reading whose positions say which reading they were found in. */
-    private static final ValueOrigin.Reading<String, String> WHERE_IT_WAS_READ =
-            new ValueOrigin.Reading<>() {
+    /** A reading whose positions say which reading they were found in, of the tree {@code root}. */
+    private static ValueOrigin.Reading<String, String> whereItWasRead(Core root) {
+        NormalReturn answering = NormalReturn.lazilyWhereTheOperationsStand(root);
+        return new ValueOrigin.Reading<>() {
+
+        @Override
+        public boolean answers(Core e, String at) {
+            return answering.at(e);
+        }
 
         @Override
         public String positionOf(Core e, String at) {
@@ -81,15 +88,22 @@ class AnArmIsReadWhereTheArmStandsTest {
                 case Choice.Decides.ByArgumentRelations _ -> at;
             });
         }
-    };
+        };
+    }
 
     /** A reading that goes inside no arm, as the reading of a clause of a {@code data} does not. */
-    private static final ValueOrigin.Reading<String, String> WHICH_GOES_INSIDE_NO_ARM =
-            new ValueOrigin.Reading<>() {
+    private static ValueOrigin.Reading<String, String> whichGoesInsideNoArm(Core root) {
+        NormalReturn answering = NormalReturn.lazilyWhereTheOperationsStand(root);
+        return new ValueOrigin.Reading<>() {
+
+        @Override
+        public boolean answers(Core e, String at) {
+            return answering.at(e);
+        }
 
         @Override
         public String positionOf(Core e, String at) {
-            return WHERE_IT_WAS_READ.positionOf(e, at);
+            return e instanceof Core.Read read ? at + ":" + read.name() : null;
         }
 
         @Override
@@ -111,7 +125,8 @@ class AnArmIsReadWhereTheArmStandsTest {
         public ValueOrigin.Opened<String> choosing(Choice.Decides decidedBy, String at) {
             return new ValueOrigin.Opened.NotEntered<>();
         }
-    };
+        };
+    }
 
     private static Core.Read read(String name, int ordinal) {
         return new Core.Read(name, new BindingId(OWNER, ordinal), Type.STRING, POS);
@@ -130,7 +145,7 @@ class AnArmIsReadWhereTheArmStandsTest {
     }
 
     private static ValueOrigin<String> originOf(Core e) {
-        return ValueOrigin.of(e, "outside", WHERE_IT_WAS_READ);
+        return ValueOrigin.of(e, "outside", whereItWasRead(e));
     }
 
     /** What {@code e} is made of, where that is a choice. */
@@ -215,9 +230,9 @@ class AnArmIsReadWhereTheArmStandsTest {
      */
     @Test
     void anArmAReadingDoesNotGoInsideIsAValueItCannotName() {
-        ValueOrigin<String> origin = ValueOrigin.of(
-                attempt(read("a", 0), read("held", 1), List.of(read("b", 2))),
-                "outside", WHICH_GOES_INSIDE_NO_ARM);
+        Core fork = attempt(read("a", 0), read("held", 1), List.of(read("b", 2)));
+        ValueOrigin<String> origin =
+                ValueOrigin.of(fork, "outside", whichGoesInsideNoArm(fork));
 
         if (!(origin instanceof ValueOrigin.OneOf<String> choice)) {
             throw new AssertionError("a fork is a value that is one of several: " + origin);

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmIsReadWhereTheArmStandsTest.java
@@ -1,0 +1,185 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.ConstructOccurrence;
+import souther.compiler.types.ResolvedCase;
+import souther.compiler.types.SourceConstruct;
+import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.WrittenOwner;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Every value a fork may be is read where that value is written, and an arm that comes to none is
+ * not one of them.
+ *
+ * <p>Asked of the walk rather than of a model, because an attempted construction reaches this from
+ * a {@code guard} inside a block and the readings a body's rules are filed from do not go there.
+ * What the walk does with a fork is the same whichever fork it is, and this is where that is
+ * settled.
+ *
+ * <p>What a name inside an arm stands for is the reading's, so the reading here answers with the
+ * name of the reading it was asked in — which is how an arm read in the wrong one shows up as a
+ * position of the wrong name rather than as nothing at all.
+ */
+class AnArmIsReadWhereTheArmStandsTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("demo", "go");
+    private static final Hir.Binders BINDERS = new Hir.Binders(OWNER);
+    private static final TypeSymbol.AtModule PERSON =
+            TypeSymbols.declared(new TypeKey("demo", "Person"));
+    private static final SourceConstructOrigin ORIGIN = SourceConstructOrigin.written(
+            new WrittenOwner.Body("demo", "go"), 0, SourceConstruct.IF);
+
+    /** A reading whose positions say which reading they were found in. */
+    private static final ValueOrigin.Reading<String, String> WHERE_IT_WAS_READ =
+            new ValueOrigin.Reading<>() {
+
+        @Override
+        public String positionOf(Core e, String at) {
+            return e instanceof Core.Read read ? at + ":" + read.name() : null;
+        }
+
+        @Override
+        public String madeFrom(Core e, String at) {
+            return null;
+        }
+
+        @Override
+        public AffineForms.ReadThrough<String> readThrough(Core.Read read, String at) {
+            return null;
+        }
+
+        @Override
+        public String inside(Core.LetIn li, String at) {
+            return at;
+        }
+
+        @Override
+        public String choosing(Choice.Decides decidedBy, String at) {
+            return switch (decidedBy) {
+                case Choice.Decides.ACondition _ -> at;
+                case Choice.Decides.ACase _ -> "arm";
+                case Choice.Decides.ItWasBuilt _ -> "built";
+                case Choice.Decides.ItDeparted _ -> at;
+                case Choice.Decides.ByArgumentRelations _ -> at;
+            };
+        }
+    };
+
+    private static Core.Read read(String name, int ordinal) {
+        return new Core.Read(name, new BindingId(OWNER, ordinal), Type.STRING, POS);
+    }
+
+    private static Core.Construct construction(Core given) {
+        return new Core.Construct(PERSON, List.of(new Core.FieldValue("name", given, POS)),
+                Type.ref(PERSON), POS);
+    }
+
+    private static Core.IfConstructed attempt(Core given, Core then, List<Core> departures) {
+        return new Core.IfConstructed(construction(given),
+                CoreBinders.of(BINDERS.binder("built", POS)), then,
+                departures.stream().map(each -> new Core.ElseArm(Optional.empty(), each)).toList(),
+                Core.ForkPlace.asWritten(ConstructOccurrence.asWritten(ORIGIN)), Type.STRING, POS);
+    }
+
+    private static ValueOrigin<String> originOf(Core e) {
+        return ValueOrigin.of(e, "outside", WHERE_IT_WAS_READ);
+    }
+
+    /** What {@code e} is made of, where that is a choice. */
+    private static ValueOrigin.OneOf<String> choiceIn(Core e) {
+        ValueOrigin<String> origin = originOf(e);
+        if (origin instanceof ValueOrigin.OneOf<String> choice) {
+            return choice;
+        }
+        throw new AssertionError("a fork is a value that is one of several: " + origin);
+    }
+
+    /**
+     * An attempt's arms are the value it built and every departure, and what it tried to build is
+     * what decided which.
+     */
+    @Test
+    void anAttemptsArmsAreTheValueItBuiltAndEveryDeparture() {
+        ValueOrigin.OneOf<String> choice =
+                choiceIn(attempt(read("a", 0), read("held", 1), List.of(read("b", 2))));
+
+        assertEquals(2, choice.alternatives().size(),
+                () -> "the value it built and the one departure: " + choice.alternatives());
+        assertEquals(List.of("outside:a"), List.copyOf(choice.decidedBy().getFirst().positions()),
+                "what it tried to build is what its invariant was tested on");
+    }
+
+    /**
+     * And the success arm is read in the reading choosing it opens, where the name the attempt
+     * writes stands for what was built.
+     */
+    @Test
+    void theArmAnAttemptOpensIsReadInTheReadingItOpens() {
+        ValueOrigin.OneOf<String> choice =
+                choiceIn(attempt(read("a", 0), read("held", 1), List.of(read("b", 2))));
+
+        assertEquals(List.of("built:held"),
+                List.copyOf(choice.alternatives().getFirst().positions()),
+                "read outside the arm, the name the attempt binds stands for nothing");
+        assertEquals(List.of("outside:b"),
+                List.copyOf(choice.alternatives().getLast().positions()),
+                "and a departure was taken where nothing was built, so it opens nothing");
+    }
+
+    /** And the same for a match, whose arm binds the value that was matched. */
+    @Test
+    void theArmAMatchOpensIsReadInTheReadingItOpens() {
+        Core.Case arm = new Core.Case(
+                new Core.ResolvedPattern.Single(ResolvedCase.of(CaseSelector.direct(PERSON),
+                        List.of(PERSON))),
+                CoreBinders.of(BINDERS.binder("it", POS)), read("it", 3), POS);
+        ValueOrigin.OneOf<String> choice = choiceIn(new Core.Match(read("subject", 4), List.of(arm),
+                Core.ForkPlace.asWritten(ConstructOccurrence.asWritten(ORIGIN)), Type.STRING, POS));
+
+        assertEquals(List.of("arm:it"), List.copyOf(choice.alternatives().getFirst().positions()));
+        assertEquals(List.of("outside:subject"),
+                List.copyOf(choice.decidedBy().getFirst().positions()));
+    }
+
+    /**
+     * A departure that comes to no value is not one of the values the attempt may be.
+     *
+     * <p>Read as one, every reader asking something of all of them answers about a path the value
+     * never came down: what the whole was made from, and whether every value it may be was made by
+     * an operation.
+     */
+    @Test
+    void anArmThatComesToNoValueIsNotOneOfTheValues() {
+        ValueOrigin.OneOf<String> choice = choiceIn(attempt(read("a", 0), read("held", 1),
+                List.of(new Core.Unreachable("never", Type.NEVER, POS))));
+
+        assertEquals(1, choice.alternatives().size(),
+                () -> "the value it built, and not the departure: " + choice.alternatives());
+    }
+
+    /** And a fork every arm of which comes to no value comes to none itself. */
+    @Test
+    void aForkEveryArmOfWhichComesToNoValueComesToNone() {
+        assertInstanceOf(ValueOrigin.NoValue.class,
+                originOf(attempt(read("a", 0), new Core.Unreachable("never", Type.NEVER, POS),
+                        List.of(new Core.Unreachable("nor this", Type.NEVER, POS)))));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -101,6 +101,33 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                         | Second -> b) then Yes else No
             """;
 
+    private static final String AN_ARM_BINDS_WHAT_IT_MATCHED = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Plain = { code: String }
+            data Special = { code: String }
+            data Item = Plain | Special
+
+            behavior f : (item: Item) -> Answer
+            let f (item) =
+                if String.startsWith("JP", match item with
+                        | Plain as p -> p.code
+                        | Special as s -> s.code) then Yes else No
+            """;
+
+    private static final String ONE_ARM_COMES_TO_NO_VALUE = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (flag: Bool, a: String) -> Answer
+            let f (flag, a) =
+                if (if flag then String.length(String.uppercase(a))
+                    else unreachable "the flag is set wherever this is read") > 10
+                    then Yes else No
+            """;
+
     private static final String AN_ELEMENT_IT_CAME_FROM = """
             module example.codes
 
@@ -189,6 +216,42 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     void aValueChosenByAMatchIsNamedAtEveryArm() {
         assertEquals(List.of("a", "b"), derived(measured(A_VALUE_CHOSEN_BY_A_MATCH)),
                 () -> "said at each arm: " + measured(A_VALUE_CHOSEN_BY_A_MATCH).notRead());
+    }
+
+    /**
+     * And an arm is read where the arm stands, so what it binds is a name with a position.
+     *
+     * <p>What a {@code match} arm binds is the value that was matched read as the case the arm
+     * selects, and that name exists inside the arm and nowhere else. Read where the fork stands,
+     * the arm's own answer is a name standing for nothing and the rule is shown nowhere — which is
+     * the same silence a model with no rule in it gives.
+     */
+    @Test
+    void whatAnArmBindsIsNamedWhereTheArmNarrowedIt() {
+        assertEquals(List.of("item@Plain.code", "item@Special.code"),
+                derived(measured(AN_ARM_BINDS_WHAT_IT_MATCHED)),
+                () -> "said under each case the arms select: "
+                        + measured(AN_ARM_BINDS_WHAT_IT_MATCHED).notRead());
+    }
+
+
+    /**
+     * And an arm that comes to no value is not one of the values the rule is about.
+     *
+     * <p>A departure is not another value the subject may be. Counted among them, the arm with
+     * nothing on it answers for the subject beside the arm that has a value, and the one value this
+     * subject may be — a length an operation took of the strings at a position — comes back as a
+     * form nothing read, which sends an author after a syntax that is not the difficulty.
+     *
+     * <p>A comparison, so both places it names carry the word: which positions it depends on
+     * includes what the choice turned on, and one comparison has one arithmetic. Which of them the
+     * value came from is the other question, and it is the one the tests above ask.
+     */
+    @Test
+    void anArmThatComesToNoValueIsNotOneOfTheValuesTheRuleIsAbout() {
+        assertEquals(List.of("flag", "a"), derived(measured(ONE_ARM_COMES_TO_NO_VALUE)),
+                () -> "the one value the subject may be was made from the strings here: "
+                        + measured(ONE_ARM_COMES_TO_NO_VALUE).notRead());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -128,6 +128,21 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                     then Yes else No
             """;
 
+    private static final String AN_ARM_BUILDS_A_VALUE_OUT_OF_AN_UNREACHABLE = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Count = Int
+            data Boxed = { n: Count }
+
+            behavior f : (flag: Bool, a: String) -> Answer
+                constructs Count, Boxed
+            let f (flag, a) =
+                if (if flag then String.length(String.uppercase(a))
+                    else Boxed { n = Count(unreachable "no number to give") }.n.value) > 10
+                    then Yes else No
+            """;
+
     private static final String AN_ELEMENT_IT_CAME_FROM = """
             module example.codes
 
@@ -252,6 +267,23 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
         assertEquals(List.of("flag", "a"), derived(measured(ONE_ARM_COMES_TO_NO_VALUE)),
                 () -> "the one value the subject may be was made from the strings here: "
                         + measured(ONE_ARM_COMES_TO_NO_VALUE).notRead());
+    }
+
+    /**
+     * And the arm need not be an {@code unreachable} to be one: it is enough that it has to
+     * evaluate one.
+     *
+     * <p>The case a rule written over the shape of the node gets wrong. There is no fork in this
+     * arm and its outermost node is a field taken of a construction, so an arm counted by what it
+     * is made of is counted here — and the value the expression may be goes back to being one of
+     * two, of which one was made by no operation.
+     */
+    @Test
+    void anArmThatHasToEvaluateAnUnreachableIsNotOneOfTheValuesEither() {
+        assertEquals(List.of("flag", "a"),
+                derived(measured(AN_ARM_BUILDS_A_VALUE_OUT_OF_AN_UNREACHABLE)),
+                () -> "the one value the subject may be was made from the strings here: "
+                        + measured(AN_ARM_BUILDS_A_VALUE_OUT_OF_AN_UNREACHABLE).notRead());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -77,6 +77,30 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                 if String.startsWith("JP", if flag then a else b) then Yes else No
             """;
 
+    private static final String A_CHOICE_DECIDED_BY_A_STRING = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (sel: String, a: String, b: String) -> Answer
+            let f (sel, a, b) =
+                if String.startsWith("JP",
+                        if String.startsWith("X", sel) then a else b) then Yes else No
+            """;
+
+    private static final String A_VALUE_CHOSEN_BY_A_MATCH = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Pick = First | Second
+
+            behavior f : (pick: Pick, a: String, b: String) -> Answer
+            let f (pick, a, b) =
+                if String.startsWith("JP", match pick with
+                        | First -> a
+                        | Second -> b) then Yes else No
+            """;
+
     private static final String AN_ELEMENT_IT_CAME_FROM = """
             module example.codes
 
@@ -130,24 +154,41 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     }
 
     /**
-     * And a rule about a value chosen between two is said nowhere, for want of a reading that
-     * tells a choice from a composition.
+     * And a rule about a value chosen between two is named where either value came from, and not
+     * where the choice was decided.
      *
-     * <p>Not what such a rule is owed. The value is what {@code a} is or what {@code b} is, and
-     * each of them is a position an author who wrote a rule about it has something to be told
-     * about — but what an expression is made of holds the arms of a choice and what it turns on in
-     * one arm, side by side with everything a value was built out of. Read as where the value came
-     * from, the rule would be filed at {@code flag} as well, which decided which value the subject
-     * is and holds none of the strings the rule is about.
-     *
-     * <p>So this is the reading falling short rather than the model saying nothing, and it is what
-     * the day a choice is told from a composition has to come back to.
+     * <p>The value is what {@code a} is or what {@code b} is, so each of them is a position an
+     * author who wrote a rule about it has something to be told about. What decided which of them
+     * it is holds none of the strings the rule is about, and a reader sent to {@code flag} is sent
+     * to a position the rule says nothing of.
      */
     @Test
-    void aValueChosenBetweenTwoIsNamedNowhereForNow() {
-        assertEquals(List.of(), derived(measured(A_VALUE_CHOSEN_BETWEEN)),
-                () -> "nothing is filed, and least of all what the choice turned on: "
+    void aValueChosenBetweenTwoIsNamedWhereEachAlternativeCameFrom() {
+        assertEquals(List.of("a", "b"), derived(measured(A_VALUE_CHOSEN_BETWEEN)),
+                () -> "said at each value it may be, and not at what decided which: "
                         + measured(A_VALUE_CHOSEN_BETWEEN).notRead());
+    }
+
+    /**
+     * And what decided it is left out for being what decided it, not for being of another kind.
+     *
+     * <p>The one above turns on a {@code Bool}, which is no position a rule about strings could be
+     * filed at anyway. Here the choice turns on a string of its own, read by a rule of the same
+     * shape as the one under test — so the only thing telling {@code sel} from {@code a} and
+     * {@code b} is which side of the choice it stands on.
+     */
+    @Test
+    void whatDecidedTheChoiceIsNotNamedEvenWhereItCouldBe() {
+        assertEquals(List.of("a", "b"), derived(measured(A_CHOICE_DECIDED_BY_A_STRING)),
+                () -> "sel decided which value the subject is and holds none of its strings: "
+                        + measured(A_CHOICE_DECIDED_BY_A_STRING).notRead());
+    }
+
+    /** And a value chosen by a match is named at every arm, the scrutinee being what decided it. */
+    @Test
+    void aValueChosenByAMatchIsNamedAtEveryArm() {
+        assertEquals(List.of("a", "b"), derived(measured(A_VALUE_CHOSEN_BY_A_MATCH)),
+                () -> "said at each arm: " + measured(A_VALUE_CHOSEN_BY_A_MATCH).notRead());
     }
 
     /**
@@ -174,7 +215,8 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      */
     @Test
     void everyOneOfThemNamesTheRuleAsAQuestionStandingThere() {
-        for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM)) {
+        for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM,
+                A_VALUE_CHOSEN_BETWEEN, A_VALUE_CHOSEN_BY_A_MATCH)) {
             PartitionEvidence measured = measured(model);
             assertTrue(measured.notRead().stream()
                             .filter(each -> each.reason()
@@ -208,8 +250,13 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                 "where the rule the report names is written");
     }
 
-    /** No line is drawn at any of them, since the strings the rule is about are not the ones
-     *  there. */
+    /**
+     * No line is drawn at any of them, since the strings the rule is about are not the ones there.
+     *
+     * <p>The models with a choice in them are not here: a fork's own condition is a rule about the
+     * values at the position it turns on, and the line drawn there is that rule's and not this
+     * one's.
+     */
     @Test
     void noLineIsDrawnAtAnyOfThem() {
         for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM)) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -82,7 +82,8 @@ class WhatAComparisonIsARuleAboutTest {
         return ComparisonAssessment.of("f", comparison.stated(), Citation.of(binary.pos()),
                 inputs.reading(rules),
                 InputReads.ofWhatIsDeclared(roots), rule.value(),
-                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), false);
+                souther.compiler.coverage.Arrivals.inTheTrees(
+                        comparison.stated().left(), comparison.stated().right()), false);
     }
 
     /** The same over two {@code Int} positions, which is what most of the table is written over. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -81,7 +81,8 @@ class WhatAComparisonIsARuleAboutTest {
         }
         return ComparisonAssessment.of("f", comparison.stated(), Citation.of(binary.pos()),
                 inputs.reading(rules),
-                InputReads.ofWhatIsDeclared(roots), rule.value(), false);
+                InputReads.ofWhatIsDeclared(roots), rule.value(),
+                souther.compiler.coverage.Arrivals.whereNothingStandsAbove(), false);
     }
 
     /** The same over two {@code Int} positions, which is what most of the table is written over. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -82,8 +82,7 @@ class WhatAComparisonIsARuleAboutTest {
         return ComparisonAssessment.of("f", comparison.stated(), Citation.of(binary.pos()),
                 inputs.reading(rules),
                 InputReads.ofWhatIsDeclared(roots), rule.value(),
-                souther.compiler.coverage.Arrivals.inTheTrees(
-                        comparison.stated().left(), comparison.stated().right()), false);
+                souther.compiler.coverage.Arrivals.inTheTree(read), false);
     }
 
     /** The same over two {@code Int} positions, which is what most of the table is written over. */


### PR DESCRIPTION
Closes #1570.

What an expression is made of walked a fork by its children, so `Core.If`,
`Core.IfConstructed` and `Core.Match` came back composed of what they turned on
and the values they choose between alike. Those are different relations:
everything under a composition contributed to the value, and the arms of a fork
are what the value may be, of which one is.

A choice is now its own arm of `ValueOrigin`, holding what decided it apart from
what it chooses between. The invariant it states:

> `decidedBy` contributes to dependency positions, but not to value provenance.

So which positions a fork names is unchanged — a comparison over a chosen value
is one no reading of the test is outside of — and where the value came from is
read off the arms alone. A rule an author wrote about a value chosen between two
is now named at every position those values came from, and never at the one the
choice turned on.

## Which several, and what decides each, is asked of the one place that says so

Which values a fork may be is `Choice`'s answer, and the arms are not read off
the node here. Listed again, the list carried neither of the things that owner
holds:

- **Which reading an arm's answer is written in.** What a `match` arm binds is
  the value that was matched read as the case the arm selects, and what an
  attempt binds is what it built — names that exist inside the arm and nowhere
  else. Read where the fork stands, such an arm came back as a value nothing
  could say anything about. `ValueOrigin.Reading` now asks what the arm a way of
  deciding chooses is read in, and each reading answers in its own vocabulary —
  `InputReads` for a body's inputs, `Terms` for a clause's denotations — as they
  already do for a `let`'s binding. Both switch over the sum of ways an arm is
  decided, so a way added later stops them until somebody says what choosing it
  binds there.
- **That a departure is not a value the expression may be.** A path that comes
  to no value now says so. Such a path is not one of the alternatives — refused
  where alternatives are built, rather than dropped — and a choice every arm of
  which comes to none comes to none itself. Counted among the values, an arm
  with nothing on it answered for the subject beside the arms that have one, and
  a rule about what an operation made came back as a form nothing read.

## What each reader was decided to ask

`positions()` reads both, which is what keeps the filing of a comparison where it
was.

`positionsItCameFrom` reads the alternatives. This is the reader #1570 is about,
and the test that pinned the old answer — a rule under a choice shown nowhere —
is the one that flips.

`madeFrom()` answers only where every value the choice may be came from the one
position. The value is one of them and nothing here says which, so a first
answer taken off the arms would claim a provenance a choice does not have.

`UnreadComparison.madeByAnOperation` asks every alternative rather than any of
them. The word it picks promises the position was found and that only following
the operation back is missing; where one arm is a position's own values that
promise is false, and what an author is owed is the word beside it.

A call an operation defines by cases is one of these too, and is left as the
application it is: a rule about what it answered is one to be followed back
through the operation, and which of its arguments the answer is comes from the
same table and is a question about the library.

## What is left short, and said so

The reading a clause of a `data` is filed from does not go inside an arm, and
declines a reading it has rather than one it lacks. The reading of values beside
it does not go inside one either, and a coordinate one names that the other never
reached is a question standing with nothing to account for it — which is the two
coming apart rather than a fact about the model. So a clause whose arm reads what
the arm bound names one position fewer than it is about.

An attempted construction reaches this from a `guard` inside a block, which the
readings a body's rules are filed from do not walk, so what the walk makes of one
is pinned at the walk.

## Measured

Dropping what decided the choice from `positions()` as well — reading the whole
type as provenance — turns `ARuleWithoutALineIsNamedByTheRuleTest
.aComparisonInsideAForkOfItsOwnIsARuleOfItsOwn` and
`AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.twoPlacesOfOneComparisonSayTwoThings`
red. A fork's condition carries rules that reading would lose, and that is a
question about what `positions()` answers rather than one #1570 settles.

Reading what decided the choice as provenance turns every new filing test red.
Asking `madeByAnOperation` of any alternative rather than all of them turns the
mixed-arm case red. Reading an arm where the fork stands turns the arm-binder
case red. Counting a departure among the values turns the walk's own tests and
the word an author is left with red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
