### PR TITLE
Reduce a projection of a construction before asking which position it names

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.types.BinOp;
+import souther.compiler.core.ConstructionProjection;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.LinearForm;
@@ -513,19 +514,13 @@ public final class AffineForms {
                     if (!(target.value() instanceof Core.Construct nd)) {
                         yield null;
                     }
-                    Standing<A, E> given = null;
-                    for (Core.FieldValue each : nd.values()) {
-                        if (each.field().equals(fa.field())) {
-                            // What a member gives a field is read with what the member is read
-                            // with, which is how one plurality stays one over the parts of it.
-                            given = new Standing<>(each.value(), target.at(), target.reading());
-                            break;
-                        }
-                    }
-                    if (given == null) {
+                    Core written = ConstructionProjection.given(nd, fa.field());
+                    if (written == null) {
                         yield null;
                     }
-                    out.add(given);
+                    // What a member gives a field is read with what the member is read with, which
+                    // is how one plurality stays one over the parts of it.
+                    out.add(new Standing<>(written, target.at(), target.reading()));
                 }
                 yield out;
             }

--- a/souther-compiler/src/main/java/souther/compiler/core/ConstructionProjection.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/ConstructionProjection.java
@@ -1,0 +1,39 @@
+package souther.compiler.core;
+
+/**
+ * What a projection out of a construction reads: the value that field was given.
+ *
+ * <p>The language's elimination of the construction beside it, written once. A construction writes
+ * what it builds a value out of where it stands, so a field taken back out of one is the expression
+ * that field was handed — and every reader that has resolved a projection's target to a construction
+ * has the same successor to go on with.
+ *
+ * <p><b>The pair and nothing around it.</b> Which value a name holds, and whether a reader may follow
+ * it there, is a question about that reader's environment and each of them answers it in its own
+ * vocabulary — a reading of occurrences, a reading of what a binding is of the input. What a
+ * construction gave a field is a fact about the node, and no environment changes it. Written out at
+ * each reader instead, a shape one of them reduced would be one the others did not, and which
+ * projections a rule covers would depend on which reader met it.
+ */
+public final class ConstructionProjection {
+
+    private ConstructionProjection() {
+    }
+
+    /**
+     * The expression {@code construct} was given for {@code field}, or null where it was given none.
+     *
+     * <p>Null is this rule not applying, and never a value standing in for the one that is missing.
+     * What a caller does about it is the caller's: a reading with a second proof to try has one, and
+     * a reader that has already settled that the field is one of the construction's is looking at
+     * this compiler disagreeing with itself.
+     */
+    public static Core given(Core.Construct construct, String field) {
+        for (Core.FieldValue each : construct.values()) {
+            if (each.field().equals(field)) {
+                return each.value();
+            }
+        }
+        return null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -155,8 +155,9 @@ final class InputPath {
             // is the same value under another name. Asked as a path of the construction instead, the
             // answer is that a value built here is at no position — which is true of the
             // construction and is not what the projection above it reads.
-            case Core.FieldAccess fa when projected(fa, names) instanceof Given given ->
-                    named(given.value(), given.names());
+            case Core.FieldAccess fa when introducing(fa.target(), names,
+                    (construct, at) -> named(given(construct, fa), at))
+                    instanceof PathResolution reduced -> reduced;
             // A field of what the target stands at, at every place the target stands. Where the
             // field is not a step of a path — a newtype's own value is the value under it — the
             // place is the target's, which is the step this takes there.
@@ -210,67 +211,70 @@ final class InputPath {
     }
 
     /**
-     * A construction an expression stands for, and the names it stands under.
+     * What a reader makes of a construction and the names it stands under.
      *
      * <p>Two values because a construction reached through a {@code let} is written under bindings
      * the expression above it is not: the value a field of it was given is read where the
      * construction is, and read where the projection stands, a name the {@code let} opened would
      * stand for nothing.
+     *
+     * @param <T> what that reader answers
      */
-    private record Introduced(Core.Construct construct, BindingEnvironment names) {}
-
-    /** A value a projection read out of a construction, and the names it stands under. */
-    private record Given(Core value, BindingEnvironment names) {}
+    private interface OfAConstruction<T> {
+        T of(Core.Construct construct, BindingEnvironment names);
+    }
 
     /**
-     * The construction {@code e} stands for, or null where it stands for none this walk reaches.
+     * What {@code found} makes of the construction {@code e} stands for, or null where {@code e}
+     * stands for none this walk reaches.
      *
-     * <p>Which value a name holds is asked of the environment the same way the answer about a
-     * position is, and by the same steps: a name that was given a value, a {@code let}'s body, and a
-     * projection already reduced. What is not asked is where the construction stands — that question
-     * is the one whose answer this exists to get right, and asked here it would be answered for the
-     * construction rather than for the field read out of it.
+     * <p>Which value a name holds is asked of the environment the same way the answer about a position
+     * is, and by the same steps: a name that was given a value, a {@code let}'s body, and a projection
+     * already reduced. What is not asked is where the construction stands — that question is the one
+     * whose answer this exists to get right, and asked here it would be answered for the construction
+     * rather than for the field read out of it.
      *
-     * <p>Crossing to what a name holds is a step over the binding graph and is kept acyclic the way
-     * every other such step is ({@link BindingTrail}). Descending from a construction to the value it
-     * gave a field is not: that stays inside one expression, which is the kind of step nothing has to
-     * bound.
+     * <p><b>The reader runs inside the walk and not after it.</b> Crossing to what a name holds is a
+     * step over the binding graph, and what keeps such a walk acyclic holds a binding only while the
+     * walk that crossed it is going on ({@link BindingTrail}). Reading the value a field was given is
+     * part of that walk: it is where the way back to the binding runs, since what the field was given
+     * may read the name again. Handed back as a value and read after the crossing, the binding is off
+     * the way while its own value is being followed, and a construction holding a read of the name it
+     * is bound to runs until the stack is gone rather than being raised as the graph this compiler
+     * does not build. So the answer is taken here, under every binding on the way to it.
+     *
+     * <p>Descending from a construction to the value it gave a field needs nothing of its own: that
+     * stays inside one expression, which is the kind of step nothing has to bound.
      */
-    private Introduced introducing(Core e, BindingEnvironment names) {
+    private <T> T introducing(Core e, BindingEnvironment names, OfAConstruction<T> found) {
         return switch (e) {
-            case Core.Construct construct -> new Introduced(construct, names);
+            case Core.Construct construct -> found.of(construct, names);
             case Core.Read r when names.roleOf(r.binding()) instanceof BindingRole.Alias(var held) ->
-                    trail.through(r.binding(), () -> introducing(held, names));
+                    trail.through(r.binding(), () -> introducing(held, names, found));
             case Core.LetIn let ->
-                    introducing(let.body(), names.inside(let.binder(), let.value()));
+                    introducing(let.body(), names.inside(let.binder(), let.value()), found);
             // A projection of a construction whose field was given another construction, which is
             // what a value built out of values written where they stand looks like.
-            case Core.FieldAccess fa -> projected(fa, names) instanceof Given given
-                    ? introducing(given.value(), given.names()) : null;
+            case Core.FieldAccess fa -> introducing(fa.target(), names,
+                    (construct, at) -> introducing(given(construct, fa), at, found));
             case null, default -> null;
         };
     }
 
     /**
-     * What {@code fa} reads out of the construction its target stands for, or null where the target
-     * stands for no construction.
+     * What {@code fa} reads out of {@code construct}.
      *
-     * <p>Null for a target that is no construction, and never for a construction that was not given
-     * the field: a construction holds every declared field and a projection names a field of the type
-     * it reads, so the second is this compiler disagreeing with itself and is said where it is found.
+     * <p>Never nothing: a construction holds every declared field and a projection names a field of
+     * the type it reads, so a construction without the field asked for is this compiler disagreeing
+     * with itself and is said where it is found.
      */
-    private Given projected(Core.FieldAccess fa, BindingEnvironment names) {
-        Introduced target = introducing(fa.target(), names);
-        if (target == null) {
-            return null;
+    private static Core given(Core.Construct construct, Core.FieldAccess fa) {
+        Core written = ConstructionProjection.given(construct, fa.field());
+        if (written == null) {
+            throw new IllegalStateException("a construction of " + construct.typeName()
+                    + " was read for a field it has none of: " + fa.field());
         }
-        Core given = ConstructionProjection.given(target.construct(), fa.field());
-        if (given == null) {
-            throw new IllegalStateException("a construction of "
-                    + target.construct().typeName() + " was read for a field it has none of: "
-                    + fa.field());
-        }
-        return new Given(given, target.names());
+        return written;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -5,6 +5,7 @@ import souther.compiler.check.DeclaredArgument;
 import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
+import souther.compiler.core.ConstructionProjection;
 import souther.compiler.core.Core;
 import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.types.BindingId;
@@ -148,6 +149,14 @@ final class InputPath {
                         trail.through(r.binding(), () -> named(held, names));
                 case BindingRole.Unknown _ -> new PathResolution.NotAPosition();
             };
+            // A projection out of a construction is the value that field was given, and it is that
+            // value's position that is asked for. The construction and the projection cancel: what
+            // the input holds at the position is what was handed in, and a field of it read back out
+            // is the same value under another name. Asked as a path of the construction instead, the
+            // answer is that a value built here is at no position — which is true of the
+            // construction and is not what the projection above it reads.
+            case Core.FieldAccess fa when projected(fa, names) instanceof Given given ->
+                    named(given.value(), given.names());
             // A field of what the target stands at, at every place the target stands. Where the
             // field is not a step of a path — a newtype's own value is the value under it — the
             // place is the target's, which is the step this takes there.
@@ -198,6 +207,70 @@ final class InputPath {
             // Nothing at all, which a caller may hand over where a body has no expression there.
             case null -> new PathResolution.NotAPosition();
         };
+    }
+
+    /**
+     * A construction an expression stands for, and the names it stands under.
+     *
+     * <p>Two values because a construction reached through a {@code let} is written under bindings
+     * the expression above it is not: the value a field of it was given is read where the
+     * construction is, and read where the projection stands, a name the {@code let} opened would
+     * stand for nothing.
+     */
+    private record Introduced(Core.Construct construct, BindingEnvironment names) {}
+
+    /** A value a projection read out of a construction, and the names it stands under. */
+    private record Given(Core value, BindingEnvironment names) {}
+
+    /**
+     * The construction {@code e} stands for, or null where it stands for none this walk reaches.
+     *
+     * <p>Which value a name holds is asked of the environment the same way the answer about a
+     * position is, and by the same steps: a name that was given a value, a {@code let}'s body, and a
+     * projection already reduced. What is not asked is where the construction stands — that question
+     * is the one whose answer this exists to get right, and asked here it would be answered for the
+     * construction rather than for the field read out of it.
+     *
+     * <p>Crossing to what a name holds is a step over the binding graph and is kept acyclic the way
+     * every other such step is ({@link BindingTrail}). Descending from a construction to the value it
+     * gave a field is not: that stays inside one expression, which is the kind of step nothing has to
+     * bound.
+     */
+    private Introduced introducing(Core e, BindingEnvironment names) {
+        return switch (e) {
+            case Core.Construct construct -> new Introduced(construct, names);
+            case Core.Read r when names.roleOf(r.binding()) instanceof BindingRole.Alias(var held) ->
+                    trail.through(r.binding(), () -> introducing(held, names));
+            case Core.LetIn let ->
+                    introducing(let.body(), names.inside(let.binder(), let.value()));
+            // A projection of a construction whose field was given another construction, which is
+            // what a value built out of values written where they stand looks like.
+            case Core.FieldAccess fa -> projected(fa, names) instanceof Given given
+                    ? introducing(given.value(), given.names()) : null;
+            case null, default -> null;
+        };
+    }
+
+    /**
+     * What {@code fa} reads out of the construction its target stands for, or null where the target
+     * stands for no construction.
+     *
+     * <p>Null for a target that is no construction, and never for a construction that was not given
+     * the field: a construction holds every declared field and a projection names a field of the type
+     * it reads, so the second is this compiler disagreeing with itself and is said where it is found.
+     */
+    private Given projected(Core.FieldAccess fa, BindingEnvironment names) {
+        Introduced target = introducing(fa.target(), names);
+        if (target == null) {
+            return null;
+        }
+        Core given = ConstructionProjection.given(target.construct(), fa.field());
+        if (given == null) {
+            throw new IllegalStateException("a construction of "
+                    + target.construct().typeName() + " was read for a field it has none of: "
+                    + fa.field());
+        }
+        return new Given(given, target.names());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AProjectionOutOfAConstructionIsWhereItWasGivenItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AProjectionOutOfAConstructionIsWhereItWasGivenItTest.java
@@ -77,8 +77,16 @@ class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
                 new Core.FieldValue("right", right, POS)), Type.ref(PAIR), POS);
     }
 
-    private static Core.FieldAccess field(Core target, String field) {
-        return new Core.FieldAccess(target, field, Type.STRING, POS);
+    /**
+     * {@code target.field}, typed as what the field holds.
+     *
+     * <p>Written out because a projection carries the type of the value it reads, and a tree that
+     * carries another is one the checker never built. What this walk asks of a type is which fields
+     * are steps of a path, so a fixture typed by what the assertion wanted would be holding the
+     * reading to a shape nothing else in the compiler answers about.
+     */
+    private static Core.FieldAccess field(Core target, String field, Type holds) {
+        return new Core.FieldAccess(target, field, holds, POS);
     }
 
     private static PathResolution readingOf(Core e, Map<BindingId, Core> bound) {
@@ -94,7 +102,8 @@ class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
     /** The value a newtype's construction was given, read back out of it, is where that value is. */
     @Test
     void aFieldReadOutOfAConstructionWrittenWhereItStandsIsAtThePositionItWasGiven() {
-        assertEquals(new PathResolution.At(TermPath.of("a")), readingOf(field(code(a()), "value")));
+        assertEquals(new PathResolution.At(TermPath.of("a")),
+                readingOf(field(code(a()), "value", Type.STRING)));
     }
 
     /**
@@ -108,7 +117,7 @@ class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
         Core held = new Core.Read("code", LOCAL, Type.ref(CODE), POS);
 
         assertEquals(new PathResolution.At(TermPath.of("a")),
-                readingOf(field(held, "value"), Map.of(LOCAL, code(a()))));
+                readingOf(field(held, "value", Type.STRING), Map.of(LOCAL, code(a()))));
     }
 
     /**
@@ -121,9 +130,9 @@ class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
     @Test
     void oneFieldOfTwoIsAtItsOwnPosition() {
         assertEquals(new PathResolution.At(TermPath.of("a")),
-                readingOf(field(pair(a(), b()), "left")));
+                readingOf(field(pair(a(), b()), "left", Type.STRING)));
         assertEquals(new PathResolution.At(TermPath.of("b")),
-                readingOf(field(pair(a(), b()), "right")));
+                readingOf(field(pair(a(), b()), "right", Type.STRING)));
     }
 
     /** However many constructions stand between the projection and the value. */
@@ -133,7 +142,7 @@ class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
                 List.of(new Core.FieldValue("inner", code(a()), POS)), Type.ref(OUTER), POS);
 
         assertEquals(new PathResolution.At(TermPath.of("a")),
-                readingOf(field(field(outer, "inner"), "value")));
+                readingOf(field(field(outer, "inner", Type.ref(CODE)), "value", Type.STRING)));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AProjectionOutOfAConstructionIsWhereItWasGivenItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AProjectionOutOfAConstructionIsWhereItWasGivenItTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.ElementBindings;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A field read back out of a construction is at the position the construction was given it.
+ *
+ * <p>The construction and the projection cancel. What a construction was handed is the value a field
+ * of it comes back as, so a reader asking which position that field is at is asking about the value
+ * that was handed in — and it is at the position that value is at. Resolved as a path of the
+ * construction and deepened by the field, the answer is that a value built here is at no position:
+ * true of the construction, and not what the projection above it reads.
+ *
+ * <p><b>The pair and not the construction.</b> A construction on its own is at no position, and that
+ * arm does not move. The values at a position are what the input holds there, and what a construction
+ * built out of them is a value of its own — a rule about it is not a rule about the strings or the
+ * numbers standing at the position it was given. Only the elimination that takes the given value back
+ * out says the two are one value, and only about the field it names.
+ *
+ * <p>Written out rather than compiled, because the environment is what is being held to: which value
+ * a name was given is an answer this reading is handed, and a model that happens to produce the shape
+ * today would be evidence about the rewrite that produced it.
+ */
+class AProjectionOutOfAConstructionIsWhereItWasGivenItTest {
+
+    private static final SourcePos POS = new SourcePos(0, 0);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("example", "f");
+    private static final BindingId LEFT = new BindingId(OWNER, 0);
+    private static final BindingId RIGHT = new BindingId(OWNER, 1);
+    private static final BindingId LOCAL = new BindingId(OWNER, 2);
+
+    private static final TypeSymbol.AtModule CODE =
+            TypeSymbols.declared(new TypeKey("example", "Code"));
+    private static final TypeSymbol.AtModule PAIR =
+            TypeSymbols.declared(new TypeKey("example", "Pair"));
+    private static final TypeSymbol.AtModule OUTER =
+            TypeSymbols.declared(new TypeKey("example", "Outer"));
+
+    private static Core.Read parameter(String name, BindingId binding) {
+        return new Core.Read(name, binding, Type.STRING, POS);
+    }
+
+    private static Core.Read a() {
+        return parameter("a", LEFT);
+    }
+
+    private static Core.Read b() {
+        return parameter("b", RIGHT);
+    }
+
+    /** {@code Code(a)}, the one-field construction a newtype is written as. */
+    private static Core.Construct code(Core given) {
+        return new Core.Construct(CODE, List.of(new Core.FieldValue("value", given, POS)),
+                Type.ref(CODE), POS);
+    }
+
+    /** {@code Pair { left = a, right = b }}. */
+    private static Core.Construct pair(Core left, Core right) {
+        return new Core.Construct(PAIR, List.of(new Core.FieldValue("left", left, POS),
+                new Core.FieldValue("right", right, POS)), Type.ref(PAIR), POS);
+    }
+
+    private static Core.FieldAccess field(Core target, String field) {
+        return new Core.FieldAccess(target, field, Type.STRING, POS);
+    }
+
+    private static PathResolution readingOf(Core e, Map<BindingId, Core> bound) {
+        return InputReads.written(Map.of(LEFT, TermPath.of("a"), RIGHT, TermPath.of("b")),
+                        bound, ElementBindings.NONE)
+                .pathOf(e, Symbols.none(DefaultStdlib.get()));
+    }
+
+    private static PathResolution readingOf(Core e) {
+        return readingOf(e, Map.of());
+    }
+
+    /** The value a newtype's construction was given, read back out of it, is where that value is. */
+    @Test
+    void aFieldReadOutOfAConstructionWrittenWhereItStandsIsAtThePositionItWasGiven() {
+        assertEquals(new PathResolution.At(TermPath.of("a")), readingOf(field(code(a()), "value")));
+    }
+
+    /**
+     * And the same where the construction stands behind a name.
+     *
+     * <p>Which is how a body writes one. The name is answered the way every name is — by what it was
+     * given — and the projection is then over the construction that answer is.
+     */
+    @Test
+    void aFieldReadOutOfAConstructionANameHoldsIsAtThePositionItWasGiven() {
+        Core held = new Core.Read("code", LOCAL, Type.ref(CODE), POS);
+
+        assertEquals(new PathResolution.At(TermPath.of("a")),
+                readingOf(field(held, "value"), Map.of(LOCAL, code(a()))));
+    }
+
+    /**
+     * And the field asked for is the one answered about.
+     *
+     * <p>What tells this rule from a construction read as one value. A construction given two
+     * positions holds the values of each under the field it was given them for, and a rule about one
+     * of those fields is about the values at that position and not at the other.
+     */
+    @Test
+    void oneFieldOfTwoIsAtItsOwnPosition() {
+        assertEquals(new PathResolution.At(TermPath.of("a")),
+                readingOf(field(pair(a(), b()), "left")));
+        assertEquals(new PathResolution.At(TermPath.of("b")),
+                readingOf(field(pair(a(), b()), "right")));
+    }
+
+    /** However many constructions stand between the projection and the value. */
+    @Test
+    void aProjectionOfAConstructionGivenAConstructionReachesTheValueInside() {
+        Core.Construct outer = new Core.Construct(OUTER,
+                List.of(new Core.FieldValue("inner", code(a()), POS)), Type.ref(OUTER), POS);
+
+        assertEquals(new PathResolution.At(TermPath.of("a")),
+                readingOf(field(field(outer, "inner"), "value")));
+    }
+
+    /**
+     * A construction itself is at no position, whatever it was given.
+     *
+     * <p>The arm this rule does not touch. What stands at the position is what the construction was
+     * handed, and the construction is a value of its own — so a rule about it is a rule about values
+     * the position does not hold, and a line drawn there would be at values the rule is not about.
+     * What makes the projection different is the elimination: it hands the given value back, and
+     * nothing else here does.
+     */
+    @Test
+    void aConstructionItselfIsAtNoPosition() {
+        assertEquals(new PathResolution.NotAPosition(), readingOf(code(a())));
+        assertEquals(new PathResolution.NotAPosition(), readingOf(pair(a(), b())));
+    }
+
+    /** And a name holding one is at none either, for the same reason. */
+    @Test
+    void aNameHoldingAConstructionIsAtNoPosition() {
+        Core held = new Core.Read("code", LOCAL, Type.ref(CODE), POS);
+
+        assertEquals(new PathResolution.NotAPosition(),
+                readingOf(held, Map.of(LOCAL, code(a()))));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
@@ -10,6 +10,9 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -42,6 +45,8 @@ class AValueReadThroughItselfIsNotAPositionNothingNamesTest {
     private static final BindingId FIRST = new BindingId(OWNER, 1);
     private static final BindingId SECOND = new BindingId(OWNER, 2);
     private static final BindingId PARAMETER = new BindingId(OWNER, 0);
+    private static final TypeSymbol.AtModule CODE =
+            TypeSymbols.declared(new TypeKey("example", "Code"));
 
     private static Core.Read read(String name, BindingId binding) {
         return new Core.Read(name, binding, Type.INT, POS);
@@ -62,6 +67,35 @@ class AValueReadThroughItselfIsNotAPositionNothingNamesTest {
         bound.put(FIRST, read("b", SECOND));
         bound.put(SECOND, read("a", FIRST));
         return reads(bound);
+    }
+
+    /** A name bound to a construction one of whose fields reads the name back. */
+    private static InputReads aNameHoldingAConstructionOfItself() {
+        Core.FieldAccess ofItself =
+                new Core.FieldAccess(read("c", FIRST), "value", Type.INT, POS);
+        Core.Construct wrapping = new Core.Construct(CODE,
+                java.util.List.of(new Core.FieldValue("value", ofItself, POS)),
+                Type.ref(CODE), POS);
+        return reads(Map.of(FIRST, wrapping));
+    }
+
+    /**
+     * And the same where the way back to the binding runs through a construction it holds.
+     *
+     * <p>The projection and the construction cancel, so the walk goes on with what the field was
+     * given — and that is the name it crossed to get here. Every step of that is one traversal: the
+     * binding is on the way while the value inside the construction is being read, not only while the
+     * construction is being found. Let go of in between, this arrives back at the binding with
+     * nothing on the way and runs until the stack is gone, which is a report about this compiler that
+     * no reader can act on.
+     */
+    @Test
+    void readingAValueThroughAConstructionItHoldsIsRaisedToo() {
+        InputReads names = aNameHoldingAConstructionOfItself();
+
+        assertThrows(BindingTrail.ReadThroughItself.class,
+                () -> names.pathOf(new Core.FieldAccess(read("c", FIRST), "value", Type.INT, POS),
+                        symbols()));
     }
 
     /** Raised where a value is read through itself, and named as this compiler's own state. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -200,6 +200,18 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
             }
             """;
 
+    private static final String A_PATH_THROUGH_THE_INPUT = """
+            module example.codes
+
+            data Answer = Yes | No
+            data Code = String
+            data Request = { code: Code, tag: String }
+
+            behavior f : (request: Request) -> Answer
+            let f (request) =
+                if String.startsWith("JP", request.code.value) then Yes else No
+            """;
+
     private static final String TWO_CONSTRUCTIONS_COMPARED = """
             module example.codes
 
@@ -530,32 +542,51 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
     }
 
     /**
-     * A predicate read over a field of a construction is not yet measured at the position the
-     * construction was given it.
+     * A predicate read over a field of a construction is measured at the position the construction
+     * was given it.
      *
-     * <p>The known boundary and not a rule about what a model deserves. What a construction was
-     * given is the value a field of it comes back as, so the strings at the position are the ones
-     * the rule is about — and a number read the same way out of the same construction is one a line
-     * does fall on. Which positions a predicate's subject resolves to is asked of the reading
-     * instead, and that reading does not see through a construction; it is a defect of its own and
-     * is filed apart from the naming this class is about.
+     * <p>Which is what naming it there was owed all along: the strings the rule is about are the ones
+     * standing at the position, the construction having been handed them, so the rule draws its line
+     * there like a rule written over the position itself. What a line falls on is a question about the
+     * values and this is the one place it is asked of these models — the tests above ask where the
+     * rule is named and are answered by a line as readily as by a question standing there.
      *
-     * <p><b>The one place the boundary is written down.</b> The tests above ask where the rule is
-     * named and hold whichever way it is named there, so this is what fails on the day the reading
-     * sees through a construction — in both halves at once, the word going and the line arriving.
-     * The answer then is a line at the position, and the tests above go on saying the same thing.
+     * <p>Nothing here is derived. A value read back out of a construction is the value that went in,
+     * and a word promising an operation to be followed back would send an author looking for one
+     * nobody wrote. An operation standing over such a projection is another matter and keeps the word
+     * it had: what {@code String.append} answered is not the strings at either position, and the
+     * tests above are where that rule is named.
      */
     @Test
-    void aPredicateOverAProjectedConstructionIsNotYetMeasuredAtItsSourcePosition() {
-        for (String model : List.of(READ_OUT_OF_A_CONSTRUCTION, A_CONSTRUCTION_AND_NOTHING_ELSE,
-                ONE_FIELD_OF_TWO)) {
-            assertEquals(named(measured(model)), derived(measured(model)),
-                    () -> "every position the rule is named at is a question about a derived value: "
+    void aPredicateOverAProjectedConstructionIsMeasuredAtItsSourcePosition() {
+        assertEquals(List.of("a"), measured(A_CONSTRUCTION_AND_NOTHING_ELSE).axes().stream()
+                        .map(PartitionEvidence.AxisCoverage::path).toList(),
+                () -> "a line falls where the construction was given the string: "
+                        + measured(A_CONSTRUCTION_AND_NOTHING_ELSE).notRead());
+        assertEquals(List.of("a"), measured(ONE_FIELD_OF_TWO).axes().stream()
+                        .map(PartitionEvidence.AxisCoverage::path).toList(),
+                "and at the position the field the rule reads was given, and no other");
+        for (String model : List.of(A_CONSTRUCTION_AND_NOTHING_ELSE, ONE_FIELD_OF_TWO)) {
+            assertEquals(List.of(), derived(measured(model)),
+                    () -> "and nothing about it is a value an operation made: "
                             + measured(model).notRead());
-            assertEquals(List.of(), measured(model).axes().stream()
-                    .map(PartitionEvidence.AxisCoverage::path).toList(),
-                    "and no line falls at any of them");
         }
+    }
+
+    /**
+     * And a newtype's value inside the input is still the position it stands under.
+     *
+     * <p>Not this rule. There is no construction here to eliminate: the value is what the input holds
+     * at a position, and whether a newtype's own value is a step of a path is what the declarations
+     * say ({@code Location.isStep}). Read as an elimination, a field of the input would be a rule
+     * about a position nothing wrote.
+     */
+    @Test
+    void aNewtypesValueInsideTheInputIsThePositionItStandsUnder() {
+        assertEquals(List.of("request.code"), measured(A_PATH_THROUGH_THE_INPUT).axes().stream()
+                        .map(PartitionEvidence.AxisCoverage::path).toList(),
+                () -> "the position the newtype stands at: "
+                        + measured(A_PATH_THROUGH_THE_INPUT).notRead());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest.java
@@ -559,17 +559,19 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      */
     @Test
     void aPredicateOverAProjectedConstructionIsMeasuredAtItsSourcePosition() {
-        assertEquals(List.of("a"), measured(A_CONSTRUCTION_AND_NOTHING_ELSE).axes().stream()
-                        .map(PartitionEvidence.AxisCoverage::path).toList(),
+        PartitionEvidence alone = measured(A_CONSTRUCTION_AND_NOTHING_ELSE);
+        PartitionEvidence oneOfTwo = measured(ONE_FIELD_OF_TWO);
+
+        assertEquals(List.of("a"),
+                alone.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList(),
                 () -> "a line falls where the construction was given the string: "
-                        + measured(A_CONSTRUCTION_AND_NOTHING_ELSE).notRead());
-        assertEquals(List.of("a"), measured(ONE_FIELD_OF_TWO).axes().stream()
-                        .map(PartitionEvidence.AxisCoverage::path).toList(),
+                        + alone.notRead());
+        assertEquals(List.of("a"),
+                oneOfTwo.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList(),
                 "and at the position the field the rule reads was given, and no other");
-        for (String model : List.of(A_CONSTRUCTION_AND_NOTHING_ELSE, ONE_FIELD_OF_TWO)) {
-            assertEquals(List.of(), derived(measured(model)),
-                    () -> "and nothing about it is a value an operation made: "
-                            + measured(model).notRead());
+        for (PartitionEvidence each : List.of(alone, oneOfTwo)) {
+            assertEquals(List.of(), derived(each),
+                    () -> "and nothing about it is a value an operation made: " + each.notRead());
         }
     }
 
@@ -583,10 +585,11 @@ class ARuleAboutTheStringsOfAMadeValueIsNamedWhereItCameFromTest {
      */
     @Test
     void aNewtypesValueInsideTheInputIsThePositionItStandsUnder() {
-        assertEquals(List.of("request.code"), measured(A_PATH_THROUGH_THE_INPUT).axes().stream()
-                        .map(PartitionEvidence.AxisCoverage::path).toList(),
-                () -> "the position the newtype stands at: "
-                        + measured(A_PATH_THROUGH_THE_INPUT).notRead());
+        PartitionEvidence measured = measured(A_PATH_THROUGH_THE_INPUT);
+
+        assertEquals(List.of("request.code"),
+                measured.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList(),
+                () -> "the position the newtype stands at: " + measured.notRead());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnArmOfAForkIsOnTheWayLikeAnyOtherConditionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnArmOfAForkIsOnTheWayLikeAnyOtherConditionTest.java
@@ -58,6 +58,17 @@ class AnArmOfAForkIsOnTheWayLikeAnyOtherConditionTest {
                 match (if p.n > 5 then Plain else Special) with
                     | Plain   -> p.n > 0
                     | Special -> p.n > 10
+
+            data Wrap = { held: Kind }
+
+            behavior onAProjectedConstruction : (kind: Kind, n: Int) -> Bool
+                constructs Wrap
+            let onAProjectedConstruction (kind, n) = {
+                let wrapped = Wrap { held = kind }
+                match wrapped.held with
+                    | Plain   -> n > 0
+                    | Special -> n > 10
+            }
             """;
 
     /** A narrowing is what a fork on a case states, named by the position it narrows. */
@@ -70,6 +81,22 @@ class AnArmOfAForkIsOnTheWayLikeAnyOtherConditionTest {
     @Test
     void aForkOnAFieldNarrowsThatField() {
         assertEquals(List.of("p.kind@Plain", "p.kind@Special"), narrowingsIn("onAField"));
+    }
+
+    /**
+     * And a fork on a field read back out of a construction narrows where the construction was given
+     * it.
+     *
+     * <p>The construction and the projection cancel: the case an arm selects is a case of the values
+     * standing at the parameter, since that is what the construction was handed. Read as a path of
+     * the construction, the scrutinee stands nowhere and both arms are declined — so a search
+     * composes rows for the comparisons inside them believing nothing stood in the way, which is the
+     * answer it gets for a comparison at the top of a body.
+     */
+    @Test
+    void aForkOnAFieldReadOutOfAConstructionNarrowsWhereItWasGivenIt() {
+        assertEquals(List.of("kind@Plain", "kind@Special"),
+                narrowingsIn("onAProjectedConstruction"));
     }
 
     /**


### PR DESCRIPTION
Which position an expression names was asked of a field read back out of a
construction as a path of the construction, deepened by the field:

```text
P(target.field) = deeper(P(target), field)
```

That law holds where the target stands somewhere — `request.address.zip` is a step
under a step — and not over a construction, which stands nowhere while holding, in
the node, the very expression the field hands back. So the projection named nothing,
and each reader that asks this walk directly lost what it was about:

- a predicate written over such a field was named at the position and drew no line
  there, while the same field read as a number was measured at it
- both arms of a fork on one were declined as narrowing nothing, so a search
  composes rows for the comparisons inside them as though nothing stood in the way

The second was invisible in the axes, a sum-typed position having an axis from its
declarations whether or not a body forks on it.

The arithmetic escaped because it never asks about the written form: it reduces the
projection against the construction first and asks about what comes out.

## What this does

The projection and the construction cancel, and that reduction is applied before the
path is asked for. The target is resolved to the construction it stands for — by the
steps this walk already has for a name that was given a value and for a body under a
binding — and the position asked for is the position of the value that field was
given.

A construction on its own still names no position. What stands at a position is what
the construction was handed, and the value it built is one of its own, so a rule about
it is not a rule about the strings or the numbers standing there. Only the elimination
says the two are one value, and only about the field it names:

| written | names |
| --- | --- |
| `a` | `a` |
| `Code(a)` | no position |
| `Code(a).value` | `a` |
| `let c = Code(a)` … `c` | no position |
| `let c = Code(a)` … `c.value` | `a` |
| `Pair { left = a, right = b }.left` | `a` |
| `request.code.value` | `request.code` |

The last row is not this rule: there is no construction there, and whether a
newtype's own value is a step of a path is what the declarations say.

Crossing to what a name holds is a step over the binding graph and is kept acyclic
the way every other such step is. Descending from a construction to the value it gave
a field is not — it stays inside one expression, which is the kind of step nothing has
to bound.

## Where the rule lives

What a construction gave a field is stated once, for every reader that gets there.
Each resolves its own names first — the arithmetic through its reading of occurrences,
this walk through what a binding is of the input — and only the pair of a resolved
construction and a field name is shared. Written out at each reader, a shape one of
them reduced would be one the others did not, and which projections a rule covers
would depend on which reader met it.

Issue: #1637 — closed by hand, a merge into `develop` not closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)