### PR TITLE
Say which rule divided a position, where the page names its classes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -35,6 +35,7 @@ import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.ReachabilityGap;
 import souther.compiler.partition.ReportedReason;
 import souther.compiler.partition.RoleAnswer;
+import souther.compiler.partition.RuleEvidenceOrigin;
 import souther.compiler.partition.UndividedPosition;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
@@ -1129,6 +1130,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
         return places;
     }
 
+    /**
+     * The handles each rule that composed a position's classes offers, one entry per rule.
+     *
+     * <p>Grouped by the rule and not by the reading. What tells two readings apart is which of them
+     * divided what, and that is a fact about the readings; what a reader is sent to is the rule the
+     * author wrote, and a sentence per reading of it is the same rule said as many times as this
+     * compiler happened to meet it.
+     *
+     * <p>In the order the rules were read, which is the order the axis holds them in. An order of
+     * this method's own would be a second answer to a question the reading already settled.
+     */
+    private static List<Set<RuleCitation>> dividedBy(PartitionEvidence.AxisCoverage axis) {
+        Map<RuleRef, Set<RuleCitation>> byRule = new LinkedHashMap<>();
+        for (RuleEvidenceOrigin origin : axis.divides()) {
+            byRule.computeIfAbsent(origin.rule(), _ -> new LinkedHashSet<>()).add(origin.cited());
+        }
+        return List.copyOf(byRule.values());
+    }
+
     /** The lines one behavior met, or none where the measure could not be made. */
     private static List<BorderAssessment> linesOf(Measure<List<BorderAssessment>> read) {
         return read == null ? List.of() : read.made().orElse(List.of());
@@ -2043,6 +2063,18 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
                     out.append(String.format("      · %s holds %d classes and this behavior's rules"
                                     + " compose %d of them%n",
                             axis.name(), axis.classes().size(), axis.divides().size()));
+                }
+                // Which rule composed the classes, for a reader told that no row is in one of them.
+                // The lines above name the class; this names what made it, so that a reader sent
+                // after a row has somewhere to open rather than a name of the model's.
+                //
+                // One line per rule and not per reading. A helper is expanded at each call, so one
+                // rule the author wrote is read at several places; what those offer is several
+                // handles onto one rule, and which of them a document writes is settled where that
+                // choice is made.
+                for (Set<RuleCitation> rule : dividedBy(axis)) {
+                    out.append(String.format("      · %s is divided by %s%n",
+                            axis.name(), cited(rule, rendering, declaredIn, places)));
                 }
                 for (ClaimAnnotations.Said said : behavior.claimed().at(axis.path())) {
                     // A case out of the denominator says what the author wrote about it; one still

--- a/souther-compiler/src/test/java/souther/compiler/report/ARuleThatDividedAPositionIsShownWithAPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/ARuleThatDividedAPositionIsShownWithAPlaceTest.java
@@ -1,0 +1,103 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.SourceRendering;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A page that names a position a rule divided says which rule, and where it is.
+ *
+ * <p>The classes of such a position are made by the rules that compose them, and a reader told that
+ * no row is in one of them is being sent to write it. What they have to read first is the rule that
+ * made the class — it says which values the class holds — and a page naming the class alone leaves
+ * them a name of the model's with nowhere to look it up.
+ *
+ * <p><b>Which rule, and not which reading.</b> A helper is expanded at each call, so one rule the
+ * author wrote is read at several places and each reading divides the position it names. What a
+ * reader is sent to is the rule, so the page writes one sentence for it however many readings of it
+ * this compiler met.
+ */
+class ARuleThatDividedAPositionIsShownWithAPlaceTest {
+
+    /**
+     * A predicate over the strings at a position, which tells a set of its values from the rest.
+     *
+     * <p>The rule is on the sixth line and its call begins at the nineteenth column, counted from
+     * one: {@code let f (code) = if } is eighteen characters.
+     */
+    private static final String A_PREDICATE = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (code: String) -> Answer
+            let f (code) = if String.startsWith("JP", code) then Yes else No
+            """;
+
+    /** Two rules over the strings at one position, which compose its classes together. */
+    private static final String TWO_PREDICATES = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            behavior f : (code: String) -> Answer
+            let f (code) =
+                if String.startsWith("JP", code) then Yes
+                else if String.endsWith("X", code) then Yes
+                else No
+            """;
+
+    /** A comparison, which puts a line on the order the values are counted on rather than telling
+     *  a set of them from the rest. */
+    private static final String A_LINE = """
+            module example.codes
+
+            data Low
+            data High
+
+            behavior f : (n: Int) -> Low | High
+            let f (n) = if n > 10 then High else Low
+            """;
+
+    /** The rule is named where the classes it composed are, and by a place a reader can open. */
+    @Test
+    void theRuleThatComposedThePositionsClassesIsNamedWithItsPlace() {
+        assertTrue(page(A_PREDICATE).contains("· code is divided by predicate@6:19"),
+                () -> "the page says which rule divided `code`:\n" + page(A_PREDICATE));
+    }
+
+    /** One sentence per rule, so a position two of them compose is a reader's two rules to read. */
+    @Test
+    void aPositionTwoRulesComposeNamesBoth() {
+        assertEquals(2, page(TWO_PREDICATES).lines()
+                        .filter(each -> each.contains("is divided by")).count(),
+                () -> "one sentence per rule that composed the classes:\n"
+                        + page(TWO_PREDICATES));
+    }
+
+    /**
+     * And a position whose rules draw a line says nothing here.
+     *
+     * <p>The control. A line is not what composed the classes — the classes on an order are the
+     * runs of values between the cuts — and a page that wrote this sentence for every position with
+     * a rule about it would be saying the same thing of two different answers.
+     */
+    @Test
+    void aPositionARuleDrewALineOnIsNotSaidToBeDividedByIt() {
+        assertFalse(page(A_LINE).contains("is divided by"),
+                () -> "a line is not what composes a position's classes:\n" + page(A_LINE));
+    }
+
+    private static String page(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation)
+                .human(SourceRendering.namedByIdentity(compilation.texts()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/ARuleThatDividedAPositionIsShownWithAPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/ARuleThatDividedAPositionIsShownWithAPlaceTest.java
@@ -2,8 +2,13 @@ package souther.compiler.report;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.SourceRendering;
+import souther.compiler.partition.RuleEvidenceOrigin;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,6 +57,28 @@ class ARuleThatDividedAPositionIsShownWithAPlaceTest {
                 else No
             """;
 
+    /**
+     * One rule read at two places of one position.
+     *
+     * <p>A helper is not a rule of its own: it is expanded at each call, so the predicate written
+     * once inside it is read wherever the behavior calls it, and each reading divides the position
+     * the call names. The rule the author wrote is on the fifth line and its call begins at the
+     * thirty-fourth column, counted from one.
+     */
+    private static final String ONE_RULE_READ_TWICE = """
+            module example.codes
+
+            data Answer = Yes | No
+
+            let japanese (s: String): Bool = String.startsWith("JP", s)
+
+            behavior f : (code: String) -> Answer
+            let f (code) =
+                if japanese(code) then
+                    (if japanese(code) then Yes else No)
+                else No
+            """;
+
     /** A comparison, which puts a line on the order the values are counted on rather than telling
      *  a set of them from the rest. */
     private static final String A_LINE = """
@@ -71,13 +98,43 @@ class ARuleThatDividedAPositionIsShownWithAPlaceTest {
                 () -> "the page says which rule divided `code`:\n" + page(A_PREDICATE));
     }
 
-    /** One sentence per rule, so a position two of them compose is a reader's two rules to read. */
+    /** One sentence per rule, so a position two of them compose is a reader's two rules to read —
+     *  and the two sentences send them to two places, since they are two rules. */
     @Test
     void aPositionTwoRulesComposeNamesBoth() {
-        assertEquals(2, page(TWO_PREDICATES).lines()
-                        .filter(each -> each.contains("is divided by")).count(),
+        assertEquals(2, dividedBy(page(TWO_PREDICATES)).size(),
                 () -> "one sentence per rule that composed the classes:\n"
                         + page(TWO_PREDICATES));
+        assertEquals(2, Set.copyOf(dividedBy(page(TWO_PREDICATES))).size(),
+                () -> "and the two rules are two places a reader can open:\n"
+                        + page(TWO_PREDICATES));
+    }
+
+    /**
+     * A rule read at several places of one position is one sentence, naming the rule.
+     *
+     * <p>What the page sends a reader to is the rule the author wrote. A helper expanded at each
+     * call is read as many times as it is called, and a sentence per reading would be the same rule
+     * said twice with nothing to tell the two apart — the second is not another thing to go and
+     * read.
+     *
+     * <p>The subject is asserted before the sentence, because a model whose rules are read once
+     * each satisfies the count below whatever the page does with the readings.
+     */
+    @Test
+    void oneRuleReadAtSeveralPlacesIsOneSentence() {
+        PartitionEvidence measured = measured(ONE_RULE_READ_TWICE);
+        PartitionEvidence.AxisCoverage code = measured.axes().stream()
+                .filter(each -> each.name().equals("code")).findFirst().orElseThrow();
+        assertEquals(2, code.divides().size(),
+                () -> "the position under test was divided by two readings: " + code.divides());
+        assertEquals(1, code.divides().stream().map(RuleEvidenceOrigin::rule).distinct().count(),
+                () -> "and both of them are readings of one rule: " + code.divides());
+
+        assertEquals(List.of("· code is divided by predicate@5:34"),
+                dividedBy(page(ONE_RULE_READ_TWICE)),
+                () -> "one sentence, naming the rule the author wrote:\n"
+                        + page(ONE_RULE_READ_TWICE));
     }
 
     /**
@@ -93,11 +150,28 @@ class ARuleThatDividedAPositionIsShownWithAPlaceTest {
                 () -> "a line is not what composes a position's classes:\n" + page(A_LINE));
     }
 
+    /** The sentences a page writes about what divided a position, in the order it writes them. */
+    private static List<String> dividedBy(String page) {
+        return page.lines().map(String::strip)
+                .filter(each -> each.contains("is divided by")).toList();
+    }
+
     private static String page(String model) {
+        Compilation compilation = compiled(model);
+        return AdequacyReport.of(compilation)
+                .human(SourceRendering.namedByIdentity(compilation.texts()));
+    }
+
+    /** What the model's positions came to, for an assertion about the readings themselves. */
+    private static PartitionEvidence measured(String model) {
+        return compiled(model).db()
+                .ask(new Adequacy.Coverage("example.codes")).value().get("f");
+    }
+
+    private static Compilation compiled(String model) {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        return AdequacyReport.of(compilation)
-                .human(SourceRendering.namedByIdentity(compilation.texts()));
+        return compilation;
     }
 }


### PR DESCRIPTION
The second half of #1571. The first PR carried the handles to where the page
could ask for one; this writes the sentence that asks.

## What the page says now

A position whose classes were composed out of rules gets one line per rule,
beside the lines that name its classes:

      · ticket is divided by predicate@23:11

Which is the rule an author is sent to when they are told no row is in one of
that position's classes. The class says which values it holds by what the rule
said, so a reader given the class alone has a name of the model's with nowhere
to look it up.

## What it is not

One sentence per rule, not per reading. A helper is expanded at each call, so
one rule the author wrote is read at several places; those offer several
handles onto one rule, and which of them a document writes is settled where
that choice already is.

Only where the classes were composed out of rules. A comparison puts a line on
the order the values are counted on, and the classes there are the runs of
values between the cuts — so a position whose rules draw a line says nothing
here, which is the control the checks hold.

## Not here

The published document has no field for this, and giving it one is a schema
version rather than a sentence. The gap is the same one the document has had;
nothing in this change widens it.

#1571 is closed by hand once this is on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)