### PR TITLE
Offer a position the value every rule about its strings admits

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1512,6 +1512,13 @@ public final class Partitions {
      * and never to withdraw one already offered: which of them the whole of the rules admits is the
      * decoder's answer, so a position carrying a format and a floor gets a value from each and the
      * order they were declared in does not decide whether one builds.
+     *
+     * <p><b>And a value every rule admits, which is none of theirs.</b> A proposal per rule is a
+     * proposal each of the others may refuse, so a position carrying two rules about its strings was
+     * offered what each asked for and nothing that clears both — the decoder refused all of it and
+     * the position had no value at all. That it went unnoticed is what the rest of this offers: a
+     * rule counting the value reaches the same meet through {@link Witnesses}, so the same two rules
+     * composed a row wherever a third rule happened to count what they were about.
      */
     static List<FixtureTemplate> representativesOf(TypeView view, RuleReadingContext reading,
                                                    NumericDomain.Bounds within,
@@ -1532,12 +1539,18 @@ public final class Partitions {
         if (!(WornNames.of(view.wrappers(), ruleSource) instanceof WornNames.Spelled spelled)) {
             return List.of();
         }
+        // What the rules say about the strings and how many characters they hold, each read once
+        // for the three readers below. Asked again per reader, a position carrying a format paid
+        // for the clauses to be walked and the counts to be read as many times as it has readers.
+        List<PatternSyntax> stated = patternsStatedOn(view, ruleSource);
+        DeclaredBounds.CountRange characters = DeclaredBounds.countsHeld(view, reading, null);
         // What the rules ask for, and then what the position is where nothing was written about it.
         List<FixtureTemplate> bare = new ArrayList<>();
+        bare.addAll(whatEveryRuleAdmits(stated, characters));
         bare.addAll(whereTheRulesLeaveTheValue(view, reading, within));
-        bare.addAll(whatAFormatAsksFor(view, ruleSource));
+        bare.addAll(whatAFormatAsksFor(stated));
         // What the rules say the value holds, before the value that would hold nothing.
-        bare.addAll(Witnesses.holding(view, leastHeld(view, reading), reading, inside));
+        bare.addAll(Witnesses.holding(view, characters.least(), reading, inside));
         List<FixtureTemplate> ofTheShape =
                 whatTheShapeStandsFor(view.shape(), reading, within, inside);
         bare.addAll(ofTheShape);
@@ -1609,43 +1622,24 @@ public final class Partitions {
     }
 
     /**
-     * A value each rule about the characters of a string admits, innermost name first.
+     * A value each of {@code stated} admits, in the order they were read.
      *
-     * <p>Read in the representation the analysis reads, which is where a library predicate is still
-     * the operation it was written as. In the settled form it is the body it expands to, and the
-     * reading below has no word for that.
+     * <p>One per rule and none of them met with another: each is what one rule asked for, and which
+     * of them the whole of the rules admits is the decoder's answer. What every rule admits at once
+     * is a value of its own ({@link #whatEveryRuleAdmits}) and is offered beside these.
      *
      * <p>Innermost first, which is an order over the proposals and not over the rules: every name's
      * rules govern the value, whichever end they are read from. What the order decides is which
      * proposal a bounded search reaches before it stops, and the value a name wraps is the one its
-     * own rules were written closest to.
+     * own rules were written closest to. It is {@link #patternsStatedOn}'s order, read once for
+     * every reader of it here.
      */
-    private static List<FixtureTemplate> whatAFormatAsksFor(TypeView view,
-                                                            RuleReadingSource ruleSource) {
-        if (!(view.shape() instanceof Shape.Scalar scalar) || scalar.prim() != Type.Prim.STRING) {
-            return List.of();
-        }
-        List<DeclaredClauses.OnAName> written = DeclaredClauses.of(view.wrappers(), ruleSource);
+    private static List<FixtureTemplate> whatAFormatAsksFor(List<PatternSyntax> stated) {
         List<FixtureTemplate> out = new ArrayList<>();
-        for (int name = written.size() - 1; name >= 0; name--) {
-            for (DeclaredClauses.Conjunct each : written.get(name).conjuncts()) {
-                // Asked of what the predicate means and not of what the decoder is told. The two are
-                // different questions: a constraint is what a generated class declares to the
-                // runtime, which is a format and nothing else, and this is which strings the rule
-                // admits — asked through the constraint, every predicate the decoder has no word for
-                // proposed no value, and a position an author had written a rule for was offered
-                // `"x"` and refused.
-                //
-                // Told which strings only where the reading came to them. Why it did not is the
-                // reading's to keep and nothing here has a use for it: a rule this could not read
-                // proposes no value, the same as one whose strings nobody can paste.
-                StringPredicates.Reading admits =
-                        StringPredicates.statedByWritten(each.expr(), ruleSource.symbols());
-                String text = admits instanceof StringPredicates.Reading.Accepting it
-                        ? writtenFor(it.accepts()) : null;
-                if (text != null) {
-                    out.add(FixtureTemplate.string(text));
-                }
+        for (PatternSyntax each : stated) {
+            String text = writtenFor(each);
+            if (text != null) {
+                out.add(FixtureTemplate.string(text));
             }
         }
         return out;
@@ -2188,6 +2182,33 @@ public final class Partitions {
     }
 
     /**
+     * A value the whole of the rules on {@code view} admits, or nothing where fewer than two of them
+     * say anything about its strings.
+     *
+     * <p>Written bare, because {@link #representativesOf} is what puts the names on. One and not
+     * more: what a position offers is what a search walks, and a second value of the same set tells
+     * a reader nothing the first did not — telling them apart is what a collection needs, and it
+     * asks for as many as it holds ({@link #admittedStrings}).
+     *
+     * <p><b>Two, because one reading has nothing to be met with.</b> Where a single rule speaks of
+     * the strings, what every rule admits is what that rule asked for, and that value is already
+     * offered by whichever reading made it. Composed here as well it would be the same string
+     * arrived at through a machine, and every position carrying a format would pay for one.
+     */
+    private static List<FixtureTemplate> whatEveryRuleAdmits(List<PatternSyntax> stated,
+                                                             DeclaredBounds.CountRange characters) {
+        // A rule counting the characters says which strings as much as a format does: it leaves out
+        // every string of another length.
+        if (stated.size() + (countsTheCharacters(characters) ? 1 : 0) < 2) {
+            return List.of();
+        }
+        Meter meter = PatternPlan.Budget.OF_A_WITNESS.meter();
+        Language admits = admittedBy(stated, characters, meter);
+        String some = admits == null ? null : admits.someWritten();
+        return some == null ? List.of() : List.of(FixtureTemplate.string(some));
+    }
+
+    /**
      * Up to {@code many} of the strings the rules on {@code view} admit, no two of them the same.
      *
      * <p>One allowance for the whole of the question, which is what looking for these values may
@@ -2237,25 +2258,74 @@ public final class Partitions {
      */
     private static Language stringsTheRulesAdmit(TypeView view, RuleReadingContext reading,
                                                  Meter meter) {
-        RuleReadingSource ruleSource = reading.source();
-        Language all = null;
-        for (DeclaredClauses.OnAName written : DeclaredClauses.of(view.wrappers(), ruleSource)) {
-            for (DeclaredClauses.Conjunct each : written.conjuncts()) {
-                if (!(StringPredicates.statedByWritten(each.expr(), ruleSource.symbols())
-                        instanceof StringPredicates.Reading.Accepting it)) {
-                    continue;
-                }
-                Language one = languageOf(it.accepts(), meter);
-                if (one == null) {
-                    return null;   // the allowance would not pay for this rule's machine
-                }
-                all = all == null ? one : all.and(one, meter);
-                if (all == null) {
-                    return null;   // nor for putting it together with the rules before it
+        return admittedBy(patternsStatedOn(view, reading.source()),
+                DeclaredBounds.countsHeld(view, reading, null), meter);
+    }
+
+    /**
+     * The patterns the rules on {@code view} state about its strings, innermost name first.
+     *
+     * <p>Read without building anything. Which rules speak of the strings is what the clauses say;
+     * what each of them admits is a machine, and a reader that wants one value from each, another
+     * that wants the meet, and a third that only asks how many there are would each be paying for
+     * every machine to find out.
+     *
+     * <p>Read in the representation the analysis reads, which is where a library predicate is still
+     * the operation it was written as. In the settled form it is the body it expands to, and this
+     * reading has no word for that.
+     *
+     * <p>Asked of what the predicate means and not of what the decoder is told. The two are
+     * different questions: a constraint is what a generated class declares to the runtime, which is
+     * a format and nothing else, and this is which strings the rule admits — asked through the
+     * constraint, every predicate the decoder has no word for stated nothing, and a position an
+     * author had written a rule for was offered {@code "x"} and refused.
+     *
+     * <p>Only where the reading came to them. Why it did not is the reading's to keep and nothing
+     * here has a use for it: a rule this could not read states no pattern, the same as one whose
+     * strings nobody can paste.
+     */
+    private static List<PatternSyntax> patternsStatedOn(TypeView view,
+                                                        RuleReadingSource ruleSource) {
+        if (!(view.shape() instanceof Shape.Scalar scalar) || scalar.prim() != Type.Prim.STRING) {
+            return List.of();
+        }
+        List<DeclaredClauses.OnAName> written = DeclaredClauses.of(view.wrappers(), ruleSource);
+        List<PatternSyntax> out = new ArrayList<>();
+        for (int name = written.size() - 1; name >= 0; name--) {
+            for (DeclaredClauses.Conjunct each : written.get(name).conjuncts()) {
+                if (StringPredicates.statedByWritten(each.expr(), ruleSource.symbols())
+                        instanceof StringPredicates.Reading.Accepting it) {
+                    out.add(it.accepts());
                 }
             }
         }
-        return all == null ? null : withinTheCount(all, view, reading, meter);
+        return List.copyOf(out);
+    }
+
+    /** Whether a rule counts the characters, which leaves out every string of another length and
+     *  is a thing to be met with the patterns like any other. */
+    private static boolean countsTheCharacters(DeclaredBounds.CountRange characters) {
+        return !(characters.least() == 0 && characters.most() == Integer.MAX_VALUE);
+    }
+
+    /**
+     * The strings {@code stated} and {@code characters} admit between them, or null where nothing
+     * was stated or the machine costs more than {@code meter} allows.
+     */
+    private static Language admittedBy(List<PatternSyntax> stated,
+                                       DeclaredBounds.CountRange characters, Meter meter) {
+        Language all = null;
+        for (PatternSyntax each : stated) {
+            Language one = languageOf(each, meter);
+            if (one == null) {
+                return null;   // the allowance would not pay for this rule's machine
+            }
+            all = all == null ? one : all.and(one, meter);
+            if (all == null) {
+                return null;   // nor for putting it together with the rules before it
+            }
+        }
+        return all == null ? null : withinTheCount(all, characters, meter);
     }
 
     /**
@@ -2266,13 +2336,12 @@ public final class Partitions {
      * rules leave is a run of counts and what is being narrowed is a set of strings, and the two are
      * put together the way every pair of sets here is.
      */
-    private static Language withinTheCount(Language strings, TypeView view,
-                                           RuleReadingContext reading, Meter meter) {
-        DeclaredBounds.CountRange characters = DeclaredBounds.countsHeld(view, reading, null);
+    private static Language withinTheCount(Language strings,
+                                           DeclaredBounds.CountRange characters, Meter meter) {
         if (characters.empty()) {
             return null;   // no count at all, so no string of the position holds one
         }
-        if (characters.least() == 0 && characters.most() == Integer.MAX_VALUE) {
+        if (!countsTheCharacters(characters)) {
             return strings;   // every count, so nothing to take away
         }
         Language counted = languageOf(PatternSyntax.ofAnySymbols(characters.least(),

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -100,6 +100,31 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         return filled.rows().stream().map(row -> row.inputs().get(0).text()).toList();
     }
 
+    // --- two rules about one position --------------------------------------------------------------
+
+    /**
+     * Two rules about the strings of a position, and a value that clears both.
+     *
+     * <p>A proposal per rule is a proposal each of the others may refuse. Offered only those, a
+     * position carrying two rules about its strings has no value at all — each is what one rule
+     * asked for and the next one refuses it — and the behavior it sits in comes back with no row
+     * anywhere.
+     *
+     * <p>Held at the row, because that is the size of what it costs. A reading of the proposals
+     * alone would have shown two values where one was wanted and said nothing about the model
+     * losing every row it has.
+     */
+    @Test
+    void aPositionCarryingTwoRulesIsOfferedAValueClearingBoth() {
+        String row = generatedRow(model("""
+                data Code = String
+                    invariant begins = String.startsWith("X", value)
+                    invariant ends = String.endsWith("Z", value)
+                """, "code: Code", "code = Code(\"XZ\")"));
+
+        assertEquals("T { kind = Overseas, code = Code(\"XZ\") }", row);
+    }
+
     // --- a collection the rules say is not empty ---------------------------------------------------
 
     @Test
@@ -495,6 +520,12 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      * is what makes this about the count rather than about the rules. Written as eight lengths no
      * string has at once, the values reading follows them and shows the declaration admits nothing,
      * and a model refused before a search is asked for is not one this can say anything about.
+     *
+     * <p>What no pair clears is the ninth rule, which this compiler cannot take apart. Strings
+     * clearing all nine exist — a run of b's of even length is one — so the declaration is not an
+     * empty one, and what stops a row is that nothing here derives a value from a rule it could not
+     * read. Held that way because the rules it can read it meets with each other: eight formats that
+     * hold together are eight a proposal clears at once, and a pair built from them is a row.
      */
     @Test
     void moreParingsThanAreBuiltIsSaidAsASearchThatStopped() {
@@ -503,6 +534,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
             formats += "    invariant p%d = String.matches(\"[a-h]{%d,}\", value)\n"
                     .formatted(i, i);
         }
+        formats += "    invariant twice = String.matches(\"(b+)\\\\1\", value)\n";
         souther.compiler.partition.FillResult filled = generated("""
                 module nd.gen
 
@@ -544,6 +576,10 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      * no minimum was read, the position offered the empty map, and it was refused. The distinction
      * still matters — a reader told a search stopped would go looking for the pairing it stopped
      * short of — but a map the rules will not let be empty is no longer an example of it.
+     *
+     * <p>The ninth rule is one this compiler cannot take apart, which is what leaves the parts
+     * unfound: the rules it can read are met with each other and a value clearing all of them is
+     * proposed, so eight formats that hold together are eight a single proposal clears.
      */
     @Test
     void aMapWhoseSearchStoppedSaysSoRatherThanCallingItARefusal() {
@@ -552,6 +588,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
             formats += "    invariant p%d = String.matches(\"[a-h]{%d,}\", value)\n"
                     .formatted(i, i);
         }
+        formats += "    invariant twice = String.matches(\"(b+)\\\\1\", value)\n";
         souther.compiler.partition.FillResult filled = generated("""
                 module nd.gen
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -591,10 +591,12 @@ class CompileExampleGenerateTest {
      * the ones not reached were not refused — nothing was written and nothing built — and calling them
      * refused tells an author their model rules out a combination it does not.
      *
-     * <p>What refuses every value here is a pattern the record states about one field, which nothing
-     * derives a value from: the field's own type says its values are x's, and the record wants y's.
-     * A rule counting the field would not do — a floor is read now, and the value built for it is
-     * one this model would accept.
+     * <p>What refuses every value here is a rule this compiler cannot take apart, which nothing
+     * derives a value from. Strings clearing both rules of a field exist — a run of y's of even
+     * length is one — so what stops a row is the search rather than the model. A second format
+     * would not do: the formats a reading can take in are met with each other, and a value clearing
+     * all of them is proposed. Nor would a rule counting the field — a floor is read too, and the
+     * value built for it is one this model would accept.
      */
     @Test
     void whatTheSearchDidNotReachIsNotReportedAsRefused() {
@@ -604,7 +606,7 @@ class CompileExampleGenerateTest {
             declarations.append("""
                     data V%1$s = String
                         invariant String.matches("[a-z]+", value)
-                        invariant String.matches("x+", value)
+                        invariant String.matches("(y+)\\\\1", value)
 
                     """.formatted(Character.toUpperCase(c)));
             fields.append(c).append(": V").append(Character.toUpperCase(c)).append(", ");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
@@ -93,10 +93,18 @@ class WhichNamesRulesAreReadWhenAValueIsProposedTest {
                 "the rule on the outer name proposed what it asks for: " + proposed);
     }
 
-    /** Both names carrying a rule: each proposes what it asks for, innermost first. */
+    /**
+     * Both names carrying a rule: each proposes what it asks for, innermost first.
+     *
+     * <p>And a value both of them admit before either, which is what a position carrying two rules
+     * has to offer: each rule's own proposal is one the other refuses, so a position offering only
+     * those has no value at all. What each rule asks for stays behind it and in its own order — a
+     * rule is a reason to offer another value, and the value every rule admits withdraws none.
+     */
     @Test
     void whereBothNamesCarryARuleEachProposesInnermostFirst() {
-        assertEquals(List.of("A(B(\"X\"))", "A(B(\"Z\"))", "A(B(\"x\"))"), proposedFor("""
+        assertEquals(List.of("A(B(\"XZ\"))", "A(B(\"X\"))", "A(B(\"Z\"))", "A(B(\"x\"))"),
+                proposedFor("""
                 data B = String
                     invariant tagged = startsWith("X", value)
 


### PR DESCRIPTION
A proposal per rule is a proposal each of the others may refuse. A position
carrying two rules about its strings was offered what each of them asked for and
nothing that clears both, so the decoder refused all of it and the position had no
value at all — and the behavior it sits in came back with no row anywhere.

What kept it out of sight is the rest of what a position offers. A rule counting
the value reaches the same meet where a value of that count is built, so the same
two rules composed a row wherever a third rule happened to count what they were
about. A model got rows or not by whether somebody had written a rule about the
length, which is not a thing the two rules say.

The meet is now offered here as well, beside what each rule asks for rather than
in place of it. Where a single rule speaks of the strings there is nothing to
meet — what every rule admits is what that one asked for, and the proposal
carrying it is already on offer — so nothing is built there.

## What it cost, and what it gave back

The clauses a position states about its strings and the counts its rules leave
are now read once for every reader of them. Three readers were asking the same
two questions of the same position, which is what a position carrying a format
paid for each of them. Measured over one fill, repeated and interleaved: a field
carrying one format is where it was before this, and a field carrying two — the
one that had no row to offer — is within a few percent of it.

## The fixtures that stood on the defect

A map whose pairings run out and a search that never reaches an assignment were
both written as positions whose every proposal is refused, which is what a value
clearing every rule takes away. They ask for a rule this compiler cannot take
apart instead: that leaves the values unfound without leaving the model empty, so
what the search did not reach is still there to be reached.

For #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)