### PR TITLE
Name a rule about a value read out of a construction where the construction was given it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -326,6 +326,12 @@ public final class UnreadComparison {
             // position, which is the same rule about a value made from one with a layer of
             // arithmetic over it.
             case ValueOrigin.Composed<K> composed -> composed.madeFrom() != null;
+            // A construction is not an operation, whatever it was given. The word this decides is
+            // about a value a closure of an operation made of what stands at a position, which is
+            // followed back by reading that operation backwards; a reader that cannot take a
+            // construction as a quantity has not got that to do. Reading what it was built with is
+            // a separate ability, and the side that has it is what a rule is filed from.
+            case ValueOrigin.Constructed<K> _ -> false;
             // Every value it could be, and not any of them. The word this picks promises the
             // position was found and only following the operation back is missing; where one arm of
             // a choice is a position's own values or a literal, that promise is false and what an

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -5,9 +5,12 @@ import souther.compiler.coverage.NormalReturn;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -92,6 +95,37 @@ public sealed interface ValueOrigin<K> {
         @Override
         public Set<K> positions() {
             return across(parts);
+        }
+    }
+
+    /**
+     * A value built where it stands, as what each of its fields was given.
+     *
+     * <p>Told apart from {@link Composed}, which is a form this walk does not take apart. What a
+     * construction builds a value out of is written where it stands, so a reader taking a field back
+     * out of one is answered with the expression that field was given — the value it hands back is
+     * the one it was handed, and not a value derived from it.
+     *
+     * <p>By the name of the field and not by where it stands among them. Which field a value was
+     * given to is what a reader taking one back out has to go on, and a construction given two
+     * positions is told apart by nothing else.
+     *
+     * @param fields what each declared field was given, in the order the construction evaluates them
+     */
+    record Constructed<K>(Map<String, ValueOrigin<K>> fields) implements ValueOrigin<K> {
+
+        public Constructed {
+            fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
+            if (fields.isEmpty()) {
+                // A construction given nothing builds a value written where it stands, and that is
+                // what such a value says of itself.
+                throw new IllegalArgumentException("a construction given nothing is a leaf");
+            }
+        }
+
+        @Override
+        public Set<K> positions() {
+            return across(fields.values());
         }
     }
 
@@ -201,7 +235,7 @@ public sealed interface ValueOrigin<K> {
     }
 
     /** The positions everything in {@code of} names, in the order they were met. */
-    private static <K> Set<K> across(List<ValueOrigin<K>> of) {
+    private static <K> Set<K> across(Collection<ValueOrigin<K>> of) {
         Set<K> out = new LinkedHashSet<>();
         for (ValueOrigin<K> each : of) {
             out.addAll(each.positions());
@@ -217,6 +251,7 @@ public sealed interface ValueOrigin<K> {
             case MadeFromAPosition<K> from -> from.at();
             case Applied<K> applied -> firstMadeFrom(applied.arguments());
             case Composed<K> composed -> firstMadeFrom(composed.parts());
+            case Constructed<K> built -> firstMadeFrom(built.fields().values());
             // Only where every value it could be came from the one position, since the value is
             // one of them and nothing here says which. What decided it is not asked: a choice made
             // on what stands at a position is not a value made from it.
@@ -239,7 +274,7 @@ public sealed interface ValueOrigin<K> {
         return agreed;
     }
 
-    private static <K> K firstMadeFrom(List<ValueOrigin<K>> of) {
+    private static <K> K firstMadeFrom(Collection<ValueOrigin<K>> of) {
         for (ValueOrigin<K> each : of) {
             K from = each.madeFrom();
             if (from != null) {
@@ -360,6 +395,29 @@ public sealed interface ValueOrigin<K> {
         }
         if (writtenOut(e)) {
             return new Written<>();
+        }
+        // What a construction was given, kept under the field it was given to. Walked by its
+        // children it would come back as a form nothing takes apart, and the provenance of a value
+        // read back out of it would be a thing this could not state — while what it was built with
+        // stands in the node.
+        if (e instanceof Core.Construct construct && !construct.values().isEmpty()) {
+            Map<String, ValueOrigin<K>> fields = new LinkedHashMap<>();
+            for (Core.FieldValue each : construct.values()) {
+                fields.put(each.field(), of(each.value(), at, reading, following));
+            }
+            return new Constructed<>(fields);
+        }
+        // A field read back out of a construction is what that field was given: the same value,
+        // named twice. So a rule about it is a rule about whatever that expression's value is made
+        // of, and the field the reader asked for is the one it is answered about — the other fields
+        // of the construction hold none of the values the rule is over.
+        if (e instanceof Core.FieldAccess access) {
+            ValueOrigin<K> target = of(access.target(), at, reading, following);
+            ValueOrigin<K> given = target instanceof Constructed<K> built
+                    ? built.fields().get(access.field()) : null;
+            // A field of anything else is the one child this node has, read once here rather than
+            // walked again below.
+            return given != null ? given : new Composed<>(List.of(target));
         }
         // What a {@code let} is made of is its body, read in the binding. The initializer is not a
         // part of the value: {@code let $x = a in 0} is zero, and reading both made a helper that

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -400,7 +400,7 @@ public sealed interface ValueOrigin<K> {
         // children it would come back as a form nothing takes apart, and the provenance of a value
         // read back out of it would be a thing this could not state — while what it was built with
         // stands in the node.
-        if (e instanceof Core.Construct construct && !construct.values().isEmpty()) {
+        if (e instanceof Core.Construct construct) {
             Map<String, ValueOrigin<K>> fields = new LinkedHashMap<>();
             for (Core.FieldValue each : construct.values()) {
                 fields.put(each.field(), of(each.value(), at, reading, following));
@@ -413,11 +413,20 @@ public sealed interface ValueOrigin<K> {
         // of the construction hold none of the values the rule is over.
         if (e instanceof Core.FieldAccess access) {
             ValueOrigin<K> target = of(access.target(), at, reading, following);
-            ValueOrigin<K> given = target instanceof Constructed<K> built
-                    ? built.fields().get(access.field()) : null;
+            if (target instanceof Constructed<K> built) {
+                ValueOrigin<K> given = built.fields().get(access.field());
+                if (given == null) {
+                    // A construction holds every declared field and a field access names a field of
+                    // the type it reads, so a field missing here is this compiler disagreeing with
+                    // itself rather than a provenance nothing can state. Said as the one it is.
+                    throw new IllegalStateException("a construction of " + built.fields().keySet()
+                            + " was read for a field it has none of: " + access.field());
+                }
+                return given;
+            }
             // A field of anything else is the one child this node has, read once here rather than
             // walked again below.
-            return given != null ? given : new Composed<>(List.of(target));
+            return new Composed<>(List.of(target));
         }
         // What a {@code let} is made of is its body, read in the binding. The initializer is not a
         // part of the value: {@code let $x = a in 0} is zero, and reading both made a helper that

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -26,6 +26,7 @@ import souther.compiler.values.Sameness;
 import souther.compiler.types.BindingId;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -438,12 +439,16 @@ public final class BehaviorSetStatements {
             // from none this can name, and a path that comes to no value came from nowhere at all.
             case ValueOrigin.Written<TermPath> _, ValueOrigin.Unnameable<TermPath> _,
                  ValueOrigin.NoValue<TermPath> _ -> Set.of();
+            // A constructed value was made out of everything the construction was given, each of
+            // them. A field taken back out of one is that field's own value and reaches here as
+            // whatever it was given, so this arm answers about the construction itself.
+            case ValueOrigin.Constructed<TermPath> it -> across(it.fields().values());
             case ValueOrigin.Composed<TermPath> _ -> Set.of();
         };
     }
 
     /** The positions everything in {@code of} came from, in the order they were met. */
-    private static Set<TermPath> across(List<ValueOrigin<TermPath>> of) {
+    private static Set<TermPath> across(Collection<ValueOrigin<TermPath>> of) {
         Set<TermPath> out = new LinkedHashSet<>();
         for (ValueOrigin<TermPath> each : of) {
             out.addAll(positionsItCameFrom(each));

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -143,6 +143,62 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                     then Yes else No
             """;
 
+    private static final String READ_OUT_OF_A_CONSTRUCTION = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Code = String
+
+            behavior f : (a: String, b: String) -> Answer
+                constructs Code
+            let f (a, b) = {
+                let code = Code(a)
+                if String.startsWith("JP", String.append(code.value, b)) then Yes else No
+            }
+            """;
+
+    private static final String A_CONSTRUCTION_AND_NOTHING_ELSE = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Code = String
+
+            behavior f : (a: String, b: String) -> Answer
+                constructs Code
+            let f (a, b) = {
+                let code = Code(a)
+                if String.startsWith("JP", code.value) then Yes else No
+            }
+            """;
+
+    private static final String ONE_FIELD_OF_TWO = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Pair = { left: String, right: String }
+
+            behavior f : (a: String, b: String) -> Answer
+                constructs Pair
+            let f (a, b) = {
+                let pair = Pair { left = a, right = b }
+                if String.startsWith("JP", pair.left) then Yes else No
+            }
+            """;
+
+    private static final String A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Code = String
+
+            behavior f : (a: String, b: String) -> Answer
+                constructs Code
+            let f (a, b) = {
+                let code = Code(String.uppercase(a))
+                if String.startsWith("JP", String.append(code.value, b)) then Yes else No
+            }
+            """;
+
     private static final String AN_ELEMENT_IT_CAME_FROM = """
             module example.codes
 
@@ -287,6 +343,66 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     }
 
     /**
+     * And a value read back out of a construction is named where the construction was given it.
+     *
+     * <p>What the construction was handed is the value the field comes back as, so the rule is about
+     * the strings standing at {@code a} as much as about the ones at {@code b}. Read as a form
+     * nothing takes apart, the construction answered for neither and the rule was named at {@code b}
+     * alone — which tells an author the model states nothing at the position the value came from.
+     */
+    @Test
+    void aValueReadOutOfAConstructionIsNamedWhereTheConstructionWasGivenIt() {
+        assertEquals(List.of("a", "b"), derived(measured(READ_OUT_OF_A_CONSTRUCTION)),
+                () -> "said where the construction was given each string: "
+                        + measured(READ_OUT_OF_A_CONSTRUCTION).notRead());
+    }
+
+    /**
+     * And a rule about nothing but the constructed value is named there too.
+     *
+     * <p>The one the construction answers for alone. Nothing else in the body reaches a position, so
+     * a reading that cannot say where a constructed value came from places the rule nowhere at all —
+     * the answer a body with no rule in it gives.
+     */
+    @Test
+    void aRuleAboutNothingButAConstructedValueIsNamedThere() {
+        assertEquals(List.of("a"), derived(measured(A_CONSTRUCTION_AND_NOTHING_ELSE)),
+                () -> "said where the construction was given it: "
+                        + measured(A_CONSTRUCTION_AND_NOTHING_ELSE).notRead());
+    }
+
+    /**
+     * And at the field the reader asked for, and not at the others the construction was given.
+     *
+     * <p>What tells the two readings apart. A construction read for everything it was given names
+     * every position a field of it came from, whichever field was taken back out — and the rule here
+     * is about the strings at {@code left} and holds none of the ones at {@code right}. A single
+     * field cannot tell the two apart, since every field of such a construction is the one asked
+     * for.
+     */
+    @Test
+    void oneFieldOfAConstructionIsNamedWithoutTheOthers() {
+        assertEquals(List.of("a"), derived(measured(ONE_FIELD_OF_TWO)),
+                () -> "b was given to the field the rule does not read: "
+                        + measured(ONE_FIELD_OF_TWO).notRead());
+    }
+
+    /**
+     * And a field given what an operation made is named where that operation's arguments stand.
+     *
+     * <p>The field comes back as what it was given, whatever that is. So a construction is not a
+     * step that turns what is under it into a position: what was handed in was made from {@code a}
+     * by an operation, and that is what the rule is about.
+     */
+    @Test
+    void aFieldGivenWhatAnOperationMadeIsNamedWhereItsArgumentsStand() {
+        assertEquals(List.of("a", "b"),
+                derived(measured(A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE)),
+                () -> "said at what the operation was applied to: "
+                        + measured(A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE).notRead());
+    }
+
+    /**
      * And a value handed out by an operation is named at the position it was taken from.
      *
      * <p>Beside the three above and reached the other way: nothing was applied to what the rule is
@@ -311,7 +427,9 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     @Test
     void everyOneOfThemNamesTheRuleAsAQuestionStandingThere() {
         for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM,
-                A_VALUE_CHOSEN_BETWEEN, A_VALUE_CHOSEN_BY_A_MATCH)) {
+                A_VALUE_CHOSEN_BETWEEN, A_VALUE_CHOSEN_BY_A_MATCH, READ_OUT_OF_A_CONSTRUCTION,
+                A_CONSTRUCTION_AND_NOTHING_ELSE, ONE_FIELD_OF_TWO,
+                A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE)) {
             PartitionEvidence measured = measured(model);
             assertTrue(measured.notRead().stream()
                             .filter(each -> each.reason()
@@ -343,6 +461,29 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
 
         assertNotNull(Sites.placeOf(compilation.db(), cited.getFirst()),
                 "where the rule the report names is written");
+    }
+
+    /**
+     * A predicate read over a field of a construction is not yet measured at the position the
+     * construction was given it.
+     *
+     * <p>The known boundary and not a rule about what a model deserves. What a construction was
+     * given is the value a field of it comes back as, so the strings at the position are the ones
+     * the rule is about — and a number read the same way out of the same construction is one a line
+     * does fall on. Which positions a predicate's subject resolves to is asked of the reading
+     * instead, and that reading does not see through a construction; it is a defect of its own and
+     * is filed apart from the naming this class is about.
+     *
+     * <p>The first test to fail on the day it does see through, and the answer then is a line at
+     * the position rather than a rule named as a question standing there.
+     */
+    @Test
+    void aPredicateOverAProjectedConstructionIsNotYetMeasuredAtItsSourcePosition() {
+        for (String model : List.of(READ_OUT_OF_A_CONSTRUCTION, A_CONSTRUCTION_AND_NOTHING_ELSE,
+                ONE_FIELD_OF_TWO)) {
+            assertEquals(List.of(), measured(model).axes().stream()
+                    .map(PartitionEvidence.AxisCoverage::path).toList());
+        }
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -8,6 +8,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.query.Sites;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -199,6 +200,19 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
             }
             """;
 
+    private static final String TWO_CONSTRUCTIONS_COMPARED = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Pair = { left: String, right: String }
+
+            behavior f : (a: String, b: String) -> Answer
+                constructs Pair
+            let f (a, b) =
+                if Pair { left = a, right = b } == Pair { left = "x", right = "y" }
+                    then Yes else No
+            """;
+
     private static final String AN_ELEMENT_IT_CAME_FROM = """
             module example.codes
 
@@ -221,6 +235,33 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
                 .ask(new Adequacy.Coverage(MODULE)).value().get("f");
         assertNotNull(f, "the model under test compiles");
         return f;
+    }
+
+    /**
+     * Every position this model's report names its rule at, whichever way it names it.
+     *
+     * <p>Read off whether an entry names a rule at all and off the axes a rule drew, and never off
+     * the word an entry came with. Where an author is owed a sentence is one question and which
+     * sentence they are given is another: a test selecting by the word states as its contract
+     * whatever this compiler calls the finding today, so the day the word moves the claim about
+     * where the rule is named moves with it and neither claim is being checked any more.
+     *
+     * <p>A line the rule drew names the position as much as a question standing there does. Which
+     * of the two a model gets is asked once, of the one test whose subject that is.
+     */
+    private static List<String> named(PartitionEvidence measured) {
+        List<String> out = new ArrayList<>();
+        for (PartitionEvidence.NotRead each : measured.notRead()) {
+            if (!each.cited().isEmpty() && !out.contains(each.at())) {
+                out.add(each.at());
+            }
+        }
+        for (PartitionEvidence.AxisCoverage each : measured.axes()) {
+            if (!out.contains(each.path())) {
+                out.add(each.path());
+            }
+        }
+        return out;
     }
 
     /** Where a rule that came to nothing was said, once per position. */
@@ -349,10 +390,13 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      * the strings standing at {@code a} as much as about the ones at {@code b}. Read as a form
      * nothing takes apart, the construction answered for neither and the rule was named at {@code b}
      * alone — which tells an author the model states nothing at the position the value came from.
+     *
+     * <p>Where and not in which words: what these four ask is the sentence an author is owed, and
+     * the word it is given in is one test's subject and not theirs.
      */
     @Test
     void aValueReadOutOfAConstructionIsNamedWhereTheConstructionWasGivenIt() {
-        assertEquals(List.of("a", "b"), derived(measured(READ_OUT_OF_A_CONSTRUCTION)),
+        assertEquals(List.of("a", "b"), named(measured(READ_OUT_OF_A_CONSTRUCTION)),
                 () -> "said where the construction was given each string: "
                         + measured(READ_OUT_OF_A_CONSTRUCTION).notRead());
     }
@@ -366,7 +410,7 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      */
     @Test
     void aRuleAboutNothingButAConstructedValueIsNamedThere() {
-        assertEquals(List.of("a"), derived(measured(A_CONSTRUCTION_AND_NOTHING_ELSE)),
+        assertEquals(List.of("a"), named(measured(A_CONSTRUCTION_AND_NOTHING_ELSE)),
                 () -> "said where the construction was given it: "
                         + measured(A_CONSTRUCTION_AND_NOTHING_ELSE).notRead());
     }
@@ -382,7 +426,7 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      */
     @Test
     void oneFieldOfAConstructionIsNamedWithoutTheOthers() {
-        assertEquals(List.of("a"), derived(measured(ONE_FIELD_OF_TWO)),
+        assertEquals(List.of("a"), named(measured(ONE_FIELD_OF_TWO)),
                 () -> "b was given to the field the rule does not read: "
                         + measured(ONE_FIELD_OF_TWO).notRead());
     }
@@ -397,9 +441,33 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     @Test
     void aFieldGivenWhatAnOperationMadeIsNamedWhereItsArgumentsStand() {
         assertEquals(List.of("a", "b"),
-                derived(measured(A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE)),
+                named(measured(A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE)),
                 () -> "said at what the operation was applied to: "
                         + measured(A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE).notRead());
+    }
+
+    /**
+     * And a construction standing as a side of a comparison is a form nothing read, not a value an
+     * operation made.
+     *
+     * <p>The other question about the same arm. Where the value came from is answered for a
+     * construction — both positions are named — and what an author is told is still not the word that
+     * promises an operation to be followed back: there is none, and a reader sent looking for one is
+     * sent after something nobody wrote. Two data compare by their fields, which is what puts a
+     * construction here; an invariant's clause cannot, since a clause observes and does not build.
+     */
+    @Test
+    void aConstructionComparedIsAFormNothingReadRatherThanAValueAnOperationMade() {
+        PartitionEvidence measured = measured(TWO_CONSTRUCTIONS_COMPARED);
+
+        assertEquals(List.of("a", "b"), named(measured),
+                () -> "the constructions were given what stands at each: " + measured.notRead());
+        assertEquals(List.of(), derived(measured),
+                () -> "and no operation made either of them: " + measured.notRead());
+        assertEquals(List.of(UndividedPosition.Reason.UNSUPPORTED_SYNTAX,
+                        UndividedPosition.Reason.UNSUPPORTED_SYNTAX),
+                measured.notRead().stream().map(PartitionEvidence.NotRead::reason).toList(),
+                () -> "what stopped the reading is the form: " + measured.notRead());
     }
 
     /**
@@ -427,9 +495,7 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     @Test
     void everyOneOfThemNamesTheRuleAsAQuestionStandingThere() {
         for (String model : List.of(ONE_POSITION, TWO_POSITIONS, AN_ELEMENT_IT_CAME_FROM,
-                A_VALUE_CHOSEN_BETWEEN, A_VALUE_CHOSEN_BY_A_MATCH, READ_OUT_OF_A_CONSTRUCTION,
-                A_CONSTRUCTION_AND_NOTHING_ELSE, ONE_FIELD_OF_TWO,
-                A_CONSTRUCTION_GIVEN_WHAT_AN_OPERATION_MADE)) {
+                A_VALUE_CHOSEN_BETWEEN, A_VALUE_CHOSEN_BY_A_MATCH)) {
             PartitionEvidence measured = measured(model);
             assertTrue(measured.notRead().stream()
                             .filter(each -> each.reason()
@@ -474,15 +540,21 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      * instead, and that reading does not see through a construction; it is a defect of its own and
      * is filed apart from the naming this class is about.
      *
-     * <p>The first test to fail on the day it does see through, and the answer then is a line at
-     * the position rather than a rule named as a question standing there.
+     * <p><b>The one place the boundary is written down.</b> The tests above ask where the rule is
+     * named and hold whichever way it is named there, so this is what fails on the day the reading
+     * sees through a construction — in both halves at once, the word going and the line arriving.
+     * The answer then is a line at the position, and the tests above go on saying the same thing.
      */
     @Test
     void aPredicateOverAProjectedConstructionIsNotYetMeasuredAtItsSourcePosition() {
         for (String model : List.of(READ_OUT_OF_A_CONSTRUCTION, A_CONSTRUCTION_AND_NOTHING_ELSE,
                 ONE_FIELD_OF_TWO)) {
+            assertEquals(named(measured(model)), derived(measured(model)),
+                    () -> "every position the rule is named at is a question about a derived value: "
+                            + measured(model).notRead());
             assertEquals(List.of(), measured(model).axes().stream()
-                    .map(PartitionEvidence.AxisCoverage::path).toList());
+                    .map(PartitionEvidence.AxisCoverage::path).toList(),
+                    "and no line falls at any of them");
         }
     }
 


### PR DESCRIPTION
A value read back out of a construction was named nowhere the construction was
given a value from. `ValueOrigin.of` walked a construction by its children, so it
came back as the arm for the arithmetic nothing takes apart — and the reading a
rule is filed from leaves that arm unread, since a form this compiler could not
read is one whose provenance it cannot state. A construction is not such a form:
what it was given is written where it stands.

A construction is now what each of its fields was given, kept under the field's
own name, and a field read back out of one is the value that field was given. So
a rule about the joined string of `Code(a).value` and `b` is named at both, and a
rule about `pair.left` is named where `left` was given its value and not where
`right` was — the field a reader asked for is the one it is answered about.

Whether a comparison's reading stopped at a value an operation made is answered
`false` for a construction. A construction is not an operation, and reading what
it was given is a separate ability from taking one as a quantity. Two data
compared by their fields reach that arm, and the word they leave is the form; a
clause cannot reach it, an invariant observing and not building.

A construction read for a field it was not given says so where it is found, that
being this compiler disagreeing with itself rather than a provenance nothing can
state.

`Composed` stays unread. What it means is a form this walk does not take apart,
and every position under such a form is one a rule may say nothing about.

Two neighbouring defects this leaves alone, each a boundary of its own:

- A predicate read over a field of a construction is named at the position but no
  line falls there, while a number read the same way out of the same construction
  is measured at it. Which positions a predicate's subject resolves to is asked of
  the reading rather than of what the value is made of, and that reading does not
  see through a construction. Filed as #1637, and pinned here as the known
  boundary by the test that fails first on the day it is closed.

  The tests about where a rule is named read that off whether an entry names a
  rule and off the axes a rule drew, never off the word an entry came with — so
  the word and the missing line are written down in one place, and closing #1637
  moves that one test rather than four.
- A tuple is a product read by an index the same way, and a projection of one
  keeps none of what it selected. Whether the two products share one grammar or
  stand as two is a design question, and answering it needs the second example
  rather than this one.

Issue: #1633 — closed by hand, a merge into `develop` not closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

