### PR TITLE
Hand a plurality a reader is shown one after another over as one that has an order

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -217,8 +217,8 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> NewData.read x1",
             "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;Lsouther/compiler/check/Denotations;Ljava/util/Map;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
             "souther/compiler/partition/FixtureTemplate#newtype(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1",
-            "souther/compiler/partition/FixtureTemplate#record(Lsouther/compiler/types/TypeReachName$Written;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
-            "souther/compiler/partition/FixtureTemplate#spreading(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
+            "souther/compiler/partition/FixtureTemplate#record(Lsouther/compiler/types/TypeReachName$Written;Ljava/util/SequencedMap;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
+            "souther/compiler/partition/FixtureTemplate#spreading(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;Ljava/util/SequencedMap;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
             "souther/compiler/partition/FixtureTemplate#temporal(Ljava/lang/String;Ljava/lang/String;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1");
 
     @Test

--- a/souther-cli/src/main/java/souther/cli/Runner.java
+++ b/souther-cli/src/main/java/souther/cli/Runner.java
@@ -278,7 +278,10 @@ public final class Runner {
         // against names the source settled.
         String requested = Reserved.name(requestedSpelling);
         Map<String, List<BehaviorRequirement>> requirements = requirementsOf(compilation, module);
-        Map<String, Hir.BehaviorDef> drivable = new java.util.LinkedHashMap<>();
+        // The ones that can be run, in the order the module declares them. A reader is given this
+        // list to pick from, so it is held as something that has an order rather than as a set of
+        // names put in whatever a walk of them came to.
+        java.util.SequencedMap<String, Hir.BehaviorDef> drivable = new java.util.LinkedHashMap<>();
         for (Hir.BehaviorDef b : module.behaviors()) {
             if (!exposes(module, b.name())) {
                 continue;
@@ -304,7 +307,7 @@ public final class Runner {
                         + " needing nothing injected, a `>->` pipeline when every stage is — and"
                         + " that the module exposes.");
             }
-            String names = String.join(", ", drivable.keySet());
+            String names = String.join(", ", drivable.sequencedKeySet());
             throw usage("run.behavior.several",
                     "several behaviors can be run — pick one with --behavior: " + names, names);
         }
@@ -312,7 +315,7 @@ public final class Runner {
         if (found != null) {
             return found;
         }
-        throw whyNotRunnable(compilation, module, requested, drivable.keySet());
+        throw whyNotRunnable(compilation, module, requested, drivable.sequencedKeySet());
     }
 
     /** A reason a behavior cannot be driven, in both forms: the catalog key with its arguments, and
@@ -384,7 +387,8 @@ public final class Runner {
      * author back to the same refusal.
      */
     private static RunException whyNotRunnable(Compilation compilation, Prepared module,
-                                               String name, java.util.Set<String> drivable) {
+                                               String name,
+                                               java.util.SequencedSet<String> drivable) {
         String available = drivable.isEmpty() ? "none" : String.join(", ", drivable);
         Map<String, List<BehaviorRequirement>> requirements = requirementsOf(compilation, module);
         for (Hir.BehaviorDef b : module.behaviors()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstructionDescent.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstructionDescent.java
@@ -5,7 +5,7 @@ import souther.compiler.types.TypeSymbol;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * Where a value at a position has to be built, one step down.
@@ -36,10 +36,10 @@ public final class ConstructionDescent {
      * @param fields      the fields, in the order the declaration writes them — which is the order
      *                    they are composed and reported in
      */
-    public record ProductBuild(TypeSymbol constructor, Map<String, Type> fields) {
+    public record ProductBuild(TypeSymbol constructor, SequencedMap<String, Type> fields) {
 
         public ProductBuild {
-            fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
+            fields = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(fields));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -885,7 +885,9 @@ public final class DataChecker {
         // the sums spread here, which a field the construction still wants was not in the shared part
         // of — all of them, because naming one of several would pick by position and send the author
         // to open a sum whose cases never had the field
-        Set<String> fromSums = new LinkedHashSet<>();
+        // Named to the author one after another, so held as something that has an order: the one the
+        // spreads are written in.
+        java.util.SequencedSet<String> fromSums = new LinkedHashSet<>();
         List<Spread> spread = new ArrayList<>();
         for (Core.Read read : spreads) {
             String sp = read.name();

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -79,11 +79,14 @@ public sealed interface Shape permits Shape.ReadablePositionShape, Shape.Cases, 
     /** A data with fields, and what they are, in the order the declaration writes them.
      *
      *  <p>The order is part of the answer, not an accident of the map: what a report names first
-     *  and which field a row is built for first are read off it. So the copy keeps it — an
-     *  unordered one would leave every reader depending on a hash. */
-    record Product(TypeSymbol name, Map<String, Type> fields) implements ReadablePositionShape {
+     *  and which field a row is built for first are read off it. So it is held as something that
+     *  has one, and a caller with only a set of fields is refused here rather than downstream,
+     *  where the reading would already be depending on a hash. */
+    record Product(TypeSymbol name, java.util.SequencedMap<String, Type> fields)
+            implements ReadablePositionShape {
         public Product {
-            fields = java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(fields));
+            fields = java.util.Collections.unmodifiableSequencedMap(
+                    new java.util.LinkedHashMap<>(fields));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1107,9 +1107,11 @@ public final class TypeOps {
         }
     }
 
-    /** Effective field name → type (included data flattened first, then own fields). */
-    public static Map<String, Type> fieldTypes(Hir.Data data, Symbols symbols) {
-        Map<String, Type> types = new LinkedHashMap<>();
+    /** Effective field name → type, in the order the declaration writes them: the data spread in
+     *  first, then the data's own. Which order that is, is what a reader is shown the fields in and
+     *  which one a row is built for first, so it is handed back as something that has one. */
+    public static java.util.SequencedMap<String, Type> fieldTypes(Hir.Data data, Symbols symbols) {
+        java.util.SequencedMap<String, Type> types = new LinkedHashMap<>();
         // Which spread put each field here, so a collision names the group that supplied the earlier
         // one. Reporting it against the taking data names a declaration that, where both fields came
         // through spreads, holds no such field at all.
@@ -1943,10 +1945,10 @@ public final class TypeOps {
                     // In scope denoting nothing: the import line that could not bring it in was
                     // reported there, and a use of it takes the error type rather than being
                     // reported again here.
-                    case Denotation.StandsForNothing ignored -> {
+                    case Denotation.StandsForNothing _ -> {
                         yield Type.ERRONEOUS;
                     }
-                    case Denotation.NotInScope ignored -> { }
+                    case Denotation.NotInScope _ -> { }
                 }
                 // A union's case names a type where a type goes. A `match` arm has always read it
                 // that way; a declaration reads it the same, which is what lets `Int |

--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * {@code souther api}: the standard library's published surface, one name per line with the
@@ -130,9 +130,14 @@ public final class ApiCommand {
      * answer, walked here rather than rebuilt: a listing assembled from the declarations and then
      * the rewrites puts every sugar after every module, whichever module it reads as. What each
      * name's signature comes from is this command's own question, and the only one it decides.
+     *
+     * <p>Answered as something that has an order, because a reader is given these one after another.
+     * A map that only said which names are on the surface would be one every caller had to walk in
+     * whatever it walked in, and the order a reader is shown would be a fact about how this was
+     * built rather than the one that was asked for.
      */
-    static Map<String, Signature> surface(Stdlib stdlib) {
-        Map<String, Signature> surface = new LinkedHashMap<>();
+    static SequencedMap<String, Signature> surface(Stdlib stdlib) {
+        SequencedMap<String, Signature> surface = new LinkedHashMap<>();
         for (String name : stdlib.published()) {
             // A published name is a spelling, and the library is what turns one into the operation
             // it reaches. Everything below is asked with that operation.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedMap;
 import java.util.Set;
 
 /**
@@ -208,11 +209,11 @@ final class ConstructionPlan {
      * @param under the positions of its fields, in the order the declaration writes them
      */
     record Built(TermPath at, Type type, TypeSymbol of, List<TypeSymbol> worn,
-                 Map<String, Node> under) implements Node {
+                 SequencedMap<String, Node> under) implements Node {
 
         Built {
             worn = List.copyOf(worn);
-            under = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(under));
+            under = java.util.Collections.unmodifiableSequencedMap(new LinkedHashMap<>(under));
         }
     }
 
@@ -651,7 +652,7 @@ final class ConstructionPlan {
             return givenUpAt(descent, here, building, settled.outer(),
                     anythingIsAskedUnder(here, decided, required));
         }
-        Map<String, Node> under = new LinkedHashMap<>();
+        SequencedMap<String, Node> under = new LinkedHashMap<>();
         Set<CompositionBudget> beyond = new LinkedHashSet<>();
         NodeResult.Unnarrowed owed = null;
         for (Map.Entry<String, Type> field : composed.fields().entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * A value written the way a row writes it — {@code Amount(0)}, {@code None}, {@code Overseas} — held
@@ -307,7 +308,7 @@ public record FixtureTemplate(String text, Hir.Expr value) {
      * @param moved the fields this writes over what the base holds, in the order they are written
      */
     public static FixtureTemplate spreading(TypeReachName.Written type, FixtureTemplate base,
-                                            Map<String, FixtureTemplate> moved) {
+                                            SequencedMap<String, FixtureTemplate> moved) {
         if (!(base.value() instanceof Hir.Var spread)) {
             throw new IllegalArgumentException("a spread names a value: " + base.text());
         }
@@ -326,8 +327,10 @@ public record FixtureTemplate(String text, Hir.Expr value) {
                         List.of(spread), NOWHERE, NO_SOURCE));
     }
 
-    /** A record, field by field, in the order the fields were declared. */
-    public static FixtureTemplate record(TypeReachName.Written type, Map<String, FixtureTemplate> fields) {
+    /** A record, field by field, in the order the fields were declared — which the fields are handed
+     *  over in, and which is why they are handed over as something that has one. */
+    public static FixtureTemplate record(TypeReachName.Written type,
+                                         SequencedMap<String, FixtureTemplate> fields) {
         List<String> written = new ArrayList<>();
         List<Hir.FieldInit> inits = new ArrayList<>();
         for (Map.Entry<String, FixtureTemplate> field : fields.entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2465,7 +2465,7 @@ public final class Generator {
                 || !(subject.symbols().scope().reach(built) instanceof TypeReachName.Written type)) {
             return null;
         }
-        Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
+        SequencedMap<String, FixtureTemplate> fields = new LinkedHashMap<>();
         LocationWrites writing = new LocationWrites();
         for (int i : moved) {
             Axis axis = axes.get(i);
@@ -2512,7 +2512,7 @@ public final class Generator {
         // is why the value the model states is where this search starts.
         List<String> declared = fieldsOf(subject, built);
         if (declared != null && fields.keySet().containsAll(declared)) {
-            Map<String, FixtureTemplate> written = new LinkedHashMap<>();
+            SequencedMap<String, FixtureTemplate> written = new LinkedHashMap<>();
             for (String field : declared) {
                 written.put(field, fields.get(field));
             }
@@ -5120,9 +5120,9 @@ public final class Generator {
         }
 
         @Override
-        public Map<String, FixtureTemplate> under(ConstructionPlan.Built built,
+        public SequencedMap<String, FixtureTemplate> under(ConstructionPlan.Built built,
                                                   PlanComposer.Under under) {
-            Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
+            SequencedMap<String, FixtureTemplate> fields = new LinkedHashMap<>();
             for (Map.Entry<String, ConstructionPlan.Node> each : built.under().entrySet()) {
                 FixtureTemplate value = under.of(each.getValue());
                 if (value == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2537,8 +2537,8 @@ public final class Generator {
         TypeView view = TypeView.of(Type.ref(built), subject.symbols());
         return !view.isWrapped()
                         && view.shape() instanceof Shape.Product(TypeSymbol _,
-                                Map<String, Type> fields)
-                ? List.copyOf(fields.keySet()) : null;
+                                SequencedMap<String, Type> fields)
+                ? List.copyOf(fields.sequencedKeySet()) : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -52,6 +52,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * The equivalence classes a model already states, read off the types a behavior takes.
@@ -1782,7 +1783,7 @@ public final class Partitions {
             return List.of();
         }
         RuleReadingSource ruleSource = reading.source();
-        Map<String, FixtureTemplate> chosen = fieldsOf(record, reading, expanding, given);
+        SequencedMap<String, FixtureTemplate> chosen = fieldsOf(record, reading, expanding, given);
         return chosen == null || !(ruleSource.symbols().scope().reach(record)
                 instanceof TypeReachName.Written written)
                         ? List.of() : List.of(FixtureTemplate.record(written, chosen));
@@ -1797,7 +1798,7 @@ public final class Partitions {
      * to write and needs what goes in it — a caller that took a written record apart again to get at
      * the fields would be reading one answer back out of another.
      */
-    static Map<String, FixtureTemplate> fieldsOf(TypeSymbol.AtModule record,
+    static SequencedMap<String, FixtureTemplate> fieldsOf(TypeSymbol.AtModule record,
                                                  RuleReadingContext reading,
                                                  java.util.Set<TypeSymbol> expanding,
                                                  Map<String, FixtureTemplate> given) {
@@ -1827,7 +1828,7 @@ public final class Partitions {
         // would be paying for every clause again to arrive where the first one already is.
         FieldDomains rules = FieldDomains.of(record, reading);
         FieldDomains.Composing left = rules.composing(Map.of());
-        Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
+        SequencedMap<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1814,7 +1814,7 @@ public final class Partitions {
         TypeView view = TypeView.of(Type.ref(record), ruleSource.symbols());
         if (expanding.contains(record) || view.isWrapped()
                 || !(view.shape() instanceof Shape.Product(TypeSymbol _,
-                        Map<String, Type> fields))) {
+                        SequencedMap<String, Type> fields))) {
             return null;
         }
         if (fields.isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -6,7 +6,7 @@ import souther.compiler.check.Shape;
 import souther.compiler.check.TypeView;
 import souther.compiler.types.TypeReachName;
 
-import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * The value a construction plan builds.
@@ -42,8 +42,13 @@ final class PlanComposer {
          * @param under composes a position of the plan, which is how a caller reaches the fields it
          *              does have a value under. Handed over rather than left to the caller so that
          *              what is below a field is still read the one way
+         *
+         *              <p>Answered in the order the record declares its fields, and answered as
+         *              something that has one, because a fixture is written field by field in that
+         *              order and a caller handed only which fields there are would write them in
+         *              whatever a walk of them came to.
          */
-        Map<String, FixtureTemplate> under(ConstructionPlan.Built built, Under under);
+        SequencedMap<String, FixtureTemplate> under(ConstructionPlan.Built built, Under under);
     }
 
     /** Composing one position of the plan, which is what a caller is given to reach below a field. */
@@ -116,7 +121,7 @@ final class PlanComposer {
     /** One record of the plan, out of whatever the caller has at the positions under it. */
     private static FixtureTemplate composed(ConstructionPlan.Built built, Values values,
                                             RuleReadingContext reading) {
-        Map<String, FixtureTemplate> fields =
+        SequencedMap<String, FixtureTemplate> fields =
                 values.under(built, node -> compose(node, values, reading));
         if (fields == null) {
             return null;

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -46,7 +46,7 @@ record ValuesCarryingANumber(TermPath fixed, FixtureTemplate value, RuleReadingC
 
     @Override
     public SequencedMap<String, FixtureTemplate> under(ConstructionPlan.Built built,
-                                              PlanComposer.Under under) {
+                                                       PlanComposer.Under under) {
         Map.Entry<String, ConstructionPlan.Node> down = fieldTowards(built);
         FixtureTemplate inner = down == null ? null : under.of(down.getValue());
         // A record this module composes is one a module declares. A constructor this cannot name is

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -6,6 +6,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.Map;
+import java.util.SequencedMap;
 
 /**
  * The values of a plan where one position inside it holds a number the caller has.
@@ -44,7 +45,7 @@ record ValuesCarryingANumber(TermPath fixed, FixtureTemplate value, RuleReadingC
     }
 
     @Override
-    public Map<String, FixtureTemplate> under(ConstructionPlan.Built built,
+    public SequencedMap<String, FixtureTemplate> under(ConstructionPlan.Built built,
                                               PlanComposer.Under under) {
         Map.Entry<String, ConstructionPlan.Node> down = fieldTowards(built);
         FixtureTemplate inner = down == null ? null : under.of(down.getValue());

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.function.IntFunction;
 
@@ -166,7 +167,7 @@ public final class Stdlib {
      *  library rather than the declaration it would have to open to find out. */
     private final Map<ValueName.Stdlib.Operation, Intrinsic> kernelOperations;
     private final Map<ValueName.Stdlib.Operation, Hir.FnDef> helpers;
-    private final Set<String> published;
+    private final SequencedSet<String> published;
     private final Map<String, List<String>> candidates;
     /** The projection a resolver takes, worked out once with everything else. A set built on each
      *  ask would be the same answer allocated again for every module of every compilation. */
@@ -178,7 +179,8 @@ public final class Stdlib {
                    Map<ValueName.Stdlib.Operation, Rewrite> sugars,
                    Map<TypeKey, Hir.Def> language, Map<Kernel, Intrinsic> intrinsics,
                    Map<ValueName.Stdlib.Operation, Intrinsic> kernelOperations,
-                   Map<ValueName.Stdlib.Operation, Hir.FnDef> helpers, Set<String> published,
+                   Map<ValueName.Stdlib.Operation, Hir.FnDef> helpers,
+                   SequencedSet<String> published,
                    Map<String, List<String>> candidates) {
         this.entries = entries;
         this.privateNames = privateNames;
@@ -280,9 +282,16 @@ public final class Stdlib {
         return entry != null && entry.declaration().params().isEmpty();
     }
 
-    /** The library's published surface: every qualified name a module outside the reserved namespace
-     *  may write, one module's vocabulary at a time. */
-    public Set<String> published() {
+    /**
+     * The library's published surface: every qualified name a module outside the reserved namespace
+     * may write, one module's vocabulary at a time.
+     *
+     * <p>One module's at a time is an order, and it is this that has it: the names are gathered by
+     * walking the load order. A reader is shown them one after another, so what is handed over says
+     * there is an order rather than leaving whoever writes the listing to take one from however the
+     * names happen to be held.
+     */
+    public SequencedSet<String> published() {
         return published;
     }
 
@@ -551,7 +560,7 @@ public final class Stdlib {
             // name a reader may write, so it belongs there.
             Map<String, ValueName.Stdlib.Operation> named = new LinkedHashMap<>(operations);
             SUGARED.forEach(sugar -> named.put(sugar.written().qualified(), sugar.written()));
-            Set<String> published = published(sugars.keySet());
+            SequencedSet<String> published = published(sugars.keySet());
             for (ValueName.Stdlib.Operation ascribed
                     : List.of(THE_WALK, THE_DISTINCTNESS_PREDICATE)) {
                 if (!helpers.containsKey(ascribed)) {
@@ -629,7 +638,7 @@ public final class Stdlib {
          *  be ordered by, so it is placed among the module it belongs to — a reader of this list is
          *  reading one module's vocabulary at a time, and a name that reads as {@code List}'s belongs
          *  among them. */
-        private Set<String> published(Set<ValueName.Stdlib.Operation> sugared) {
+        private SequencedSet<String> published(Set<ValueName.Stdlib.Operation> sugared) {
             Set<ValueName.Stdlib.Operation> named = new LinkedHashSet<>();
             for (ValueName.Stdlib.Operation operation : entries.keySet()) {
                 if (!privateNames.contains(operation)) {
@@ -639,7 +648,7 @@ public final class Stdlib {
             named.addAll(sugared);
             // Which module a name belongs to is the operation's alias, which it holds. Read off a
             // spelling, this had to be given the operations back to look each one up again.
-            Set<String> byModule = new LinkedHashSet<>();
+            SequencedSet<String> byModule = new LinkedHashSet<>();
             for (String qualifier : Reserved.QUALIFIERS) {
                 for (ValueName.Stdlib.Operation operation : named) {
                     if (operation.alias().equals(qualifier)) {
@@ -649,7 +658,7 @@ public final class Stdlib {
             }
             // anything under a qualifier not in the load order
             named.forEach(operation -> byModule.add(operation.qualified()));
-            return Collections.unmodifiableSet(byModule);
+            return Collections.unmodifiableSequencedSet(byModule);
         }
 
         /** Bare name → every published name it could be, in the order they are published in. */

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedMap;
 import java.util.SequencedSet;
 import java.util.Set;
 import java.util.function.IntFunction;
@@ -146,14 +147,14 @@ public final class Stdlib {
     public record Intrinsic(Kernel kernel, KernelSignature signature) {
     }
 
-    private final Map<ValueName.Stdlib.Operation, Entry> entries;
+    private final SequencedMap<ValueName.Stdlib.Operation, Entry> entries;
     private final Set<ValueName.Stdlib.Operation> privateNames;
     /** Which operation each spelling reaches — the one table here a written name is the key of, and
      *  the only way into the rest. What the library publishes an operation as is the library's, so
      *  a reader holding a spelling asks here for the operation and asks everything else with that;
      *  a reader holding an operation never comes through. */
     private final Map<String, ValueName.Stdlib.Operation> operations;
-    private final Map<ValueName.Stdlib.Operation, Rewrite> sugars;
+    private final SequencedMap<ValueName.Stdlib.Operation, Rewrite> sugars;
     private final Map<TypeKey, Hir.Def> language;
     /** And the same declarations by the library module that writes them, worked out once with
      *  everything else rather than gathered on each ask. */
@@ -173,10 +174,10 @@ public final class Stdlib {
      *  ask would be the same answer allocated again for every module of every compilation. */
     private final LibraryNames names;
 
-    private Stdlib(Map<ValueName.Stdlib.Operation, Entry> entries,
+    private Stdlib(SequencedMap<ValueName.Stdlib.Operation, Entry> entries,
                    Set<ValueName.Stdlib.Operation> privateNames,
                    Map<String, ValueName.Stdlib.Operation> operations,
-                   Map<ValueName.Stdlib.Operation, Rewrite> sugars,
+                   SequencedMap<ValueName.Stdlib.Operation, Rewrite> sugars,
                    Map<TypeKey, Hir.Def> language, Map<Kernel, Intrinsic> intrinsics,
                    Map<ValueName.Stdlib.Operation, Intrinsic> kernelOperations,
                    Map<ValueName.Stdlib.Operation, Hir.FnDef> helpers,
@@ -222,8 +223,10 @@ public final class Stdlib {
     }
 
     /** Every entry, by the operation it declares, in declaration order — private ones included,
-     *  because a checker and a backend still have to type and emit what they are behind. */
-    public Map<ValueName.Stdlib.Operation, Entry> entries() {
+     *  because a checker and a backend still have to type and emit what they are behind. Declaration
+     *  order is what the surface a reader is shown is gathered by, so it is what is handed over and
+     *  not something a reader of this has to know to keep. */
+    public SequencedMap<ValueName.Stdlib.Operation, Entry> entries() {
         return entries;
     }
 
@@ -268,8 +271,8 @@ public final class Stdlib {
         return sugars.get(operation);
     }
 
-    /** Every sugared operation, by what it rewrites to. */
-    public Map<ValueName.Stdlib.Operation, Rewrite> rewrites() {
+    /** Every sugared operation, by what it rewrites to, in the order the sugars are written. */
+    public SequencedMap<ValueName.Stdlib.Operation, Rewrite> rewrites() {
         return sugars;
     }
 
@@ -464,7 +467,8 @@ public final class Stdlib {
      */
     public static final class Builder {
 
-        private final Map<ValueName.Stdlib.Operation, Entry> entries = new LinkedHashMap<>();
+        private final SequencedMap<ValueName.Stdlib.Operation, Entry> entries =
+                new LinkedHashMap<>();
         private final Set<ValueName.Stdlib.Operation> privateNames = new LinkedHashSet<>();
         private final Map<String, ValueName.Stdlib.Operation> operations = new LinkedHashMap<>();
         private final Map<TypeKey, Hir.Def> language = new LinkedHashMap<>();
@@ -522,7 +526,7 @@ public final class Stdlib {
 
         /** The finished library. */
         public Stdlib freeze() {
-            Map<ValueName.Stdlib.Operation, Rewrite> sugars = sugars();
+            SequencedMap<ValueName.Stdlib.Operation, Rewrite> sugars = sugars();
             Map<String, Kernel> byKey = kernelsByKey();
             Map<Kernel, Intrinsic> intrinsics = new EnumMap<>(Kernel.class);
             Map<ValueName.Stdlib.Operation, Intrinsic> kernelOperations = new LinkedHashMap<>();
@@ -560,7 +564,7 @@ public final class Stdlib {
             // name a reader may write, so it belongs there.
             Map<String, ValueName.Stdlib.Operation> named = new LinkedHashMap<>(operations);
             SUGARED.forEach(sugar -> named.put(sugar.written().qualified(), sugar.written()));
-            SequencedSet<String> published = published(sugars.keySet());
+            SequencedSet<String> published = published(sugars.sequencedKeySet());
             for (ValueName.Stdlib.Operation ascribed
                     : List.of(THE_WALK, THE_DISTINCTNESS_PREDICATE)) {
                 if (!helpers.containsKey(ascribed)) {
@@ -569,10 +573,10 @@ public final class Stdlib {
                 }
             }
             return new Stdlib(
-                    Collections.unmodifiableMap(new LinkedHashMap<>(entries)),
+                    Collections.unmodifiableSequencedMap(new LinkedHashMap<>(entries)),
                     Collections.unmodifiableSet(new LinkedHashSet<>(privateNames)),
                     Collections.unmodifiableMap(named),
-                    Collections.unmodifiableMap(sugars),
+                    Collections.unmodifiableSequencedMap(sugars),
                     Collections.unmodifiableMap(new LinkedHashMap<>(language)),
                     Collections.unmodifiableMap(intrinsics),
                     Collections.unmodifiableMap(kernelOperations),
@@ -618,8 +622,8 @@ public final class Stdlib {
         /** Each sugar with what it keeps in place: the target's own parameter count, less what the
          *  rewrite supplies. A sugar naming a target the library does not declare is refused —
          *  nothing downstream would report it, because everything downstream reads this. */
-        private Map<ValueName.Stdlib.Operation, Rewrite> sugars() {
-            Map<ValueName.Stdlib.Operation, Rewrite> sugars = new LinkedHashMap<>();
+        private SequencedMap<ValueName.Stdlib.Operation, Rewrite> sugars() {
+            SequencedMap<ValueName.Stdlib.Operation, Rewrite> sugars = new LinkedHashMap<>();
             for (Sugar sugar : SUGARED) {
                 Entry declared = entries.get(sugar.target());
                 if (declared == null) {
@@ -638,8 +642,8 @@ public final class Stdlib {
          *  be ordered by, so it is placed among the module it belongs to — a reader of this list is
          *  reading one module's vocabulary at a time, and a name that reads as {@code List}'s belongs
          *  among them. */
-        private SequencedSet<String> published(Set<ValueName.Stdlib.Operation> sugared) {
-            Set<ValueName.Stdlib.Operation> named = new LinkedHashSet<>();
+        private SequencedSet<String> published(SequencedSet<ValueName.Stdlib.Operation> sugared) {
+            SequencedSet<ValueName.Stdlib.Operation> named = new LinkedHashSet<>();
             for (ValueName.Stdlib.Operation operation : entries.keySet()) {
                 if (!privateNames.contains(operation)) {
                     named.add(operation);

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -20,6 +20,7 @@ import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,7 +112,7 @@ class ANameGoesBackOnTheWayItCameOffTest {
         assertEquals(List.of(reached("DecisionNN"), reached("DecisionN")), compose.worn());
         assertEquals("DecisionNN(DecisionN(Approved { id = 1 }))",
                 compose.written(FixtureTemplate.record(reached("Approved"),
-                        Map.of("id", FixtureTemplate.integer(1)))).text());
+                        new LinkedHashMap<>(Map.of("id", FixtureTemplate.integer(1))))).text());
     }
 
     // --- and taken off again ---------------------------------------------------------------------


### PR DESCRIPTION
The canonical half of the sweep #1553 asks for. Nothing a reader is shown changes; what
changes is that the order it is shown in is stated where it crosses, instead of being
whatever container the producer happened to reach for.

### How the population was found

From the sinks backwards, off the compiled code rather than the source, so that what feeds
a sink is decided by its type. The sinks are the methods that write a sequence for a reader;
of those, the ones that also hold something whose type states no order were read one by one.
Two earlier attempts answered nothing and are worth recording: a grep over the source left
most feeds with no type at all, and a pass over `javap` output attributed methods to the
wrong classes.

Most of what the walk named turned out to be the collection being asked whether it holds
something rather than being written out — which is what a sweep meant to miss nothing looks
like. The rest were already in an order somebody decided: a `SequencedMap`, a `TreeSet`, a
list sorted before use, or the crossing added for a union's members.

What was left is here. Each already comes out right today, because each producer reached
for a `LinkedHashMap`; none of them said so.

### What is in it

The surface a listing is read off, the behaviors a caller is asked to pick one of, the
fields a fixture is written from, and the sums a field is looked for in now cross as
something that has an encounter order.

The compiler then found the callers. Widening the fields a fixture is written from made
five call sites answer for their own order, through the plan composer's `Values` and the
fields a record is chosen for — none of which had said anything either. That is the guard
this half wanted: a caller holding only a set is refused where it hands one over, rather
than being let through to decide.

The ledger of who settles a construction carries two of those signatures and is written
with them. No new place answers for a construction.

### What is left on the issue

The one shape in the population that is not just unstated but genuinely a number's: a
model's own `Map` value rendered into a mismatch message, which comes out of the runtime's
hash trie. Fixing it changes what an author reads, and which order it should take is a
question worth settling on its own — a rendered value has no author's order, while the
side it is compared against was written by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)