### PR TITLE
Say what gave a decision rule's offer no value, and not the category alone

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayWhatARuleHandleReadsAsTest.java
@@ -89,6 +89,11 @@ class WhoMaySayWhatARuleHandleReadsAsTest {
     private static final List<String> WRITING_IT_INTO_THE_DOCUMENT = List.of(
             "souther/compiler/report/AdequacyReport"
                     + "#about(ObjectNode, PublishedSubject, DocumentSources)",
+            // The rule a search of a decision rule was given no value by, written where that search
+            // is. The same rule reaches a consumer under the position as well, and the two are one
+            // piece of news only while both are handles.
+            "souther/compiler/report/AdequacyReport#causes(ObjectNode, Generator$"
+                    + "UnresolvedCombination, DocumentSources, PublishedRuleHandle$WhereARuleIs)",
             "souther/compiler/report/AdequacyReport#findings(DocumentArray, List, DocumentSources,"
                     + " PublishedRuleHandle$WhereARuleIs)",
             "souther/compiler/report/AdequacyReport"

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedShortfall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedShortfall.java
@@ -1,0 +1,69 @@
+package souther.compiler.partition;
+
+import souther.compiler.regex.Meter;
+
+/**
+ * The words an adequacy document writes for what gave an offer no value.
+ *
+ * <p>Between the two vocabularies and belonging to neither, the way {@link ReportedReason} is.
+ * {@link StringOfferShortfall} records what this compiler was doing and what refused it;
+ * a consumer reads what the shortfall is attributed to and what stopped that. A document written
+ * by spelling the shapes of {@link StringOfferShortfall.Subject} would be a contract that moves
+ * whenever those are rearranged, and the words a consumer keys on are not the compiler's to
+ * rearrange.
+ *
+ * <p>Two questions and two fields, because they are not one answer. What the shortfall is
+ * attributed to says where an author goes; what stopped it says what they do there — and a rule
+ * this compiler could not read and a rule whose machine it would not build are one attribution and
+ * two pieces of work.
+ */
+public final class ReportedShortfall {
+
+    private ReportedShortfall() {
+    }
+
+    /**
+     * What a shortfall is attributed to.
+     *
+     * <p>A rule is the author's to rewrite. What the rules leave between them is nobody's rule and
+     * is a size this compiler declined to work out, so an author sent to either of the rules would
+     * be sent to one that reads perfectly. Composing a value is the whole question's allowance and
+     * is about no rule of it at all.
+     */
+    public enum Attribution {
+        A_RULE,
+        THE_RULES_TOGETHER,
+        COMPOSING_A_VALUE
+    }
+
+    /**
+     * Which limit refused it, where a limit did.
+     *
+     * <p>Kept apart from the reasons a reading stops. A machine larger than a machine may be is a
+     * pattern somebody can write smaller; an allowance already spent is not, and the same pattern
+     * asked for first would have been built. Under one word, a consumer counting what a wider
+     * allowance would reach would count both.
+     */
+    public enum Limit {
+        A_MACHINE_LARGER_THAN_ONE_MAY_BE,
+        WHAT_COMPOSING_A_VALUE_MAY_SPEND
+    }
+
+    /** What {@code of} is attributed to, in the word a document writes for it. */
+    public static Attribution attribution(StringOfferShortfall.Subject of) {
+        return switch (of) {
+            case StringOfferShortfall.Subject.ARule _ -> Attribution.A_RULE;
+            case StringOfferShortfall.Subject.WhatTheyLeaveTogether _ ->
+                    Attribution.THE_RULES_TOGETHER;
+            case StringOfferShortfall.Subject.ComposingAValue _ -> Attribution.COMPOSING_A_VALUE;
+        };
+    }
+
+    /** The same of what refused a value, where what refused it was a limit. */
+    public static Limit limit(Meter.Stopped stopped) {
+        return switch (stopped) {
+            case ONE_MACHINE -> Limit.A_MACHINE_LARGER_THAN_ONE_MAY_BE;
+            case THE_ANSWER -> Limit.WHAT_COMPOSING_A_VALUE_MAY_SPEND;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/DocumentPart.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/DocumentPart.java
@@ -36,7 +36,11 @@ public enum DocumentPart {
     OBLIGATIONS("obligations", "/$defs/obligations"),
 
     /** What a measure found, published by two sections through one definition. */
-    FINDINGS("findings", "/$defs/findings");
+    FINDINGS("findings", "/$defs/findings"),
+
+    /** What gave the offer no value, where a search of a rule of a decision composed nothing. */
+    SYNTHESIS_SHORTFALL_CAUSES("synthesisShortfallCauses",
+            "/$defs/decision/properties/obligations/items/properties/synthesisShortfallCauses");
 
     private final String key;
     private final String schemaPath;

--- a/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/RuleHandleSurface.java
@@ -52,7 +52,17 @@ public enum RuleHandleSurface {
 
     /** What a finding is about, which names the rule among other things. */
     FINDING_SUBJECT("/$defs/findings/items/properties/subject",
-            "subject", Carries.A_SENTENCE_AROUND_IT);
+            "subject", Carries.A_SENTENCE_AROUND_IT),
+
+    /**
+     * The rule that gave a search of a decision rule no value to try.
+     *
+     * <p>The same handle the questions under the position publish, written where the search that
+     * was short of it is. What such an entry tells a reader is which rule to rewrite, and one
+     * naming only the position hands them every rule written there.
+     */
+    SYNTHESIS_SHORTFALL_RULE("/$defs/decision/properties/obligations/items/properties"
+            + "/synthesisShortfallCauses/items/properties/rule", "rule", Carries.THE_HANDLE_ALONE);
 
     private final String schemaPath;
     private final String key;

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -34,6 +34,8 @@ import souther.compiler.partition.NotOwedReason;
 import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.ReachabilityGap;
 import souther.compiler.partition.ReportedReason;
+import souther.compiler.partition.ReportedShortfall;
+import souther.compiler.partition.StringOfferShortfall;
 import souther.compiler.partition.RoleAnswer;
 import souther.compiler.partition.RuleEvidenceOrigin;
 import souther.compiler.partition.UndividedPosition;
@@ -44,6 +46,7 @@ import souther.compiler.inputs.AuthoredOrder;
 import souther.compiler.inputs.InputQuestion;
 import souther.compiler.inputs.StandingQuestion;
 import souther.compiler.inputs.RuleSite;
+import souther.compiler.inputs.TermPath;
 import souther.compiler.meta.ModuleMetadata;
 import souther.compiler.check.CheckSurface;
 import souther.compiler.observe.Disposition;
@@ -2632,9 +2635,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
         // of them, which is the account being shown as a backlog. The numbers close over the count
         // all the same, so nothing is lost and the rules themselves are in the document.
         gathered(out, behavior, decision, RuleRequirement.Unsettled.class,
-                "      ? nothing could show a row can be written at %d decision rule%s%n");
+                "      ? nothing could show a row can be written at %d decision rule%s%n",
+                rendering, behavior.rulePlace());
         gathered(out, behavior, decision, RuleRequirement.Excluded.class,
-                "      · no row is owed at %d decision rule%s%n");
+                "      · no row is owed at %d decision rule%s%n",
+                rendering, behavior.rulePlace());
     }
 
     /**
@@ -2651,7 +2656,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
      */
     private static void gathered(StringBuilder out, BehaviorReport behavior,
                                  DecisionEvidence decision,
-                                 Class<? extends RuleRequirement> answer, String opening) {
+                                 Class<? extends RuleRequirement> answer, String opening,
+                                 SourceRendering rendering,
+                                 PublishedRuleHandle.WhereARuleIs places) {
         Set<Said> order = new java.util.TreeSet<>(Said.IN_ORDER);
         Map<String, Integer> counted = new LinkedHashMap<>();
         int all = 0;
@@ -2660,7 +2667,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
             if (came == null || !answer.isInstance(came.requirement())) {
                 continue;
             }
-            Said said = said(came);
+            Said said = said(came, rendering, places);
             order.add(said);
             counted.merge(said.text(), 1, Integer::sum);
             all++;
@@ -2717,8 +2724,16 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
      * nothing, what the sentence says is the shortfall — which is this compiler's and is what
      * could be done about it — and the requirement's own word for it says only that there was
      * nothing to try the rule with, which no reader acts on.
+     *
+     * <p>And what the offer was short of, where anything was, in the words the block says it in.
+     * The category is what the search came to and the attribution is why the values it had to try
+     * were not everything the rules leave, and a line carrying the first alone sends a reader after
+     * a rule that refuses nothing. Said here and not left to the questions under the position: a
+     * rule this compiler could not read is named there, an allowance spent on composing a value is
+     * named nowhere, and a sentence that relied on the neighbour would be complete for one of them.
      */
-    private static Said said(RuleSettlement came) {
+    private static Said said(RuleSettlement came, SourceRendering rendering,
+                             PublishedRuleHandle.WhereARuleIs places) {
         return switch (came.requirement()) {
             // Composed and run first, because they are what a reader can tell this compiler about:
             // a row that went elsewhere is a way this steered wrong and the model may be fine.
@@ -2727,7 +2742,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
             case RuleRequirement.Unsettled.NothingWasComposedToTry _ ->
                     new Said(1, PublicationOrders.positionOf(
                                     came.synthesisShortfall().reason()),
-                            whyUnresolved(came.synthesisShortfall()));
+                            GeneratedRows.beside(whyUnresolved(came.synthesisShortfall()),
+                                    came.synthesisShortfall(), rendering, places));
             case RuleRequirement.Unsettled.CouldNotTellWhereTheRowWent(var reading) ->
                     new Said(2, PublicationOrders.positionOf(reading), switch (reading) {
                         case NO_RULE_IS_RECOGNISABLE ->
@@ -4119,7 +4135,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
                         behavior.account(), behavior.claimed(), sources,
                         behavior.rulePlace(), behavior.partPlace());
                 branch(b, behavior, sources);
-                decision(b, behavior);
+                decision(b, behavior, sources);
                 findings(b, behavior, sources);
             }
         }
@@ -4668,7 +4684,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
      * than about any entry. A reading that stopped comes back with some of the body's ways, so the
      * entries here are of those and the ones it did not reach are in no document.
      */
-    static void decision(ObjectNode into, BehaviorReport behavior) {
+    static void decision(ObjectNode into, BehaviorReport behavior, DocumentSources sources) {
         DecisionEvidence decision = behavior.evidence().decision();
         if (decision == null) {
             return;
@@ -4702,6 +4718,63 @@ public record AdequacyReport(int schemaVersion, String compilerVersion,
                 // never handed a generator's failure as the answer to that question.
                 if (came.synthesisShortfall() != null) {
                     one.put("synthesisShortfall", word(came.synthesisShortfall().reason()));
+                    // And why the offer it was refusing was not everything the rules leave, where
+                    // anything made it short. Beside the word and not spelled into it: the word is
+                    // what the search came to and this is what it was given to try, and a consumer
+                    // told the first alone counts a rule this compiler never read as a rule the
+                    // values were refused by.
+                    causes(one, came.synthesisShortfall(), sources, behavior.rulePlace());
+                }
+            }
+        }
+    }
+
+    /**
+     * What gave the offer no value, one entry per thing that gave none.
+     *
+     * <p>The structure and not the sentence. What a reader of the page is shown is words, and a
+     * document carrying those words would be a contract on how this compiler phrases them — so what
+     * is written here is what the shortfall is attributed to, the rule where the attribution is one,
+     * and what stopped it, each in a vocabulary of the document's own.
+     *
+     * <p>What stopped it under one of two keys, because the two are not one vocabulary. A reading
+     * that stopped is said in the words this document already writes for a reading that stopped, so
+     * a rule reported unread here and the same rule reported unread under the position are one
+     * piece of news. A limit is no reading at all.
+     *
+     * <p>Nothing where the offer was everything the rules leave, which is most searches. An empty
+     * array would be a consumer asked to tell "nothing was short" from "nobody looked", and the
+     * absence says the first because the word beside it says a search ran.
+     */
+    private static void causes(ObjectNode into, Generator.UnresolvedCombination why,
+                               DocumentSources sources,
+                               PublishedRuleHandle.WhereARuleIs places) {
+        if (why.alsoShort().isEmpty()) {
+            return;
+        }
+        DocumentArray causes = DocumentPart.SYNTHESIS_SHORTFALL_CAUSES.putArray(into);
+        for (Map.Entry<TermPath, StringOfferShortfall> at : why.alsoShort().entrySet()) {
+            for (StringOfferShortfall.NotOffered each : at.getValue().these()) {
+                DocumentItem row = causes.addObject();
+                ObjectNode said = row.node();
+                said.put("position", at.getKey().toString());
+                said.put("attribution", word(ReportedShortfall.attribution(each.of())));
+                // And which rule, where the attribution is one. The pair is the one the rest of
+                // this document writes: `rule` is the handle an author acts on and `ruleId` is what
+                // tells one rule from another, and the two are not in step wherever a rule has no
+                // name of its own.
+                if (each.of() instanceof StringOfferShortfall.Subject.ARule it) {
+                    RuleHandleSurface.SYNTHESIS_SHORTFALL_RULE.put(row,
+                            PublishedRuleHandle.of(new RuleCitation.Named(it.part().rule()),
+                                    places),
+                            sources.rendering(), null);
+                    ruleId(said.putObject("ruleId"), it.part().rule());
+                }
+                switch (each.why()) {
+                    case StringOfferShortfall.Why.NotRead it ->
+                            said.put("unread", word(ReportedReason.of(it.why())));
+                    case StringOfferShortfall.Why.TooCostly it ->
+                            said.put("limit", word(ReportedShortfall.limit(it.stopped())));
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -771,7 +771,19 @@ public final class GeneratedRows {
      */
     private static String saidOf(Generator.UnresolvedCombination left, SourceRendering rendering,
                                  PublishedRuleHandle.WhereARuleIs places) {
-        String category = left.said().orElseGet(() -> why(left.reason()));
+        return beside(left.said().orElseGet(() -> why(left.reason())), left, rendering, places);
+    }
+
+    /**
+     * {@code category} and what else was true of the search, in one sentence.
+     *
+     * <p>Here rather than at each surface, because the join is part of what is said: a surface that
+     * put the attribution first would say which rule gave nothing before saying what the search
+     * came to, and one that wrote its own separator would tell a reader who meets both surfaces
+     * that they are reading two different facts.
+     */
+    static String beside(String category, Generator.UnresolvedCombination left,
+                         SourceRendering rendering, PublishedRuleHandle.WhereARuleIs places) {
         String also = alsoShort(left.alsoShort(), rendering, places);
         return also.isEmpty() ? category : category + ", and " + also;
     }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
@@ -2164,6 +2164,51 @@
                   "not_all_candidates_could_be_offered",
                   "no_reading_of_the_line_could_be_searched"
                 ]
+              },
+              "synthesisShortfallCauses": {
+                "type": "array",
+                "description": "Why the values this compiler had to try were not everything the rules leave, one entry per thing that gave the offer none. Beside `synthesisShortfall` and never inside it: that word is what the search came to and these are what it was given to work with, and a consumer reading the word alone counts a rule this compiler never read as a rule the values were refused by. Absent where the offer was everything the rules leave, which is what an entry carrying a word for the search and no array here says.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "position",
+                    "attribution"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "position": {
+                      "type": "string",
+                      "description": "Where in the row the values were being composed for, in the terms a row is written in."
+                    },
+                    "attribution": {
+                      "description": "What the shortfall is attributed to, which is what decides where an author goes about it. `a_rule` is one they wrote and may rewrite; `the_rules_together` is what two of them leave between them, which is nobody's rule and a size this compiler declined to work out; `composing_a_value` is the allowance for working out a value at all, which is about no rule of the position.",
+                      "enum": [
+                        "a_rule",
+                        "the_rules_together",
+                        "composing_a_value"
+                      ]
+                    },
+                    "rule": {
+                      "$ref": "#/$defs/ruleHandle",
+                      "description": "How a reader finds the rule that gave the offer no value, present exactly where `attribution` is `a_rule`. The same handle a `notRead` entry carries for the same rule. Not what tells one rule from another: `ruleId` beside this is."
+                    },
+                    "ruleId": {
+                      "$ref": "#/$defs/ruleId",
+                      "description": "Which rule the entry is about, present exactly with `rule`."
+                    },
+                    "unread": {
+                      "$ref": "#/$defs/notReadReason",
+                      "description": "What stopped the reading of it, where what gave nothing was a reading that stopped. The vocabulary `notRead` writes, so a rule reported unread here and the same rule reported unread under the position are one piece of news rather than two. Present exactly where `limit` is absent."
+                    },
+                    "limit": {
+                      "description": "Which limit refused it, where a limit did. `a_machine_larger_than_one_may_be` is a pattern that can be written smaller; `what_composing_a_value_may_spend` is an allowance already spent, which the same pattern asked for first would not have met. Present exactly where `unread` is absent, and no reading stopped: the rule was read from end to end.",
+                      "enum": [
+                        "a_machine_larger_than_one_may_be",
+                        "what_composing_a_value_may_spend"
+                      ]
+                    }
+                  }
+                }
               }
             }
           }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
@@ -2175,6 +2175,56 @@
                     "attribution"
                   ],
                   "additionalProperties": false,
+                  "dependentRequired": {
+                    "rule": [
+                      "ruleId"
+                    ],
+                    "ruleId": [
+                      "rule"
+                    ]
+                  },
+                  "allOf": [
+                    {
+                      "description": "A rule is named exactly where the shortfall is attributed to one. Written as a shape and not only as a sentence: what the rules leave between them is nobody's rule and the allowance for composing a value is about no rule of the position, so an entry carrying one under either would send an author to a rule that reads perfectly — and an entry attributed to a rule and naming none would leave them every rule written at the position to look at.",
+                      "if": {
+                        "properties": {
+                          "attribution": {
+                            "const": "a_rule"
+                          }
+                        },
+                        "required": [
+                          "attribution"
+                        ]
+                      },
+                      "then": {
+                        "required": [
+                          "rule"
+                        ]
+                      },
+                      "else": {
+                        "not": {
+                          "required": [
+                            "rule"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "description": "And what stopped it is one of the two, never both and never neither. They are two vocabularies rather than two words: a reading that stopped is a rule somebody may write another way and a limit is a figure, and an entry carrying both would be one thing that gave nothing wearing two accounts of why.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "unread"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "limit"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
                   "properties": {
                     "position": {
                       "type": "string",

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -405,6 +405,22 @@ class EverySchemaWordIsAccountedForTest {
                     List.of("$defs", "decision", "properties", "obligations", "items",
                             "properties", "synthesisShortfall"),
                     souther.compiler.partition.Generator.UnresolvedCombination.Reason.class),
+            // What the shortfall is attributed to, which is the axis the word above is not. Held
+            // against the document's own vocabulary rather than against the shapes this compiler
+            // records: what a consumer keys on is where an author goes about it, and how those are
+            // arranged here is nothing a consumer was promised.
+            new Vocabulary("decision.obligations[].synthesisShortfallCauses[].attribution",
+                    List.of("$defs", "decision", "properties", "obligations", "items",
+                            "properties", "synthesisShortfallCauses", "items",
+                            "properties", "attribution"),
+                    souther.compiler.partition.ReportedShortfall.Attribution.class),
+            // And which limit refused it, where one did. Apart from the reasons a reading stops,
+            // which the entry beside this writes in the vocabulary `notRead` already has.
+            new Vocabulary("decision.obligations[].synthesisShortfallCauses[].limit",
+                    List.of("$defs", "decision", "properties", "obligations", "items",
+                            "properties", "synthesisShortfallCauses", "items",
+                            "properties", "limit"),
+                    souther.compiler.partition.ReportedShortfall.Limit.class),
             new Vocabulary("findings[].kind",
                     List.of("$defs", "findings", "items", "properties", "kind"),
                     Adequacy.Kind.class),

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferWasShortOfReachesTheAccountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferWasShortOfReachesTheAccountTest.java
@@ -1,0 +1,284 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceRendering;
+import souther.compiler.partition.ReportedShortfall;
+import souther.compiler.partition.StringOfferShortfall;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The account says why a search had less than the rules leave to try, and not only that it had.
+ *
+ * <p>What the search came to and why the offer was short of the rules are two axes. A rule this
+ * compiler could not read and a rule it read from end to end whose machine it would not build are
+ * one category — every value tried was refused, and the values tried were not everything — and they
+ * are different work: one is rewritten and one is allowed more. Published as the category alone,
+ * the page and the document say the same thing of both.
+ *
+ * <p>The point rows of the account are not the other half. They say what reading a position met,
+ * which is a different question asked by a different walk: the limit a machine ran into is said
+ * there of the rules of the position met with each other, where this says which rule was being
+ * built. So what is held here is that the decision-level sentence is complete on its own.
+ */
+class WhatTheOfferWasShortOfReachesTheAccountTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** A rule about the strings written in a construct this compiler's reader does not enter. */
+    private static final String OUTSIDE_THE_SUBSET = "String.matches(\"(a+)\\\\1\", value)";
+
+    /** One it reads and will not build a machine for, which is the other way to be short. */
+    private static final String MORE_THAN_A_WITNESS_MAY_SPEND =
+            "String.matches(\"a{60000}\", value)";
+
+    private static String model(String rule) {
+        return """
+                module example.offer
+
+                data Code = String
+                    invariant shape = RULE
+
+                data Flag = Yes | No
+
+                data T = { flag: Flag, code: Code }
+
+                data Ok
+
+                behavior look : (t: T) -> Ok
+
+                let look (t) = Ok
+                """.replace("RULE", rule);
+    }
+
+    /**
+     * A body whose every rule about the position was read, and every value they leave was refused.
+     *
+     * <p>The other half of the pair, and the control for every claim below: nothing here was short
+     * of anything, so an entry saying what the offer was short of would be one written for a search
+     * that had everything.
+     */
+    private static final String NOTHING_WAS_SHORT = """
+            module example.refused
+
+            data Amount = Int
+                invariant range = value >= 0 && value <= 3
+
+            data R = { a1: Amount, a2: Amount }
+                invariant rule = a1.value * a2.value >= 100
+
+            data Ok
+
+            behavior f : (r: R) -> Ok
+
+            let f (r) = if r.a1.value > 1 then Ok else Ok
+            """;
+
+    /**
+     * The rule is named where the page counts the rules nothing settled, so a reader of the account
+     * is sent to the rule rather than to the position.
+     */
+    @Test
+    void theDecisionSentenceNamesTheRuleThatGaveTheOfferNoValue() {
+        String line = whereNothingCouldShowARow(human(model(OUTSIDE_THE_SUBSET)));
+
+        assertTrue(line.contains("every value tried at a rule of the decision was refused, and what"
+                        + " was tried was not everything the rules leave"),
+                () -> "what the search came to: " + line);
+        assertTrue(line.contains("invariant Code (shape) at `t.code` gave none of them: written in"
+                        + " a form this compiler does not read"),
+                () -> "and which rule gave it no value: " + line);
+    }
+
+    /**
+     * And a rule read from end to end is a different sentence, which is the whole of what the
+     * attribution is for: one of them is rewritten and the other is allowed more.
+     */
+    @Test
+    void aRuleReadToTheEndIsNotSaidAsOneThisCompilerCannotRead() {
+        String unread = whereNothingCouldShowARow(human(model(OUTSIDE_THE_SUBSET)));
+        String costly = whereNothingCouldShowARow(human(model(MORE_THAN_A_WITNESS_MAY_SPEND)));
+
+        assertNotEquals(unread, costly,
+                "an author rewriting a rule and an author raising a figure are doing different"
+                        + " work, and the account sent both to the same place");
+        assertTrue(costly.contains("invariant Code (shape) at `t.code` gave none of them: working a"
+                        + " value out of it asks for a larger machine than one may be"),
+                () -> costly);
+        assertFalse(costly.contains("does not read"),
+                () -> "this rule was read from end to end: " + costly);
+    }
+
+    /**
+     * The document carries the same distinction as a shape, and not as the sentence the page shows.
+     *
+     * <p>The category stays what it was. What the search came to is the same on both ways in — the
+     * values tried were refused and they were not everything — and splitting the word would say the
+     * searches came to different answers when what differs is why they were given less.
+     */
+    @Test
+    void theDocumentCarriesTheAttributionBesideTheCategory() {
+        JsonNode unread = onlyCause(json(model(OUTSIDE_THE_SUBSET)));
+        JsonNode costly = onlyCause(json(model(MORE_THAN_A_WITNESS_MAY_SPEND)));
+
+        assertEquals("not_all_candidates_could_be_offered",
+                shortfallWord(json(model(OUTSIDE_THE_SUBSET))));
+        assertEquals("not_all_candidates_could_be_offered",
+                shortfallWord(json(model(MORE_THAN_A_WITNESS_MAY_SPEND))));
+
+        // Both are attributed to the rule, and what stopped it is written under the key whose
+        // vocabulary says what kind of thing it was: a reading that stopped is said in the words
+        // `notRead` already has, and a limit is no reading at all.
+        assertEquals("a_rule", unread.get("attribution").stringValue());
+        assertEquals("a_rule", costly.get("attribution").stringValue());
+        assertEquals("unsupported_syntax", unread.get("unread").stringValue());
+        assertNull(unread.get("limit"), () -> "no limit refused this one: " + unread);
+        assertEquals("a_machine_larger_than_one_may_be", costly.get("limit").stringValue());
+        assertNull(costly.get("unread"), () -> "this rule was read to the end: " + costly);
+
+        // And which rule, by the pair the rest of this document names rules with.
+        assertNotNull(unread.get("rule"), () -> "the handle an author is sent to: " + unread);
+        assertEquals("Code", unread.get("ruleId").get("declaredOn").stringValue());
+        assertEquals("t.code", unread.get("position").stringValue());
+    }
+
+    /**
+     * And a search that had everything the rules leave carries none of this, which is what the
+     * absence of the array means.
+     */
+    @Test
+    void aSearchThatWasShortOfNothingCarriesNoCause() {
+        List<JsonNode> owed = withAShortfall(json(NOTHING_WAS_SHORT));
+
+        assertFalse(owed.isEmpty(), "both ways of this body had nothing composed to try");
+        for (JsonNode each : owed) {
+            assertEquals("all_candidates_rejected", each.get("synthesisShortfall").stringValue(),
+                    () -> "every value the rules leave was tried: " + each);
+            assertNull(each.get("synthesisShortfallCauses"),
+                    () -> "and nothing was short of anything: " + each);
+        }
+        assertFalse(whereNothingCouldShowARow(human(NOTHING_WAS_SHORT)).contains("gave none of"),
+                "the page says the same by saying nothing");
+    }
+
+    /**
+     * The questions under the position say what they said before, which is another axis and not the
+     * half this was missing.
+     *
+     * <p>Held as a non-regression. The limit is said there of the rules of the position met with
+     * each other, and the decision sentence names the rule that was being built — so a reader who
+     * meets both meets one limit attributed at two grains, and neither line is the other's.
+     */
+    @Test
+    void thePointRowStillSaysWhatTheReadingOfThePositionMet() {
+        String page = human(model(MORE_THAN_A_WITNESS_MAY_SPEND));
+
+        assertTrue(page.contains("not accounted for: invariant Code (shape) — which values may"
+                        + " stand at t.code: read to the end, and the values the rules about this"
+                        + " position leave between them are more than this compiler will work out"),
+                () -> page);
+    }
+
+    /**
+     * And a cause with no rule behind it publishes none, which is the way the allowance for
+     * composing a value arrives.
+     *
+     * <p>Said of the subject and not through a compile: reaching the end of that allowance means
+     * having built most of what it allows, which is the one thing about this that cannot be made
+     * cheap. That the allowance is attributed to composing a value at all is held where the
+     * attribution is decided ({@code AnAllowanceSpentIsNotOneRulesDoing}).
+     */
+    @Test
+    void aCauseWithNoRuleBehindItNamesNone() {
+        assertEquals(ReportedShortfall.Attribution.COMPOSING_A_VALUE,
+                ReportedShortfall.attribution(
+                        new StringOfferShortfall.Subject.ComposingAValue()));
+        assertEquals(ReportedShortfall.Attribution.THE_RULES_TOGETHER,
+                ReportedShortfall.attribution(
+                        new StringOfferShortfall.Subject.WhatTheyLeaveTogether()),
+                "what two rules leave between them is nobody's rule, and an author sent to either"
+                        + " would be sent to one that reads perfectly");
+    }
+
+    /** The line the page counts the rules nothing settled under. */
+    private static String whereNothingCouldShowARow(String page) {
+        List<String> found = new ArrayList<>();
+        for (String line : page.split("\n")) {
+            // The line the rules of the decision are counted under, and not a point of a line: the
+            // page opens both the same way and what this is about is the decision's.
+            if (line.contains("nothing could show a row can be written at")
+                    && line.contains("decision rule")) {
+                found.add(line);
+            }
+        }
+        assertEquals(1, found.size(), () -> "one body here has a rule nothing settled: " + found);
+        return found.get(0);
+    }
+
+    /** Every rule of the document whose search had nothing composed to try it with. */
+    private static List<JsonNode> withAShortfall(String document) {
+        JsonNode behaviors = JSON.readTree(document).get("modules").get(0).get("behaviors");
+        List<JsonNode> found = new ArrayList<>();
+        behaviors.forEach(behavior -> behavior.get("decision").get("obligations").forEach(rule -> {
+            if (rule.get("synthesisShortfall") != null) {
+                found.add(rule);
+            }
+        }));
+        return found;
+    }
+
+    /** The one of them these models have, where the model is one that has one. */
+    private static JsonNode unsettled(String document) {
+        List<JsonNode> found = withAShortfall(document);
+        assertEquals(1, found.size(), () -> "one rule here had nothing composed to try: " + found);
+        return found.get(0);
+    }
+
+    private static String shortfallWord(String document) {
+        return unsettled(document).get("synthesisShortfall").stringValue();
+    }
+
+    /** The one thing that gave that search's offer no value. */
+    private static JsonNode onlyCause(String document) {
+        JsonNode causes = unsettled(document).get("synthesisShortfallCauses");
+        assertNotNull(causes, "the offer was short of something");
+        assertEquals(1, causes.size(), () -> "one rule gave it no value: " + causes);
+        return causes.get(0);
+    }
+
+    private static String human(String model) {
+        Compilation compilation = measured(model);
+        return AdequacyReport.of(compilation)
+                .human(SourceRendering.namedByIdentity(compilation.texts()));
+    }
+
+    private static String json(String model) {
+        Compilation compilation = measured(model);
+        return AdequacyReport.of(compilation)
+                .json(SourceRendering.namedByIdentity(compilation.texts()));
+    }
+
+    private static Compilation measured(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.errors().stream()
+                        .map(e -> e.diagnostic().code().toString()).toList(),
+                "the model under test compiles");
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferWasShortOfReachesTheAccountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferWasShortOfReachesTheAccountTest.java
@@ -176,6 +176,44 @@ class WhatTheOfferWasShortOfReachesTheAccountTest {
     }
 
     /**
+     * And every entry is shaped the way the document says entries of this are shaped.
+     *
+     * <p>The schema states it, and what evaluates a schema is a consumer's validator rather than
+     * anything here — so what holds the writer to it is this. Over every model below and not over
+     * the one that shows the news, because what is being held is a shape and the shape is the same
+     * wherever an entry is written.
+     *
+     * <p>The count first, so that a walk that found no entries is this failing rather than this
+     * passing with nothing to say.
+     */
+    @Test
+    void everyCauseIsShapedTheWayTheDocumentSaysTheyAre() {
+        List<JsonNode> seen = new ArrayList<>();
+        for (String document : List.of(json(model(OUTSIDE_THE_SUBSET)),
+                json(model(MORE_THAN_A_WITNESS_MAY_SPEND)), json(NOTHING_WAS_SHORT))) {
+            for (JsonNode owed : withAShortfall(document)) {
+                JsonNode causes = owed.get("synthesisShortfallCauses");
+                if (causes != null) {
+                    causes.forEach(seen::add);
+                }
+            }
+        }
+
+        assertFalse(seen.isEmpty(), "the models below write entries for this to be about");
+        for (JsonNode each : seen) {
+            boolean named = each.get("rule") != null;
+            assertEquals("a_rule".equals(each.get("attribution").stringValue()), named,
+                    () -> "a rule is named exactly where the shortfall is attributed to one: "
+                            + each);
+            assertEquals(named, each.get("ruleId") != null,
+                    () -> "and what tells one rule from another travels with it: " + each);
+            assertNotEquals(each.get("unread") == null, each.get("limit") == null,
+                    () -> "what stopped it is one of the two, never both and never neither: "
+                            + each);
+        }
+    }
+
+    /**
      * The questions under the position say what they said before, which is another axis and not the
      * half this was missing.
      *

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAllowanceSpentIsNotOneRulesDoingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAllowanceSpentIsNotOneRulesDoingTest.java
@@ -83,6 +83,33 @@ class AnAllowanceSpentIsNotOneRulesDoingTest {
     }
 
     /**
+     * And the word a document writes for it says the same, so nothing downstream has a rule to
+     * publish for an entry there is no rule behind.
+     *
+     * <p>The other half of the decision above. A projection that read the limit rather than the
+     * subject would put the rule back under a key a consumer joins on, and the check that the
+     * subject is right would go on passing.
+     */
+    @Test
+    void theDocumentAttributesAnAllowanceSpentToComposingAValue() {
+        StringOfferShortfall.NotOffered made =
+                StringOfferShortfall.NotOffered.whileMaking(aRule(), stoppedBy(
+                        Meter.Stopped.THE_ANSWER));
+
+        assertEquals(ReportedShortfall.Attribution.COMPOSING_A_VALUE,
+                ReportedShortfall.attribution(made.of()));
+        assertEquals(ReportedShortfall.Limit.WHAT_COMPOSING_A_VALUE_MAY_SPEND,
+                ReportedShortfall.limit(Meter.Stopped.THE_ANSWER));
+        // And a machine larger than a machine may be keeps its own word, which is the one an author
+        // writes a smaller pattern about.
+        assertEquals(ReportedShortfall.Attribution.A_RULE,
+                ReportedShortfall.attribution(StringOfferShortfall.NotOffered.whileMaking(
+                        aRule(), stoppedBy(Meter.Stopped.ONE_MACHINE)).of()));
+        assertEquals(ReportedShortfall.Limit.A_MACHINE_LARGER_THAN_ONE_MAY_BE,
+                ReportedShortfall.limit(Meter.Stopped.ONE_MACHINE));
+    }
+
+    /**
      * And what a combination carries is what it was made with, whatever the caller does with the
      * map afterwards.
      *


### PR DESCRIPTION
Both account surfaces took an unresolved combination and kept the word for what the search came to.
A rule this compiler could not read and a rule it read from end to end whose machine it would not
build are that same word, and they are different work — one is rewritten, the other is allowed more
— so the page wrote one sentence for both and the document wrote one word. Nothing was lost in the
carrying: the combination reaches the account whole, and the block was the only reader of the half
that says why the offer was short.

## The page

The decision sentence is self-contained now, and says the attribution in the words the block says it
in, so a reader who meets the rule in both places meets one sentence rather than two readings of it.

    ? nothing could show a row can be written at 1 decision rule — every value tried at a rule of
      the decision was refused, and what was tried was not everything the rules leave, and
      invariant Code (shape) at `t.code` gave none of them: written in a form this compiler does
      not read

Not left to the questions under the position. Those answer another question, asked by another walk:
a machine larger than one may be is said there of the rules of the position met with each other,
where this names the rule that was being built — and an allowance spent on composing a value raises
no such question at all, so a sentence that leaned on the neighbour would be complete for some of
the ways and not the rest.

## The document

The word for what the search came to stays what it was, because that is not what differs. Beside it
is what the shortfall is attributed to, the rule where the attribution is one, and what stopped it.

    "synthesisShortfall": "not_all_candidates_could_be_offered",
    "synthesisShortfallCauses": [
      { "position": "t.code", "attribution": "a_rule", "rule": ..., "ruleId": { ... },
        "unread": "unsupported_syntax" }
    ]

A structure and not the page's sentence, so the contract does not turn on how this compiler phrases
things. A reading that stopped is written in the vocabulary `notRead` already has, so one rule
reported unread in both places is one piece of news; a limit is no reading and has a key of its own.
The words are the document's rather than a spelling of the shapes this compiler records.

An array and not one object: what gave an offer nothing is per position and per thing, the way
`notRead` is. The key is optional, so the schema version is unchanged.

## What is held

A new test walks the pair through a compile: the page's decision sentences differ, the document's
word for what the search came to does not and its causes do, and a search that was short of nothing
carries no array — that last over a body whose every rule was read and whose every value was
refused. The questions under the position are held to what they said before.

The allowance spent on composing a value is held where the attribution is decided rather than
through a compile: reaching the end of it means having built most of what it allows, which is the
one thing about this that cannot be made cheap. What is held there is that it is attributed to
composing a value and names no rule.

## One to settle in review

`ruleId` names the clause, as the rest of this document does. Two parts of one clause that each gave
the offer nothing are then two entries a consumer cannot tell apart. Every other surface stops at
the clause too, so this follows them rather than inventing a finer identity here — worth a word if
that is the wrong call.

Answers #1643, which is closed by hand once this lands on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
