### PR TITLE
Group the refinement's rows by their cells rather than as collections

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -568,12 +568,20 @@ final class Automaton {
      *
      * <p>What a round asks of a state is a row — the block it is in, and then the block each symbol
      * leads to — and what it groups is the states whose rows are equal. A row is as wide as the runs
-     * the labels cut, and two rows are equal exactly when their cells are, so the rows of a round go
-     * into one array that the next round writes over and the grouping is an open table read off
-     * those cells: the hash below is the cells, and a collision is settled by comparing them. The
-     * table is sized once for the states there are, which is as many rows as a round can have, so no
-     * round grows it. Blocks are numbered in the order a row is first seen; which numbers they get
-     * is nothing {@link #numbered} reads, since it renames them by walking the machine.
+     * the labels cut, and two rows are equal exactly when their cells are, so the grouping is an
+     * open table read off those cells: the hash below is the cells, and a collision is settled by
+     * comparing them.
+     *
+     * <p>What is kept is a row per block and not a row per state. Every row a state is compared
+     * against is the first row of some block, so a row per state would be holding what the grouping
+     * has already brought together — as many rows as the machine has states, each as wide as its
+     * alphabet. A state's row is written where the next block's would begin and stays there only if
+     * it opened one, which is why nothing is copied to keep it. The table of slots is the one thing
+     * sized for the states there are, because a round can put that many rows in it, and it never
+     * grows.
+     *
+     * <p>Blocks are numbered in the order a row is first seen; which numbers they get is nothing
+     * {@link #numbered} reads, since it renames them by walking the machine.
      */
     private static int[] smallest(List<int[]> table, BitSet accepting) {
         int states = table.size();
@@ -582,7 +590,7 @@ final class Automaton {
         for (int state = 0; state < states; state++) {
             block[state] = accepting.get(state) ? 1 : 0;
         }
-        int[] cells = new int[states * width];
+        int[] shown = new int[width];
         int[] next = new int[states];
         int slots = 4;
         while (slots < states * 2) {
@@ -594,27 +602,30 @@ final class Automaton {
             Arrays.fill(seen, 0);
             int found = 0;
             for (int state = 0; state < states; state++) {
-                int at = state * width;
-                cells[at] = block[state];
-                int[] row = table.get(state);
-                for (int over = 0; over < row.length; over++) {
-                    cells[at + 1 + over] = block[row[over]];
+                if (shown.length < (found + 1) * width) {
+                    shown = Arrays.copyOf(shown, shown.length * 2);
+                }
+                int at = found * width;
+                shown[at] = block[state];
+                int[] out = table.get(state);
+                for (int over = 0; over < out.length; over++) {
+                    shown[at + 1 + over] = block[out[over]];
                 }
                 int hash = 1;
                 for (int cell = at; cell < at + width; cell++) {
-                    hash = 31 * hash + cells[cell];
+                    hash = 31 * hash + shown[cell];
                 }
                 int probe = (hash ^ (hash >>> 16)) & (slots - 1);
                 while (true) {
                     int held = seen[probe];
                     if (held == 0) {
-                        seen[probe] = state + 1;
+                        seen[probe] = found + 1;
                         next[state] = found++;
                         break;
                     }
-                    if (Arrays.equals(cells, (held - 1) * width, held * width,
-                            cells, at, at + width)) {
-                        next[state] = next[held - 1];
+                    if (Arrays.equals(shown, (held - 1) * width, held * width,
+                            shown, at, at + width)) {
+                        next[state] = held - 1;
                         break;
                     }
                     probe = (probe + 1) & (slots - 1);

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -1,6 +1,7 @@
 package souther.compiler.regex;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
@@ -564,31 +565,63 @@ final class Automaton {
      * symbols lead: two states in one block that step into different blocks are two states, and
      * asking that over and over until nothing moves is what leaves the blocks a string could tell
      * apart and no others.
+     *
+     * <p>What a round asks of a state is a row — the block it is in, and then the block each symbol
+     * leads to — and what it groups is the states whose rows are equal. A row is as wide as the runs
+     * the labels cut, and two rows are equal exactly when their cells are, so the rows of a round go
+     * into one array that the next round writes over and the grouping is an open table read off
+     * those cells: the hash below is the cells, and a collision is settled by comparing them. The
+     * table is sized once for the states there are, which is as many rows as a round can have, so no
+     * round grows it. Blocks are numbered in the order a row is first seen; which numbers they get
+     * is nothing {@link #numbered} reads, since it renames them by walking the machine.
      */
     private static int[] smallest(List<int[]> table, BitSet accepting) {
-        int[] block = new int[table.size()];
-        for (int state = 0; state < block.length; state++) {
+        int states = table.size();
+        int width = 1 + table.get(0).length;
+        int[] block = new int[states];
+        for (int state = 0; state < states; state++) {
             block[state] = accepting.get(state) ? 1 : 0;
         }
+        int[] cells = new int[states * width];
+        int[] next = new int[states];
+        int slots = 4;
+        while (slots < states * 2) {
+            slots <<= 1;
+        }
+        int[] seen = new int[slots];
         for (int blocks = 2, was = 0; blocks != was;) {
             was = blocks;
-            java.util.Map<List<Integer>, Integer> found = new java.util.LinkedHashMap<>();
-            int[] next = new int[block.length];
-            for (int state = 0; state < block.length; state++) {
-                List<Integer> tells = new ArrayList<>();
-                tells.add(block[state]);
-                for (int to : table.get(state)) {
-                    tells.add(block[to]);
+            Arrays.fill(seen, 0);
+            int found = 0;
+            for (int state = 0; state < states; state++) {
+                int at = state * width;
+                cells[at] = block[state];
+                int[] row = table.get(state);
+                for (int over = 0; over < row.length; over++) {
+                    cells[at + 1 + over] = block[row[over]];
                 }
-                Integer had = found.get(tells);
-                if (had == null) {
-                    had = found.size();
-                    found.put(tells, had);
+                int hash = 1;
+                for (int cell = at; cell < at + width; cell++) {
+                    hash = 31 * hash + cells[cell];
                 }
-                next[state] = had;
+                int probe = (hash ^ (hash >>> 16)) & (slots - 1);
+                while (true) {
+                    int held = seen[probe];
+                    if (held == 0) {
+                        seen[probe] = state + 1;
+                        next[state] = found++;
+                        break;
+                    }
+                    if (Arrays.equals(cells, (held - 1) * width, held * width,
+                            cells, at, at + width)) {
+                        next[state] = next[held - 1];
+                        break;
+                    }
+                    probe = (probe + 1) & (slots - 1);
+                }
             }
-            block = next;
-            blocks = found.size();
+            System.arraycopy(next, 0, block, 0, states);
+            blocks = found;
         }
         return block;
     }

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -592,6 +592,8 @@ final class Automaton {
         }
         int[] shown = new int[width];
         int[] next = new int[states];
+        // A power of two, so a hash is brought into range by masking, and twice the rows a round
+        // can have, so the slots a probe walks past stay few.
         int slots = 4;
         while (slots < states * 2) {
             slots <<= 1;
@@ -617,6 +619,8 @@ final class Automaton {
                 }
                 int probe = (hash ^ (hash >>> 16)) & (slots - 1);
                 while (true) {
+                    // A slot holds the block whose first row is there, counted from one so that
+                    // nought is a slot nothing has been put in.
                     int held = seen[probe];
                     if (held == 0) {
                         seen[probe] = found + 1;

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheStatesNoStringTellsApartAreOneStateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheStatesNoStringTellsApartAreOneStateTest.java
@@ -1,0 +1,135 @@
+package souther.compiler.regex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * However many states a construction made, what comes out has one per thing a string can tell apart.
+ *
+ * <p>The refinement is the only place that decides it, and both ways of getting it wrong are quiet.
+ * Leaving two states apart that no string separates still accepts the right strings, so nothing that
+ * walks the machine complains — what it costs is the one machine, since two ways of writing one
+ * language would then come to two tables and every reader comparing languages would be comparing
+ * spellings. Putting two states together that a string does separate accepts strings the language
+ * has not got, and a set that is quietly wider goes on being counted like any other.
+ *
+ * <p>Both are caught by the same question, which is why it is the one asked here: the words and the
+ * pattern for those same words are made into machines by two roads and held against each other,
+ * table for table. Either mistake leaves a table one road has and the other does not. Asking the
+ * machine about strings is not that question — a grouping that has gathered up the wrong states
+ * answers about most strings the way the right one does — so what the strings below are for is that
+ * the count of states is a count of the right language's states.
+ *
+ * <p>Asked of a machine large enough for the grouping to be doing something: every word of a length
+ * over two letters, built as a tree of two thousand states with an answer of ten.
+ */
+class TheStatesNoStringTellsApartAreOneStateTest {
+
+    /** More than either machine here reaches, so that what is measured is the grouping. */
+    private static Meter roomy() {
+        return new Meter(100_000, 10_000_000);
+    }
+
+    /** How long the words are, and so how many of them there are. */
+    private static final int LETTERS = 8;
+
+    /** Every string of {@link #LETTERS} letters over {@code a} and {@code b}. */
+    private static List<String> words() {
+        List<String> words = new ArrayList<>(List.of(""));
+        for (int at = 0; at < LETTERS; at++) {
+            List<String> longer = new ArrayList<>();
+            for (String word : words) {
+                longer.add(word + "a");
+                longer.add(word + "b");
+            }
+            words = longer;
+        }
+        return words;
+    }
+
+    private static Automaton canonicalMachineOf(String regex, Meter meter) {
+        PatternSyntax syntax =
+                assertInstanceOf(PatternRead.Read.class, PatternParser.read(regex), regex).syntax();
+        Automaton made = Automaton.of(syntax, meter);
+        assertNotNull(made, regex);
+        Automaton one = made.canonical(meter);
+        assertNotNull(one, regex);
+        return one;
+    }
+
+    /**
+     * The tree the words are built as, and the ten states a string can tell apart.
+     *
+     * <p>What a string of these letters can be is how many of them have been read and nothing else,
+     * so the answer is one state per count up to the length and one for a string that is already not
+     * one of the words. The construction has no way of knowing that: it makes a state per letter of
+     * per word, and the subsets after it a state per prefix. Both are held to here, because a
+     * grouping asked of a machine that was small to begin with is a grouping that was never asked.
+     */
+    @Test
+    void aTreeOfEveryWordComesToOneStatePerLetterRead() {
+        Meter meter = roomy();
+        List<String> words = words();
+
+        Automaton tree = Automaton.ofWords(words, meter);
+        assertNotNull(tree);
+        Automaton one = tree.canonical(meter);
+        assertNotNull(one);
+
+        assertEquals(256, words.size(), "every string of eight letters over two of them");
+        assertEquals(words.size() * LETTERS + 1, tree.size(), "a state per letter of per word");
+        assertTrue(tree.size() > 2000, "which is the many the grouping has to bring down");
+        assertEquals(LETTERS + 2, one.size(),
+                "one state per letter read, one for read them all, and one for read something else");
+    }
+
+    /**
+     * And the pattern for those same strings comes to that same machine, table for table.
+     *
+     * <p>Two roads with nothing in common past what they accept: one is a tree of two hundred and
+     * fifty-six words made deterministic, the other is a repetition read straight off the pattern
+     * and already deterministic when the grouping sees it. A machine still carrying a state no
+     * string tells apart is a machine one of these has and the other does not, and equal tables are
+     * what says neither does.
+     */
+    @Test
+    void theWordsAndThePatternForThemAreOneMachine() {
+        Meter meter = roomy();
+
+        Automaton fromWords = Automaton.ofWords(words(), meter);
+        assertNotNull(fromWords);
+        Automaton one = fromWords.canonical(meter);
+        assertNotNull(one);
+        Automaton other = canonicalMachineOf("[ab]{" + LETTERS + "}", meter);
+
+        assertTrue(one.sameAs(other), "one set of strings is one machine, however it was reached");
+    }
+
+    /**
+     * And the strings it holds are the words and not a letter more.
+     *
+     * <p>What makes the ten states above a count of this language's states rather than of some
+     * other's. It is not the question the grouping is checked by: a machine that gathered up states
+     * a string does tell apart still answers about these the way the right one does.
+     */
+    @Test
+    void itHoldsTheWordsAndNothingBeside() {
+        Meter meter = roomy();
+        Language held = Language.ofWords(words(), meter);
+        assertNotNull(held);
+
+        assertTrue(held.has("a".repeat(LETTERS)), "a word of the right letters and the right length");
+        assertTrue(held.has("abababab"), "and another");
+        assertEquals(false, held.has("a".repeat(LETTERS - 1)), "one letter short is not a word");
+        assertEquals(false, held.has("a".repeat(LETTERS + 1)), "nor is one letter long");
+        assertEquals(false, held.has("c".repeat(LETTERS)), "nor is the right length in other letters");
+        assertEquals(false, held.has(""), "nor is nothing at all");
+    }
+}


### PR DESCRIPTION
The minimisation refines the blocks by asking, of each state, which block it is
in and which block each symbol leads to, and grouping the states that answer
alike. That answer is a row of cells. Written as a list per state and grouped by
a map keyed on it, it is a collection built for one question and thrown away,
and comparing two of them walks the elements through hashing and equality that
know nothing about what they hold.

The grouping is now an open table read off those cells — the hash is the cells,
and a collision is settled by comparing them. A round can put as many rows in
that table as the machine has states, which is known before the first one, so
the table of slots is sized once and no round grows it.

What the rows themselves are kept in is a row per block rather than a row per
state, because every row a state is compared against is the first row of some
block. A state's row is written where the next block's would begin and stays
there only if it opened one, so nothing is copied either way. Kept per state, it
would be a second table the size of the one the caller already built out of the
subsets, holding what the grouping has brought together.

Nothing about the machine changes. The partition is the one that was there,
blocks numbered in the same first-seen order, and the numbering downstream does
not read those numbers anyway.

## What #1445 said, and what the measurement said back

The issue's account was that a round boxes a value per symbol per state. It does
not: every block number is small enough to come out of the `Integer` cache, so
the boxes are not allocations. What a round does build is a list and its backing
array per state, and a map node per distinct row, and what it spends is generic
hashing and equality walking the elements. That is the cost this takes out.

Measured over a warm compile of the crm corpus, the two keyings interleaved both
ways on a quiet machine: the refinement goes from a median of 4.51 ms to 1.43 ms,
about 3.2 times, which is roughly 1% of the whole compile. Both numbers are here
because both are needed later. A general collection has been swapped for a table
this file now maintains itself, and whether that is still worth keeping is a
question about the local figure and the whole-compile figure together.

The issue's other question — whether to key the rows by a hash over the cells or
by an order over them — is answered for the hash without measuring the order.
The largest machine the corpus builds has thirty-five states and its rows are
about nine cells wide, so a further refinement of a term this size could not move
the whole compile enough to decide anything. That is a decision not to measure it,
not a measurement the hash won.

The refinement is a small part of a warm compile, and smaller than the issue
expected it to be, because #1439 and #1440 took what was in front of it. What
recommends this is not the share: it is that the representation now says what a
row is.

## What holds it

A test committed first, and passing against the implementation it replaces, says
what the refinement decides: the machine for a tree of every word of a length and
the machine for the pattern accepting those same words are held against each
other, table for table. Both ways of getting the grouping wrong were mutated in
and the test saw each of them — a state left apart that no string separates, and
two gathered up that a string does. It is not proof against every wrong grouping,
since one that went wrong the same way down both roads would leave two tables
that still agree; what makes it a guard for a change of representation is that a
representation does not go wrong the same way twice. Beside it the count of
states is pinned, and the strings the language holds, which is what makes that
count a count of the right language's states.

Every partition the refinement reaches over the measurement corpora was also
compared between the keyings, under a probe that is not part of this change.

Closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
