### PR TITLE
Carry the world a reading is made in down the walk that reads it

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -239,8 +239,23 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
                         + " with nothing lent to it.");
     }
 
-    /** Every edge into a reading nobody else made, said in full at both ends. */
+    /**
+     * Every edge into a reading nobody else made, said in full at both ends.
+     *
+     * <p>Walked once for the class. The two questions below are two readings of one walk over every
+     * method of every compiled class, and asking each of them for its own walk reads the whole
+     * output twice to answer about the same instructions.
+     */
     private static Set<String> everyEdgeIntoAReadingOfOnesOwn() {
+        if (EVERY_EDGE == null) {
+            EVERY_EDGE = walkForEveryEdgeIntoAReadingOfOnesOwn();
+        }
+        return EVERY_EDGE;
+    }
+
+    private static Set<String> EVERY_EDGE;
+
+    private static Set<String> walkForEveryEdgeIntoAReadingOfOnesOwn() {
         Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
         Set<Named> waysIn = theWaysInThatSayTheyReadForThemselves(pairs);
         Set<String> reaching = new TreeSet<>();

--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -48,13 +48,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * such a reading is reached by a call, and a table of readers says nothing about who is calling
  * them: a way in named here as allowed would let a new caller of it arrive with nothing to fail.
  * So each row is one production instruction reaching one place, both ends said in full, and the
- * whole set is compared — a row that has gone is as much a finding as one that has appeared,
- * because a reader that stops reading for itself is what settles this and the row has to go with
- * it.
+ * whole set is compared — a row that has gone is as much a finding as one that has appeared.
  *
- * <p>The shorter entry points stay, because a test standing one declaration up to look at it is a
- * reader with no store and saying so is not a defect. What may not happen is this compiler reaching
- * for one without a row here.
+ * <p><b>Two claims and not one.</b> That this compiler can express an evaluation with no store
+ * behind it, which is one way in and is named; and that nothing here spends one, which is no
+ * readers at all. Read as a single population the second would be satisfied by the first going
+ * missing, and a walk that had stopped reading call sites would report a compiler that starts no
+ * such reading. So the way in is asserted to be there, and the readers to be none.
+ *
+ * <p>The shorter entry points stay for the same reason the way in does: a test standing one
+ * declaration up to look at it is a reader with no store, and saying so is not a defect. What may
+ * not happen is this compiler reaching for one.
  *
  * <p>Read off the compiled classes, because what is being asked is which method a call site
  * resolved to. The overloads differ by one argument and the shorter is reached by leaving it out,
@@ -77,64 +81,42 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
      *  that does. */
     private static final String NOTHING_TO_BORROW_FROM = LENDING + "#NONE";
 
-    /**
-     * Every edge this compiler has into a reading nobody else made, and why each of them is one.
-     *
-     * <p>Two kinds, and both are the same fact said at a different distance. A reader that names
-     * {@link #NOTHING_TO_BORROW_FROM} is starting such a reading itself; one that calls a way in is
-     * starting it a call away. Written together because what is being counted is the places, and
-     * which of the two shapes a place happens to have is not what anybody has to settle.
-     *
-     * <p>Each of them sits under a walk over what an author wrote, which is handed what it is
-     * reading and nothing that says where a reading comes from. Some are the readers under such a
-     * walk and some build the walk itself; borrowing in any of them would take a capability carried
-     * through it, and whether it belongs there — and what a borrower asking for a reading that is
-     * already being made should be handed — is not settled.
-     *
-     * <p>Settling it takes these rows away, and taking one away without settling it is what the
-     * comparison below refuses in the other direction.
-     */
     private static final String CHECK = "souther/compiler/check/";
 
     private static final String SOURCE_AND_POLICY =
             "L" + CHECK + "RuleReadingSource;L" + CHECK + "ReadingPolicy;";
 
-    private static final Set<String> EDGES_INTO_A_READING_OF_ONES_OWN = Set.of(
-            // The two ways in themselves, which is where a reading with nothing to borrow from is
-            // started for whoever asked.
-            CHECK + "FieldDomains#unshared(Lsouther/compiler/types/TypeSymbol$AtModule;"
-                    + SOURCE_AND_POLICY + "Ljava/util/Map;)L" + CHECK + "FieldDomains; -> "
-                    + NOTHING_TO_BORROW_FROM,
-            CHECK + "InvariantChecker#seedFieldsUnshared("
-                    + "Lsouther/compiler/types/TypeSymbol$AtModule;" + SOURCE_AND_POLICY + ")L"
-                    + CHECK + "InvariantChecker$Seeded; -> " + NOTHING_TO_BORROW_FROM,
-            // The world a walk over a declaration's rules reads in, made for a caller that has
-            // nowhere to borrow from. Asked for by name and never supplied by leaving the lender
-            // out, so that a walk reading each declaration again is a caller that said so.
+    /**
+     * The one way in that says outright it reads for itself, and the whole of what may say it.
+     *
+     * <p>An evaluation with no store behind it is a thing this compiler can express, and this is
+     * how: a world made of rules and a budget and nothing lent, asked for by that name. A test
+     * standing one declaration up to look at it is such an evaluation, and saying so is not a
+     * defect — said by naming this rather than by assembling a world around
+     * {@link #NOTHING_TO_BORROW_FROM}, so that why the lender is missing survives being read back.
+     *
+     * <p>Which is why the row is here rather than gone. What was settled is that no walk over what
+     * an author wrote reads for itself, not that a reading with nowhere to borrow from stopped
+     * being a thing anybody may build. A second way in is a finding; so is this one's
+     * disappearance, and that is what makes it the control below.
+     */
+    private static final String THE_WAY_IN_THAT_READS_FOR_ITSELF =
             CHECK + "RuleReadingContext#unshared(" + SOURCE_AND_POLICY + ")L" + CHECK
-                    + "RuleReadingContext; -> " + NOTHING_TO_BORROW_FROM,
-            // What a value's rules guarantee, asked from under a reading that is under way.
-            CHECK + "ValueGuarantees#seededOf(Lsouther/compiler/types/TypeSymbol$AtModule;"
-                    + SOURCE_AND_POLICY + ")L" + CHECK + "InvariantChecker$Seeded; -> "
-                    + CHECK + "InvariantChecker#seedFieldsUnshared",
-            // What a clause of a contract may take, read in the terms of the walk it stands in.
-            // Both shapes, and the store question that asks for one: what a capability is read
-            // against is the reading in hand, and there is nothing there that says where another
-            // declaration's reading comes from.
-            CHECK + "InvariantChecker#capabilityOf(L" + CHECK
-                    + "ClausesForDischarge$ClauseReading;Lsouther/compiler/types/"
-                    + "TypeSymbol$AtModule;" + SOURCE_AND_POLICY + ")L" + CHECK
-                    + "ClauseDischarge; -> " + NOTHING_TO_BORROW_FROM,
-            CHECK + "InvariantChecker#capabilityOf(L" + CHECK + "StatedContract$Conjunct;L"
-                    + CHECK + "Denotations;" + SOURCE_AND_POLICY + "Ljava/lang/String;)L"
-                    + CHECK + "ClauseDischarge; -> " + NOTHING_TO_BORROW_FROM,
-            "souther/compiler/query/Shapes$InvariantCapabilities#compute("
-                    + "Lsouther/compiler/query/Db;)Lsouther/compiler/query/Answer; -> "
-                    + CHECK + "InvariantChecker#capabilityOf",
-            // What each conjunct of a contract's rule may take, asked where the rule is read.
-            CHECK + "ContractDischarge#of(L" + CHECK + "StatedContract;L" + CHECK
-                    + "StatedContract$StatedRule;" + SOURCE_AND_POLICY + ")Ljava/util/List; -> "
-                    + CHECK + "InvariantChecker#capabilityOf");
+                    + "RuleReadingContext; -> " + NOTHING_TO_BORROW_FROM;
+
+    /**
+     * Every reader of this compiler that reaches one, which is none of them.
+     *
+     * <p>Apart from the way in above because they are two claims. That one is about what this
+     * compiler can express; this one is about who spends it — and a walk over what an author wrote
+     * spends it nowhere, because the world it is handed says where to borrow from and is handed on
+     * as it arrived ({@code RuleReadingContext}).
+     *
+     * <p>Empty, and an entry is a finding. A reader here is one that was given a world and read
+     * past it: what it makes is filed under a source nothing lends against, and the reading
+     * somebody already made of that declaration is paid for a second time.
+     */
+    private static final Set<String> EDGES_INTO_A_READING_OF_ONES_OWN = Set.of();
 
     /**
      * Every pair: a static method taking the lending, and one of the same name on the same class
@@ -220,14 +202,45 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
     }
 
     /**
-     * Every edge into a reading nobody else made is one that is written down.
+     * The way in that reads for itself is the one written down, and it is there.
+     *
+     * <p>The control for everything below, and it is one because it is a row the extraction has to
+     * find rather than a count of what it looked at. A walk that stopped reading call sites, or
+     * stopped resolving them to a method, comes back with nothing — and nothing is exactly what a
+     * compiler with no such edge looks like, so a check whose only claim was emptiness would pass
+     * at its most broken. This one fails there instead.
+     *
+     * <p>And it is the other half of the population: a second way in is a reading with nowhere to
+     * borrow from that nobody wrote down as one.
+     */
+    @Test
+    void theWayInThatReadsForItselfIsFound() {
+        assertEquals(Set.of(THE_WAY_IN_THAT_READS_FOR_ITSELF), waysInReachingNothingToBorrowFrom(),
+                "the ways in that read for themselves are not the one written down");
+    }
+
+    /**
+     * No reader of this compiler reaches a reading nobody else made.
      *
      * <p>Compared whole and in both directions. An edge nobody wrote down is a reader that lost its
      * lending with nothing to say so; a row nothing reaches any more is a licence outliving what it
-     * was for, and the day somebody settles where a lending may go the rows have to go with it.
+     * was for.
      */
     @Test
-    void everyEdgeIntoAReadingOfOnesOwnIsWrittenDown() {
+    void nothingHereReachesAReadingOfItsOwn() {
+        Set<String> reaching = readersReachingAReadingOfTheirOwn();
+        assertEquals(EDGES_INTO_A_READING_OF_ONES_OWN, reaching,
+                () -> "the edges into a reading nobody else made are not the ones written down.\n"
+                        + "  found and not written down:\n    "
+                        + String.join("\n    ", minus(reaching, EDGES_INTO_A_READING_OF_ONES_OWN))
+                        + "\n  written down and not found:\n    "
+                        + String.join("\n    ", minus(EDGES_INTO_A_READING_OF_ONES_OWN, reaching))
+                        + "\nHand this reader the world its caller read in, rather than a world"
+                        + " with nothing lent to it.");
+    }
+
+    /** Every edge into a reading nobody else made, said in full at both ends. */
+    private static Set<String> everyEdgeIntoAReadingOfOnesOwn() {
         Map<String, Set<MethodTypeDesc>> pairs = theShorterOfEachPair();
         Set<Named> waysIn = theWaysInThatSayTheyReadForThemselves(pairs);
         Set<String> reaching = new TreeSet<>();
@@ -250,16 +263,30 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
                 }
             }
         }
