### PR TITLE
Apply the conditions the adequacy schema states, and state the ones it only described

### DIFF
--- a/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-21.json
@@ -1449,6 +1449,31 @@
         "unavailable"
       ]
     },
+    "measureReason": {
+      "description": "Where a measure writes the reason beside its status: at `unavailable` and nowhere else. Said once and referred to by every measure rather than written into each of them, because it is one relation — spelled at each, it would be a relation wherever somebody wrote it again and prose wherever they did not, which is what it was. A measure with a number has nothing here to say: what stopped it is a question about a measure that stopped.",
+      "if": {
+        "properties": {
+          "status": {
+            "const": "unavailable"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "reason"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "reason"
+          ]
+        }
+      }
+    },
     "module": {
       "type": "object",
       "required": [
@@ -1551,6 +1576,14 @@
         "status"
       ],
       "additionalProperties": false,
+      "dependentRequired": {
+        "rows": [
+          "pending"
+        ],
+        "pending": [
+          "rows"
+        ]
+      },
       "properties": {
         "name": {
           "type": "string"
@@ -1566,7 +1599,7 @@
         "rows": {
           "type": "integer",
           "minimum": 0,
-          "description": "How many example rows name this behavior, across every source that writes one. Present exactly where this behavior's rows were read, and absent where they were not: a source nobody could evaluate leaves no row to count, and a build that reads no rows counted none of them. So `0` is a behavior whose rows were read and numbered none, which is what an author acts on differently from rows nobody looked at — the two were one number until this version, and a model being migrated onto read as one with no rows written. Which of the ways it was is `status` and `weakening` beside it."
+          "description": "How many example rows name this behavior, across every source that writes one. Written where this behavior's rows were read and absent where they were not, which is a fact about the reading and is in no field of this object — so the absence is the answer rather than something a reader works out from what is beside it: a source nobody could evaluate leaves no row to count, and a build that reads no rows counted none of them. So `0` is a behavior whose rows were read and numbered none, which is what an author acts on differently from rows nobody looked at — the two were one number until this version, and a model being migrated onto read as one with no rows written. Which of the ways it was is `status` and `weakening` beside it."
         },
         "pending": {
           "type": "integer",
@@ -1608,6 +1641,65 @@
         ],
         "additionalProperties": false,
         "allOf": [
+          {
+            "description": "The code is written for the kinds a build is told about and for no others. A kind that carries one carries it wherever it is written, since which code a finding is told under is the kind's and not this finding's.",
+            "if": {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "output_case_unspecified",
+                    "input_case_unspecified",
+                    "boundary_unmet",
+                    "arm_unreached",
+                    "unanswered_row",
+                    "axis_class_uncovered",
+                    "decision_rule_uncovered",
+                    "domain_point_uncovered"
+                  ]
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "required": [
+                "code"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "code"
+                ]
+              }
+            }
+          },
+          {
+            "description": "And the place is written for the one kind whose place is its own. The rest are cited at the declaration the entry already names, and a place written for them would be that declaration's said twice.",
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "arm_unreached"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "required": [
+                "at"
+              ]
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "at"
+                ]
+              }
+            }
+          },
           {
             "if": {
               "properties": {
@@ -2082,6 +2174,11 @@
             "status"
           ],
           "additionalProperties": false,
+          "allOf": [
+            {
+              "$ref": "#/$defs/measureReason"
+            }
+          ],
           "properties": {
             "status": {
               "$ref": "#/$defs/status"
@@ -2114,6 +2211,33 @@
               "obligationId"
             ],
             "additionalProperties": false,
+            "allOf": [
+              {
+                "description": "What the composing came to is written exactly where the search had no candidate to try the rule with, which is the one answer it is about. Beside any other answer it would be a shortfall recorded of a search that composed a row and ran it.",
+                "if": {
+                  "properties": {
+                    "because": {
+                      "const": "nothing_was_composed_to_try"
+                    }
+                  },
+                  "required": [
+                    "because"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "synthesisShortfall"
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "required": [
+                      "synthesisShortfall"
+                    ]
+                  }
+                }
+              }
+            ],
             "properties": {
               "obligationId": {
                 "$ref": "#/$defs/ruleObligationId"
@@ -2272,6 +2396,11 @@
         "status"
       ],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/$defs/measureReason"
+        }
+      ],
       "if": {
         "properties": {
           "status": {
@@ -2471,6 +2600,11 @@
             "status"
           ],
           "additionalProperties": false,
+          "allOf": [
+            {
+              "$ref": "#/$defs/measureReason"
+            }
+          ],
           "properties": {
             "status": {
               "$ref": "#/$defs/status"
@@ -2497,6 +2631,11 @@
             "status"
           ],
           "additionalProperties": false,
+          "allOf": [
+            {
+              "$ref": "#/$defs/measureReason"
+            }
+          ],
           "properties": {
             "status": {
               "$ref": "#/$defs/status"
@@ -2527,6 +2666,11 @@
               "status"
             ],
             "additionalProperties": false,
+            "allOf": [
+              {
+                "$ref": "#/$defs/measureReason"
+              }
+            ],
             "properties": {
               "axis": {
                 "type": "string"
@@ -2795,6 +2939,9 @@
                   },
                   "allOf": [
                     {
+                      "$ref": "#/$defs/measureReason"
+                    },
+                    {
                       "description": "The verdict and the grounds are one answer written twice, so this says they cannot differ. Where the array is there and `knownWritable` is `true`, some ground is in it.",
                       "if": {
                         "required": [
@@ -2942,6 +3089,11 @@
             "between"
           ],
           "additionalProperties": false,
+          "allOf": [
+            {
+              "$ref": "#/$defs/measureReason"
+            }
+          ],
           "properties": {
             "total": {
               "type": "integer",
@@ -3166,7 +3318,7 @@
         },
         "claimsOffAxis": {
           "type": "array",
-          "description": "Claims about positions this report has no axis for — a position deeper than the walk goes, or one whose rules the reading never arrived at. Named by position, and carrying `why` exactly where nothing settled the claim.",
+          "description": "Claims about positions this report has no axis for — a position deeper than the walk goes, or one whose rules the reading never arrived at. Named by position, and carrying `why` where nothing settled the claim.",
           "items": {
             "type": "object",
             "required": [
@@ -3189,7 +3341,7 @@
                 }
               },
               "why": {
-                "description": "What stopped the answer, present exactly where nothing settled the claim.",
+                "description": "What stopped the answer, where nothing settled the claim. Its presence is how a reader tells the two apart: what settled a claim is not in this document, so an entry without this is one nothing was left open about rather than one whose reason went unwritten.",
                 "enum": [
                   "a_rule_went_unread",
                   "the_rules_leave_the_position_nothing",
@@ -3259,6 +3411,11 @@
         "inputs"
       ],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/$defs/measureReason"
+        }
+      ],
       "properties": {
         "status": {
           "$ref": "#/$defs/status"

--- a/souther-compiler/src/test/java/souther/compiler/DocumentShape.java
+++ b/souther-compiler/src/test/java/souther/compiler/DocumentShape.java
@@ -64,15 +64,21 @@ public final class DocumentShape {
             // (`EveryFormOfARuleHandleIsOneTheContractDescribes`)
             "x-souther-contains");
 
-    /** What a walk of one document came to: how much of it was reached, and what the schema
-     *  refuses. */
-    public record Read(int objects, List<String> wrong) {}
+    /**
+     * What a walk of one document came to: how much of it was reached, how many of the schema's
+     * conditions were put to it, and what the schema refuses.
+     *
+     * <p>The conditions are counted because a condition that never applies is a check that passes
+     * for saying nothing. A document holding none of the shapes they are about is a document this
+     * walk agrees with the way it agrees with an empty file.
+     */
+    public record Read(int objects, int conditions, List<String> wrong) {}
 
     /** {@code document} read against the schema this compiler ships. */
     public static Read of(JsonNode document) {
         Walk walk = new Walk(schema());
         walk.of(document, "");
-        return new Read(walk.objects, walk.wrong);
+        return new Read(walk.objects, walk.conditions, walk.wrong);
     }
 
     /** The same, for a caller that wants the document held to the schema and nothing else. */
@@ -98,6 +104,7 @@ public final class DocumentShape {
         private final JsonNode schema;
         private final List<String> wrong = new ArrayList<>();
         private int objects;
+        private int conditions;
 
         Walk(JsonNode schema) {
             this.schema = schema;
@@ -133,6 +140,7 @@ public final class DocumentShape {
                         }
                     });
                 }
+                conditions(said, node, at);
                 node.properties().forEach(entry -> {
                     JsonNode under = declares(said, entry.getKey());
                     if (under != null) {
@@ -218,6 +226,174 @@ public final class DocumentShape {
                 }
             }
             return true;
+        }
+
+        /**
+         * Which keys an object must have and must not have where that turns on what it holds.
+         *
+         * <p>Evaluated, unlike the branches of an {@code oneOf}. Which branch of those a value took
+         * is a question about the value, and answering it here would report a document as short of
+         * a key another branch asks for — but an {@code if} names what it turns on and a
+         * {@code dependentRequired} names the key that brings another with it, so there is nothing
+         * to guess at. Stepped over, these were the part of the contract a consumer is held to and
+         * this compiler was not: a relation the schema states and nothing applies is prose with
+         * punctuation.
+         *
+         * <p>Through an {@code allOf}, where a relation several objects share is written once and
+         * referred to, and through the {@code if} of a branch that was taken, where one condition
+         * is written as the next question after another.
+         */
+        private void conditions(JsonNode said, JsonNode node, String at) {
+            if (said.has("if")) {
+                Boolean answered = guarded(said.get("if"), node, at);
+                JsonNode taken = answered == null ? null : said.get(answered ? "then" : "else");
+                if (taken != null) {
+                    conditions++;
+                    for (String key : required(taken)) {
+                        if (!node.has(key)) {
+                            wrong.add(at + ": the schema requires a `" + key + "` here");
+                        }
+                    }
+                    for (String key : refused(taken, at)) {
+                        if (node.has(key)) {
+                            wrong.add(at + ": the schema writes no `" + key + "` here");
+                        }
+                    }
+                    conditions(resolved(taken), node, at);
+                }
+            }
+            for (JsonNode each : said.has("allOf") ? said.get("allOf") : List.<JsonNode>of()) {
+                conditions(resolved(each), node, at);
+            }
+            if (said.has("dependentRequired")) {
+                JsonNode with = said.get("dependentRequired");
+                with.propertyNames().forEach(key -> {
+                    if (node.has(key)) {
+                        with.get(key).forEach(also -> {
+                            if (!node.has(also.asString())) {
+                                wrong.add(at + ": the schema has `" + key + "` bring `"
+                                        + also.asString() + "` with it");
+                            }
+                        });
+                    }
+                });
+            }
+        }
+
+        /**
+         * Whether the question an {@code if} asks is answered yes by what was written, or null
+         * where the question is spelled a way this walk does not read.
+         *
+         * <p>A word at a key, or one of several, the keys the question is put of at all, and a
+         * question that is any of a list of those. Null rather than no for the rest: read as a no,
+         * the other branch would be applied to every document and the condition would be reported
+         * as broken wherever it holds — and read as a yes, it would say nothing anywhere. So it is
+         * reported as a question nobody here can answer, which is what it is.
+         */
+        private Boolean guarded(JsonNode asked, JsonNode node, String at) {
+            boolean answered = true;
+            for (String keyword : names(asked)) {
+                if (!List.of("properties", "required", "anyOf", "description").contains(keyword)) {
+                    wrong.add(at + ": a condition spelled a way this walk does not read: `"
+                            + keyword + "`");
+                    return null;
+                }
+            }
+            if (asked.has("properties")) {
+                for (var each : asked.get("properties").properties()) {
+                    JsonNode said = each.getValue();
+                    JsonNode held = node.get(each.getKey());
+                    // A question about what stands under a key, which is how a condition on
+                    // something written inside another object is put. Asked of the object there,
+                    // and answered no where nothing is.
+                    if (!said.has("const") && !said.has("enum")) {
+                        if (!said.has("properties") && !said.has("required")) {
+                            wrong.add(at + ": a condition spelled a way this walk does not read: "
+                                    + said);
+                            return null;
+                        }
+                        if (held == null || !held.isObject()) {
+                            answered = false;
+                            continue;
+                        }
+                        Boolean under = guarded(said, held, at + "/" + each.getKey());
+                        if (under == null) {
+                            return null;
+                        }
+                        answered &= under;
+                        continue;
+                    }
+                    answered &= held != null && (said.has("const")
+                            ? said.get("const").asString().equals(held.asString())
+                            : anyIs(said.get("enum"), held.asString()));
+                }
+            }
+            for (String key : required(asked)) {
+                answered &= node.has(key);
+            }
+            // And a question that is any of several, which is how a condition over more than one
+            // word is written where the words sit at different keys.
+            if (asked.has("anyOf")) {
+                boolean some = false;
+                for (JsonNode each : asked.get("anyOf")) {
+                    Boolean branch = guarded(each, node, at);
+                    if (branch == null) {
+                        return null;
+                    }
+                    some |= branch;
+                }
+                answered &= some;
+            }
+            return answered;
+        }
+
+        private List<String> names(JsonNode of) {
+            List<String> out = new ArrayList<>();
+            of.propertyNames().forEach(out::add);
+            return out;
+        }
+
+        private boolean anyIs(JsonNode words, String word) {
+            for (JsonNode each : words) {
+                if (word.equals(each.asString())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private List<String> required(JsonNode of) {
+            List<String> out = new ArrayList<>();
+            if (of.has("required")) {
+                of.get("required").forEach(each -> out.add(each.asString()));
+            }
+            return out;
+        }
+
+        /**
+         * The keys a branch writes out of the document, however it spells the refusal.
+         *
+         * <p>Two spellings, because the schema needed two: one key is {@code not: {required: [k]}}
+         * and several are {@code not: {anyOf: [{required: [k]}, ...]}}. Anything else is reported
+         * rather than passed over, for the reason the keywords above are.
+         */
+        private List<String> refused(JsonNode of, String at) {
+            if (!of.has("not")) {
+                return List.of();
+            }
+            JsonNode not = of.get("not");
+            if (not.has("required")) {
+                return required(not);
+            }
+            if (!not.has("anyOf")) {
+                wrong.add(at + ": a refusal spelled a way this walk does not read: " + not);
+                return List.of();
+            }
+            List<String> out = new ArrayList<>();
+            for (JsonNode each : not.get("anyOf")) {
+                out.addAll(required(each));
+            }
+            return out;
         }
 
         /** Every keyword of this schema object, held to what this walk was taught. */

--- a/souther-compiler/src/test/java/souther/compiler/EveryObjectThisWritesIsShapedTheWayTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryObjectThisWritesIsShapedTheWayTheSchemaSaysTest.java
@@ -85,6 +85,11 @@ class EveryObjectThisWritesIsShapedTheWayTheSchemaSaysTest {
         DocumentShape.Read read = DocumentShape.of(document());
         assertTrue(read.objects() > 20,
                 () -> "the model reaches the objects of the document: " + read.objects());
+        // And the conditions the schema states were put to it, which is what tells a document this
+        // walk agrees with from one that holds none of the shapes they are about.
+        assertTrue(read.conditions() > 0,
+                () -> "the model reaches what the schema states conditions about: "
+                        + read.conditions());
         assertEquals(List.of(), read.wrong(), "what the schema shipped beside this refuses");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -249,6 +250,17 @@ class EverySchemaWordIsAccountedForTest {
         return words;
     }
 
+    /** The words for the kinds of finding a build is told about, which is the ones with a code. */
+    private static Set<String> kindsWithACode() {
+        Set<String> words = new LinkedHashSet<>();
+        for (Adequacy.Kind kind : Adequacy.Kind.values()) {
+            if (kind.code().isPresent()) {
+                words.add(kind.name().toLowerCase(Locale.ROOT));
+            }
+        }
+        return words;
+    }
+
     /**
      * What a document may say about how the requirement of one rule came to its answer.
      *
@@ -424,6 +436,13 @@ class EverySchemaWordIsAccountedForTest {
             new Vocabulary("findings[].kind",
                     List.of("$defs", "findings", "items", "properties", "kind"),
                     Adequacy.Kind.class),
+            // The kinds a build is told about, which is the condition saying where a `code` is
+            // written. Read off the kinds rather than kept here: which of them carries a code is
+            // the kind's own answer, and a list of those written by hand is a condition that goes
+            // on promising a code for a kind that stopped having one.
+            new Vocabulary("findings[].code, in the condition that says where it is written",
+                    List.of("$defs", "findings", "items", "allOf", "0", "if", "properties", "kind"),
+                    List.of(), kindsWithACode(), Set.of()),
             // What wrote a block a caller handed in. The set comes from the owners a source can
             // write, so a sixth of them has to teach this its word before the schema will pass;
             // only the spelling is written down here, the report's own switch being exhaustive over

--- a/souther-compiler/src/test/java/souther/compiler/report/AMeasureWithNoValueWritesNoFieldOfOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AMeasureWithNoValueWritesNoFieldOfOneTest.java
@@ -3,6 +3,7 @@ package souther.compiler.report;
 import souther.compiler.diag.SourceRendering;
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.DocumentShape;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
@@ -13,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -313,37 +313,42 @@ class AMeasureWithNoValueWritesNoFieldOfOneTest {
      */
     @Test
     void theConditionsTheSchemaStatesAreTrueOfWhatIsWritten() {
-        JsonNode schema = schema();
         JsonNode report = reportOf(INJECTED, Adequacy.Level.WITNESS);
 
-        JsonNode branches = schema.get("$defs").get("branch");
+        // Every condition of every object, put to the document by the walk that holds the two
+        // together. Read out of the schema there rather than here: applied by whoever happened to
+        // remember, a condition is enforced over the objects somebody wrote a loop for and is prose
+        // everywhere else, which is what these were.
+        DocumentShape.Read walked = DocumentShape.of(report);
+        assertTrue(walked.conditions() > 0,
+                () -> "the report reaches what the schema states conditions about: "
+                        + walked.conditions());
+        assertEquals(List.of(), walked.wrong(), "what the schema shipped beside this refuses");
+
         int checked = 0;
         for (JsonNode module : report.get("modules")) {
             for (JsonNode each : module.get("behaviors")) {
                 if (each.has("branch")) {
-                    holds(branches, each.get("branch"));
                     checked++;
                 }
             }
         }
         assertTrue(checked >= 2, "both a measured branch and an unmeasured one are in this report");
 
-        // And what each arm of a measured branch says. The conditions here are what keeps the
-        // document's normal form the account's: an arm says where it stands once, and beside it
-        // whatever left it open — so `undecided` carries what the reading went without and the two
-        // settled states carry nothing. Applied over a report holding all three.
-        JsonNode arms = schema.get("$defs").get("branch").get("properties").get("obligations")
-                .get("items");
+        // And that the arms the conditions are about are all reached. The conditions here are what
+        // keeps the document's normal form the account's: an arm says where it stands once, and
+        // beside it whatever left it open — so `undecided` carries what the reading went without
+        // and the two settled states carry nothing. Applied over a report holding all three.
+        JsonNode arms = armAccounts();
+        assertEquals(List.of(), DocumentShape.of(arms).wrong(),
+                "what the schema refuses of a report holding every state an arm reaches");
         Set<String> reached = new java.util.LinkedHashSet<>();
-        for (JsonNode module : armAccounts().get("modules")) {
+        for (JsonNode module : arms.get("modules")) {
             for (JsonNode each : module.get("behaviors")) {
                 if (!each.get("branch").has("obligations")) {
                     continue;
                 }
                 for (JsonNode arm : each.get("branch").get("obligations")) {
-                    for (JsonNode condition : arms.get("allOf")) {
-                        holds(condition, arm);
-                    }
                     reached.add(arm.get("disposition").asString());
                 }
             }
@@ -354,8 +359,6 @@ class AMeasureWithNoValueWritesNoFieldOfOneTest {
         assertEquals(Set.of("met", "unmet", "undecided"), reached,
                 "every state a model reaches is in the document this was applied to");
 
-        JsonNode items = schema.get("$defs").get("partition").get("properties").get("boundaries")
-                .get("items").get("properties").get("items").get("items");
         int measured = 0;
         int not = 0;
         for (JsonNode module : report.get("modules")) {
@@ -365,7 +368,6 @@ class AMeasureWithNoValueWritesNoFieldOfOneTest {
                 }
                 for (JsonNode border : each.get("partition").get("boundaries")) {
                     for (JsonNode point : border.get("items")) {
-                        holds(items, point);
                         if (point.has("status")) {
                             boolean withAValue = List.of("complete", "partial")
                                     .contains(point.get("status").asString());
@@ -384,83 +386,6 @@ class AMeasureWithNoValueWritesNoFieldOfOneTest {
         assertTrue(withAValue > 0 && without > 0,
                 () -> "the level was chosen so that both arms occur: " + withAValue + " measured, "
                         + without + " not");
-    }
-
-    /** The {@code if}/{@code then}/{@code else} of one object, applied to one document node. */
-    private static void holds(JsonNode declared, JsonNode written) {
-        boolean guard = true;
-        for (String key : declared.get("if").get("properties").propertyNames()) {
-            JsonNode said = declared.get("if").get("properties").get(key);
-            // A condition on one word and a condition on several are the same question spelled two
-            // ways. Reading only the second would step over a condition rather than fail on it,
-            // which is what this test exists not to do.
-            assertTrue(said.has("enum") || said.has("const"),
-                    () -> "a condition spelled a way this does not read: " + said);
-            boolean here = written.has(key) && (said.has("const")
-                    ? said.get("const").asString().equals(written.get(key).asString())
-                    : anyIs(said.get("enum"), written.get(key).asString()));
-            guard &= here;
-        }
-        for (String required : declared.get("if").has("required")
-                ? names(declared.get("if").get("required")) : List.<String>of()) {
-            guard &= written.has(required);
-        }
-        JsonNode taken = declared.get(guard ? "then" : "else");
-        for (String key : required(taken)) {
-            assertTrue(written.has(key),
-                    () -> "the schema requires " + key + " here and it is not written: " + written);
-        }
-        for (String key : forbidden(taken)) {
-            assertFalse(written.has(key),
-                    () -> "the schema forbids " + key + " here and it is written: " + written);
-        }
-    }
-
-    private static boolean anyIs(JsonNode words, String word) {
-        for (JsonNode each : words) {
-            if (word.equals(each.asString())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static List<String> names(JsonNode array) {
-        List<String> out = new java.util.ArrayList<>();
-        for (JsonNode each : array) {
-            out.add(each.asString());
-        }
-        return out;
-    }
-
-    private static List<String> required(JsonNode of) {
-        return of != null && of.has("required") ? names(of.get("required")) : List.of();
-    }
-
-    /**
-     * The keys a branch of the condition writes out of the document, however it spells it.
-     *
-     * <p>Two spellings because two conditions needed two: one key is {@code not: {required: [k]}}
-     * and several are {@code not: {anyOf: [{required: [k]}, ...]}}. A reader of this that understood
-     * only one of them would pass over the other in silence, which is the failure it is here to
-     * catch, so meeting anything else is a failure rather than something skipped.
-     */
-    private static List<String> forbidden(JsonNode of) {
-        if (of == null || !of.has("not")) {
-            return List.of();
-        }
-        JsonNode not = of.get("not");
-        if (not.has("required")) {
-            return names(not.get("required"));
-        }
-        assertTrue(not.has("anyOf"), () -> "a refusal spelled a way this does not read: " + not);
-        List<String> out = new java.util.ArrayList<>();
-        for (JsonNode each : not.get("anyOf")) {
-            assertTrue(each.has("required") && each.size() == 1,
-                    () -> "a refusal spelled a way this does not read: " + each);
-            out.addAll(names(each.get("required")));
-        }
-        return out;
     }
 
     private static JsonNode schema() {


### PR DESCRIPTION
The adequacy schema promised of several fields that they are written exactly where another part of
the same object has a particular shape, and left the relation in the description. A document
breaking one was a document the contract described and did not refuse.

Each case was read on its own, because the answer is not the same for all of them: some of those
sentences are the schema's to state, and some are about something the object does not carry.

## Written as shape

A measure writes its `reason` at `unavailable` and nowhere else. That relation is one relation, so
it is said once — `$defs/measureReason` — and referred to by every measure that has it, rather than
spelled at each. Spelled at each, it would be a relation wherever somebody wrote it again and prose
wherever they did not, which is how it came to be prose here.

A finding carries `code` for the kinds a build is told about, and `at` for the one kind whose place
is its own. Which kinds carry a code is not kept in the schema by hand: the condition's words are
held against the kinds whose own answer has one, so a kind that stops carrying a code fails the
check rather than leaving the schema promising one.

A rule of a decision carries `synthesisShortfall` exactly where nothing was composed to try it
with, which is the one answer it is about.

A behavior's `rows` brings `pending` with it, which is what the description already said of the two.

## Written with less

How many rows were read, and whether a claim off the axes was settled, are facts about the reading
that no field of those objects carries. The descriptions promised a reader something they cannot
check and this compiler could drift from without anything noticing, so they now say what the field
is and what its absence means, and promise nothing about a field that is not there.

## Applied

The walk that holds a document to the schema reads a composition's branches for the keys they allow
and passed over what they require, which is why a condition in this file was a sentence nothing
enforced. It now applies the ones that name what they turn on — `if`/`then`/`else` and
`dependentRequired` — and refuses a spelling it does not know rather than reading it as a no. What
it still declines to guess is which branch of an `oneOf` a value took: that is a question about the
value, and answering it would report a document as short of a key another branch asks for.

The conditions it applied are counted and the count is asserted, so a document holding none of the
shapes they are about is not a document it agrees with. The one test that had read two of these
conditions out of the schema itself now asks the walk, and keeps what only it can say: that the
documents it walks reach both sides of them.

Checked by breaking it: a writer putting a `reason` beside every measure is refused at each of the
measures, which is what says the shared relation is reached from all of them.

Answers #1646, which is closed by hand once this lands on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
