### PR TITLE
Ask what read a rule where the handle is, rather than where its outcome was filed

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitations.java
@@ -1,0 +1,34 @@
+package souther.compiler.check;
+
+import java.util.Set;
+
+/**
+ * Every handle a value holds for a rule of the model it read.
+ *
+ * <p>What a document has to answer before it can send a reader anywhere: a page that names a rule
+ * needs somewhere to point, and where that is, is looked up once per handle when the report is
+ * assembled. Which handles there are is the question this asks, and it is asked of the value that
+ * did the reading rather than of the page.
+ *
+ * <p><b>Asked of the producer, because the consumer cannot be told.</b> A report gathering these by
+ * listing the places a rule turns up in is a list somebody has to keep in step: a reading filed
+ * somewhere new is a reading nothing points at, nothing fails, and the page names a class with no
+ * handle for the rule that made it. Which is what happened to the readings that compose a
+ * position's classes. So the value that holds the reading answers for it, and a whole answers by
+ * asking its parts.
+ *
+ * <p><b>No default answer.</b> A value that reads no rule says so by writing the empty answer out,
+ * and one that reads rules cannot compile without saying which — an inherited empty would put the
+ * silence back where this exists to remove it.
+ *
+ * <p>Handles and not identities. Two readings of one rule offer one handle, and a value holding
+ * both offers it once: what is asked about here is where a reader is sent, and which reading sent
+ * them is no part of that. Unordered for the same reason — a document choosing between two handles
+ * chooses by the canonical order it publishes under, and an order promised here would be a second
+ * answer to that comparison.
+ */
+public interface RuleCitations {
+
+    /** Every handle for a rule this value read, which is none where it read none. */
+    Set<RuleCitation> ruleCitations();
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.RowIdentity;
@@ -229,10 +230,18 @@ public sealed interface About {
      * identity, which is one rule's findings coming out identical in every field with nothing to
      * join them by. A shape that is about a rule says so by being one of these.
      */
-    sealed interface OfARule extends About {
+    sealed interface OfARule extends About, RuleCitations {
 
         /** Which rule, as everything that names a rule names it. */
         souther.compiler.check.RuleRef rule();
+
+        /** The handles this finding offers, which are the ones it was made with. Written here
+         *  because what a finding holds is one answer under two names — the seal's own question,
+         *  and the one every value holding a handle is asked. */
+        @Override
+        default Set<RuleCitation> ruleCitations() {
+            return cited();
+        }
 
         /**
          * Every handle a reader was offered for that rule.

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -6158,7 +6158,7 @@ public final class Adequacy {
                     // One marker, from the one handle a document would write of the several a rule
                     // reached at several calls offers — chosen where that choice is made rather
                     // than by whichever reading this happened to walk first.
-                    if (PublicationOrders.handleFor(point.citations(),
+                    if (PublicationOrders.handleFor(point.ruleCitations(),
                                     cited -> Sites.placeOf(db, cited)).orElse(null)
                             instanceof RuleCitation.Written written) {
                         switch (Sites.placeOf(db, written)) {

--- a/souther-compiler/src/main/java/souther/compiler/query/BehaviorEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BehaviorEvidence.java
@@ -1,5 +1,13 @@
 package souther.compiler.query;
 
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * Everything measured about one behavior, and the one place what it went without is worked out.
  *
@@ -50,7 +58,7 @@ public record BehaviorEvidence(Adequacy.RowReading reading,
                                Measure<java.util.List<BorderAssessment>> boundaryReadings,
                                Measure<java.util.List<BorderObligationPointAssessment>> account,
                                Adequacy.BranchEvidence branch,
-                               DecisionEvidence decision) {
+                               DecisionEvidence decision) implements RuleCitations {
 
     public BehaviorEvidence {
         java.util.Objects.requireNonNull(reading,
@@ -146,5 +154,35 @@ public record BehaviorEvidence(Adequacy.RowReading reading,
             out = out.union(point.item().weakening());
         }
         return out;
+    }
+
+    /**
+     * Every handle this behavior's measures hold for a rule they read, all of them.
+     *
+     * <p>Asked of the parts, and each of those answers for its own, which is what
+     * {@link #weakening()} does one question over. A page that names a rule is sent somewhere by
+     * this, and what it may name is what was read rather than what some list of arrays happened to
+     * hold — the gathering it replaces was kept in step by whoever remembered, and the readings
+     * that compose a position's classes were the ones nobody did.
+     *
+     * <p><b>The parts that hold a handle, named as fields.</b> A measure is a measurement of some
+     * value and a handle is the value's, so this cannot be asked of {@link #parts()}: what comes
+     * back from there says how far a measurement ran and nothing about what it measured. Which
+     * fields those are is held to what this record is made of, where the union over the parts is.
+     */
+    @Override
+    public Set<RuleCitation> ruleCitations() {
+        Set<RuleCitation> out = new LinkedHashSet<>();
+        if (partition != null) {
+            out.addAll(partition.ruleCitations());
+        }
+        readings(boundaryReadings).forEach(each -> out.addAll(each.ruleCitations()));
+        readings(account).forEach(each -> out.addAll(each.ruleCitations()));
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** What one of these measures made, or nothing where it was not made or not asked for. */
+    private static <T> List<T> readings(Measure<List<T>> measure) {
+        return measure == null ? List.of() : measure.made().orElseGet(List::of);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
 import souther.compiler.partition.Border;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.BoundaryTarget;
@@ -10,6 +12,7 @@ import souther.compiler.publish.PublishedRuleHandle;
 import souther.compiler.publish.PublishedSentence;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Everything known about one reading of one border: the line as this position met it, and what
@@ -29,7 +32,20 @@ import java.util.Map;
  * two points of one border can be the same one, so a measure keyed on the role would hold one entry
  * where there are two.
  */
-public record BorderAssessment(Border border, Map<DomainPoint, ItemAssessment> items) {
+public record BorderAssessment(Border border, Map<DomainPoint, ItemAssessment> items)
+        implements RuleCitations {
+
+    /**
+     * The one handle this reading holds, which is the one the rule that drew the line was cited by.
+     *
+     * <p>One, because a reading is of one line and a line is drawn by one rule. The several a debt
+     * holds are the several readings of it gathered ({@link BorderObligationPointAssessment}), and
+     * are that value's answer rather than this one's.
+     */
+    @Override
+    public Set<RuleCitation> ruleCitations() {
+        return Set.of(origin().cited());
+    }
 
     public BorderAssessment {
         if (items == null || !items.keySet().equals(border.answers().keySet())) {

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -5,6 +5,7 @@ import souther.compiler.partition.BorderQuantity;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.PointRole;
+import souther.compiler.check.RuleCitations;
 import souther.compiler.check.RuleReportAnchor;
 import souther.compiler.publish.PublicationOrders;
 import souther.compiler.publish.PublishedRuleHandle;
@@ -66,7 +67,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                                               java.util.Set<RuleReportAnchor> reachedBy,
                                               Demand demand, ObligationAssessment item,
                                               java.util.SequencedMap<Reading, BorderAssessment>
-                                                      met) {
+                                                      met) implements RuleCitations {
 
     /**
      * Every handle a reader was offered for the rule that drew this line.
@@ -82,7 +83,8 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * handle, the debt would name whichever way in the walk met first, which is what the
      * publication order exists to decide instead.
      */
-    public java.util.Set<souther.compiler.check.RuleCitation> citations() {
+    @Override
+    public java.util.Set<souther.compiler.check.RuleCitation> ruleCitations() {
         return souther.compiler.check.RuleCitation.handlesFor(point.line().provenance(), reachedBy);
     }
 
@@ -307,7 +309,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      */
     public PublishedRuleHandle handle(PublishedRuleHandle.WhereARuleIs places) {
         return PublishedRuleHandle.of(
-                PublicationOrders.handleFor(citations(), places)
+                PublicationOrders.handleFor(ruleCitations(), places)
                         .orElseThrow(() -> new IllegalStateException("a line a reader is sent to is"
                                 + " one some reading said how to find: " + point)),
                 places);

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.check.CoverageObligation;
 import souther.compiler.check.NumberAt;
 import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.FilingCoordinate;
@@ -18,6 +19,7 @@ import souther.compiler.partition.UndividedPosition;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.SequencedMap;
 import java.util.Set;
@@ -69,7 +71,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
                                 List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                 List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                 List<Unanswered> unanswered,
-                                List<Incompleteness> whyUnclassified) {
+                                List<Incompleteness> whyUnclassified) implements RuleCitations {
 
 
     /**
@@ -497,6 +499,30 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
             out = out.union(axis.reached().weakening());
         }
         return out;
+    }
+
+    /**
+     * Every handle this measure holds for a rule it read.
+     *
+     * <p>Three ways a rule of the model reaches this measure and all three are here. A question
+     * nothing answered names the rule it stands on; a rule this reading could not turn into a line
+     * names itself; and a rule that did divide a position is what the classes were composed out of,
+     * which is the axis's to say ({@link AxisCoverage#divides()}). The third used to be nobody's:
+     * the page that names a class no row is in had no handle for the rule that made that class.
+     *
+     * <p>Asked here and not of the axes. Which arrays a rule can reach this measure through is what
+     * this record is made of, and a reader gathering them from outside is a reader who has to be
+     * told when a fourth arrives.
+     */
+    @Override
+    public Set<RuleCitation> ruleCitations() {
+        Set<RuleCitation> out = new LinkedHashSet<>();
+        unanswered().forEach(each -> out.addAll(each.cited()));
+        notRead().forEach(each -> out.addAll(each.cited()));
+        for (AxisCoverage axis : axes()) {
+            axis.divides().forEach(each -> out.add(each.cited()));
+        }
+        return Collections.unmodifiableSet(out);
     }
 
     /** The positions, for a reader that wants them and not what the measure made of itself. Empty

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1066,14 +1066,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
         return cited;
     }
 
-    /** Every handle the findings hold, read through the one question that spans the kinds of them
-     *  about a rule ({@link About.OfARule}). */
+    /**
+     * Every handle the findings hold.
+     *
+     * <p>Asked of what a finding is about, by the same question every value holding a handle
+     * answers ({@link RuleCitations}). Matched against the kinds that happen to be about a rule
+     * instead, a kind added later is a kind whose rules a page names with nowhere to point — which
+     * is the fault this gathering was rewritten to keep out, one seal over.
+     */
     private static Set<RuleCitation> citedBy(List<ReportedFinding> found) {
         Set<RuleCitation> cited = new LinkedHashSet<>();
         if (found != null) {
             found.stream().map(ReportedFinding::about)
-                    .filter(About.OfARule.class::isInstance)
-                    .map(About.OfARule.class::cast)
+                    .filter(RuleCitations.class::isInstance)
+                    .map(RuleCitations.class::cast)
                     .forEach(each -> cited.addAll(each.ruleCitations()));
         }
         return cited;
@@ -1121,12 +1127,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
                     .forEach(each -> take.accept(each.finding().finding().sentTo()));
         }
         return places;
-    }
-
-    /** The points one behavior's account holds, or none where the measure could not be made. */
-    private static List<BorderObligationPointAssessment> pointsOf(
-            Measure<List<BorderObligationPointAssessment>> account) {
-        return account == null ? List.of() : account.made().orElse(List.of());
     }
 
     /** The lines one behavior met, or none where the measure could not be made. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -12,6 +12,7 @@ import souther.compiler.check.CoverageObligation;
 import souther.compiler.check.PartId;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.Towards;
 import souther.compiler.partition.AuthoredLine;
@@ -761,20 +762,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
             Map<DecisionRule, RuleSettlement> requirements = ruleSettlements(compilation, name,
                     behavior.name(),
                     decisions == null ? null : decisions.get(behavior.name()));
+            // The measures this behavior was made of, held as one value before the page is: what
+            // the page may send a reader to is asked of it, and a whole that answers for its parts
+            // is the one thing that has to be in reach for that question to be asked at all.
+            BehaviorEvidence evidence = new BehaviorEvidence(reading, signature, partition, read,
+                    accounts == null ? null : accounts.get(behavior.name()), branch,
+                    decisions == null ? null : decisions.get(behavior.name()));
             behaviors.add(new BehaviorReport(behavior.name(),
                     module.implementationOf(behavior),
-                    new BehaviorEvidence(reading, signature, partition, read,
-                            accounts == null ? null : accounts.get(behavior.name()), branch,
-                            decisions == null ? null : decisions.get(behavior.name())),
+                    evidence,
                     claims == null ? ClaimAnnotations.NONE
                             : claims.getOrDefault(behavior.name(), ClaimAnnotations.NONE),
                     reported,
                     armPlaces(compilation, branch),
                     conditionPlaces(compilation, linesOf(read)),
-                    rulePlaces(compilation, partition, linesOf(read),
-                            accounts == null ? List.of()
-                                    : pointsOf(accounts.get(behavior.name())),
-                            reported),
+                    rulePlaces(compilation, citedBy(evidence, reported)),
                     partPlaces(compilation, partition, reported),
                     ruleReadings(compilation, name, behavior.name(),
                             decisions == null ? null : decisions.get(behavior.name()),
@@ -794,7 +796,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
                 // under are the debts' rather than any behavior's.
                 new DeclarationsShown(declared,
                         conditionPlaces(compilation, declaredLines(declared)),
-                        rulePlaces(compilation, null, declaredLines(declared), null, owed)));
+                        rulePlaces(compilation, citedByDeclarations(declared, owed))));
     }
 
     /** The lines a module's declarations were read at, which is where the block about them looks
@@ -1012,37 +1014,69 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
      * sentence is decided where the sentence is written; a gathering that asked it here would be
      * that decision made twice.
      *
-     * <p>Every kind of finding about a rule is read through the one question that spans them
-     * ({@link About.OfARule#cited}), and the rules the document's own arrays name are read off
-     * those arrays. A rule found by two readers is one entry: what is asked about is the handle,
-     * and two readers offering one handle offer one value.
+     * <p><b>Asked of what read the rules, and never gathered from where their outcomes were
+     * filed.</b> Every value holding a handle answers one question ({@link RuleCitations}), and a
+     * whole answers by asking its parts — so what this takes in is already the closure, and there
+     * is no list here to keep in step. Listed instead, a reading filed somewhere new is a reading
+     * nothing points at, nothing fails, and the page names a class with no handle for the rule that
+     * made it.
+     *
+     * <p>Only the rules with somewhere to be asked about get an entry: a rule the author named is
+     * found by that name from anywhere. A rule two readers hold a handle for is one entry — what is
+     * asked about is the handle, and two readers offering one handle offer one value.
      */
     private static Map<RuleCitation.Written, Citation> rulePlaces(
-            Compilation compilation, PartitionEvidence partition,
-            List<BorderAssessment> lines, List<BorderObligationPointAssessment> account,
-            List<ReportedFinding> found) {
+            Compilation compilation, Set<RuleCitation> cited) {
         Map<RuleCitation.Written, Citation> places = new LinkedHashMap<>();
-        Consumer<RuleCitation> take = cited -> {
-            if (cited instanceof RuleCitation.Written written) {
-                places.computeIfAbsent(written,
-                        it -> Sites.placeOf(compilation.db(), it));
+        for (RuleCitation each : cited) {
+            if (each instanceof RuleCitation.Written written) {
+                places.computeIfAbsent(written, it -> Sites.placeOf(compilation.db(), it));
             }
-        };
-        if (partition != null) {
-            partition.unanswered().forEach(each -> each.cited().forEach(take));
-            partition.notRead().forEach(each -> each.cited().forEach(take));
-        }
-        lines.forEach(line -> take.accept(line.origin().cited()));
-        if (account != null) {
-            account.forEach(each -> each.citations().forEach(take));
-        }
-        if (found != null) {
-            found.stream().map(ReportedFinding::finding).map(Adequacy.Finding::about)
-                    .filter(About.OfARule.class::isInstance)
-                    .map(About.OfARule.class::cast)
-                    .forEach(each -> each.cited().forEach(take));
         }
         return places;
+    }
+
+    /**
+     * Every handle the page about one behavior may send a reader to.
+     *
+     * <p>Two, because a page shows two things: the measures this behavior was made of, which
+     * answer for the rules they read, and the findings written under it, which answer for the rules
+     * they are about. A finding is not a measure — it is what a measure came to, kept beside it —
+     * so neither is recovered from the other.
+     */
+    private static Set<RuleCitation> citedBy(BehaviorEvidence evidence,
+                                             List<ReportedFinding> found) {
+        Set<RuleCitation> cited = new LinkedHashSet<>(evidence.ruleCitations());
+        cited.addAll(citedBy(found));
+        return cited;
+    }
+
+    /**
+     * Every handle the block about a module's declarations may send a reader to.
+     *
+     * <p>The lines the declarations drew, which are read at no behavior's page, and the findings
+     * about them. There is no behavior here and so no measures to ask: what a module's declarations
+     * are owed is read off the lines themselves.
+     */
+    private static Set<RuleCitation> citedByDeclarations(Adequacy.DeclaredBoundaries declared,
+                                                         List<ReportedFinding> found) {
+        Set<RuleCitation> cited = new LinkedHashSet<>();
+        declaredLines(declared).forEach(line -> cited.addAll(line.ruleCitations()));
+        cited.addAll(citedBy(found));
+        return cited;
+    }
+
+    /** Every handle the findings hold, read through the one question that spans the kinds of them
+     *  about a rule ({@link About.OfARule}). */
+    private static Set<RuleCitation> citedBy(List<ReportedFinding> found) {
+        Set<RuleCitation> cited = new LinkedHashSet<>();
+        if (found != null) {
+            found.stream().map(ReportedFinding::about)
+                    .filter(About.OfARule.class::isInstance)
+                    .map(About.OfARule.class::cast)
+                    .forEach(each -> cited.addAll(each.ruleCitations()));
+        }
+        return cited;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest.java
@@ -1,0 +1,141 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleCitations;
+import souther.compiler.conformance.RepositoryModels;
+import souther.compiler.report.AdequacyReport;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a behavior's evidence holds handles for is what its parts hold handles for.
+ *
+ * <p>The union over the parts and nothing else, which is the rule {@code weakening} already
+ * follows. What it costs to get this wrong is what issue #996 cost one question over: the parts are
+ * fields, the union is written out by hand, and a part left out of it reaches nobody while the whole
+ * answers as though it had been asked. A page then names a rule with nowhere to point, or — as
+ * happened here — never names it at all, and nothing fails either way.
+ *
+ * <p><b>Walked over the values, not over the field types.</b> A part is a measurement of some value
+ * and the handles are the value's, so the type of the field says {@code Measure} and answers
+ * nothing. What a run holds is what it holds: every model this repository carries is compiled, and
+ * each part of each behavior is asked whether the value in it is one of the things that answers for
+ * a rule it read.
+ */
+@Tag("population")
+class EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest {
+
+    @Test
+    void theWholeHoldsWhatEveryPartHolds() {
+        int walked = 0;
+        Set<String> holding = new LinkedHashSet<>();
+        for (Compilation compilation : RepositoryModels.all()) {
+            for (BehaviorEvidence evidence : behaviorsOf(compilation)) {
+                Set<RuleCitation> held = new LinkedHashSet<>();
+                for (RecordComponent part : BehaviorEvidence.class.getRecordComponents()) {
+                    Set<RuleCitation> mine = handlesIn(valueOf(evidence, part));
+                    if (!mine.isEmpty()) {
+                        holding.add(part.getName());
+                    }
+                    held.addAll(mine);
+                }
+                assertEquals(held, evidence.ruleCitations(),
+                        "a behavior's evidence holds the handles its parts hold");
+                walked += held.size();
+            }
+        }
+        // The walk found something to be about. Every assertion above holds of a walk that read no
+        // value at all, which is what a check written from the field types would have been.
+        assertTrue(walked > 0, "the models walked hold behaviors whose measures read rules");
+
+        // And which parts those are, because the assertion above is only as wide as the parts that
+        // hold a handle. A measure added to this record that reads rules is a part nothing asks
+        // unless somebody writes it into the union, which is the failure this is here to raise —
+        // and the union coming out equal says nothing about a part that holds nothing.
+        assertEquals(Set.of("partition", "boundaryReadings", "account"), holding,
+                "the parts of a behavior's evidence that hold a handle for a rule they read");
+    }
+
+    /**
+     * Which of those parts the union would be short of if it were not asked.
+     *
+     * <p>Written down because it is not all of them. The account's handles are the ones its lines
+     * already hold — a point is owed at a line, and the rule is the line's — so the union comes out
+     * the same whether or not the account is asked, and a mutation dropping it is green. What that
+     * means is that the assertion above has no subject at that part and not that the part is
+     * exempt: the whole asks each of its parts because that is what a whole does, and the day the
+     * account holds a handle of its own is the day the asking is what carries it.
+     */
+    @Test
+    void andWhichOfThemTheUnionWouldBeShortOfWithoutTheAsking() {
+        Set<String> alone = new LinkedHashSet<>();
+        for (Compilation compilation : RepositoryModels.all()) {
+            for (BehaviorEvidence evidence : behaviorsOf(compilation)) {
+                Map<String, Set<RuleCitation>> held = new LinkedHashMap<>();
+                for (RecordComponent part : BehaviorEvidence.class.getRecordComponents()) {
+                    held.put(part.getName(), handlesIn(valueOf(evidence, part)));
+                }
+                held.forEach((name, mine) -> {
+                    Set<RuleCitation> beside = new LinkedHashSet<>();
+                    held.forEach((other, cited) -> {
+                        if (!other.equals(name)) {
+                            beside.addAll(cited);
+                        }
+                    });
+                    if (!beside.containsAll(mine)) {
+                        alone.add(name);
+                    }
+                });
+            }
+        }
+        assertEquals(Set.of("partition", "boundaryReadings"), alone,
+                "the parts that hold a handle no other part of the same behavior holds");
+    }
+
+    /**
+     * The handles one part holds, which is the part's own answer wherever it has one.
+     *
+     * <p>Two shapes and both are what a field of this record can be: the value itself, and a
+     * measurement of a list of them. Nothing deeper — a shape this cannot read is a part whose
+     * handles the assertion above will find missing from the whole, which is the answer wanted
+     * rather than a walk that goes looking.
+     */
+    private static Set<RuleCitation> handlesIn(Object value) {
+        Set<RuleCitation> out = new LinkedHashSet<>();
+        switch (value) {
+            case null -> { }
+            case RuleCitations it -> out.addAll(it.ruleCitations());
+            case Measure<?> it -> it.made().ifPresent(made -> out.addAll(handlesIn(made)));
+            case List<?> it -> it.forEach(each -> out.addAll(handlesIn(each)));
+            default -> { }
+        }
+        return out;
+    }
+
+    private static Object valueOf(BehaviorEvidence evidence, RecordComponent part) {
+        try {
+            return part.getAccessor().invoke(evidence);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("a part of a behavior's evidence is readable", e);
+        }
+    }
+
+    private static List<BehaviorEvidence> behaviorsOf(Compilation compilation) {
+        List<BehaviorEvidence> out = new ArrayList<>();
+        AdequacyReport.of(compilation).modules()
+                .forEach(module -> module.behaviors()
+                        .forEach(behavior -> out.add(behavior.evidence())));
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest.java
@@ -4,9 +4,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleCitations;
+import souther.compiler.WhatWasCompiled;
 import souther.compiler.conformance.RepositoryModels;
 import souther.compiler.report.AdequacyReport;
 
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.constant.ClassDesc;
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -17,6 +22,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * What a behavior's evidence holds handles for is what its parts hold handles for.
@@ -39,16 +45,11 @@ class EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest {
     @Test
     void theWholeHoldsWhatEveryPartHolds() {
         int walked = 0;
-        Set<String> holding = new LinkedHashSet<>();
         for (Compilation compilation : RepositoryModels.all()) {
             for (BehaviorEvidence evidence : behaviorsOf(compilation)) {
                 Set<RuleCitation> held = new LinkedHashSet<>();
                 for (RecordComponent part : BehaviorEvidence.class.getRecordComponents()) {
-                    Set<RuleCitation> mine = handlesIn(valueOf(evidence, part));
-                    if (!mine.isEmpty()) {
-                        holding.add(part.getName());
-                    }
-                    held.addAll(mine);
+                    held.addAll(handlesIn(valueOf(evidence, part)));
                 }
                 assertEquals(held, evidence.ruleCitations(),
                         "a behavior's evidence holds the handles its parts hold");
@@ -59,11 +60,10 @@ class EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest {
         // value at all, which is what a check written from the field types would have been.
         assertTrue(walked > 0, "the models walked hold behaviors whose measures read rules");
 
-        // And which parts those are, because the assertion above is only as wide as the parts that
-        // hold a handle. A measure added to this record that reads rules is a part nothing asks
-        // unless somebody writes it into the union, which is the failure this is here to raise —
-        // and the union coming out equal says nothing about a part that holds nothing.
-        assertEquals(Set.of("partition", "boundaryReadings", "account"), holding,
+        // And which parts those are, written down because the equality above is only as wide as
+        // the parts that hold a handle: a part that holds none says nothing about the union either
+        // way, and a part that starts holding one is what this names.
+        assertEquals(Set.of("partition", "boundaryReadings", "account"), partsHoldingAHandle(),
                 "the parts of a behavior's evidence that hold a handle for a rule they read");
     }
 
@@ -106,10 +106,11 @@ class EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest {
     /**
      * The handles one part holds, which is the part's own answer wherever it has one.
      *
-     * <p>Two shapes and both are what a field of this record can be: the value itself, and a
-     * measurement of a list of them. Nothing deeper — a shape this cannot read is a part whose
-     * handles the assertion above will find missing from the whole, which is the answer wanted
-     * rather than a walk that goes looking.
+     * <p><b>Nothing unknown is read as empty.</b> A shape this walk does not know is a shape it
+     * cannot say holds no handle, and saying it anyway is how an oracle comes to share the omission
+     * it is checking: a part added to the record and forgotten by the union would be nought here
+     * and nought there, and the two would agree. So the kinds that hold no handle say so by being
+     * written down, and anything else stops the check.
      */
     private static Set<RuleCitation> handlesIn(Object value) {
         Set<RuleCitation> out = new LinkedHashSet<>();
@@ -118,9 +119,76 @@ class EveryPartOfABehaviorsEvidenceIsAskedForItsHandlesTest {
             case RuleCitations it -> out.addAll(it.ruleCitations());
             case Measure<?> it -> it.made().ifPresent(made -> out.addAll(handlesIn(made)));
             case List<?> it -> it.forEach(each -> out.addAll(handlesIn(each)));
-            default -> { }
+            // Read and known to carry no handle for a rule: what the rows themselves came to, what
+            // they establish about the cases, about the arms, and which rules of the body's
+            // decision they took. None of them is a reading of a rule of the model.
+            case Adequacy.RowReading _, Adequacy.SignatureEvidence _,
+                 Adequacy.BranchEvidence _, DecisionEvidence _ -> { }
+            default -> fail("a part of a behavior's evidence has not said whether it holds a handle"
+                    + " for a rule it read: " + value.getClass());
         }
         return out;
+    }
+
+    /**
+     * And the whole reads each of the parts that hold one, rather than coming out equal to them.
+     *
+     * <p>Two different things, and the set above only holds the first. The account's handles are
+     * the ones its lines already hold — a point is owed at a line, and the rule is the line's — so
+     * a union that never asked the account comes out the same, and the equality above is green. The
+     * question this asks is the other one: which parts the method actually reads, taken off what
+     * javac made of it rather than off what the answer came to.
+     *
+     * <p>Which parts it must read is not written down here either. It is the parts a run finds a
+     * handle in, so the two answers are one fact — a part that starts holding one is a part the
+     * whole has to be reading by then, and the failure names it.
+     */
+    @Test
+    void andTheWholeReadsEachPartThatHoldsOne() {
+        assertEquals(partsHoldingAHandle(), partsReadBy("ruleCitations"),
+                "the parts a behavior's evidence reads when it is asked for its handles");
+    }
+
+    /** Which parts of the record {@code method} reads, as the compiled method reads them. */
+    private static Set<String> partsReadBy(String method) {
+        ClassDesc owner = BehaviorEvidence.class.describeConstable().orElseThrow();
+        Set<String> read = new LinkedHashSet<>();
+        ClassModel model = WhatWasCompiled.compiled()
+                .find(BehaviorEvidence.class.getName()).orElseThrow();
+        Set<String> components = new LinkedHashSet<>();
+        for (RecordComponent each : BehaviorEvidence.class.getRecordComponents()) {
+            components.add(each.getName());
+        }
+        for (MethodModel each : model.methods()) {
+            if (!each.methodName().stringValue().equals(method)) {
+                continue;
+            }
+            each.code().ifPresent(code -> {
+                for (var element : code) {
+                    if (element instanceof FieldInstruction field
+                            && field.owner().asSymbol().equals(owner)
+                            && components.contains(field.name().stringValue())) {
+                        read.add(field.name().stringValue());
+                    }
+                }
+            });
+        }
+        return read;
+    }
+
+    /** Which parts a run of every model this repository carries finds a handle in. */
+    private static Set<String> partsHoldingAHandle() {
+        Set<String> holding = new LinkedHashSet<>();
+        for (Compilation compilation : RepositoryModels.all()) {
+            for (BehaviorEvidence evidence : behaviorsOf(compilation)) {
+                for (RecordComponent part : BehaviorEvidence.class.getRecordComponents()) {
+                    if (!handlesIn(valueOf(evidence, part)).isEmpty()) {
+                        holding.add(part.getName());
+                    }
+                }
+            }
+        }
+        return holding;
     }
 
     private static Object valueOf(BehaviorEvidence evidence, RecordComponent part) {

--- a/souther-compiler/src/test/java/souther/compiler/query/TheRuleThatDividesAPositionIsAmongWhatItsMeasureReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/TheRuleThatDividesAPositionIsAmongWhatItsMeasureReadTest.java
@@ -1,0 +1,108 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.partition.RuleEvidenceOrigin;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule that divided a position is among the handles that position's measure holds.
+ *
+ * <p>What a reader is sent to is asked of the measure that read the rule. A rule that composed the
+ * classes at a position is read nowhere else: it is not a question nothing answered, and it is not
+ * a rule this reading gave up on — those are the two arms a gathering written from the arrays
+ * happened to hold, and a rule that did divide the position reached neither. So the page named the
+ * class no row is in and had no handle for the rule that made that class.
+ *
+ * <p><b>The third arm is what this is about.</b> Below, the citation is asserted to reach the
+ * closure while reaching neither of the other two — so a closure that answered from those alone is
+ * red here, which is the state the defect was found in.
+ */
+class TheRuleThatDividesAPositionIsAmongWhatItsMeasureReadTest {
+
+    private static final String MODULE = "example.codes";
+
+    /**
+     * A predicate over the strings at a position, which tells a set of its values from the rest.
+     *
+     * <p>A rule with no line, so the classes it composes are sets and the reading of it is what
+     * they were composed out of. A numeric guard would draw a line instead, and the classes would
+     * be the runs of values on the order — which is a position whose measure holds no such reading
+     * at all, and would hold this rule over nothing.
+     */
+    private static final String MODEL = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (code: String) -> Answer
+            let f (code) = if String.startsWith("JP", code) then Yes else No
+            """;
+
+    @Test
+    void aRuleThatComposedThePositionsClassesIsOneThePageCanBeSentTo() {
+        PartitionEvidence measured = measured();
+
+        Set<RuleCitation> divides = new LinkedHashSet<>();
+        for (PartitionEvidence.AxisCoverage axis : measured.axes()) {
+            for (RuleEvidenceOrigin origin : axis.divides()) {
+                divides.add(origin.cited());
+            }
+        }
+        // The subject exists. Asked of a model whose positions no rule divides, everything below
+        // holds of a measure that reads no rules at all.
+        assertEquals(1, divides.size(),
+                () -> "the model under test has a rule that divided a position: " + measured.axes());
+
+        assertTrue(measured.ruleCitations().containsAll(divides),
+                () -> "the rule that composed the classes is among what this measure read: "
+                        + divides + " against " + measured.ruleCitations());
+    }
+
+    /**
+     * And it is there by being what divided the position, rather than by turning up beside it.
+     *
+     * <p>The control for the assertion above. A closure gathered from the questions nothing
+     * answered and the rules this reading gave up on would hold every other handle this measure has
+     * and not this one, and would pass the first test on a model where some rule happened to be in
+     * both.
+     */
+    @Test
+    void andReachesTheClosureThroughNothingElse() {
+        PartitionEvidence measured = measured();
+
+        Set<RuleCitation> elsewhere = new LinkedHashSet<>();
+        measured.unanswered().forEach(each -> elsewhere.addAll(each.cited()));
+        measured.notRead().forEach(each -> elsewhere.addAll(each.cited()));
+
+        for (PartitionEvidence.AxisCoverage axis : measured.axes()) {
+            for (RuleEvidenceOrigin origin : axis.divides()) {
+                assertFalse(elsewhere.contains(origin.cited()),
+                        () -> "the rule that divided `" + axis.name() + "` is read by no other"
+                                + " array of this measure: " + origin.cited() + " among "
+                                + elsewhere);
+            }
+        }
+    }
+
+    private static PartitionEvidence measured() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        PartitionEvidence f = compilation.db()
+                .ask(new Adequacy.Coverage(MODULE)).value().get("f");
+        assertNotNull(f, "the model under test compiles");
+        assertEquals(List.of("code"),
+                f.axes().stream().map(PartitionEvidence.AxisCoverage::name).toList(),
+                "the position under test was measured");
+        return f;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryRuleTheEvidenceReadHasAPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryRuleTheEvidenceReadHasAPlaceTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.conformance.RepositoryModels;
+import souther.compiler.query.Compilation;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every rule a compilation read has somewhere a report can send a reader.
+ *
+ * <p>Where a rule with no name is shown is worked out once, when the report is assembled, and a
+ * page asked for one it was not assembled with raises rather than pointing nowhere. So what the
+ * report is assembled with has to be every rule its evidence read — not the ones some list of
+ * arrays happened to hold, which is what it was, and which left the readings that compose a
+ * position's classes with no place at all.
+ *
+ * <p><b>Held over every model this repository carries.</b> The subject is the assembly and not one
+ * source: a rule reaches a page by whichever reading found it, and a population of one model is an
+ * answer about the readings that model happens to raise.
+ */
+@Tag("population")
+class EveryRuleTheEvidenceReadHasAPlaceTest {
+
+    @Test
+    void aPageIsAssembledWithEveryRuleItsMeasuresRead() {
+        int checked = 0;
+        for (Compilation compilation : RepositoryModels.all()) {
+            for (AdequacyReport.ModuleReport module : AdequacyReport.of(compilation).modules()) {
+                for (AdequacyReport.BehaviorReport behavior : module.behaviors()) {
+                    Set<RuleCitation.Written> read = written(behavior.evidence().ruleCitations());
+                    assertTrue(behavior.rulePlaces().keySet().containsAll(read),
+                            () -> "every rule `" + behavior.name() + "`'s measures read has a"
+                                    + " place: " + missing(read, behavior.rulePlaces().keySet()));
+                    checked += read.size();
+                }
+            }
+        }
+        // The models walked have rules a reader is sent to by place. Asked of a population with
+        // none, the assertion above holds of a report that is assembled with nothing.
+        assertTrue(checked > 0, "the models walked hold rules a page sends a reader to by place");
+    }
+
+    /**
+     * And the one rule in this repository that reaches a page by having divided a position is one
+     * of them.
+     *
+     * <p>The population the assertion above runs over holds exactly one such reading, so the
+     * subset it measures is satisfied by a closure that reads none of them wherever that one
+     * happens to be cited by something else. This names it.
+     */
+    @Test
+    void includingTheOneThatDividedAPosition() {
+        Set<String> found = new LinkedHashSet<>();
+        for (Compilation compilation : RepositoryModels.all()) {
+            for (AdequacyReport.ModuleReport module : AdequacyReport.of(compilation).modules()) {
+                for (AdequacyReport.BehaviorReport behavior : module.behaviors()) {
+                    if (behavior.partition() == null) {
+                        continue;
+                    }
+                    behavior.partition().axes().forEach(axis -> axis.divides().forEach(each -> {
+                        if (each.cited() instanceof RuleCitation.Written written) {
+                            found.add(module.module() + "." + behavior.name());
+                            assertTrue(behavior.rulePlaces().containsKey(written),
+                                    () -> "the rule that divided `" + axis.name() + "` of `"
+                                            + behavior.name() + "` has a place");
+                        }
+                    }));
+                }
+            }
+        }
+        assertTrue(found.contains("conformance.waitlist.seat"),
+                () -> "the models carry a behavior whose rule divided a position by telling a set"
+                        + " of its values from the rest: " + found);
+    }
+
+    private static Set<RuleCitation.Written> written(Set<RuleCitation> cited) {
+        Set<RuleCitation.Written> out = new LinkedHashSet<>();
+        for (RuleCitation each : cited) {
+            if (each instanceof RuleCitation.Written it) {
+                out.add(it);
+            }
+        }
+        return out;
+    }
+
+    private static Set<RuleCitation.Written> missing(Set<RuleCitation.Written> read,
+                                                     Set<RuleCitation.Written> shown) {
+        Set<RuleCitation.Written> out = new LinkedHashSet<>(read);
+        out.removeAll(shown);
+        return out;
+    }
+}


### PR DESCRIPTION
`AdequacyReport.rulePlaces` gathered the rules a page may send a reader to by
listing the places a rule can turn up in — the questions nothing answered, the
rules a reading gave up on, the border lines, the account's points, the
findings. A reading that composed the classes at a position turns up in none of
them, so the page named the class no row is in and had no handle for the rule
that made that class. Nothing failed: the map is only consulted where a
sentence asks, and no sentence asked.

## What changed

A value that read a rule answers for the handles it holds (`RuleCitations`),
and a whole answers by asking its parts, which is the rule `weakening` already
follows. The measure of a position answers for all three ways a rule reaches
it. A behavior's evidence answers for its parts. The report looks up places for
what comes back and lists nothing.

The protocol has no default answer, so a value that reads no rule writes the
empty one out.

## What holds it

A rule that divided a position is among what that position's measure read, and
reaches the closure through no other array of it — red on the code this
replaces. A behavior's evidence holds what its parts hold, walked over the
values a run produces rather than over the types of the fields. Every rule a
page's measures read has somewhere that page can send a reader.

The parts that hold a handle are written down, and so are the ones that hold
one no other part of the same behavior does. The account is not among the
second, and the commit says why.

## Not here

The page still says which class no row is in without saying which rule divided
it. That sentence is what the provenance is for and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)