+        return reaching;
+    }
 
-        assertFalse(reaching.isEmpty(), "this check is reading no edges at all");
-        assertEquals(EDGES_INTO_A_READING_OF_ONES_OWN, reaching,
-                () -> "the edges into a reading nobody else made are not the ones written down.\n"
-                        + "  found and not written down:\n    "
-                        + String.join("\n    ", minus(reaching, EDGES_INTO_A_READING_OF_ONES_OWN))
-                        + "\n  written down and not found:\n    "
-                        + String.join("\n    ", minus(EDGES_INTO_A_READING_OF_ONES_OWN, reaching))
-                        + "\nTake the entry point that is handed somewhere to borrow from, or say"
-                        + " here what this reader has nowhere to borrow from.");
+    /** Those of them whose reader is a way in saying it reads for itself, which is how one of those
+     *  is written rather than a place this compiler spends one. */
+    private static Set<String> waysInReachingNothingToBorrowFrom() {
+        Set<String> found = new TreeSet<>();
+        for (String edge : everyEdgeIntoAReadingOfOnesOwn()) {
+            if (edge.endsWith(" -> " + NOTHING_TO_BORROW_FROM)) {
+                found.add(edge);
+            }
+        }
+        return found;
+    }
+
+    /** And those whose reader is anything else, which is this compiler spending one. */
+    private static Set<String> readersReachingAReadingOfTheirOwn() {
+        Set<String> found = new TreeSet<>();
+        for (String edge : everyEdgeIntoAReadingOfOnesOwn()) {
+            if (!edge.endsWith(" -> " + NOTHING_TO_BORROW_FROM)) {
+                found.add(edge);
+            }
+        }
+        return found;
     }
 
     private static List<String> minus(Set<String> these, Set<String> those) {

--- a/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest.java
@@ -204,19 +204,75 @@ class NothingHereStartsAReadingSomebodyElseHasAlreadyMadeTest {
     /**
      * The way in that reads for itself is the one written down, and it is there.
      *
-     * <p>The control for everything below, and it is one because it is a row the extraction has to
-     * find rather than a count of what it looked at. A walk that stopped reading call sites, or
-     * stopped resolving them to a method, comes back with nothing — and nothing is exactly what a
-     * compiler with no such edge looks like, so a check whose only claim was emptiness would pass
-     * at its most broken. This one fails there instead.
+     * <p>The population's other half: a second way in is a reading with nowhere to borrow from that
+     * nobody wrote down as one, and this one's disappearance is a way in that stopped saying what
+     * it is.
      *
-     * <p>And it is the other half of the population: a second way in is a reading with nowhere to
-     * borrow from that nobody wrote down as one.
+     * <p>Not the control for the emptiness below. This row is named by a {@code GETSTATIC}, so what
+     * it witnesses is that one of the three ways an instruction names a member is read. The
+     * emptiness is about the other two.
      */
     @Test
     void theWayInThatReadsForItselfIsFound() {
         assertEquals(Set.of(THE_WAY_IN_THAT_READS_FOR_ITSELF), waysInReachingNothingToBorrowFrom(),
                 "the ways in that read for themselves are not the one written down");
+    }
+
+    /**
+     * Each way an instruction names a member is read, witnessed on a member known to be named that
+     * way.
+     *
+     * <p>The control for the emptiness below, and it takes three because {@link #whatItNames} has
+     * three answers and they are three extractions. A member called is one; a static field read is
+     * another; a member handed over to be called later is a third, and it is named among the
+     * arguments a bootstrap is given rather than by an instruction of its own. Blinding any one of
+     * them leaves the other two reading, so a control standing on one says nothing about the rest.
+     *
+     * <p>What that costs is the claim below. A reader reaching a reading of its own reaches it by
+     * calling, so the emptiness there is an answer about the first of the three — and blinding that
+     * one empties it, which is what a compiler with no such reader looks like. Witnessed here
+     * instead, on members this test does not otherwise depend on.
+     *
+     * <p>Three assertions and not a walk over the three: nothing here can ask a switch what cases
+     * it has. A fourth way to name a member is a fourth line, and is noticed where the case is
+     * written rather than by anything failing.
+     */
+    @Test
+    void everyWayAnInstructionNamesAMemberIsRead() {
+        assertTrue(whatIsNamedIn(CHECK + "RuleReadingContext", "whileTheAnswerIsMade")
+                        .contains(LENDING + "#whileTheAnswerIsMade"),
+                "a member that is called is not read: deriving a bounded world calls the lender's"
+                        + " own, and nothing here saw it");
+        assertTrue(whatIsNamedIn(CHECK + "RuleReadingContext", "unshared")
+                        .contains(NOTHING_TO_BORROW_FROM),
+                "a static field that is read is not read: the way in names what there is nothing to"
+                        + " borrow from, and nothing here saw it");
+        assertTrue(whatIsNamedIn(CHECK + "InvariantChecker", "capabilityOf")
+                        .contains(CHECK + "Terms#placeSubject"),
+                "a member handed over to be called later is not read: reading a clause on its own"
+                        + " hands over where a name stands, and nothing here saw it");
+    }
+
+    /** Every member named by any instruction of any method called {@code method} on {@code owner},
+     *  read the way the walk below reads one. */
+    private static Set<String> whatIsNamedIn(String owner, String method) {
+        Set<String> named = new TreeSet<>();
+        for (ClassModel read : COMPILED.all()) {
+            if (!read.thisClass().name().stringValue().equals(owner)) {
+                continue;
+            }
+            for (MethodModel each : read.methods()) {
+                if (!each.methodName().stringValue().equals(method)) {
+                    continue;
+                }
+                for (Instruction instruction : instructionsOf(each)) {
+                    for (Named what : whatItNames(instruction)) {
+                        named.add(what.member());
+                    }
+                }
+            }
+        }
+        return named;
     }
 
     /**

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayTakeTheLenderOutOfAWorldIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayTakeTheLenderOutOfAWorldIsWrittenDownTest.java
@@ -1,0 +1,137 @@
+package souther.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.LoadableConstantEntry;
+import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Where the lender is taken out of the world a reading is made in.
+ *
+ * <p>A walk over what an author wrote is handed the world it reads in — the rules, what a reading
+ * may spend, and where it borrows what has already been made of a declaration — and hands the same
+ * one on. That is what keeps a reading under way from being reached past: the world a producer
+ * hands down is already bounded for the answer it is making
+ * ({@code RuleReadingContext#whileTheAnswerIsMade}), and a reader below has no other to hand on.
+ *
+ * <p>Taking the lender out of the world is how that stops being true. Handed the lender, a reader
+ * may put a world of its own together around it, or hand it to something that takes the three
+ * apart — and the bound the producer put on it is not in either.
+ *
+ * <p><b>Being package-private is not what holds this.</b> Every class beside {@code
+ * RuleReadingContext} in {@code souther.compiler.check} may read it, and the walk this is about
+ * lives in that package. The rows below are what says which methods do.
+ *
+ * <p>Written per method and not per class. What is entitled is a bridge to the shape that still
+ * takes the three apart, and it is entitled because it hands all three on unchanged. A class
+ * holding one such bridge is not a class whose every method may reach the lender — least of all the
+ * ones that are the walk.
+ *
+ * <p>Read off the compiled classes, and a reader that hands the accessor over to be called later is
+ * one of these: a method handed to something that will call it reads the lender as surely as
+ * calling it.
+ *
+ * <p>The rows are named rather than counted, which is what stands in for a control here. A walk
+ * that stopped reading instructions comes back with nothing, and nothing is not what this expects —
+ * so the comparison fails rather than passing on an extraction that reads nothing.
+ */
+class WhoMayTakeTheLenderOutOfAWorldIsWrittenDownTest {
+
+    private static final String CHECK = "souther/compiler/check/";
+
+    private static final String OWNER = CHECK + "RuleReadingContext";
+
+    private static final String THE_LENDER = "readings";
+
+    private static final CompiledOutputs COMPILED = CompiledOutputs.ofWhatThisRepositoryPublishes();
+
+    /**
+     * Every method that reaches it, and why each of them is entitled to.
+     *
+     * <p>Both are ways in to the shape that takes the rules, the budget and the lender apart, and
+     * both hand over the three they were given. A reader calling one of these is reading in the
+     * world it was handed, which is what the shape taking three arguments cannot say on its own.
+     *
+     * <p>The seeding's way in also reads it for what the revision worked out about where a set's
+     * strings stop, which is a fact the revision has rather than a place to borrow a reading from.
+     * It is a row all the same: what it holds is the lender, and a method that has the lender can
+     * do anything with it that this is about.
+     */
+    private static final List<String> TAKING_IT_OUT = List.of(
+            CHECK + "FieldDomains#of -> " + OWNER + "#" + THE_LENDER,
+            CHECK + "InvariantChecker#<init> -> " + OWNER + "#" + THE_LENDER,
+            CHECK + "InvariantChecker#seedFields -> " + OWNER + "#" + THE_LENDER);
+
+    @Test
+    void everyMethodThatTakesTheLenderOutOfAWorldIsWrittenDown() {
+        assertEquals(TAKING_IT_OUT, List.copyOf(takingItOut()),
+                () -> "the methods that take the lender out of a world are not the ones written"
+                        + " down.\n  found: " + takingItOut() + "\n  written down: " + TAKING_IT_OUT
+                        + "\nRead in the world rather than out of it, or say here why this method"
+                        + " hands the lender on unchanged.");
+    }
+
+    /** Every method naming the accessor, as the method and what it named. */
+    private static Set<String> takingItOut() {
+        Set<String> found = new TreeSet<>();
+        for (ClassModel model : COMPILED.all()) {
+            String owner = model.thisClass().name().stringValue();
+            for (MethodModel method : model.methods()) {
+                for (Instruction instruction : instructionsOf(method)) {
+                    if (namesTheLender(instruction)) {
+                        found.add(owner + "#" + method.methodName().stringValue()
+                                + " -> " + OWNER + "#" + THE_LENDER);
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether an instruction names it: by calling it, or by handing it over to be called later.
+     *
+     * <p>The second arrives as a handle among the arguments a bootstrap is given, which is what a
+     * method reference comes to. A reader passing one along reaches the lender the same way a caller
+     * does.
+     */
+    private static boolean namesTheLender(Instruction instruction) {
+        return switch (instruction) {
+            case InvokeInstruction call -> OWNER.equals(call.owner().name().stringValue())
+                    && THE_LENDER.equals(call.name().stringValue());
+            case InvokeDynamicInstruction handed -> {
+                for (LoadableConstantEntry each : handed.invokedynamic().bootstrap().arguments()) {
+                    if (each instanceof MethodHandleEntry handle) {
+                        MemberRefEntry member = handle.reference();
+                        if (OWNER.equals(member.owner().name().stringValue())
+                                && THE_LENDER.equals(member.name().stringValue())) {
+                            yield true;
+                        }
+                    }
+                }
+                yield false;
+            }
+            default -> false;
+        };
+    }
+
+    private static List<Instruction> instructionsOf(MethodModel method) {
+        Optional<java.lang.classfile.CodeModel> code = method.code();
+        return code.map(each -> each.elementList().stream()
+                .filter(Instruction.class::isInstance)
+                .map(Instruction.class::cast)
+                .toList()).orElse(List.of());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -49,13 +49,13 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * author is shown and what a caller is given cannot drift apart.
      *
      */
-    public static ContractDischarge of(StatedContract stated, RuleReadingSource source,
-                                       ReadingPolicy policy) {
+    public static ContractDischarge of(StatedContract stated, RuleReadingContext reading) {
         List<RuleDischarge> classified = new ArrayList<>();
         for (StatedContract.StatedRule rule : stated.rules()) {
-            classified.addAll(of(stated, rule, source, policy));
+            classified.addAll(of(stated, rule, reading));
         }
-        return new ContractDischarge(classified, unstatedCases(stated, source.symbols()));
+        return new ContractDischarge(classified,
+                unstatedCases(stated, reading.source().symbols()));
     }
 
     /**
@@ -67,7 +67,7 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * it was written as.
      */
     private static List<RuleDischarge> of(StatedContract contract, StatedContract.StatedRule rule,
-                                          RuleReadingSource source, ReadingPolicy policy) {
+                                          RuleReadingContext reading) {
         // The parameters and `value` stand for themselves. A caller hands one value per parameter and
         // the behavior answers one value, so a rule naming either names something wherever it is read
         // — entered as locations, and nothing is seeded of them, since what the rule states is the
@@ -80,14 +80,14 @@ public record ContractDischarge(List<RuleDischarge> rules,
         // Its own reading, over the clauses as the analysis reads them. A rule may reach a
         // declaration through the values it names, and the representation those are read in is the
         // one every other reader of this module's rules uses.
-        Terms naming = new Terms(Terms.Of.THE_DISCHARGE_TREE, policy, new Clauses(source));
+        Terms naming = new Terms(Terms.Of.THE_DISCHARGE_TREE, reading);
         Denotations locations =
                 Denotations.none().locations(named, naming::placeSubject, naming::placeTerm);
 
         List<RuleDischarge> out = new ArrayList<>();
         for (StatedContract.Conjunct conjunct : rule.conjuncts()) {
             out.add(new RuleDischarge(rule.id(), InvariantChecker
-                    .capabilityOf(conjunct, locations, source, policy,
+                    .capabilityOf(conjunct, locations, reading,
                             contract.behavior().name())
                     .named(rule.clause())));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -224,8 +224,7 @@ public final class DeclaredBounds {
         NumberAt.OfWhatNumber kind = measure == null
                 ? new NumberAt.OfWhatNumber.OfItsOwnValue()
                 : new NumberAt.OfWhatNumber.OfWhatAnOperationAnswers(measure);
-        FieldDomains own = FieldDomains.of(outermost, reading.source(), reading.policy(),
-                reading.readings());
+        FieldDomains own = FieldDomains.of(outermost, reading);
         Bounds bounds = placed(own.placedAt(RuleKey.THE_VALUE), kind, carrier);
         return bounds == null ? everything : bounds.range();
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -379,16 +379,33 @@ public final class FieldDomains {
         return of(named, source, policy, Map.of(), machines);
     }
 
+    /**
+     * The same, read in the world a walk carries.
+     *
+     * <p>What a reader under a walk asks, and the shape that leaves it nothing to choose. Handed
+     * the three apart, a reader picks a lender for the reading it is about to make; handed the
+     * world it was given, it reads in the one its caller read in and hands the same one on.
+     */
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingContext reading) {
+        return of(named, reading, Map.of());
+    }
+
+    /** The same, with some fields already settled at a value. */
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingContext reading,
+                                  Map<RuleKey, Count> settled) {
+        return of(named, reading.source(), reading.policy(), settled, reading.readings());
+    }
+
     /** The same, reading for itself. */
     public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy) {
-        return unshared(named, source, policy, Map.of());
+        return of(named, source, policy, Map.of(), DeclarationReadings.NONE);
     }
 
     /** The same, with some fields already settled at a value and reading for itself. */
     public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy, Map<RuleKey, Count> settled) {
-        return unshared(named, source, policy, settled);
+        return of(named, source, policy, settled, DeclarationReadings.NONE);
     }
 
     /**
@@ -410,24 +427,6 @@ public final class FieldDomains {
                 ? of(named, data, source, policy, atValues(settled),
                         InvariantChecker.Reach.EVERYTHING, machines)
                 : NONE;
-    }
-
-    /**
-     * The same, read without borrowing anything anybody else has made of the declaration.
-     *
-     * <p><b>For a caller that genuinely has nowhere to borrow from.</b> Not for one that has
-     * somewhere and did not carry it: the composing of a value takes the world it reads in
-     * ({@link RuleReadingContext}) and hands the same one down, so a reading reached from several
-     * positions of one row is made once. A caller here is saying there is no store to lend from at
-     * all, which is a different thing from a caller that was handed one and read past it.
-     *
-     * <p>Named for that, and separate from {@link DeclarationReadings#NONE}, which is what a reader
-     * with no store says. Which callers are entitled to it is checked rather than described: the
-     * ways into a reading nobody else made are written down, and a new one is a finding.
-     */
-    public static FieldDomains unshared(TypeSymbol.AtModule named, RuleReadingSource source,
-                                        ReadingPolicy policy, Map<RuleKey, Count> settled) {
-        return of(named, source, policy, settled, DeclarationReadings.NONE);
     }
 
     /** Settlings written as names, read as what stands at each. What a caller naming a place means

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -344,10 +344,10 @@ public final class InvariantChecker {
      *
      * @param conjunct the conjunct, as written and as this check reads it
      * @param locations the names it may read, each standing for itself
-     * @param source what the rule is read against — the symbols that type the form here and the
-     *               invariants it may reach — which is what says where the reading comes from
-     *               rather than leaving each reader to assemble one
-     * @param policy what to do where the reading does not finish
+     * @param reading the world the rule is read in — the symbols that type the form here and the
+     *                invariants it may reach, what the reading may spend where it does not finish,
+     *                and where it borrows what has already been made of a declaration. Handed over
+     *                whole rather than assembled by each reader
      * @param describing what is being read, for the record a fail-open leaves behind
      */
     static ClauseDischarge capabilityOf(StatedContract.Conjunct conjunct,

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -228,8 +228,7 @@ public final class InvariantChecker {
      * every name in. One value and not a scope beside a lookup, so that what is read and what a
      * reading made here is filed under cannot come from two places.
      */
-    public record Source(Hir.Expr body, ElementProvenance elements, RuleReadingSource rules,
-                         DeclarationReadings machines,
+    public record Source(Hir.Expr body, ElementProvenance elements, RuleReadingContext reading,
                          Map<ValueName.Behavior, AssumedContract> contracts) {
 
         public Source {
@@ -278,19 +277,16 @@ public final class InvariantChecker {
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 
-    private InvariantChecker(RuleReadingSource source,
-                             DeclarationReadings machines, ReadingPolicy policy) {
-        this(source, machines, Map.of(), policy);
+    private InvariantChecker(RuleReadingContext reading) {
+        this(reading, Map.of());
     }
 
-    private InvariantChecker(RuleReadingSource source,
-                             DeclarationReadings machines,
-                             Map<ValueName.Behavior, AssumedContract> contracts,
-                             ReadingPolicy policy) {
-        this.engine = new PathEngine(source, contracts, policy);
+    private InvariantChecker(RuleReadingContext reading,
+                             Map<ValueName.Behavior, AssumedContract> contracts) {
+        this.engine = new PathEngine(reading, contracts);
         // Borrowing nothing, since no declaration is being seeded yet, and knowing what the
         // revision knows: where a set stops is the same answer whoever met it.
-        this.answers = StringMachineAnswers.unborrowed(machines.extents());
+        this.answers = StringMachineAnswers.unborrowed(reading.readings().extents());
         // Named here because this check reads them directly and often. They are the engine's, not a
         // second copy: one engine builds them once and everything below sees those.
         this.symbols = engine.symbols();
@@ -308,8 +304,8 @@ public final class InvariantChecker {
      */
     public static ClauseDischarge capabilityOf(ClausesForDischarge.ClauseReading clause,
                                                TypeSymbol.AtModule named,
-                                               RuleReadingSource source, ReadingPolicy policy) {
-        InvariantChecker c = new InvariantChecker(source, DeclarationReadings.NONE, policy);
+                                               RuleReadingContext reading) {
+        InvariantChecker c = new InvariantChecker(reading);
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built. These
         // stand for a value rather than holding one, so they are entered as locations and nothing is
@@ -355,9 +351,9 @@ public final class InvariantChecker {
      * @param describing what is being read, for the record a fail-open leaves behind
      */
     static ClauseDischarge capabilityOf(StatedContract.Conjunct conjunct,
-                                        Denotations locations, RuleReadingSource source,
-                                        ReadingPolicy policy, String describing) {
-        return new InvariantChecker(source, DeclarationReadings.NONE, policy)
+                                        Denotations locations, RuleReadingContext reading,
+                                        String describing) {
+        return new InvariantChecker(reading)
                 .capabilityOf(conjunct.stated(), conjunct.at(), locations, describing);
     }
 
@@ -660,20 +656,15 @@ public final class InvariantChecker {
     }
 
     /**
-     * The same, borrowing nothing anybody else has made of the declaration.
+     * The same, read in the world a walk carries.
      *
-     * <p><b>Where a reading cannot be reached rather than where none would help.</b> The caller
-     * here runs while a reading is being made, from a reader that is handed the terms of the
-     * reading in progress and nothing that says where another declaration's reading comes from — so
-     * borrowing would take a capability carried into the reading itself, and what such a borrower
-     * should be handed when the reading it asks for is the one under way is not settled. This keeps
-     * what that caller did before while saying that is what it is: named, so that what is unsettled
-     * can be found by looking for it, and separate from {@link DeclarationReadings#NONE}, which is
-     * what a reader with no store says.
+     * <p>What a reader under a walk asks. It is handed the world the reading it stands inside was
+     * made in, so where it borrows from is already decided — including where that world was bounded
+     * for a reading under way ({@link RuleReadingContext#whileTheAnswerIsMade}), which a reader
+     * choosing a lender for itself would be choosing past.
      */
-    static Seeded seedFieldsUnshared(TypeSymbol.AtModule named, RuleReadingSource source,
-                                     ReadingPolicy policy) {
-        return seedFields(named, source, policy, DeclarationReadings.NONE);
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingContext reading) {
+        return seedFields(named, reading.source(), reading.policy(), reading.readings());
     }
 
     /** The same, reading for itself. */
@@ -791,7 +782,10 @@ public final class InvariantChecker {
                              StringMachineAnswers answers) {
         READINGS.incrementAndGet();
         Symbols symbols = source.symbols();
-        InvariantChecker c = new InvariantChecker(source, machines, policy);
+        // The three this was handed, put back together to hand on. Not a world of its own: nothing
+        // here chooses any of them, and a reader below is given what this reader was given.
+        InvariantChecker c =
+                new InvariantChecker(RuleReadingContext.of(source, policy, machines));
         c.answers = answers;
         // A newtype's value is the same location as the newtype, so it is at no name of its own and
         // its fields are the first step there is. Read from the world rather than off a node handed
@@ -3525,11 +3519,10 @@ public final class InvariantChecker {
      * analysis representation could not be built or typed for, and is not analyzed at all, which is
      * the {@code ABANDONED} this answers with.
      */
-    static Findings analyze(Core body, RuleReadingSource source,
-                            DeclarationReadings machines,
+    static Findings analyze(Core body, RuleReadingContext reading,
                             Map<ValueName.Behavior, AssumedContract> contracts,
-                            Scope params, ReadingPolicy policy) {
-        InvariantChecker c = new InvariantChecker(source, machines, contracts, policy);
+                            Scope params) {
+        InvariantChecker c = new InvariantChecker(reading, contracts);
         if (body == null) {
             return new Findings(c.errors, c.warnings, Status.ABANDONED);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -71,13 +71,13 @@ final class PathEngine {
     /** What each behavior a body may call states about its answer, by the name it is called under. */
     private final Map<ValueName.Behavior, AssumedContract> contracts;
 
-    PathEngine(RuleReadingSource source, ReadingPolicy policy) {
-        this(source, Map.of(), Terms.Of.THE_DISCHARGE_TREE, policy);
+    PathEngine(RuleReadingContext reading) {
+        this(reading, Map.of(), Terms.Of.THE_DISCHARGE_TREE);
     }
 
-    PathEngine(RuleReadingSource source,
-               Map<ValueName.Behavior, AssumedContract> contracts, ReadingPolicy policy) {
-        this(source, contracts, Terms.Of.THE_DISCHARGE_TREE, policy);
+    PathEngine(RuleReadingContext reading,
+               Map<ValueName.Behavior, AssumedContract> contracts) {
+        this(reading, contracts, Terms.Of.THE_DISCHARGE_TREE);
     }
 
     /**
@@ -88,17 +88,16 @@ final class PathEngine {
      * recorded the fold as a shape this compiler has no term for would be answering about the
      * representation under the name of a gap.
      */
-    PathEngine(RuleReadingSource source, Terms.Of reading,
-               ReadingPolicy policy) {
-        this(source, Map.of(), reading, policy);
+    PathEngine(RuleReadingContext ruleReading, Terms.Of reading) {
+        this(ruleReading, Map.of(), reading);
     }
 
-    PathEngine(RuleReadingSource source,
+    PathEngine(RuleReadingContext ruleReading,
                Map<ValueName.Behavior, AssumedContract> contracts,
-               Terms.Of reading, ReadingPolicy policy) {
-        this.symbols = source.symbols();
-        this.clauses = new Clauses(source);
-        this.terms = new Terms(reading, policy, clauses);
+               Terms.Of reading) {
+        this.symbols = ruleReading.source().symbols();
+        this.terms = new Terms(reading, ruleReading);
+        this.clauses = terms.clauses();
         this.predicates = terms.predicates();
         this.guarantees = terms.guarantees();
         this.walk = terms.walk();

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -231,9 +231,9 @@ public final class PathReachability {
      * reading, and a walk of a body against one made up says about this compilation having stopped
      * what it would say about the model. A caller without one measures nothing here.
      */
-    public static Answers of(Core body, ReadingPolicy policy,
-                             SpecImplementation.Implemented implemented,
-                             CoverageSites.Plan plan, InputDomain read, RuleReadingSource source) {
+    public static Answers of(Core body, SpecImplementation.Implemented implemented,
+                             CoverageSites.Plan plan, InputDomain read,
+                             RuleReadingContext ruleReading) {
         Objects.requireNonNull(read, "a reachability reading is made against an input that was read");
         if (implemented == null) {
             return Answers.NONE;
@@ -247,7 +247,7 @@ public final class PathReachability {
             params = params.with(input.written().binder(),
                     TypeOps.successType(input.declared().type()));
         }
-        return of(body, params, plan, read, source, policy);
+        return of(body, params, plan, read, ruleReading);
     }
 
     /**
@@ -258,12 +258,12 @@ public final class PathReachability {
      * answers about what it had reached and no more.
      */
     public static Answers of(Core body, Scope params, CoverageSites.Plan plan, InputDomain read,
-                             RuleReadingSource source, ReadingPolicy policy) {
+                             RuleReadingContext ruleReading) {
         Objects.requireNonNull(read, "a reachability reading is made against an input that was read");
         if (body == null) {
             return Answers.NONE;
         }
-        PathEngine engine = new PathEngine(source, Terms.Of.THE_TREE_THAT_RUNS, policy);
+        PathEngine engine = new PathEngine(ruleReading, Terms.Of.THE_TREE_THAT_RUNS);
         Map<ControlPlace, Reachability> out = new LinkedHashMap<>();
         Map<ConstructOccurrence,
                 souther.compiler.reach.ComparisonArrival> arriving = new LinkedHashMap<>();
@@ -273,7 +273,8 @@ public final class PathReachability {
                     p.getValue().type(), body.pos()), in.known(), in.at());
         }
         PathReachability reading =
-                new PathReachability(engine, plan, read, source.symbols(), out, arriving);
+                new PathReachability(engine, plan, read, ruleReading.source().symbols(), out,
+                        arriving);
         reading.entry = in.known();
         reading.entered = in.at();
         reading.walk(body, in.known(), in.at(),

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleReadingContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleReadingContext.java
@@ -1,5 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.types.TypeKey;
+import souther.compiler.values.StringMachineAnswers;
+
 /**
  * The one world a reading of a declaration's rules is made in: where the rules are read from, what
  * the reading may spend, and where it borrows what somebody has already made of the same
@@ -22,6 +25,11 @@ package souther.compiler.check;
  * <p>Three accessors and nothing else. A context that answered questions of its own — what a name
  * resolves to, what a declaration's fields leave — would be where a reader goes instead of where a
  * reader gets what it was given, and every such answer is one somebody already owns.
+ *
+ * <p>And one world derived from another ({@link #whileTheAnswerIsMade}), which is not an answer of
+ * that kind: what comes back is the same three under a bound on one of them. It is here because a
+ * bound put on the lender alone holds only while the world around it is put back together by hand,
+ * and a walk handed the lender can reach past a bound nobody rebuilt.
  *
  * <p>No identity of its own, which is why this is not a record. Two of the three are capabilities,
  * so two contexts built from one compilation for one reading answer alike and compare unlike, and
@@ -75,8 +83,31 @@ public final class RuleReadingContext {
         return policy;
     }
 
-    /** Where it borrows what has already been made of a declaration. */
-    public DeclarationReadings readings() {
+    /**
+     * Where it borrows what has already been made of a declaration.
+     *
+     * <p>For whoever still takes the three apart, and for nobody under a walk. A reader below is
+     * handed this and reads in it; reaching past it for the lender is how a reader comes to hand
+     * some other lender down, and {@link #whileTheAnswerIsMade} is what a reader that has to bound
+     * one uses instead.
+     */
+    DeclarationReadings readings() {
         return readings;
+    }
+
+    /**
+     * The same world, for the length of the answer about {@code named}'s machines that is being
+     * made: the same rules, the same budget, and a lender bounded as
+     * {@link DeclarationReadings#whileTheAnswerIsMade} bounds one.
+     *
+     * <p>Here rather than at the lender because what travels down a walk is this. A reader that
+     * took the lender out, bounded it and put a world back together would be building a world of
+     * its own, and the boundary would hold only for as long as every such reader remembered to
+     * rebuild it — which is what a walk reaching the lender from underneath walks around. Derived
+     * here, a reader below is handed a bounded world and has no other to hand on.
+     */
+    public RuleReadingContext whileTheAnswerIsMade(TypeKey named, StringMachineAnswers recorder) {
+        return new RuleReadingContext(source, policy,
+                readings.whileTheAnswerIsMade(named, recorder));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -457,8 +457,8 @@ public final class SpecChecker {
                                 .withDependencies(dependsOn).forDischarge(), output);
         InvariantChecker.Findings inv = discharge == null
                 ? InvariantChecker.Findings.notRun()
-                : InvariantChecker.analyze(dischargeBody, discharge.rules(), discharge.machines(),
-                        discharge.contracts(), env, policy);
+                : InvariantChecker.analyze(dischargeBody, discharge.reading(),
+                        discharge.contracts(), env);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
@@ -73,12 +73,11 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
      * one of the things {@link UniversalElementFacts} reads to answer it.
      */
     static StepInputFacts of(Reductions.Reducing r, Denotations inside, Terms terms,
-                             RuleReadingSource source, ReadingPolicy policy,
                              Set<FactSubject> namedByTheStep) {
         Gathering gathering = new Gathering(terms, namedByTheStep);
         List<Core.Binder> params = r.step().params();
         UniversalElementFacts elements =
-                UniversalElementFacts.of(r.container(), inside, terms, source, policy);
+                UniversalElementFacts.of(r.container(), inside, terms);
         for (int i = 0; i < params.size(); i++) {
             Core.Binder param = params.get(i);
             if (param == r.accumulator()) {
@@ -88,7 +87,7 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
                 elements.at(inside.subject(param.binding()), terms).forEach(gathering::holds);
                 continue;
             }
-            guaranteed(param, handedAt(r, i), inside, terms, source, policy, gathering);
+            guaranteed(param, handedAt(r, i), inside, terms, gathering);
         }
         return gathering.gathered();
     }
@@ -135,13 +134,12 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
      * on the other, and nothing here reads a declaration.
      */
     private static void guaranteed(Core.Binder param, Type handed, Denotations inside, Terms terms,
-                                   RuleReadingSource source, ReadingPolicy policy,
                                    Gathering gathering) {
         FactSubject root = inside.subject(param.binding());
         if (root == null) {
             return;
         }
-        ValueGuarantees.of(handed, source, policy).forEach(
+        ValueGuarantees.of(handed, terms.ruleReading()).forEach(
                 (path, bounds) -> gathering.holds(terms.under(root, path), bounds));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -54,17 +54,22 @@ import java.util.Set;
  */
 final class Terms {
 
-    /** What a declaration read from here is read under. Handed down rather than made: two readings
-     *  of one declaration under different policies answer a position differently, and nothing that
-     *  reads one is in a position to know which the compilation asked for. */
-    private final ReadingPolicy policy;
+    /**
+     * The world a declaration read from here is read in: where its clauses come from, what the
+     * reading may spend, and what has already been made of it.
+     *
+     * <p>Handed down rather than made. Two readings of one declaration under different policies
+     * answer a position differently and nothing reading one knows which the compilation asked for;
+     * a source composed here would be one nothing else can name, and a lender chosen here would be
+     * chosen past whatever bound the reading this walk stands inside was made under. So the three
+     * arrive together and are handed on together ({@link RuleReadingContext}).
+     */
+    private final RuleReadingContext ruleReading;
 
     private final Symbols symbols;
 
-    /** The scope and the clause representation this reading was made with, for the readings below
-     *  that ask what a declaration states. Held rather than rebuilt: a reader composing its own
-     *  would be free to compose a different one. */
-    private final RuleReadingSource rules;
+    /** The declarations' clauses as this reading reads them, expanded from the world's source. */
+    private final Clauses clauses;
 
     /** The symbols this reading was made against — what a reader holding this reading folds an
      *  expression of it against, rather than reaching for a library of its own. */
@@ -301,7 +306,12 @@ final class Terms {
 
     /** What this reading may spend, which the compilation set and nothing here makes. */
     ReadingPolicy policy() {
-        return policy;
+        return ruleReading.policy();
+    }
+
+    /** The world the readings below this one are made in, which is the one this was handed. */
+    RuleReadingContext ruleReading() {
+        return ruleReading;
     }
 
     /** What a clause states, read through this reading. */
@@ -320,25 +330,32 @@ final class Terms {
     }
 
     /**
-     * A reading over {@code reading}'s tree, told where the declarations' invariants are.
+     * A reading over {@code reading}'s tree, made in the world {@code ruleReading} is of.
      *
-     * <p>{@code clauses} is what lets a recipe say what choosing an arm settles where the arm binds
-     * a value: the answer is what that value's type guarantees, read through the one reading of a
-     * declaration there is ({@link TypeGuarantees}).
+     * <p>The clauses are this reading's own and are made here rather than handed in. What they are
+     * read from is the world's source, and a reader that was handed both could hand a pair that
+     * disagree — clauses of one module and a world naming another — which is a reading of neither.
+     * Made here there is one source and nothing to keep agreeing.
      *
-     * <p>Where this reads is {@code clauses}'s own source and is not assembled here. A reading made
-     * under a source put together by whoever is reading is one nothing else can name, so a reader
-     * that rebuilt the source from the parts it was handed would be reading a world of its own and
-     * would be lent nothing ({@link RuleReadingSource#origin}).
+     * <p>What they are for is what lets a recipe say what choosing an arm settles where the arm
+     * binds a value: the answer is what that value's type guarantees, read through the one reading
+     * of a declaration there is ({@link TypeGuarantees}).
      */
-    Terms(Of reading, ReadingPolicy policy, Clauses clauses) {
-        this.rules = clauses.source();
-        this.symbols = rules.symbols();
+    Terms(Of reading, RuleReadingContext ruleReading) {
+        this.ruleReading = ruleReading;
+        this.symbols = ruleReading.source().symbols();
         this.reading = reading;
-        this.policy = policy;
+        this.clauses = new Clauses(ruleReading.source());
         this.predicates = new Predicates(this);
         this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
         this.walk = new GuaranteeWalk(guarantees, symbols);
+    }
+
+    /** The clauses this reading is over, for a reader beside it that asks what a declaration
+     *  states. The same ones this reads, since a second set read from the same source is a second
+     *  expansion of what one of them already holds. */
+    Clauses clauses() {
+        return clauses;
     }
 
     /**
@@ -990,7 +1007,7 @@ final class Terms {
         // this has to keep, so the reaching is taken over both kinds of edge and not over the
         // recipes alone ({@link #reached}).
         InductiveBounds.Walk made = new InductiveBounds.Walk(seed, accumulator, step,
-                StepInputFacts.of(walk, inside, this, rules, policy, reached(step)));
+                StepInputFacts.of(walk, inside, this, reached(step)));
         computedBy(atom, new AtomKnowledge.Computation.Reduction(made));
     }
 
@@ -1027,7 +1044,7 @@ final class Terms {
             return;
         }
         UniversalElementFacts elements =
-                UniversalElementFacts.of(accumulating.container(), at, this, rules, policy);
+                UniversalElementFacts.of(accumulating.container(), at, this);
         computedBy(atom, new AtomKnowledge.Computation.Reduction(new InductiveBounds.Walk(
                 seed, accumulator, step,
                 StepInputFacts.ofTheElement(elements, element, this, reached(step)))));

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -72,9 +72,8 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
      * not the other would answer them differently, which is the shape this class was written to
      * stop, seen inside it.
      */
-    static UniversalElementFacts of(Core written, Denotations at, Terms terms,
-                                    RuleReadingSource rules, ReadingPolicy policy) {
-        Symbols symbols = rules.symbols();
+    static UniversalElementFacts of(Core written, Denotations at, Terms terms) {
+        Symbols symbols = terms.symbols();
         if (written == null) {
             return NONE;
         }
@@ -82,10 +81,10 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
         Core container = given.value();
         Map<RuleKey, Bounds> held = new LinkedHashMap<>();
         Type element = Terms.elementType(container.type());
-        ValueGuarantees.of(element, rules, policy)
+        ValueGuarantees.of(element, terms.ruleReading())
                 .forEach((path, bounds) -> holds(held, path, bounds));
         writtenOut(container, element, symbols, held);
-        transferred(container, given.at(), terms, rules, policy, held);
+        transferred(container, given.at(), terms, held);
         return held.isEmpty() ? NONE : new UniversalElementFacts(held);
     }
 
@@ -153,8 +152,7 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
      * span of what each keeps.
      */
     private static void transferred(Core container, Denotations at, Terms terms,
-                                    RuleReadingSource rules,
-                                    ReadingPolicy policy, Map<RuleKey, Bounds> held) {
+                                    Map<RuleKey, Bounds> held) {
         if (!(container instanceof Core.PreservedCall call)) {
             return;
         }
@@ -162,26 +160,25 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
         if (kept == null || kept.container() == null) {
             return;
         }
-        keptBy(kept.lineage(), call, kept.container(), at, terms, rules, policy)
+        keptBy(kept.lineage(), call, kept.container(), at, terms)
                 .forEach((path, bounds) -> holds(held, path, bounds));
     }
 
     /** What one lineage keeps of {@code source}, by the path under an element. */
     private static Map<RuleKey, Bounds> keptBy(ElementLineage<DeclaredArgument> lineage,
                                               Core.PreservedCall call,
-                                              Core source, Denotations at, Terms terms,
-                                              RuleReadingSource rules, ReadingPolicy policy) {
+                                              Core source, Denotations at, Terms terms) {
         return switch (lineage) {
             case ElementLineage.SameAs<DeclaredArgument> _ ->
-                    of(source, at, terms, rules, policy).byPath();
+                    of(source, at, terms).byPath();
             case ElementLineage.ClosureResult<DeclaredArgument> _ ->
-                    throughTheClosure(call, source, at, terms, rules, policy);
+                    throughTheClosure(call, source, at, terms);
             case ElementLineage.InsideClosureResult<DeclaredArgument> _ -> Map.of();
             case ElementLineage.OneOf<DeclaredArgument> one -> {
                 Map<RuleKey, Bounds> both = null;
                 for (ElementLineage<DeclaredArgument> alternative : one.alternatives()) {
                     Map<RuleKey, Bounds> keeps =
-                            keptBy(alternative, call, source, at, terms, rules, policy);
+                            keptBy(alternative, call, source, at, terms);
                     both = both == null ? keeps : spanning(both, keeps);
                 }
                 yield both == null ? Map.of() : both;
@@ -220,13 +217,12 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
      * map was written, which is what this class is for.
      */
     private static Map<RuleKey, Bounds> throughTheClosure(Core.PreservedCall call, Core source,
-                                                         Denotations at, Terms terms,
-                                                         RuleReadingSource rules, ReadingPolicy policy) {
+                                                         Denotations at, Terms terms) {
         Combinators.Handed handed = Combinators.handedTo(call, at);
         if (handed == null) {
             return Map.of();
         }
-        UniversalElementFacts kept = of(source, at, terms, rules, policy);
+        UniversalElementFacts kept = of(source, at, terms);
         BindingId element = handed.element().binding();
         FactSubject root = terms.placeSubject(element);
         Denotations reading = at.location(element, root, terms.placeTerm(element));

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
@@ -44,16 +44,15 @@ public final class ValueGuarantees {
      * <p>{@link InvariantChecker#seedFields} is what decides it and this reads that answer: a
      * record's own invariant bounds its fields, and a reading of the declarations is what has that.
      */
-    public static Map<RuleKey, Bounds> of(Type type, RuleReadingSource source,
-                                          ReadingPolicy policy) {
+    public static Map<RuleKey, Bounds> of(Type type, RuleReadingContext reading) {
         // Whose clauses hold of a value of this type is the one reading's answer. Asked here from
         // the declaration instead, an element that is a sum is an element nothing is known about,
         // while the same value read as a field of a record carries the shared part's bounds.
-        List<ValueReading.Owner> owners = ValueReading.of(type, source.symbols()).owners();
+        List<ValueReading.Owner> owners =
+                ValueReading.of(type, reading.source().symbols()).owners();
         Map<RuleKey, Bounds> guaranteed = new LinkedHashMap<>();
         for (ValueReading.Owner owner : owners) {
-            InvariantChecker.Seeded seeded =
-                    seededOf(owner.named(), source, policy);
+            InvariantChecker.Seeded seeded = seededOf(owner.named(), reading);
             if (seeded == null) {
                 // All of them or none, which is what leaves a value unbounded rather than bounded
                 // by half of what the declarations say.
@@ -76,9 +75,8 @@ public final class ValueGuarantees {
      * this says nothing from, which leaves a value unbounded rather than bounded by half of what
      * a declaration says. */
     private static InvariantChecker.Seeded seededOf(TypeSymbol.AtModule named,
-                                                    RuleReadingSource source, ReadingPolicy policy) {
-        InvariantChecker.Seeded seeded =
-                InvariantChecker.seedFieldsUnshared(named, source, policy);
+                                                    RuleReadingContext reading) {
+        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, reading);
         return seeded.everyClauseRead() && !seeded.constraints().isBottom() ? seeded : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -2,6 +2,7 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.DeclaredSig;
 import souther.compiler.check.NumberAt;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.DeclarationReadings;
@@ -854,8 +855,12 @@ public final class InputDomain {
         // position first and the declarations under one the reading stopped above, which is the one
         // resolution of it — worked out again from the positions this hands over, a rule about a
         // name every case of a sum spreads would be read as naming nothing.
+        // The world this reading was made in, handed on whole. What a quantity reaches below is a
+        // declaration this reading already reached, so it is read from the same rules under the
+        // same budget and borrows what this reading's own made of it.
         return ReadQuantities.of(byRoot, byRoot.keySet(), byPath, cases,
-                path -> typeAt(path, source), source, policy);
+                path -> typeAt(path, source),
+                source == null ? null : RuleReadingContext.of(source, policy, machines));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -1,7 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.NumberAt;
-import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.ConstraintState;
 import souther.compiler.check.Emptiness;
 import souther.compiler.check.FieldDomains;
@@ -49,14 +49,16 @@ final class ReadQuantities implements Quantities {
     /** Every sum this input holds, and what became of each of its cases. What the choice between
      *  alternatives is folded over. */
     private final List<CasesRead> cases;
-    /** What says how the values of a position are spaced, which the arithmetic needs of every
-     *  number it is told a bound on. Held rather than asked for per question: the reading of an
-     *  input is what a caller has, and where a position's values step is a fact about its type. */
-    private final RuleReadingSource ruleSource;
-    /** How far a declaration is read, which the reading of what a value guarantees is held to. The
-     *  reading of this input was made under it, so a question asked of the declarations afterwards
-     *  is answered under the same one or it is a second reading of them. */
-    private final souther.compiler.check.ReadingPolicy policy;
+    /**
+     * The world a declaration reached from here is read in: where the rules come from, how far one
+     * is read, and what has already been made of it.
+     *
+     * <p>Held rather than asked for per question, and held as the three together. The reading of an
+     * input is what a caller has; a question asked of the declarations afterwards under another
+     * budget is a second reading of them, and one asked without what the reading of this input was
+     * handed reads again what that reading already made ({@link RuleReadingContext}).
+     */
+    private final RuleReadingContext ruleReading;
     /** What the behavior takes, which is what a path of this input starts at. */
     private final Set<TermPath> roots;
     /** Every position that was read, by where it sits. What one of them was read to hold is what
@@ -136,11 +138,9 @@ final class ReadQuantities implements Quantities {
                            Map<TermPath, Position> byPath, List<CasesRead> cases,
                            java.util.function.Function<TermPath, Type> typeAt,
                            Map<NumericTerm, Fixed> fixed,
-                           RuleReadingSource ruleSource,
-                           souther.compiler.check.ReadingPolicy policy, List<Assumed> assumed) {
-        this.policy = policy;
+                           RuleReadingContext ruleReading, List<Assumed> assumed) {
         this.cases = List.copyOf(cases);
-        this.ruleSource = ruleSource;
+        this.ruleReading = ruleReading;
         this.typeAt = typeAt;
         this.assumed = List.copyOf(assumed);
         // In the order the behavior declares its parameters. A proof of emptiness names one of them
@@ -160,9 +160,8 @@ final class ReadQuantities implements Quantities {
     static ReadQuantities of(Map<TermPath, OpenedRules> byRoot, Set<TermPath> roots,
                              Map<TermPath, Position> byPath, List<CasesRead> cases,
                              java.util.function.Function<TermPath, Type> typeAt,
-                             RuleReadingSource ruleSource,
-                             souther.compiler.check.ReadingPolicy policy) {
-        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, Map.of(), ruleSource, policy,
+                             RuleReadingContext ruleReading) {
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, Map.of(), ruleReading,
                 List.of());
     }
 
@@ -180,7 +179,8 @@ final class ReadQuantities implements Quantities {
         // absent, so a term of another input comes back with an order on one end and nothing on the
         // other — an answer about no reading, wearing this one's name.
         held(term);
-        return TermOrdering.of(term, typeAt.apply(term.subjectPath()), ruleSource.symbols());
+        return TermOrdering.of(term, typeAt.apply(term.subjectPath()),
+                ruleReading.source().symbols());
     }
 
     @Override
@@ -237,7 +237,8 @@ final class ReadQuantities implements Quantities {
             return null;
         }
         NumericTerm.TakenOf term =
-                NumericTerm.TakenOf.of(operation, at, typeAt.apply(at), ruleSource.symbols());
+                NumericTerm.TakenOf.of(operation, at, typeAt.apply(at),
+                        ruleReading.source().symbols());
         return term != null && term.takenAs() instanceof TakenAs.HowManyItHolds ? term : null;
     }
 
@@ -334,7 +335,7 @@ final class ReadQuantities implements Quantities {
         }
         List<Assumed> both = new ArrayList<>(assumed);
         both.add(taking);
-        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, fixed, ruleSource, policy,
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, fixed, ruleReading,
                 both);
     }
 
@@ -367,7 +368,8 @@ final class ReadQuantities implements Quantities {
         // and the set a position finally admits here is met out of all of them — so this is the
         // answer being built and this is where building it is charged. Handed to each meet, since
         // that is where a set neither reading holds comes to be.
-        souther.compiler.values.Allowance<InputAtom> sets = policy.allowanceForAdmittedValues();
+        souther.compiler.values.Allowance<InputAtom> sets =
+                ruleReading.policy().allowanceForAdmittedValues();
         for (FieldDomains.Carried<InputAtom> each : conditioned(under).values()) {
             made = made.meet(each.constraints(), sets);
         }
@@ -720,7 +722,7 @@ final class ReadQuantities implements Quantities {
         if (had != null) {
             return had;
         }
-        if (ruleSource == null) {
+        if (ruleReading == null) {
             return null;
         }
         // The order this reading measures the term on, which is the same answer every other reader
@@ -816,7 +818,7 @@ final class ReadQuantities implements Quantities {
             both.merge(term, new Fixed(each.getValue(), each.getValue()),
                     (had, one) -> had.and(one.least()));
         }
-        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, both, ruleSource, policy,
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, both, ruleReading,
                 assumed);
     }
 
@@ -1177,7 +1179,7 @@ final class ReadQuantities implements Quantities {
         return switch (term) {
             case NumericTerm.FromOnePosition one -> ownOf(one);
             case NumericTerm.TakenOver over ->
-                    RunReach.of(over, ordersOf(over), typeAt, ruleSource, policy);
+                    RunReach.of(over, ordersOf(over), typeAt, ruleReading);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RunReach.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RunReach.java
@@ -1,9 +1,8 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.DefaultBoundOperationFacts;
-import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleKey;
-import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.ValueGuarantees;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
@@ -95,11 +94,10 @@ final class RunReach {
      * @param typeAt what stands where a path names
      */
     static NumericDomain.Bounds of(NumericTerm.TakenOver over, TermOrders orders,
-                                   Function<TermPath, Type> typeAt, RuleReadingSource rules,
-                                   ReadingPolicy policy) {
+                                   Function<TermPath, Type> typeAt, RuleReadingContext reading) {
         orders.areOf(over);
         Accumulation walk = DefaultBoundOperationFacts.get().accumulation(over.operation());
-        NumericDomain.Bounds element = ofTheValuesWalked(over.source(), typeAt, rules, policy);
+        NumericDomain.Bounds element = ofTheValuesWalked(over.source(), typeAt, reading);
         Granularity answeredOn = spacingOf(orders.answered());
         Granularity observedOn = spacingOf(orders.observed());
         if (walk == null || element == null || answeredOn == null || observedOn == null) {
@@ -140,11 +138,10 @@ final class RunReach {
      */
     private static NumericDomain.Bounds ofTheValuesWalked(RunSource source,
                                                           Function<TermPath, Type> typeAt,
-                                                          RuleReadingSource rules,
-                                                          ReadingPolicy policy) {
+                                                          RuleReadingContext reading) {
         Type walked = typeAt.apply(source.subjectPath());
         return walked == null ? null
-                : ValueGuarantees.of(walked, rules, policy).get(RuleKey.THE_VALUE);
+                : ValueGuarantees.of(walked, reading).get(RuleKey.THE_VALUE);
     }
 
     /** The value the walk starts from, as a range, or null where this reading has no number for it.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1826,8 +1826,7 @@ public final class Partitions {
         // The record's rules, read once. Each field is then chosen against this with the fields
         // before it settled into it, which is what a settling states — a reading per settled field
         // would be paying for every clause again to arrive where the first one already is.
-        FieldDomains rules = FieldDomains.of(record, ruleSource, reading.policy(),
-                reading.readings());
+        FieldDomains rules = FieldDomains.of(record, reading);
         FieldDomains.Composing left = rules.composing(Map.of());
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -833,6 +833,9 @@ public final class Adequacy {
             }
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             Map<String, souther.compiler.check.PathReachability.Answers> out = new LinkedHashMap<>();
+            // One world for every behavior of the module, since every walk below reads in it.
+            RuleReadingContext ruleReading = RuleReadingContext.of(reading.value(),
+                    db.ask(new Front.Reading()).value(), db.readings());
             for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
                 // A composition has no body of its own and so no places of its own, and a behavior
                 // whose input this compilation could not read is one nothing here is measured
@@ -852,9 +855,7 @@ public final class Adequacy {
                     continue;
                 }
                 out.put(spec.name(), souther.compiler.check.PathReachability.of(
-                        body, SpecImplementation.align(spec, fn), plan, read,
-                        RuleReadingContext.of(reading.value(),
-                                db.ask(new Front.Reading()).value(), db.readings())));
+                        body, SpecImplementation.align(spec, fn), plan, read, ruleReading));
             }
             return Answer.of(Ordered.map(out));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -33,6 +33,7 @@ import souther.compiler.check.DeclaredSig;
 import souther.compiler.check.PublishedDeclarations;
 import souther.compiler.check.RuleRef;
 import souther.compiler.publish.PublicationOrders;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.CheckSurface;
 import souther.compiler.check.Sig;
@@ -851,8 +852,9 @@ public final class Adequacy {
                     continue;
                 }
                 out.put(spec.name(), souther.compiler.check.PathReachability.of(
-                        body, db.ask(new Front.Reading()).value(),
-                        SpecImplementation.align(spec, fn), plan, read, reading.value()));
+                        body, SpecImplementation.align(spec, fn), plan, read,
+                        RuleReadingContext.of(reading.value(),
+                                db.ask(new Front.Reading()).value(), db.readings())));
             }
             return Answer.of(Ordered.map(out));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.DefinitionName;
@@ -644,7 +645,8 @@ public final class Bodies {
             }
             Map<String, ContractDischarge> out = new LinkedHashMap<>();
             stated.value().forEach((behavior, rules) -> out.put(behavior, ContractDischarge.of(
-                    rules, reading.value(), db.ask(new Front.Reading()).value())));
+                    rules, RuleReadingContext.of(reading.value(),
+                            db.ask(new Front.Reading()).value(), db.readings()))));
             return Answer.of(Ordered.map(out));
         }
     }
@@ -2098,9 +2100,12 @@ public final class Bodies {
                             // over the declarations as resolution left them: the two are different
                             // scopes, so a reading made here is not a reading made there and says
                             // so.
-                            new RuleReadingSource(scope.value(), Shapes.expandedClauses(db),
-                                    Shapes.publishedDeclarations(db), Shapes.clauseLocations(db)),
-                            db.readings(),
+                            RuleReadingContext.of(
+                                    new RuleReadingSource(scope.value(),
+                                            Shapes.expandedClauses(db),
+                                            Shapes.publishedDeclarations(db),
+                                            Shapes.clauseLocations(db)),
+                                    db.ask(new Front.Reading()).value(), db.readings()),
                             contracts.present() ? contracts.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();
@@ -2211,9 +2216,10 @@ public final class Bodies {
             Hir.FnDef fn = db.ask(new SettledFn(module, spec.name())).value();
             out.put(spec.name(), souther.compiler.claims.Claims.of(
                     souther.compiler.claims.UnreachableClaims.of(body, read, scope.value(), plan),
-                    souther.compiler.check.PathReachability.of(body, policy,
+                    souther.compiler.check.PathReachability.of(body,
                             fn == null ? null : SpecImplementation.align(spec, fn),
-                            plan, read, reading.value())));
+                            plan, read,
+                            RuleReadingContext.of(reading.value(), policy, db.readings()))));
         }
         // In the order the module declares them, which is the order a reader meets the diagnostics
         // these carry. `Map.copyOf` keeps the entries and not the order (see `Ordered`), so a

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -644,9 +644,12 @@ public final class Bodies {
                 return Answer.absent();
             }
             Map<String, ContractDischarge> out = new LinkedHashMap<>();
-            stated.value().forEach((behavior, rules) -> out.put(behavior, ContractDischarge.of(
-                    rules, RuleReadingContext.of(reading.value(),
-                            db.ask(new Front.Reading()).value(), db.readings()))));
+            // One world for every behavior of the module, since every rule of every one of them is
+            // read in it.
+            RuleReadingContext ruleReading = RuleReadingContext.of(reading.value(),
+                    db.ask(new Front.Reading()).value(), db.readings());
+            stated.value().forEach((behavior, rules) ->
+                    out.put(behavior, ContractDischarge.of(rules, ruleReading)));
             return Answer.of(Ordered.map(out));
         }
     }
@@ -2081,6 +2084,7 @@ public final class Bodies {
                     || !sigs.present() || !constructs.present()) {
                 return Answer.absent();
             }
+            ReadingPolicy policy = db.ask(new Front.Reading()).value();
             // The invariant-discharge analysis reads its own representation of the body and of the
             // invariants (spec §invariant-discharge). Where the body's is not available the check is
             // skipped rather than run against the emitted tree, whose operations are no longer
@@ -2105,7 +2109,7 @@ public final class Bodies {
                                             Shapes.expandedClauses(db),
                                             Shapes.publishedDeclarations(db),
                                             Shapes.clauseLocations(db)),
-                                    db.ask(new Front.Reading()).value(), db.readings()),
+                                    policy, db.readings()),
                             contracts.present() ? contracts.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();
@@ -2113,7 +2117,7 @@ public final class Bodies {
                 SpecChecker.Checked checked =
                         TypeChecker.checkBehavior(spec.value(), fn.value(),
                         body.value().value().writtenBody(),
-                        db.ask(new Front.Reading()).value(),
+                        policy,
                         dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
                         inliner.value(), sigs.value(), constructs.value(),
                         warnings);
@@ -2199,6 +2203,9 @@ public final class Bodies {
             return Map.of();
         }
         Map<String, souther.compiler.claims.Claims> out = new LinkedHashMap<>();
+        // One world for every behavior of the module, since every walk below reads in it.
+        RuleReadingContext ruleReading =
+                RuleReadingContext.of(reading.value(), policy, db.readings());
         for (Hir.BehaviorDef behavior : settled.behaviors()) {
             Core body = bodies.get(behavior.name());
             // What this compilation worked out about the behavior's boundary, read off the one
@@ -2218,8 +2225,7 @@ public final class Bodies {
                     souther.compiler.claims.UnreachableClaims.of(body, read, scope.value(), plan),
                     souther.compiler.check.PathReachability.of(body,
                             fn == null ? null : SpecImplementation.align(spec, fn),
-                            plan, read,
-                            RuleReadingContext.of(reading.value(), policy, db.readings()))));
+                            plan, read, ruleReading)));
         }
         // In the order the module declares them, which is the order a reader meets the diagnostics
         // these carry. `Map.copyOf` keeps the entries and not the order (see `Ordered`), so a

--- a/souther-compiler/src/main/java/souther/compiler/query/Machines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Machines.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.values.StringMachineAnswers;
 import souther.compiler.types.TypeKey;
@@ -64,9 +65,10 @@ public final class Machines {
             }
             StringMachineAnswers recorder =
                     StringMachineAnswers.unborrowed(db.readings().extents());
-            FieldDomains domains = FieldDomains.of(TypeSymbols.declared(named), source.value(),
-                    policy.value(),
-                    db.readings().whileTheAnswerIsMade(named, recorder));
+            RuleReadingContext reading =
+                    RuleReadingContext.of(source.value(), policy.value(), db.readings());
+            FieldDomains domains = FieldDomains.of(TypeSymbols.declared(named),
+                    reading.whileTheAnswerIsMade(named, recorder));
             // And whether the rules leave a value at all, which is the question every reading of
             // an input puts to the declaration and the one that meets each language with the
             // whole of the order. Asked here so that the machines it takes are the declaration's

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -12,6 +12,7 @@ import souther.compiler.stdlib.Stdlib;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.ExpandedClauseResult;
 import souther.compiler.check.ExpandedClauses;
+import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.InvariantSettled;
 import souther.compiler.check.Lower;
@@ -547,8 +548,9 @@ public final class Shapes {
                         for (ClausesForDischarge.ClauseReading written
                                 : declaring.conjunctsOf(declared.expr(), new BindingOwner.OfData(named))) {
                             clauses.add(InvariantChecker.capabilityOf(written, named,
-                                    reading.value(),
-                                    db.ask(new Front.Reading()).value()).named(declared.name()));
+                                    RuleReadingContext.of(reading.value(),
+                                            db.ask(new Front.Reading()).value(), db.readings()))
+                                    .named(declared.name()));
                         }
                     }
                     out.put(named, List.copyOf(clauses));

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -537,6 +537,10 @@ public final class Shapes {
                 // an answer, so nothing here can place one wrongly.
                 ClausesForDischarge declaring =
                         ClausesForDischarge.of(expandable.value(), scope.value(), published);
+                // One world for every conjunct below, since every one of them is read in it. Made
+                // per conjunct, this asked the store what a reading may spend once for each.
+                RuleReadingContext ruleReading = RuleReadingContext.of(reading.value(),
+                        db.ask(new Front.Reading()).value(), db.readings());
                 Map<TypeSymbol, List<ClauseDischarge>> out = new LinkedHashMap<>();
                 for (Hir.Data data : declaring.declarationsThatState()) {
                     List<ClauseDischarge> clauses = new ArrayList<>();
@@ -547,9 +551,7 @@ public final class Shapes {
                     for (Hir.InvariantClause declared : data.invariants()) {
                         for (ClausesForDischarge.ClauseReading written
                                 : declaring.conjunctsOf(declared.expr(), new BindingOwner.OfData(named))) {
-                            clauses.add(InvariantChecker.capabilityOf(written, named,
-                                    RuleReadingContext.of(reading.value(),
-                                            db.ask(new Front.Reading()).value(), db.readings()))
+                            clauses.add(InvariantChecker.capabilityOf(written, named, ruleReading)
                                     .named(declared.name()));
                         }
                     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
@@ -76,8 +76,9 @@ class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(rules,
-            Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    private final PathEngine engine = new PathEngine(
+            RuleReadingContext.unshared(rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+            Terms.Of.THE_DISCHARGE_TREE);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -57,10 +57,11 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     private static final TypeSymbol AN_INT = TypeSymbol.primitive("Int");
 
     private final Hir.Binders binders = new Hir.Binders(OWNER);
-    private final PathEngine engine =
-            new PathEngine(RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    private final PathEngine engine = new PathEngine(
+            RuleReadingContext.unshared(
+                    RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+            Terms.Of.THE_DISCHARGE_TREE);
 
     @Test
     void anArmOverOneCaseIsAboutTheValueItOpened() {
@@ -191,9 +192,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
         Core.Binder y = CoreBinders.of(binders.binder("y", POS));
         PathEngine reading = new PathEngine(
-                RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                Map.of(FIND, statesThatTheIntIsPositive()), Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+                RuleReadingContext.unshared(
+                        RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                Map.of(FIND, statesThatTheIntIsPositive()), Terms.Of.THE_DISCHARGE_TREE);
 
         Denotations outer = reading.enteringArm(
                 arm(new Core.ResolvedPattern.AnyOf(
@@ -283,9 +285,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     @Test
     void aRuleHoldsOfAnArmWhoseValuesAreAllOnesItIsAbout() {
         Symbols symbols = symbolsOf(NESTED);
-        PathEngine reading = new PathEngine(RuleReadings.ofNoClauseFiled(symbols),
-                Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        PathEngine reading = new PathEngine(
+                RuleReadingContext.unshared(RuleReadings.ofNoClauseFiled(symbols),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                Terms.Of.THE_DISCHARGE_TREE);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");
         Guard aboutOnceKind = new Guard.Case(
@@ -303,9 +306,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     @Test
     void anArmNamingSeveralTakesARuleThatIsAboutAllOfThem() {
         Symbols symbols = symbolsOf(NESTED);
-        PathEngine reading = new PathEngine(RuleReadings.ofNoClauseFiled(symbols),
-                Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        PathEngine reading = new PathEngine(
+                RuleReadingContext.unshared(RuleReadings.ofNoClauseFiled(symbols),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                Terms.Of.THE_DISCHARGE_TREE);
         TypeSymbol once = named(symbols, "OnceKind");
         TypeSymbol station = named(symbols, "Station");
         TypeSymbol hospital = named(symbols, "Hospital");

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryTermIsReadForWhatItSaysTest.java
@@ -157,8 +157,10 @@ class EveryTermIsReadForWhatItSaysTest {
     @Test
     void twoReadingsOfOneTermAreAssumedAlike() {
         PathEngine engine = new PathEngine(
-                RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                Terms.Of.THE_DISCHARGE_TREE, ReadAs.THE_COMPILATION_DOES);
+                RuleReadingContext.unshared(
+                        RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                        ReadAs.THE_COMPILATION_DOES),
+                Terms.Of.THE_DISCHARGE_TREE);
         Predicates predicates = engine.predicates();
 
         Predicates.Owed one = TermMeaning.of(containment(POS))

--- a/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/FollowingWhatANameWasGivenCostsTheChainOnceTest.java
@@ -51,9 +51,10 @@ class FollowingWhatANameWasGivenCostsTheChainOnceTest {
      * link is a name for the one before it and the first is arithmetic. */
     private static long followedOver(int links) {
         PathEngine engine = new PathEngine(
-                RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+                RuleReadingContext.unshared(
+                        RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                Terms.Of.THE_DISCHARGE_TREE);
         Hir.Binders binders = new Hir.Binders(OWNER);
         Core.Binder first = CoreBinders.of(binders.binder("x0", POS));
         Denotations at = engine.enter(Terms.read(CoreBinders.of(binders.binder("a", POS)), Type.INT, POS),

--- a/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
@@ -78,7 +78,7 @@ public final class RuleReadings {
      *  that a reading of a module's declarations is built by saying which representation it reads
      *  and never by handing over a scope alone. */
     static Terms termsOfNoClauseFiled(Symbols symbols, ReadingPolicy policy) {
-        return new Terms(Terms.Of.THE_DISCHARGE_TREE, policy,
-                new Clauses(ofNoClauseFiled(symbols)));
+        return new Terms(Terms.Of.THE_DISCHARGE_TREE,
+                RuleReadingContext.unshared(ofNoClauseFiled(symbols), policy));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
@@ -42,10 +42,11 @@ class WhatANameIsAboutIsWhatItWasGivenIsAboutTest {
             new ValueName.Behavior("demo", "findIt");
 
     private final Hir.Binders binders = new Hir.Binders(OWNER);
-    private final PathEngine engine =
-            new PathEngine(RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                Terms.Of.THE_DISCHARGE_TREE,
-                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    private final PathEngine engine = new PathEngine(
+            RuleReadingContext.unshared(
+                    RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+            Terms.Of.THE_DISCHARGE_TREE);
 
     @Test
     void aNameGivenAPlaceIsAboutThatPlace() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -69,8 +69,9 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
 
     private final Symbols symbols = rules.symbols();
 
-    private final PathEngine engine = new PathEngine(rules,
-            Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    private final PathEngine engine = new PathEngine(
+            RuleReadingContext.unshared(rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+            Terms.Of.THE_DISCHARGE_TREE);
 
     private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees(), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
@@ -231,16 +231,18 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         Scope params = heldTo(new Type.Ref(TypeSymbols.declared(new TypeKey("demo", "制限木"))));
 
         assertEquals(InvariantChecker.Status.COMPLETE,
-                InvariantChecker.analyze(body, readingOf(c, saidBy(c)),
-                        DeclarationReadings.NONE, Map.of(), params, POLICY).status(),
+                InvariantChecker.analyze(body,
+                        RuleReadingContext.unshared(readingOf(c, saidBy(c)), POLICY),
+                        Map.of(), params).status(),
                 "the control: read through a lookup that answers, this analysis runs to the end");
 
         PublishedDeclarations broken = _ -> {
             throw new IllegalStateException("this compiler could not read its own answer");
         };
         IllegalStateException why = assertThrows(IllegalStateException.class,
-                () -> InvariantChecker.analyze(body, readingOf(c, broken),
-                        DeclarationReadings.NONE, Map.of(), params, POLICY),
+                () -> InvariantChecker.analyze(body,
+                        RuleReadingContext.unshared(readingOf(c, broken), POLICY),
+                        Map.of(), params),
                 "the analysis has no rule that makes this the program's problem");
 
         assertEquals("this compiler could not read its own answer", why.getMessage(),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
@@ -46,10 +46,11 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
     private static final TypeSymbol.AtModule FOUND = TypeSymbols.declared(new TypeKey("demo", "Found"));
 
     private final Hir.Binders binders = new Hir.Binders(OWNER);
-    private final PathEngine engine =
-            new PathEngine(RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
-                    Terms.Of.THE_DISCHARGE_TREE,
-                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    private final PathEngine engine = new PathEngine(
+            RuleReadingContext.unshared(
+                    RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get())),
+                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+            Terms.Of.THE_DISCHARGE_TREE);
 
     @Test
     void aNameGivenTextIsThatText() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoMaySayThisCheckMetALimitIsWrittenDownTest.java
@@ -121,8 +121,7 @@ class WhoMaySayThisCheckMetALimitIsWrittenDownTest {
                     + ".of(Lsouther/compiler/core/Core;Lsouther/compiler/check/Scope;"
                     + "Lsouther/compiler/coverage/CoverageSites$Plan;"
                     + "Lsouther/compiler/inputs/InputDomain;"
-                    + "Lsouther/compiler/check/RuleReadingSource;"
-                    + "Lsouther/compiler/check/ReadingPolicy;)",
+                    + "Lsouther/compiler/check/RuleReadingContext;)",
                     "reads which of a plan's comparisons the walk settled nothing about"));
 
     @Test


### PR DESCRIPTION
A reading of a declaration is lent. Where the lending was reached a reader said
where it borrowed from; inside a walk over what an author wrote it was not
reached, so every reader under one read each declaration whole however many
times it arrived at one.

What such a walk needed was not the lender but the world it reads in, and that
already existed: rules, a budget and where to borrow from, travelling together
so that a step substituting one of them is a step reading some other world. The
walk that builds values already carried it. The walk over the terms did not, nor
did the reading of an input, which was handed the lender and dropped it.

Both carry it now. What a value guarantees, what a step is handed and what a run
reaches read in the world their caller read in, and the way in that read without
borrowing for them is gone.

## What a borrower is handed when the reading it asks for is being made

The reading being made bounds what may be borrowed while it is made, and the
bound was put on the lender alone — so whoever put it there rebuilt the world
around it to hand it down, and the bound held only for as long as every such
reader remembered to. A walk handed the lender could reach past one nobody had
rebuilt.

The world derives it now: same rules, same budget, lender bounded. A reader
below is handed a bounded world and has no other to hand on, and the lender is
out of reach from outside the package.

## What is checked

The places this compiler starts a reading somebody else has already made were
written down as one set, and the set was saying two things at once: that a world
with nothing lent to it is a thing anybody may build, and who was building one.
Read together, the second is satisfied by the first going missing — an extraction
that stopped resolving call sites reports no such reader, which is what a
compiler with none looks like.

They are apart now. The way in is asserted to be there, and the readers to be
none. Both were put to a control: a reader reaching the way in fails the second
and not the first, and blinding the walk to how a field is named fails the first
and not the second.

## What this does not settle

The discharge analysis reads a scope of its own and is handed a world of its
own, which is what it had. A reading made in it is still one nothing lends
against, and whether the compilation should mint a source over that scope is
open.

Whether a strategy may hold a world is left as it stands. One does, and its
generated equality includes the particular world; nothing compares two of them,
so there is nothing to repair — which is not evidence that a world belongs in a
strategy's identity.

Refs #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)