### PR TITLE
Fill a collection from what its element type admits

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -73,7 +73,7 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
             Map.entry("souther.compiler.partition.Witnesses#<clinit>()V",
                     "how many elements and characters a proposal holds, and how many pairings"),
             Map.entry("souther.compiler.partition.Witnesses#sized("
-                            + "Lsouther/compiler/check/Shape;I"
+                            + "Lsouther/compiler/check/TypeView;I"
                             + "Lsouther/compiler/check/RuleReadingContext;Ljava/util/Set;)"
                             + "Lsouther/compiler/partition/Witnesses$Built;",
                     "stops at the elements and the characters, and says which"),

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -302,7 +302,7 @@ final class Intervals {
         }
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each
-                : Witnesses.ofSize(view.shape(), size, reading, Set.of()).values()) {
+                : Witnesses.ofSize(view, size, reading, Set.of()).values()) {
             out.add(RepresentativeSource.under(worn.names(), each));
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -36,7 +36,10 @@ import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Place;
+import souther.compiler.regex.Language;
+import souther.compiler.regex.Meter;
 import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternSyntax;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeReachName;
@@ -2108,10 +2111,97 @@ public final class Partitions {
      * own, which meant two answers to "what does this pattern accept" and one model where they
      * could differ.
      */
-    private static String writtenFor(souther.compiler.regex.PatternSyntax syntax) {
-        souther.compiler.regex.Language language = souther.compiler.regex.PatternPlan.of(syntax)
-                .compile(souther.compiler.regex.PatternPlan.Budget.OF_A_WITNESS.meter());
+    private static String writtenFor(PatternSyntax syntax) {
+        Language language = languageOf(syntax, PatternPlan.Budget.OF_A_WITNESS.meter());
         return language == null ? null : language.someWritten();
+    }
+
+    /** The strings {@code syntax} accepts, or null where making the machine costs more than
+     *  {@code meter} allows. */
+    private static Language languageOf(PatternSyntax syntax, Meter meter) {
+        return PatternPlan.of(syntax).compile(meter);
+    }
+
+    /**
+     * Up to {@code many} strings the rules on {@code type} admit, written under the names the
+     * position wears, and none of them the same string twice.
+     *
+     * <p>Asked where several values of one type are needed and they have to differ — the elements of
+     * a set, the keys of a map. The counterpart of {@link #numberInside} over the strings, and it is
+     * here for the same reason: a second value stepped off the first by the carrier alone is a value
+     * the type's own rules may refuse, and a collection filled from those comes back as one every
+     * value tried was refused at while the strings the rule admits are as many as anybody could want.
+     *
+     * <p><b>What the whole of the rules admits, which is not what {@link #whatAFormatAsksFor}
+     * offers.</b> That one is a proposal per rule, put to the decoder one at a time, and a value
+     * refused there costs a caller one candidate. These go inside a collection, where a value the
+     * rules refuse takes the whole collection with it and no other element can make up for it — so
+     * the rules are met with each other first and what comes back is from the meet.
+     *
+     * <p>A rule this could not read is left out of the meet rather than stopping it, which widens
+     * what is offered and never narrows it: these are proposals like any other and the decoder
+     * answers them. Empty where no rule about the strings was read at all — there the position has
+     * nothing to say about which strings, and what a value of one more is is the carrier's to step.
+     */
+    static List<FixtureTemplate> admittedStrings(Type type, RuleReadingContext reading, int many) {
+        if (type == null || many <= 0) {
+            return List.of();
+        }
+        RuleReadingSource ruleSource = reading.source();
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        if (!(view.shape() instanceof Shape.Scalar scalar) || scalar.prim() != Type.Prim.STRING) {
+            return List.of();
+        }
+        // One allowance for the whole of this question, which is what looking for these values may
+        // cost: the meet and every string taken out of it are steps of one search, and a fresh
+        // figure per step would be this spending as much as the number asked for.
+        Meter meter = PatternPlan.Budget.OF_A_WITNESS.meter();
+        Language left = stringsTheRulesAdmit(view, ruleSource, meter);
+        List<FixtureTemplate> out = new ArrayList<>();
+        while (left != null && out.size() < many) {
+            String some = left.someWritten();
+            if (some == null) {
+                break;   // nothing left in it that anybody could paste
+            }
+            FixtureTemplate written =
+                    WornNames.under(view.wrappers(), FixtureTemplate.string(some), ruleSource);
+            if (written == null) {
+                return List.of();   // a name this module cannot write leaves no value to offer
+            }
+            out.add(written);
+            left = left.without(List.of(some), meter);
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The strings every rule about them read on {@code view} admits, or null where none was read or
+     * the machine costs more than {@code meter} allows.
+     *
+     * <p>Every name the position wears, because a value wearing two names is held to the rules
+     * written on either. Met rather than listed: what is wanted is a string the rules admit
+     * together, and a string one of them admits is what {@link #whatAFormatAsksFor} already offers.
+     */
+    private static Language stringsTheRulesAdmit(TypeView view, RuleReadingSource ruleSource,
+                                                 Meter meter) {
+        Language all = null;
+        for (DeclaredClauses.OnAName written : DeclaredClauses.of(view.wrappers(), ruleSource)) {
+            for (DeclaredClauses.Conjunct each : written.conjuncts()) {
+                if (!(StringPredicates.statedByWritten(each.expr(), ruleSource.symbols())
+                        instanceof StringPredicates.Reading.Accepting it)) {
+                    continue;
+                }
+                Language one = languageOf(it.accepts(), meter);
+                if (one == null) {
+                    return null;   // the allowance would not pay for this rule's machine
+                }
+                all = all == null ? one : all.and(one, meter);
+                if (all == null) {
+                    return null;   // nor for putting it together with the rules before it
+                }
+            }
+        }
+        return all;
     }
 
     /** A count the position holds, or null where it holds none. The ends decide it, so nothing here

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1537,7 +1537,7 @@ public final class Partitions {
         bare.addAll(whereTheRulesLeaveTheValue(view, reading, within));
         bare.addAll(whatAFormatAsksFor(view, ruleSource));
         // What the rules say the value holds, before the value that would hold nothing.
-        bare.addAll(Witnesses.holding(view.shape(), leastHeld(view, reading), reading, inside));
+        bare.addAll(Witnesses.holding(view, leastHeld(view, reading), reading, inside));
         List<FixtureTemplate> ofTheShape =
                 whatTheShapeStandsFor(view.shape(), reading, within, inside);
         bare.addAll(ofTheShape);
@@ -1908,7 +1908,7 @@ public final class Partitions {
     static java.util.Set<CompositionBudget> notBuilt(Type type, RuleReadingContext reading,
                                                      FieldDomains.Held held) {
         TypeView view = TypeView.of(type, reading.source().symbols());
-        return Witnesses.heldBackFor(view.shape(), leastHeld(view, reading, held), reading);
+        return Witnesses.heldBackFor(view, leastHeld(view, reading, held), reading);
     }
 
     /**
@@ -2007,7 +2007,7 @@ public final class Partitions {
         // A name this module cannot write leaves no value to write, which is asked once of the
         // position rather than of each value built for it.
         if (WornNames.of(view.wrappers(), ruleSource) instanceof WornNames.Spelled spelled) {
-            for (FixtureTemplate bare : Witnesses.holding(view.shape(),
+            for (FixtureTemplate bare : Witnesses.holding(view,
                     leastHeld(view, reading, held), reading, expanding)) {
                 candidates.add(RepresentativeSource.under(spelled.names(), bare));
             }
@@ -2144,46 +2144,101 @@ public final class Partitions {
      * nothing to say about which strings, and what a value of one more is is the carrier's to step.
      */
     static List<FixtureTemplate> admittedStrings(Type type, RuleReadingContext reading, int many) {
-        if (type == null || many <= 0) {
+        if (type == null) {
             return List.of();
         }
         RuleReadingSource ruleSource = reading.source();
         TypeView view = TypeView.of(type, ruleSource.symbols());
-        if (!(view.shape() instanceof Shape.Scalar scalar) || scalar.prim() != Type.Prim.STRING) {
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (String each : textsTheRulesAdmit(view, reading, many)) {
+            FixtureTemplate written =
+                    WornNames.under(view.wrappers(), FixtureTemplate.string(each), ruleSource);
+            if (written == null) {
+                return List.of();   // a name this module cannot write leaves no value to offer
+            }
+            out.add(written);
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * A string of exactly {@code size} characters the rules on {@code view} admit, or nothing where
+     * they say nothing about its strings or leave none of that many.
+     *
+     * <p>For a caller that has a count to meet and the position's reading in hand. What a value of
+     * a shape counting that many looks like is {@link Witnesses}'s, asked of the shape and shared
+     * by every caller; which of those strings this position admits is the position's, and a caller
+     * holding both offers this one first and that one after it. Kept apart because the two answer
+     * different questions: whether a string of that length exists at all is a claim about strings,
+     * and a reading of it that had consulted one type's format would be that claim taken from an
+     * opinion about that type.
+     */
+    static List<FixtureTemplate> admittedStringOfSize(TypeView view, RuleReadingContext reading,
+                                                      int size) {
+        if (size < 0 || !(view.shape() instanceof Shape.Scalar scalar)
+                || scalar.prim() != Type.Prim.STRING) {
             return List.of();
         }
-        // One allowance for the whole of this question, which is what looking for these values may
-        // cost: the meet and every string taken out of it are steps of one search, and a fresh
-        // figure per step would be this spending as much as the number asked for.
         Meter meter = PatternPlan.Budget.OF_A_WITNESS.meter();
-        Language left = stringsTheRulesAdmit(view, ruleSource, meter);
-        List<FixtureTemplate> out = new ArrayList<>();
+        Language admits = stringsTheRulesAdmit(view, reading, meter);
+        Language counted = admits == null ? null
+                : languageOf(PatternSyntax.ofAnySymbols(size, size), meter);
+        Language both = counted == null ? null : admits.and(counted, meter);
+        String some = both == null ? null : both.someWritten();
+        return some == null ? List.of() : List.of(FixtureTemplate.string(some));
+    }
+
+    /**
+     * Up to {@code many} of the strings the rules on {@code view} admit, no two of them the same.
+     *
+     * <p>One allowance for the whole of the question, which is what looking for these values may
+     * cost: the meet and every string taken out of it are steps of one search, and a fresh figure
+     * per step would be this spending as much as the number asked for.
+     */
+    private static List<String> textsTheRulesAdmit(TypeView view, RuleReadingContext reading,
+                                                   int many) {
+        if (many <= 0 || !(view.shape() instanceof Shape.Scalar scalar)
+                || scalar.prim() != Type.Prim.STRING) {
+            return List.of();
+        }
+        Meter meter = PatternPlan.Budget.OF_A_WITNESS.meter();
+        Language left = stringsTheRulesAdmit(view, reading, meter);
+        List<String> out = new ArrayList<>();
         while (left != null && out.size() < many) {
             String some = left.someWritten();
             if (some == null) {
                 break;   // nothing left in it that anybody could paste
             }
-            FixtureTemplate written =
-                    WornNames.under(view.wrappers(), FixtureTemplate.string(some), ruleSource);
-            if (written == null) {
-                return List.of();   // a name this module cannot write leaves no value to offer
-            }
-            out.add(written);
+            out.add(some);
             left = left.without(List.of(some), meter);
         }
         return List.copyOf(out);
     }
 
     /**
-     * The strings every rule about them read on {@code view} admits, or null where none was read or
-     * the machine costs more than {@code meter} allows.
+     * The strings every rule about them read on {@code view} admits, or null where nothing says
+     * which strings or the machine costs more than {@code meter} allows.
+     *
+     * <p><b>Both vocabularies the rules reach a string in.</b> Which strings is a predicate over
+     * them; how many characters is a number, counted by the measure the type is written in
+     * ({@link DeclaredBounds#countsHeld}) and read where numbers are read. A value has to clear
+     * both, so a reader of one of them alone hands out a string the other refuses — a format met
+     * with a floor gives the shortest string the format accepts, which is the one the floor was
+     * written to exclude.
      *
      * <p>Every name the position wears, because a value wearing two names is held to the rules
      * written on either. Met rather than listed: what is wanted is a string the rules admit
      * together, and a string one of them admits is what {@link #whatAFormatAsksFor} already offers.
+     *
+     * <p><b>The count is read to narrow what was said about the strings, and never on its own.</b>
+     * A position nothing says the strings of has nothing here to narrow: what one more of its
+     * values is is a character on the end of the last ({@link Witnesses}), which is the count
+     * answered where counts are answered. Answered here as well, every string a length rule leaves
+     * would come from a machine built to say what stepping already says.
      */
-    private static Language stringsTheRulesAdmit(TypeView view, RuleReadingSource ruleSource,
+    private static Language stringsTheRulesAdmit(TypeView view, RuleReadingContext reading,
                                                  Meter meter) {
+        RuleReadingSource ruleSource = reading.source();
         Language all = null;
         for (DeclaredClauses.OnAName written : DeclaredClauses.of(view.wrappers(), ruleSource)) {
             for (DeclaredClauses.Conjunct each : written.conjuncts()) {
@@ -2201,7 +2256,30 @@ public final class Partitions {
                 }
             }
         }
-        return all;
+        return all == null ? null : withinTheCount(all, view, reading, meter);
+    }
+
+    /**
+     * {@code strings} less the ones the rules leave no room for, or null where the count leaves
+     * none at all or the machine costs more than {@code meter} allows.
+     *
+     * <p>The count as a language, because that is what meeting it with the strings takes. What the
+     * rules leave is a run of counts and what is being narrowed is a set of strings, and the two are
+     * put together the way every pair of sets here is.
+     */
+    private static Language withinTheCount(Language strings, TypeView view,
+                                           RuleReadingContext reading, Meter meter) {
+        DeclaredBounds.CountRange characters = DeclaredBounds.countsHeld(view, reading, null);
+        if (characters.empty()) {
+            return null;   // no count at all, so no string of the position holds one
+        }
+        if (characters.least() == 0 && characters.most() == Integer.MAX_VALUE) {
+            return strings;   // every count, so nothing to take away
+        }
+        Language counted = languageOf(PatternSyntax.ofAnySymbols(characters.least(),
+                characters.most() == Integer.MAX_VALUE
+                        ? PatternSyntax.Repeated.NO_CEILING : characters.most()), meter);
+        return counted == null ? null : strings.and(counted, meter);
     }
 
     /** A count the position holds, or null where it holds none. The ends decide it, so nothing here

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -319,7 +319,7 @@ final class TermRealizations {
             return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        Witnesses.Sized built = Witnesses.ofSize(holder.shape(), many, reading, Set.of());
+        Witnesses.Sized built = Witnesses.ofSize(holder, many, reading, Set.of());
         if (built.values().isEmpty()) {
             // Read off the build that was already done. `Witnesses` keeps what it made and why it
             // stopped as two halves of one answer for exactly this, and asking it again would be

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -403,11 +403,19 @@ final class Witnesses {
      *
      * <p>What the type divides into comes first. A {@code Bool} is two values and a sum is its cases,
      * and each of those is a value of the type rather than a proposal about it — a set of two booleans
-     * is built from both of them or from nothing. Then values made by stepping the carrier, which stay
-     * inside the rules the type carries. The type's own proposals come last: each is what one rule
-     * asked for and any of them may be one the whole of the rules refuses, so a collection filled from
-     * them is refused for its elements — which is still better than a collection short of its size,
-     * and is all there is where the carrier neither divides nor steps.
+     * is built from both of them or from nothing. Then the values the rules about the strings admit,
+     * which are values of the type in the same way and are as many as the rules leave. Then values
+     * made by stepping the carrier, which stay inside the rules the type carries. The type's own
+     * proposals come last: each is what one rule asked for and any of them may be one the whole of
+     * the rules refuses, so a collection filled from them is refused for its elements — which is
+     * still better than a collection short of its size, and is all there is where the carrier
+     * neither divides nor steps.
+     *
+     * <p><b>Which is why the rules about the strings are asked before the carrier is stepped.</b> A
+     * string stepped by a character is a value of the carrier and not of the type: what the carrier
+     * answers is how many characters, and a type whose rule says which of them gets a string it
+     * refuses at every element after the first. The rules are what tell the values apart there, the
+     * same as a range does for a number ({@link Partitions#numberInside}).
      */
     private static List<FixtureTemplate> distinctValuesOf(Type type, int many,
                                                           RuleReadingContext reading,
@@ -415,6 +423,14 @@ final class Witnesses {
         Set<String> written = new LinkedHashSet<>();
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : dividesInto(type, reading, expanding)) {
+            if (out.size() >= many) {
+                return List.copyOf(out);
+            }
+            if (written.add(each.text())) {
+                out.add(each);
+            }
+        }
+        for (FixtureTemplate each : Partitions.admittedStrings(type, reading, many)) {
             if (out.size() >= many) {
                 return List.copyOf(out);
             }
@@ -466,7 +482,11 @@ final class Witnesses {
      * has no order to step.
      *
      * <p>A string grows by a character from the length its rules ask for, and a whole number steps
-     * through the range they leave. A date or a record has no such step that keeps every rule the
+     * through the range they leave. Which characters is a question the carrier has no answer to, so
+     * a type whose rules say which of them is answered before this is reached
+     * ({@link Partitions#admittedStrings}) and what is left here is the length.
+     *
+     * <p>A date or a record has no such step that keeps every rule the
      * position carries, and inventing one would put a value in a row the type's own chooser had reason
      * not to offer — which is what the values a type divides into are for, above.
      */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -81,7 +81,8 @@ final class Witnesses {
     }
 
     /**
-     * Values of {@code carrier} whose count is exactly {@code size}, or none where this can build none.
+     * Values of {@code position} whose count is exactly {@code size}, or none where this can build
+     * none.
      *
      * <p>The narrower of the two promises about a count. A caller holding a line drawn on one needs
      * the count itself and not a value that merely clears it: a row at {@code String.length = 5} is a
@@ -98,8 +99,9 @@ final class Witnesses {
      * proposal for a floor and are not the count asked for here, and offering them would put a row of
      * two under a line drawn at three.
      */
-    static Sized ofSize(Shape carrier, int size, RuleReadingContext reading,
+    static Sized ofSize(TypeView position, int size, RuleReadingContext reading,
                         Set<TypeSymbol> expanding) {
+        Shape carrier = position.shape();
         if (size == 0) {
             // The same shapes {@link #sized} builds for, and for the same reason they are written
             // out: what a value of none looks like is a question about each shape.
@@ -114,12 +116,13 @@ final class Witnesses {
                      Shape.Undecided _ -> List.<FixtureTemplate>of();
             });
         }
-        Built built = sized(carrier, size, reading, expanding);
+        Built built = sized(position, size, reading, expanding);
         return new Sized(built.exactly(size), built.heldBack());
     }
 
     /**
-     * Why no value of {@code carrier} counting exactly {@code size} was built, or null where one was.
+     * Why no value of {@code position} counting exactly {@code size} was built, or null where one
+     * was.
      *
      * <p>The same decision {@link #ofSize} reads, asked for its other half, so that what could not be
      * built and why are one answer given twice rather than two answers that may disagree. Whenever
@@ -130,9 +133,9 @@ final class Witnesses {
      * ({@link Sized#heldBack()}) and travels as itself; what is here is the word a search comes back
      * with, for readers that have only ever wanted that.
      */
-    static Generator.UnresolvedCombination.Reason reasonForSize(Shape carrier, int size,
+    static Generator.UnresolvedCombination.Reason reasonForSize(TypeView position, int size,
                                                                 RuleReadingContext reading) {
-        Sized made = ofSize(carrier, size, reading, Set.of());
+        Sized made = ofSize(position, size, reading, Set.of());
         if (!made.values().isEmpty()) {
             return null;
         }
@@ -161,13 +164,13 @@ final class Witnesses {
      * too few values for comes back as nothing at all. The two read one build and neither is written
      * in terms of the other, so a cheaper value for a floor cannot move a line.
      */
-    static List<FixtureTemplate> holding(Shape carrier, int least, RuleReadingContext reading,
+    static List<FixtureTemplate> holding(TypeView position, int least, RuleReadingContext reading,
                                          Set<TypeSymbol> expanding) {
-        return least <= 0 ? List.of() : sized(carrier, least, reading, expanding).all();
+        return least <= 0 ? List.of() : sized(position, least, reading, expanding).all();
     }
 
     /**
-     * Which budgets of this compiler's stopped a value of {@code carrier} holding {@code least} from
+     * Which budgets of this compiler's stopped a value of {@code position} holding {@code least} from
      * being built in full, and empty where none did.
      *
      * <p>The same decision {@link #holding} reads, asked for its other half. Written once because the
@@ -178,10 +181,10 @@ final class Witnesses {
      * floor nothing was built for is a position offering what it ordinarily offers, and naming a
      * reason there would put "nothing composes one" under every position that has no floor at all.
      */
-    static Set<CompositionBudget> heldBackFor(Shape carrier, int least,
+    static Set<CompositionBudget> heldBackFor(TypeView position, int least,
                                               RuleReadingContext reading) {
         return least <= 0 ? Set.of()
-                : sized(carrier, least, reading, Set.of()).heldBack();
+                : sized(position, least, reading, Set.of()).heldBack();
     }
 
     /**
@@ -194,7 +197,7 @@ final class Witnesses {
      */
     private record Made(FixtureTemplate value, int count) {}
 
-    /** What a value of {@code carrier} counting {@code size} comes to: what was built, and which
+    /** What a value of the position counting {@code size} comes to: what was built, and which
      * budgets of this compiler's stopped the rest of it being built. */
     private record Built(List<Made> proposals, Set<CompositionBudget> heldBack) {
 
@@ -221,7 +224,7 @@ final class Witnesses {
         }
     }
 
-    private static Built sized(Shape carrier, int least, RuleReadingContext reading,
+    private static Built sized(TypeView position, int least, RuleReadingContext reading,
                                Set<TypeSymbol> expanding) {
         if (least <= 0) {
             return Built.NONE;
@@ -229,15 +232,15 @@ final class Witnesses {
         // Exhaustive over what a position can be, with no `default`. Whether a value of a shape
         // counts anything is a question about each of them, and a chain of tests answers "no" for a
         // shape added later without being asked.
-        return switch (carrier) {
-            // A string is counted by its characters, and one character is as good as another where
-            // the rule is about how many there are. What a format asks for instead is a proposal of
-            // its own, put beside this one by the caller.
+        return switch (position.shape()) {
+            // A string is counted by its characters. Which characters is a question the count does
+            // not answer, so what the position's own rules admit of that many comes first and a
+            // string of any characters at all after it — both are proposals, and the one every rule
+            // admits is the one a caller with a single chance needs.
             case Shape.Scalar scalar when scalar.prim() == Type.Prim.STRING ->
                     least > MOST_CHARACTERS
                             ? Built.stoppedBy(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS)
-                            : Built.of(List.of(
-                                    new Made(FixtureTemplate.string("x".repeat(least)), least)));
+                            : Built.of(ofThatManyCharacters(position, least, reading));
             case Shape.Sequence sequence -> least > MOST_ELEMENTS
                     ? Built.stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS)
                     : ofSequence(sequence, least, reading, expanding);
@@ -252,6 +255,27 @@ final class Witnesses {
                  Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _,
                  Shape.Undecided _ -> Built.NONE;
         };
+    }
+
+    /**
+     * Strings of exactly {@code least} characters: the one the position's rules admit, and the one
+     * any string of that many is.
+     *
+     * <p>Both, and in that order. What a string of that length looks like is a question about
+     * strings and is the same answer for every position — which is why the second is always here,
+     * and why what this reports when nothing builds stays a claim about strings rather than an
+     * opinion about one type. The first is that answer narrowed by what the position's own rules
+     * say its strings are, which is a value the decoder can accept where the second is one a format
+     * refuses.
+     */
+    private static List<Made> ofThatManyCharacters(TypeView position, int least,
+                                                   RuleReadingContext reading) {
+        List<Made> out = new ArrayList<>();
+        for (FixtureTemplate each : Partitions.admittedStringOfSize(position, reading, least)) {
+            out.add(new Made(each, least));
+        }
+        out.add(new Made(FixtureTemplate.string("x".repeat(least)), least));
+        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -10,6 +10,7 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -298,6 +299,12 @@ final class Witnesses {
         // they are the same two numbers whether or not it was this that stopped it — so a reader
         // asking which budget ran out would be reading it off a subtraction that does not know.
         boolean stopped = false;
+        // What a key proposal's other keys are, worked out once however many values it is put
+        // beside. The question is the key's and the count's — what stands under them is not in it —
+        // so a reading per pair is one walk over the element's values run again for every value the
+        // other side proposed.
+        List<List<FixtureTemplate>> keysFrom =
+                new ArrayList<>(Collections.nCopies(keys.size(), null));
         pairing:
         for (int apart = 0; apart <= keys.size() + values.size() - 2; apart++) {
             for (int i = Math.max(0, apart - values.size() + 1);
@@ -306,10 +313,13 @@ final class Witnesses {
                     stopped = true;
                     break pairing;
                 }
+                if (keysFrom.get(i) == null) {
+                    keysFrom.set(i,
+                            distinctFrom(keys.get(i), map.key(), least, reading, expanding));
+                }
                 FixtureTemplate value = values.get(apart - i);
                 List<FixtureTemplate> entries = new ArrayList<>();
-                for (FixtureTemplate key
-                        : distinctFrom(keys.get(i), map.key(), least, reading, expanding)) {
+                for (FixtureTemplate key : keysFrom.get(i)) {
                     entries.add(FixtureTemplate.entry(key, value));
                 }
                 out.add(new Made(FixtureTemplate.collection(entries), entries.size()));
@@ -447,6 +457,12 @@ final class Witnesses {
                 out.add(each);
             }
         }
+        if (out.size() >= many) {
+            return List.copyOf(out);
+        }
+        // Asked last and only where there is room for what it answers. What a position is offered
+        // is a reading of every rule on it and costs what that reading costs, and a loop that asks
+        // for the list and then leaves it alone pays for it at every count already filled.
         for (FixtureTemplate each : Partitions.representativesOf(type, reading, null, expanding)) {
             if (out.size() >= many) {
                 break;

--- a/souther-compiler/src/main/java/souther/compiler/regex/PatternSyntax.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/PatternSyntax.java
@@ -173,7 +173,22 @@ public sealed interface PatternSyntax {
      * text somebody looked for is any string at all, newlines included.
      */
     static PatternSyntax anything() {
-        return new Repeated(new Symbols(CodePoints.EVERYTHING), 0, Repeated.NO_CEILING);
+        return ofAnySymbols(0, Repeated.NO_CEILING);
+    }
+
+    /**
+     * Every string of between {@code least} and {@code most} symbols.
+     *
+     * <p>What a rule counting a string's characters leaves, said in the one vocabulary a language is
+     * written in. A rule about how many there are and a rule about which they are reach one position
+     * and are read by different things, and a value has to clear both — so whoever holds the count
+     * puts it here and meets the two.
+     *
+     * <p>{@link Repeated#NO_CEILING} for a count nothing caps, which is the bound nothing reaches
+     * rather than a large one.
+     */
+    static PatternSyntax ofAnySymbols(int least, int most) {
+        return new Repeated(new Symbols(CodePoints.EVERYTHING), least, most);
     }
 }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -1151,6 +1151,11 @@ class CompileExampleGenerateTest {
      * A model with a gap at every point of a border, and a search that composes a row for none of
      * them: the string the rules admit is one the generator's candidates never spell.
      *
+     * <p>A rule this compiler cannot read is what leaves it there. Rules it can read are met with
+     * each other and a value clearing all of them is composed, so a position whose rules are all
+     * readable is one a row is offered at — what is left unspelled is what a reading stopped short
+     * of, and the candidates are then the other rules' alone.
+     *
      * <p>What it is for is the note beside a withheld row. A run asking for no edges withholds the
      * rows at them, so a line saying why one could not be composed is a line about work that run did
      * not ask for — and an author reads it as a report on the rows above it.
@@ -1164,14 +1169,14 @@ class CompileExampleGenerateTest {
             data Tag = Big | Small
 
             data C = String
-                invariant String.length(value) >= 2 && String.matches("[0-9]+", value)
+                invariant String.length(value) >= 2 && String.matches("(a+)\\\\1", value)
 
             behavior label : (c: C, s: Size) -> Tag
 
             let label (c, s) = if s.value >= 5 then Big else Small
 
             example label
-                | "digits" : (C("123"), Size(9)) -> Big
+                | "doubled" : (C("aa"), Size(9)) -> Big
             """;
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
@@ -7,7 +7,6 @@ import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
-import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
@@ -55,9 +54,10 @@ class ABudgetIsNamedByThePlaceItStopsTest {
     private static final RuleReadingContext READING =
             RuleReadingContext.unshared(RULES, POLICY);
 
-    /** What a position of this type is, which is what the builder is asked about. */
-    private static Shape shape(Type type) {
-        return TypeView.of(type, SYMBOLS).shape();
+    /** The position of this type as the builder is asked about it: what it is, and what the rules
+     *  every name it wears carries say of it. */
+    private static TypeView position(Type type) {
+        return TypeView.of(type, SYMBOLS);
     }
 
     /**
@@ -71,10 +71,10 @@ class ABudgetIsNamedByThePlaceItStopsTest {
         int most = CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS.maximum();
 
         assertEquals(Set.of(),
-                Witnesses.heldBackFor(shape(Type.list(Type.INT)), most, READING),
+                Witnesses.heldBackFor(position(Type.list(Type.INT)), most, READING),
                 "a collection of exactly as many as a row carries is one this builds");
         assertEquals(Set.of(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS),
-                Witnesses.heldBackFor(shape(Type.list(Type.INT)), most + 1, READING),
+                Witnesses.heldBackFor(position(Type.list(Type.INT)), most + 1, READING),
                 "and one past it is this compiler declining, said as the figure it declined at");
     }
 
@@ -83,10 +83,10 @@ class ABudgetIsNamedByThePlaceItStopsTest {
     void aProposalHoldsAsManyCharactersAsItsOwnFigure() {
         int most = CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS.maximum();
 
-        assertEquals(Set.of(), Witnesses.heldBackFor(shape(Type.STRING), most, READING),
+        assertEquals(Set.of(), Witnesses.heldBackFor(position(Type.STRING), most, READING),
                 "a string of exactly as many characters as one is worth building");
         assertEquals(Set.of(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS),
-                Witnesses.heldBackFor(shape(Type.STRING), most + 1, READING),
+                Witnesses.heldBackFor(position(Type.STRING), most + 1, READING),
                 "and one past it names the string's figure and not the collection's");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -89,7 +89,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
     @Test
     void aCollectionRequiredToHoldOneOfASumOfRecordsIsBuilt() {
         List<FixtureTemplate> held =
-                Witnesses.holding(TypeView.of(new Type.ListOf(sum()), rules.symbols()).shape(),
+                Witnesses.holding(TypeView.of(new Type.ListOf(sum()), rules.symbols()),
                         1, reading, Set.of());
 
         assertFalse(held.isEmpty(), "a list of one is built from a case of the sum");
@@ -100,7 +100,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
     @Test
     void aSetOfTwoIsBuiltFromTwoCasesOfASumOfRecords() {
         List<FixtureTemplate> held =
-                Witnesses.holding(TypeView.of(new Type.SetOf(sum()), rules.symbols()).shape(),
+                Witnesses.holding(TypeView.of(new Type.SetOf(sum()), rules.symbols()),
                         2, reading, Set.of());
 
         assertFalse(held.isEmpty(), "the two cases are two distinct values");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest.java
@@ -1,0 +1,230 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.DeclaredSig;
+import souther.compiler.check.RuleReadingContext;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The elements after the first come from what the element's type admits.
+ *
+ * <p>A collection the rules ask several elements of used to be filled by composing the first out of
+ * the element's rules and the rest by stepping the carrier — a string grown by a character. Which
+ * is a value of the carrier and not of the type: where the type states which strings, every element
+ * after the first was one the type refuses, and the row came back as one every value tried was
+ * refused at while the strings the rule admits are as many as anybody could want.
+ *
+ * <p>Held at the fill and not at the report. What a collection of several holds is decided where
+ * values are built, and a test on the block an author reads would go on passing for a behavior
+ * whose elements happen to be told apart another way.
+ */
+class ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest {
+
+    /** A record whose one collection field the rules ask {@code floor} of, over {@code held}. */
+    private static String model(String held, String floor, String measure) {
+        return """
+                module ex.fill
+
+                data ContactId = String
+                    invariant String.matches("003[0-9]{12}", value)
+
+                data Held =
+                    { xs: %s
+                    }
+                    invariant enough = %s
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, h: Held) -> Ok
+                    constructs Ok
+
+                let countThem (flag, h) = Ok { n = %s }
+                """.formatted(held, floor, measure);
+    }
+
+    private static FillResult filled(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Map<String, DeclaredSig> sigs =
+                compilation.db().ask(new Bodies.DeclaredSignatures(module)).value();
+        assertNotNull(sigs, "the model did not compile");
+        RuleReadingSource rules = RuleReadings.of(compilation, module);
+        InputDomain domain =
+                InputDomain.of(sigs.get("countThem"), rules, ReadAs.THE_COMPILATION_DOES);
+        Partitions.Partitioning partitioning =
+                Partitions.of("countThem", domain, rules, ReadAs.THE_COMPILATION_DOES);
+        return Generator.fill(MeasuredInput.of("countThem", domain.reading(rules), partitioning),
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
+    }
+
+    /** The collection the first row was offered, which is the one the search reached first. */
+    private static String heldInTheFirstRow(String source) {
+        FillResult filled = filled(source);
+        assertEquals(List.of(), filled.unresolved(), "nothing should have gone unresolved");
+        return filled.rows().get(0).inputs().get(1).text();
+    }
+
+    /**
+     * Two elements, and the rule that says which strings is read for both of them.
+     *
+     * <p>Two and not one, so that a fill reading the rule once is not mistaken for one reading it
+     * for every element it composes.
+     */
+    @Test
+    void aSetOfTwoHoldsTwoStringsTheRuleAccepts() {
+        assertEquals("Held { xs = [ContactId(\"003000000000000\"),"
+                + " ContactId(\"003000000000001\")] }",
+                heldInTheFirstRow(model("Set<ContactId>", "Set.size(xs) >= 2", "Set.size(h.xs)")));
+    }
+
+    /**
+     * And three, which is the same rule read again rather than a second element got another way.
+     *
+     * <p>A fill that answered two by stepping once off the first would pass the test above and have
+     * nothing to offer here.
+     */
+    @Test
+    void aSetOfThreeGoesOnTakingThemFromTheSameRule() {
+        assertEquals("Held { xs = [ContactId(\"003000000000000\"),"
+                + " ContactId(\"003000000000001\"), ContactId(\"003000000000002\")] }",
+                heldInTheFirstRow(model("Set<ContactId>", "Set.size(xs) >= 3", "Set.size(h.xs)")));
+    }
+
+    /**
+     * A list holds the same element again, which is what a list is.
+     *
+     * <p>Held beside the sets because the two are one change away from each other. What tells a
+     * set's elements apart is the set's own rule, and a fill that took the values apart wherever it
+     * could would write a list nothing asked to be told apart.
+     */
+    @Test
+    void aListOfTwoHoldsOneOfThemTwice() {
+        assertEquals("Held { xs = [ContactId(\"003000000000000\"),"
+                + " ContactId(\"003000000000000\")] }",
+                heldInTheFirstRow(model("List<ContactId>",
+                        "List.length(xs) >= 2", "List.length(h.xs)")));
+    }
+
+    /** A map's keys are told apart the way a set's elements are, and the values under them are
+     * free to repeat. */
+    @Test
+    void aMapOfTwoIsKeyedByTwoStringsTheRuleAccepts() {
+        assertEquals("Held { xs = [(ContactId(\"003000000000000\"), 0),"
+                + " (ContactId(\"003000000000001\"), 0)] }",
+                heldInTheFirstRow(model("Map<ContactId, Int>",
+                        "Map.size(xs) >= 2", "Map.size(h.xs)")));
+    }
+
+    /**
+     * Two rules about the strings are met with each other, and every value clears both.
+     *
+     * <p>Which is not what a position is offered for itself. There each rule is a reason to propose
+     * another value and the decoder says which of them the whole of the rules admits — a proposal
+     * refused there costs one candidate. Inside a collection a refused element takes the whole
+     * collection with it and no other element makes up for it, so what goes in comes from the meet.
+     *
+     * <p>Asked of the values and not of a row, because a row carries the element the collection was
+     * built around as well, and that one is still a proposal of one rule's.
+     */
+    @Test
+    void twoRulesAboutTheStringsAreBothReadForEveryValue() {
+        Model model = modelOf("""
+                module ex.narrow
+
+                data Narrow = String
+                    invariant shape = String.matches("003[0-9]{12}", value)
+                    invariant begins = String.startsWith("0031", value)
+                """);
+
+        assertEquals(List.of("Narrow(\"003100000000000\")", "Narrow(\"003100000000001\")"),
+                model.admitted("Narrow", 2));
+    }
+
+    /**
+     * And nothing where no rule says which strings, which is where the length is what one more of
+     * them is.
+     *
+     * <p>The negative control of the one above. Asked of every string type, this would answer for a
+     * position carrying no rule about its strings at all, and the values a collection tells apart
+     * would stop coming from the carrier for a reason nothing stated.
+     */
+    @Test
+    void aTypeWithNoRuleAboutItsStringsAdmitsNoneOfThemHere() {
+        Model model = modelOf("""
+                module ex.plain
+
+                data Plain = String
+                    invariant long = String.length(value) >= 3
+                """);
+
+        assertEquals(List.of(), model.admitted("Plain", 2));
+    }
+
+    /** A model to read a type's own rules off, held to compiling. */
+    private record Model(RuleReadingSource rules, String module) {
+
+        /** Up to {@code many} of the strings {@code type}'s rules admit, as they would be written. */
+        List<String> admitted(String type, int many) {
+            Type named = new Type.Ref(TypeSymbols.declared(new TypeKey(module, type)));
+            return Partitions.admittedStrings(named,
+                            RuleReadingContext.unshared(rules, ReadAs.THE_COMPILATION_DOES), many)
+                    .stream().map(FixtureTemplate::text).toList();
+        }
+    }
+
+    private static Model modelOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model under test is a program that can be written");
+        return new Model(RuleReadings.of(compilation, module), module);
+    }
+
+    /**
+     * A type whose rules say nothing about which strings is still stepped by the carrier.
+     *
+     * <p>The other side of the claim, and the one a change here takes away by accident. Where no
+     * rule about the strings was read there is nothing to take the values from, and a length is
+     * what one more of them is — a fill that went to the rules whatever they said would have
+     * nothing to offer at a position that carries none.
+     */
+    @Test
+    void aStringNoRuleSpeaksOfIsStillToldApartByItsLength() {
+        assertEquals("Held { xs = [\"x\", \"xx\"] }",
+                heldInTheFirstRow(model("Set<String>", "Set.size(xs) >= 2", "Set.size(h.xs)")));
+    }
+
+    /**
+     * A type with fewer values than the rules ask for composes nothing, and no row goes out.
+     *
+     * <p>{@code Bool} is two values and a set of three of them is a thing no value satisfies. What
+     * is held to is that no row is offered: which word the search comes back with is a question
+     * about how a search that found nothing is reported, and this one is about what is filled.
+     */
+    @Test
+    void aTypeOfTooFewValuesIsNotFilledOutToTheCountAsked() {
+        FillResult filled = filled(model("Set<Bool>", "Set.size(xs) >= 3", "Set.size(h.xs)"));
+
+        assertEquals(List.of(), filled.rows(), "no row holds a set of three booleans");
+        assertTrue(!filled.unresolved().isEmpty(), "and the combinations are said to be unresolved");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest.java
@@ -2,11 +2,13 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.OfferedAtTheLines;
 import souther.compiler.check.DeclaredSig;
 import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
@@ -158,6 +160,29 @@ class ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest {
     }
 
     /**
+     * A rule about which strings and a rule about how many characters are met with each other.
+     *
+     * <p>The two reach one position in vocabularies read by different things — a predicate over the
+     * strings, and a number counted by the measure the type is written in. A value clears both or
+     * it is refused, so a reader of either alone hands out a string the other rules out: the
+     * shortest string a format accepts is exactly what a floor on the characters was written to
+     * exclude.
+     */
+    @Test
+    void aFormatAndAFloorOnTheCharactersAreBothRead() {
+        Model model = modelOf("""
+                module ex.sized
+
+                data Sized = String
+                    invariant format = String.matches("003[0-9]+", value)
+                    invariant size = String.length(value) >= 15
+                """);
+
+        assertEquals(List.of("Sized(\"003000000000000\")", "Sized(\"003000000000001\")"),
+                model.admitted("Sized", 2));
+    }
+
+    /**
      * And nothing where no rule says which strings, which is where the length is what one more of
      * them is.
      *
@@ -175,6 +200,59 @@ class ACollectionOfSeveralIsFilledFromWhatItsElementTypeAdmitsTest {
                 """);
 
         assertEquals(List.of(), model.admitted("Plain", 2));
+    }
+
+    /**
+     * And the row an author is offered for such a collection, which is where the decoder answers.
+     *
+     * <p>The one claim here asked of the block a person reads rather than of the fill. What the
+     * fill composes is a proposal, and whether the model admits it is the decoder's — so a test
+     * that only read what was composed would go on passing for a collection of values every rule
+     * refuses, which is the report #1624 is about.
+     */
+    @Test
+    void aRowIsOfferedWhereTheValuesExist() {
+        Compilation compilation = Compilation.ofSource("""
+                module ex.offered
+
+                data ContactId = String
+                    invariant format = String.matches("003[0-9]+", value)
+                    invariant size = String.length(value) >= 15
+
+                data DecisionMakers = Set<ContactId>
+                    invariant atLeastOne = Set.size(value) >= 1
+
+                data Opportunity = { makers: DecisionMakers }
+                data Decided = { makers: DecisionMakers }
+
+                behavior decide : (opp: Opportunity) -> Decided
+                    constructs Decided
+
+                let decide (opp) = Decided { makers = opp.makers }
+
+                example decide
+                    | (Opportunity { makers = DecisionMakers([ContactId("003000000000000")]) })
+                        -> Decided { makers = DecisionMakers([ContactId("003000000000000")]) }
+                """, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model under test is a program that can be written");
+        Generator.GenerationResult offered = OfferedAtTheLines.of(
+                compilation, compilation.modules().get(0), "decide");
+
+        assertEquals(List.of(), offered.unresolved(),
+                "the values are there, so no combination is left unresolved");
+        // One row for the set holding more than one, and one for the element above the line its
+        // characters are counted at. Both are a string the format and the count admit together:
+        // either read alone writes the other's refusal into the row.
+        assertEquals(List.of(
+                        "Opportunity { makers = DecisionMakers([ContactId(\"003000000000000\"),"
+                                + " ContactId(\"003000000000001\")]) }",
+                        "Opportunity { makers = DecisionMakers(["
+                                + "ContactId(\"0030000000000000\")]) }"),
+                offered.rows().stream().map(row -> row.inputs().get(0).text()).toList());
     }
 
     /** A model to read a type's own rules off, held to compiling. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
@@ -6,7 +6,6 @@ import souther.compiler.DefaultStdlib;
 import souther.compiler.check.RuleReadingContext;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
-import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
 import souther.compiler.types.Type;
@@ -36,15 +35,16 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     private static final RuleReadingContext READING =
             RuleReadingContext.unshared(NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
-    /** What a position of this type is, which is what the builder is asked about. */
-    private static Shape shape(Type type) {
-        return TypeView.of(type, NONE.symbols()).shape();
+    /** The position of this type as the builder is asked about it: what it is, and what the rules
+     *  every name it wears carries say of it. */
+    private static TypeView position(Type type) {
+        return TypeView.of(type, NONE.symbols());
     }
 
     @Test
     void aStringOfTheSizeAskedForIsBuilt() {
         assertEquals(List.of("\"xxx\""),
-                Witnesses.ofSize(shape(Type.STRING), 3, READING, Set.of()).values().stream()
+                Witnesses.ofSize(position(Type.STRING), 3, READING, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -56,10 +56,10 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aSizeOfZeroIsTheEmptyValue() {
         assertEquals(List.of("\"\""),
-                Witnesses.ofSize(shape(Type.STRING), 0, READING, Set.of()).values().stream()
+                Witnesses.ofSize(position(Type.STRING), 0, READING, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
         assertEquals(List.of("[]"),
-                Witnesses.ofSize(shape(new Type.ListOf(Type.INT)), 0, READING, Set.of()).values().stream()
+                Witnesses.ofSize(position(new Type.ListOf(Type.INT)), 0, READING, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -72,24 +72,24 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
      */
     @Test
     void aFloorOfNoneAsksForNothingWhereASizeOfZeroAsksForTheEmptyValue() {
-        assertEquals(List.of(), Witnesses.holding(shape(Type.STRING), 0, READING, Set.of()));
-        assertTrue(!Witnesses.ofSize(shape(Type.STRING), 0, READING, Set.of()).values().isEmpty());
+        assertEquals(List.of(), Witnesses.holding(position(Type.STRING), 0, READING, Set.of()));
+        assertTrue(!Witnesses.ofSize(position(Type.STRING), 0, READING, Set.of()).values().isEmpty());
     }
 
     /** A count past what a row is worth carrying is one nothing composes, and says which it is. */
     @Test
     void aSizeNoRowWouldCarrySaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(shape(Type.STRING), 100_000, READING, Set.of()).values());
+        assertEquals(List.of(), Witnesses.ofSize(position(Type.STRING), 100_000, READING, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                Witnesses.reasonForSize(shape(Type.STRING), 100_000, READING));
+                Witnesses.reasonForSize(position(Type.STRING), 100_000, READING));
     }
 
     /** A carrier nothing counts has no size to build at, and says which silence that is. */
     @Test
     void aCarrierNothingCountsSaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(shape(Type.INT), 3, READING, Set.of()).values());
+        assertEquals(List.of(), Witnesses.ofSize(position(Type.INT), 3, READING, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                Witnesses.reasonForSize(shape(Type.INT), 3, READING));
+                Witnesses.reasonForSize(position(Type.INT), 3, READING));
     }
 
     /**
@@ -103,7 +103,7 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
      */
     @Test
     void aSetIsNothingWhereTheTypeHasFewerValuesThanTheCountAsksFor() {
-        Shape set = shape(new Type.SetOf(Type.BOOL));
+        TypeView set = position(new Type.SetOf(Type.BOOL));
 
         assertEquals(List.of("[true, false]"), Witnesses.ofSize(set, 2, READING, Set.of()).values().stream()
                 .map(FixtureTemplate::text).toList());
@@ -116,14 +116,14 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aFloorIsStillOfferedTheValueTheTypeCanReach() {
         assertEquals(List.of("[true, false]"),
-                Witnesses.holding(shape(new Type.SetOf(Type.BOOL)), 3, READING, Set.of()).stream()
+                Witnesses.holding(position(new Type.SetOf(Type.BOOL)), 3, READING, Set.of()).stream()
                         .map(FixtureTemplate::text).toList());
     }
 
     /** A map counts its entries, and a key that cannot be told from the others is not one more. */
     @Test
     void aMapIsNothingWhereItsKeysRunOutBeforeTheCount() {
-        Shape map = shape(new Type.MapOf(Type.BOOL, Type.INT));
+        TypeView map = position(new Type.MapOf(Type.BOOL, Type.INT));
 
         assertTrue(!Witnesses.ofSize(map, 2, READING, Set.of()).values().isEmpty(),
                 "two keys are two the type has");


### PR DESCRIPTION
A collection whose rules ask for more than one element was filled by composing
the first out of the element's rules and the rest by stepping the carrier. Over
strings that step is a character on the end of the one before it, which is a
value of the carrier and not of the type: where the element's type states which
strings, every element after the first was one the type refuses, and the row came
back as one every value tried was refused at — of a type whose admitted strings
are as many as anybody could want.

What tells a collection's values apart now comes from the strings the rules about
them admit, asked before the carrier is stepped. The rules are met with each
other rather than taken one at a time: a position offered a proposal per rule
loses one candidate when the decoder refuses it, and an element inside a
collection takes the whole collection with it.

## Both vocabularies a rule reaches a string in

Which strings a position holds is a predicate over them; how many characters is a
number, counted by the measure the type is written in and read where numbers are
read. A value has to clear both, and a reader of one of them alone hands out the
string the other was written to exclude — the shortest string a format accepts is
exactly what a floor on the characters rules out. So what the rules admit is the
two met with each other. Where nothing says which strings there is nothing to
narrow, and what one more value is stays a character on the end of the last.

A value counting that many is also asked for of the position rather than of its
shape. Every caller already held the position's reading and handed over the part
of it that counts, which is the whole of what a string of that length was read
from. The value the rules admit is offered first and the string of any characters
at all after it, so what is reported when neither builds is unchanged: whether a
string of that length exists is a claim about strings, and it stays one.

Nothing about a list changes: what a list holds again is the same element, and
what a set and a map's keys hold is what the rules leave distinct.

## Two fixtures were models of the defect

A border whose points nothing filled was a format met with a floor, and it is
filled now. It asks for a rule this compiler cannot read instead, which is what
leaves a position with no value the rules admit.

## What is still open

A string type carrying two rules about which strings and none about how many is
still offered a first value that clears one of them. Offering the meet there as
well is a change of its own: the models that witness a search running out of
assignments, and the ones that witness a map's pairings running out, are written
as positions whose every proposal is refused, and a value clearing every rule
retires them as witnesses.

A pattern this compiler cannot take apart still ends as a refusal. The fill falls
back to the carrier, the decoder refuses what it wrote, and the report says every
value tried was refused with nothing said about the rule that was never read.

For #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)