### PR TITLE
Say what nothing composed, not what the position holds

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -210,12 +210,13 @@ final class Intervals {
             // — so it held every value, and two such classes each held everything the other did.
             Recognition is = new Recognition.OfACount(of, orders,
                     new Recognition.CountIs.InARun(run));
-            // Nothing composed here is what this compiler did not manage, and never what the run
-            // holds. Above a string a rule stops short of, the order declines to name a value on
-            // purpose — every string with that one as a prefix is greater, and choosing between
-            // them puts a character nobody wrote into a row somebody reads. Which is why both empty
-            // answers are said in the one sentence, and why that sentence is about this compiler
-            // rather than about the model (ADR-0091).
+            // Nothing composed here says what this compiler did not manage, and says nothing about
+            // what the run holds. Above a string a rule stops short of, the order declines to name
+            // a value on purpose — every string with that one as a prefix is greater, and choosing
+            // between them puts a character nobody wrote into a row somebody reads. So the sentence
+            // both empty answers carry is about composing: it is true of a run that holds nothing
+            // as much as of one the order would not choose in, and it is the only one of the two
+            // claims this compiler is in a position to make (ADR-0091).
             List<FixtureTemplate> values = inside == null ? List.of()
                     : standingIn(of, inside, type, carrier, ruleReading);
             classes.add(values.isEmpty()
@@ -245,9 +246,13 @@ final class Intervals {
      * whether the range holds the value it stops at is written down.
      *
      * <p>Null says what came back and not what the range holds. Which values are in it is
-     * {@link LevelSpace#inspect}'s answer and is asked where the runs are chosen; this asks the
-     * other question, and a caller that read the two as one would put the order's restraint into a
-     * sentence about the model.
+     * {@link LevelSpace#inspect}'s answer; this asks the other question, and a caller that read the
+     * two as one would put the order's own restraint into a sentence about the model.
+     *
+     * <p>Nothing asks the first question of a run that reaches here. What a run is held to before
+     * this is {@code Interval.inhabited}, which reads the ends as places and never asks the carrier
+     * — so an empty answer here is a run the order would not choose in and a run it has nothing in
+     * at all, and the caller is owed a sentence that is true of both.
      *
      * <p>How the values step is the carrier's to say and is asked of it. Carried as "is it a decimal"
      * it was a second spelling of the same fact, and a carrier that is dense without being the

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -210,13 +210,14 @@ final class Intervals {
             // — so it held every value, and two such classes each held everything the other did.
             Recognition is = new Recognition.OfACount(of, orders,
                     new Recognition.CountIs.InARun(run));
-            if (inside == null) {
-                classes.add(PartitionClass.ungeneratable(id, label, is,
-                        "no value this position can hold lies inside this range"));
-                continue;
-            }
-            List<FixtureTemplate> values =
-                    standingIn(of, inside, type, carrier, ruleReading);
+            // Nothing composed here is what this compiler did not manage, and never what the run
+            // holds. Above a string a rule stops short of, the order declines to name a value on
+            // purpose — every string with that one as a prefix is greater, and choosing between
+            // them puts a character nobody wrote into a row somebody reads. Which is why both empty
+            // answers are said in the one sentence, and why that sentence is about this compiler
+            // rather than about the model (ADR-0091).
+            List<FixtureTemplate> values = inside == null ? List.of()
+                    : standingIn(of, inside, type, carrier, ruleReading);
             classes.add(values.isEmpty()
                     ? PartitionClass.ungeneratable(id, label, is,
                             "nothing here writes a value whose " + measureOf(of) + " is in this range")
@@ -240,8 +241,13 @@ final class Intervals {
     }
 
     /**
-     * A value inside a range, or null where it holds none. Asked of the ends, which is where whether
-     * the range holds the value it stops at is written down.
+     * A value inside a range, or null where nothing composed one. Asked of the ends, which is where
+     * whether the range holds the value it stops at is written down.
+     *
+     * <p>Null says what came back and not what the range holds. Which values are in it is
+     * {@link LevelSpace#inspect}'s answer and is asked where the runs are chosen; this asks the
+     * other question, and a caller that read the two as one would put the order's restraint into a
+     * sentence about the model.
      *
      * <p>How the values step is the carrier's to say and is asked of it. Carried as "is it a decimal"
      * it was a second spelling of the same fact, and a carrier that is dense without being the

--- a/souther-compiler/src/test/java/souther/compiler/AClassNothingComposedAValueForNamesThisCompilerAndNotTheModelTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AClassNothingComposedAValueForNamesThisCompilerAndNotTheModelTest.java
@@ -1,0 +1,80 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceRendering;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.GeneratedRows;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A class this compiler composed nothing for says what it did not manage, and not what the model
+ * holds.
+ *
+ * <p>The two license different work. Told the position has no value in a range, an author has
+ * nothing to do; told nothing here composed one, they can write the row by hand. And the first is
+ * a claim about the model that the order is in no position to make: above a string a rule stops
+ * short of, it declines to name a value on purpose, because choosing between the strings with that
+ * one as a prefix puts a character nobody wrote into a row somebody reads.
+ *
+ * <p>Which is a difference a report can be caught getting wrong from the inside: the range the
+ * sentence is about is one the same report writes a row in.
+ */
+class AClassNothingComposedAValueForNamesThisCompilerAndNotTheModelTest {
+
+    private static String rowsOffered() {
+        Compilation compilation = Compilation.ofSource("""
+                module example.text
+
+                data Code = String
+
+                data Taken = { code: Code }
+                data NotIt = { why: Int }
+                data Result = Taken | NotIt
+
+                behavior take : (code: Code) -> Result
+                    constructs Taken, NotIt
+
+                let take (code) = {
+                    guard code.value <= "spring" else NotIt { why = 0 }
+                    Taken { code = code }
+                }
+
+                example take
+                    | "one" : (Code("spring")) -> Taken { code = Code("spring") }
+                """, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return GeneratedRows.of(compilation, "example.text", "take",
+                SourceRendering.namedByIdentity(compilation.texts())).text();
+    }
+
+    /**
+     * The range above the line is one the report writes a row in, and the class of it is not
+     * reported as one the position holds no value in.
+     */
+    @Test
+    void aRangeTheReportWritesARowInIsNotSaidToHoldNoValue() {
+        String rows = rowsOffered();
+
+        assertTrue(rows.contains("(Code(\"t\"))"),
+                () -> "a row above `spring`, which the boundary search composes:\n" + rows);
+        assertFalse(rows.contains("no value this position can hold"),
+                () -> "and the class of that same range is not said to be empty of values:\n"
+                        + rows);
+    }
+
+    /** And what it says instead is what nothing here managed to write. */
+    @Test
+    void theClassSaysWhatNothingHereComposed() {
+        String rows = rowsOffered();
+
+        assertTrue(rows.contains("no row for `code=spring < x` in `take`: nothing here writes a"
+                        + " value whose value is in this range"),
+                () -> "the reason is the one about composing, said of the range the class is:\n"
+                        + rows);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
@@ -353,7 +353,7 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
             String rows = souther.compiler.report.GeneratedRows.of(compilation, "example.bounded",
                     "f", souther.compiler.diag.SourceRendering.namedByIdentity(compilation.texts())).text();
 
-            assertFalse(rows.contains("no value this position can hold lies inside this range"),
+            assertFalse(rows.contains("nothing here writes a value whose value is in this range"),
                     "a decimal lies between the bound and the third, so the class between them is"
                             + " not one nothing can be written in (" + facing + "):\n" + rows);
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -372,7 +372,7 @@ class GeneratorTest {
         RuleReadingSource rules = modelOf(TRIP, "submit").rules();
         MeasuredInput subject = twoNumbers(rules,
                 List.of(PartitionClass.ungeneratable("empty", "empty", new Recognition.Nothing(),
-                        "no value this position can hold lies inside this range")),
+                        "nothing here writes a value whose value is in this range")),
                 List.of(number("high", 10)));
 
         FillResult filled =
@@ -382,7 +382,7 @@ class GeneratorTest {
         Generator.UnresolvedCombination only = filled.unresolved().getFirst();
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, only.reason(),
                 "a value this could not compose, not one that cannot exist");
-        assertEquals(Optional.of("no value this position can hold lies inside this range"),
+        assertEquals(Optional.of("nothing here writes a value whose value is in this range"),
                 only.said(), "the sentence the class recorded, and not one made up here");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -454,7 +454,7 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
                 compilation, "example.matrix", "openOnBothSidesDense",
                 SourceRendering.namedByIdentity(compilation.texts())).text();
         assertTrue(dense.contains("1 < x < 2"), dense);
-        assertFalse(dense.contains("no value this position can hold"),
+        assertFalse(dense.contains("nothing here writes a value whose value is in this range"),
                 "a decimal lies between two decimals a whole apart: " + dense);
 
         String moment = souther.compiler.report.GeneratedRows.of(


### PR DESCRIPTION
A class of a string position was reported as one the model holds no value in,
two lines under a row the same report writes inside that range.

The order declines to name a value above a string a rule stops short of, and
says why: every string with that one as a prefix is greater, choosing between
them is a choice, and a choice made there puts a character nobody wrote into a
row somebody reads. `Carrier.somethingInside` states that its empty answer is
this composing none and never the range holding none, and `LevelSpace` keeps
the two questions apart as `inspect` and `witness`. `Intervals.classesOf` read
the empty answer as the second one and wrote a sentence about the model.

Both empty answers now carry the sentence about composing. It is true of a run
that holds nothing as much as of one the order would not choose in, so it does
not depend on which of the two the run is — and the claim it makes is one the
compiler is in a position to make, which is what ADR-0091 separates.

The checks that guarded the old sentence now read the new one. Left where they
were, they would have been measuring a sentence nothing writes.

Closes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)